### PR TITLE
Wfs data export event for writing common spatial file formats (http:/…

### DIFF
--- a/bundles/framework/featuredata2/event/WFSSetExport.js
+++ b/bundles/framework/featuredata2/event/WFSSetExport.js
@@ -1,0 +1,49 @@
+/**
+ * @class Oskari.mapframework.bundle.featuredata2.event.WFSSetExport
+ *
+ * <GIEV MIEH! COMMENTS>
+ */
+Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.event.WFSSetExport',
+    /**
+     * @method create called automatically on construction
+     * @static
+     * @param {Object} format    gdal code for export file format
+     * @param {Object} LayerId   id of wfs layer for to export
+     *
+     */
+
+    function (format, layerId) {
+        this._format = format;
+        this._layerId = layerId;
+    }, {
+        /** @static @property __name event name */
+        __name: "WFSSetExport",
+        /**
+         * @method getName
+         * @return {String} event name
+         */
+        getName: function () {
+            return this.__name;
+        },
+        /**
+         * WFS layer id for the export
+         * @method getLayerId
+         */
+        getLayerId: function () {
+            return this._layerId;
+        },
+        /**
+         * WFS export file format
+         * @method getFormat
+         */
+        getFormat: function () {
+            return this._format;
+        }
+
+    }, {
+        /**
+         * @property {String[]} protocol array of superclasses as {String}
+         * @static
+         */
+        'protocol': ['Oskari.mapframework.event.Event']
+    });

--- a/bundles/mapping/mapwfs2/plugin/WfsLayerPlugin.ol2.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsLayerPlugin.ol2.js
@@ -456,6 +456,13 @@ Oskari.clazz.define(
                 WFSSetFilter: function (event) {
                     me.setFilterHandler(event);
                 },
+                /**
+                 * @method WFSSetExport
+                 * @param {Object} event
+                 */
+                WFSSetExport: function (event) {
+                    me.setExportHandler(event);
+                },
 
                 /**
                  * @method WFSSetPropertyFilter
@@ -1035,6 +1042,17 @@ Oskari.clazz.define(
             this.getIO().setFilter(event.getGeoJson(), keepPrevious);
         },
 
+        /**
+         * @method setExportHandler
+         * @param {Object} event
+         */
+        setExportHandler: function (event) {
+            var format;
+            if(event.getLayerId()) {
+                event.getFormat() ? format = event.getFormat() : 'GEOJSON';
+                this.getIO().setExport(format, event.getLayerId());
+            }
+        },
         /**
          * @method setPropertyFilterHandler
          * @param {Object} event

--- a/bundles/mapping/mapwfs2/service/Mediator.js
+++ b/bundles/mapping/mapwfs2/service/Mediator.js
@@ -90,6 +90,9 @@ Oskari.clazz.define(
                 '/wfs/filter': function () {
                     self.getWFSFilter.apply(self, arguments);
                 },
+                '/wfs/export': function () {
+                    self.getWFSExport.apply(self, arguments);
+                },
                 '/wfs/propertyfilter': function () {
                     self.getWFSFilter.apply(self, arguments);
                 },
@@ -372,6 +375,19 @@ Oskari.clazz.category('Oskari.mapframework.bundle.mapwfs2.service.Mediator', 'ge
         var event = sandbox.getEventBuilder('WFSFeatureGeometriesEvent')(layer, keepPrevious);
         sandbox.notifyAll(event);
 
+    },
+    /**
+     * @method getWFSExport
+     * @param {Object} data
+     *
+     * response when wfs export data file is available
+     * Creates xxEvent
+     */
+    getWFSExport: function (data) {
+        var sandbox = this.plugin.getSandbox();
+        // Returns fileid (is now filename) data.data.fileId
+        // TODO: Add filename to redis in transport service and return here fileid
+        // TODO: Create action to load the export file via fileId
     },
 
     /**
@@ -692,6 +708,18 @@ Oskari.clazz.category(
             this.sendMessage('/service/wfs/setFilter', {
                 'filter': filter,
                 'keepPrevious': keepPrevious
+            });
+        },
+        /**
+         * @method setExport
+         * @param {String} format
+         *
+         * sends message to /service/wfs/setExport
+         */
+        setExport: function (format, id) {
+            this.sendMessage('/service/wfs/setExport', {
+                'format': format,
+                'layerId': id
             });
         },
         /**

--- a/packages/framework/bundle/featuredata2/bundle.js
+++ b/packages/framework/bundle/featuredata2/bundle.js
@@ -51,7 +51,10 @@ Oskari.clazz.define("Oskari.mapframework.bundle.featuredata2.FeatureDataBundle",
         }, {
             "type": "text/javascript",
             "src": "../../../../bundles/framework/featuredata2/event/WFSSetFilter.js"
-        },{
+        }, {
+            "type": "text/javascript",
+            "src": "../../../../bundles/framework/featuredata2/event/WFSSetExport.js"
+        }, {
             "type": "text/javascript",
             "src": "../../../../bundles/framework/featuredata2/event/WFSSetPropertyFilter.js"
         }, {


### PR DESCRIPTION
Wfs data export functionality for writing common spatial file formats

::: Environmetnt Preparations :::

1. Install GDAL library for geotools in the Transport servlet platform
   - http://oskari.org/documentation/backend/configuring-dataset-import
2. Setup security for GDAL library
   - https://www.identrust.com/certificates/trustid/root-download-x3.html
   - >keytool -importcert -alias identrust -keystore  
       .../Java/jdk1.8.0_60/jre/lib/security/cacerts" -file identrust.crt
3. Create "export" path under <Jetty home> with write access

::: Test use :::

Remark: There is not yet UI in Oskari for this functionality

1. Open WFS layer in Oskari and find out its layer id
   - console> Oskari.getSandbox().findAllSelectedMapLayers();
2. Open browser console and execute below commands
   var event = Oskari.getSandbox().getEventBuilder('WFSSetExport')('<format>','<layerId>');
 
   Oskari.getSandbox().notifyAll(event);
   e.g.
   var event = Oskari.getSandbox().getEventBuilder('WFSSetExport')('GPX','26');
 
   Oskari.getSandbox().notifyAll(event);
3. Format value is OGR GDAL code (http://www.gdal.org/ogr_formats.html)
   - following formats tested succefully
     GEOJSON, Geopackage (GPKG), GPX, KML, ESRI Shapefile, Mapinfo file, PDF

4. Result file(s) are written into /export directory  in transport environment and file id is sent to Oskari
   - result is a single file  or file directory 

::: TODO :::
1. Set export UI into featuredata2 bundle ?
2. Add download permission check into frontend UI and also in Transport
   - now there is only common view permission check in Transport
3. New action to deliver the export file(s) to the user
   - add copyright.txt file to result set files
   - zip result set
   - deliver the download link to the user

::: REMARKS :::
1. Each format in ORG Gdal library may have special limits for the result file
   - look at more details http://www.gdal.org/ogr_formats.html
   - property field name length (Shape)
   - property fields (e.g. GPX)
   - supported property types
   - supported geometry types (e.g. GPX: Point,LineString and MultiLineString)

2. Some workarounds has been made in WFSExport.java to handle those limits
   - property field names has been truncated for Shape file (OGR truncate didn't work)
   - Object type properties are strigified ( not optimal solution)
   - Geometry type is retyped in GPX format in certain cases