### PR TITLE
Statistical data provider attribution fix

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 1.41.2
+
+### Datasources UI in LogoPlugin
+
+Fixes an issue where data providers were not listed on the attribution listing.
+LogoPlugin now has a service which can be used to push information to the data providers/attribution list.
+LogoPlugin no longer references statistics data on its own.
+Statsgrid bundles push the attribution data to the LogoPlugin via the new ´map.DataProviderInfoService´.
+
 ## 1.41.1
 
 ### MapModulePlugin.AddFeaturesToMapRequest

--- a/bundles/mapping/mapmodule/plugin/logo/DataProviderInfoService.js
+++ b/bundles/mapping/mapmodule/plugin/logo/DataProviderInfoService.js
@@ -46,6 +46,15 @@ service.addItemToGroup('map.layers', { 'id' : 'dummy id the second', 'name' : 'i
         getName: function () {
             return this.__name;
         },
+        /**
+         * Add a group with id. Will show on the UI with the given name if it has any items.
+         * Items can be added also after the group has been created.
+         * Triggers a change-event if the group was added. Doesn't add the group if one exists with the same id.
+         * @param {Number | String} id id for the group
+         * @param {String} name  UI label for the group
+         * @param {Object[]} items optional array of items for the group.
+         * @return {Object} The group that was added
+         */
         addGroup : function(id, name, items) {
             var group = {
                 id : id,
@@ -67,6 +76,12 @@ service.addItemToGroup('map.layers', { 'id' : 'dummy id the second', 'name' : 'i
             }
             return list[indexForGroup];
         },
+        /**
+         * Removes the group matching the id.
+         * Triggers a change-event if the group was removed. Doesn't trigger the event if group was not found.
+         * @param  {Number | String} id if for the group to remove
+         * @return {Boolean} true if the group was removed
+         */
         removeGroup : function(id) {
             var list = this.groups;
             var indexForGroup = this._getItemIndex('id', id, list);
@@ -77,7 +92,13 @@ service.addItemToGroup('map.layers', { 'id' : 'dummy id the second', 'name' : 'i
             }
             list.splice(indexForGroup, 1);
             this.trigger('change');
+            return true;
         },
+        /**
+         * Returns a filtered list of all the groups.
+         * Only includes groups that have items and should be shown in the UI.
+         * @return {Object[]} Array of groups to be shown in the UI.
+         */
         getNonEmptyGroups : function() {
             var list =[];
             this.groups.forEach(function(group) {
@@ -87,6 +108,11 @@ service.addItemToGroup('map.layers', { 'id' : 'dummy id the second', 'name' : 'i
             });
             return list;
         },
+        /**
+         * Returns the unfiltered datamodel of the groups listing/single group.
+         * @param  {Number | String} id optional if for a group
+         * @return {Object[] | Object | Boolean} returns all the groups if parameter was undefined, boolean false if the requested group did not exist or the requested group.
+         */
         getGroups : function(id) {
             if(typeof id === 'undefined') {
                 return this.groups;
@@ -100,6 +126,13 @@ service.addItemToGroup('map.layers', { 'id' : 'dummy id the second', 'name' : 'i
             }
             return this.groups[indexForGroup];
         },
+        /**
+         * Removes an item from the group.
+         * Triggers a change-event if the item was removed.
+         * @param  {Number | String} groupId id for the group
+         * @param  {Number | String} itemId  id for the item
+         * @return {Boolean} true if item was removed, false if group/item was not found.
+         */
         removeItemFromGroup : function(groupId, itemId) {
             if(!groupId || !itemId) {
                 return false;
@@ -118,6 +151,13 @@ service.addItemToGroup('map.layers', { 'id' : 'dummy id the second', 'name' : 'i
             this.trigger('change');
             return true;
         },
+        /**
+         * Adds an item to the group. The item should be an object that has an id, name and source.
+         * Triggers a change-event if the item was added.
+         * @param {Number | String} groupId id for the group
+         * @param {Object} item     object to add for the group
+         * @return {Boolean} true if the item was added.
+         */
         addItemToGroup : function(groupId, item) {
             if(!groupId || !item) {
                 return false;
@@ -136,6 +176,14 @@ service.addItemToGroup('map.layers', { 'id' : 'dummy id the second', 'name' : 'i
             this.trigger('change');
             return true;
         },
+        /**
+         * Returns an index for an object in the list.
+         * @private
+         * @param  {String} key   key in object to use like 'id'
+         * @param  {String | Number} value value of the key to match
+         * @param  {Object[]} list  list to search through
+         * @return {Number} index for the item or -1 if not found
+         */
         _getItemIndex: function (key, value, list) {
             list = list || [];
             var len = list.length;

--- a/bundles/mapping/mapmodule/plugin/logo/DataProviderInfoService.js
+++ b/bundles/mapping/mapmodule/plugin/logo/DataProviderInfoService.js
@@ -52,9 +52,20 @@ service.addItemFromGroup('map.layers', { 'id' : 'dummy id the second'});
                 name : name || id,
                 items : items || []
             };
-            this.groups.push(group);
-            this.trigger('change');
-            return group;
+            var me = this;
+            var list = this.groups;
+            var indexForGroup = this._getItemIndex('id', id, list);
+            if(indexForGroup === -1) {
+                list.push(group);
+                this.trigger('change');
+                return group;
+            }
+            if(items && typeof items.forEach === 'function') {
+                items.forEach(function(item) {
+                    me.addItemToGroup(id, item);
+                });
+            }
+            return list[indexForGroup];
         },
         removeGroup : function(id) {
             var list = this.groups;
@@ -107,7 +118,7 @@ service.addItemFromGroup('map.layers', { 'id' : 'dummy id the second'});
             this.trigger('change');
             return true;
         },
-        addItemFromGroup : function(groupId, item) {
+        addItemToGroup : function(groupId, item) {
             if(!groupId || !item) {
                 return false;
             }

--- a/bundles/mapping/mapmodule/plugin/logo/DataProviderInfoService.js
+++ b/bundles/mapping/mapmodule/plugin/logo/DataProviderInfoService.js
@@ -1,0 +1,141 @@
+/**
+ * @class Oskari.map.DataProviderInfoService
+ *
+var service = Oskari.getSandbox().getService('Oskari.map.DataProviderInfoService');
+service.on('change', function() {
+    console.log('groups', this._service.getGroups());
+    console.log('groups for ui', this._service.getNonEmptyGroups());
+});
+service.addGroup('map.layers', 'Map layers');
+service.addGroup('statsgrid.indicators', 'Statistics indicators', [{ 'id' : 'dummy id'}]);
+service.removeItemFromGroup('statsgrid.indicators', 'dummy id');
+service.addItemFromGroup('map.layers', { 'id' : 'dummy id the second'});
+ */
+(function(Oskari) {
+    var _log = Oskari.log('Oskari.map.DataProviderInfoService');
+
+    Oskari.clazz.define('Oskari.map.DataProviderInfoService',
+
+    /**
+     * @method create called automatically on construction
+     * @static
+     */
+    function (sandbox) {
+        if(!sandbox) {
+            // don't create if sandbox is not provided
+            return null;
+        }
+        this.sandbox = sandbox;
+        var me = sandbox.getService(this.getQName());
+        if(me) {
+            // "singleton"
+            return me;
+        }
+        sandbox.registerService(this);
+        this.groups = [];
+
+        // attach on, off, trigger functions
+        Oskari.makeObservable(this);
+    }, {
+        __name: "map.DataProviderInfoService",
+        __qname: "Oskari.map.DataProviderInfoService",
+
+        getQName: function () {
+            return this.__qname;
+        },
+        getName: function () {
+            return this.__name;
+        },
+        addGroup : function(id, name, items) {
+            var group = {
+                id : id,
+                name : name || id,
+                items : items || []
+            };
+            this.groups.push(group);
+            this.trigger('change');
+            return group;
+        },
+        removeGroup : function(id) {
+            var list = this.groups;
+            var indexForGroup = this._getItemIndex('id', id, list);
+            if(indexForGroup === -1) {
+                // not found
+                _log.debug('Group with id "' + id + '" is not available.');
+                return false;
+            }
+            list.splice(indexForGroup, 1);
+            this.trigger('change');
+        },
+        getNonEmptyGroups : function() {
+            var list =[];
+            this.groups.forEach(function(group) {
+                if(group.items.length) {
+                    list.push(group);
+                }
+            });
+            return list;
+        },
+        getGroups : function(id) {
+            if(typeof id === 'undefined') {
+                return this.groups;
+            }
+            var list = this.groups;
+            var indexForGroup = this._getItemIndex('id', id, list);
+            if(indexForGroup === -1) {
+                // not found
+                _log.debug('Group with id "' + id + '" is not available.');
+                return false;
+            }
+            return this.groups[indexForGroup];
+        },
+        removeItemFromGroup : function(groupId, itemId) {
+            if(!groupId || !itemId) {
+                return false;
+            }
+            var group = this.getGroups(groupId);
+            if(!group) {
+                return false;
+            }
+            var itemIndex = this._getItemIndex('id', itemId, group.items);
+            if(itemIndex === -1) {
+                // not found
+                _log.debug('Item with id "' + itemId + '" not part of group"' + groupId + '".');
+                return false;
+            }
+            group.items.splice(itemIndex, 1);
+            this.trigger('change');
+            return true;
+        },
+        addItemFromGroup : function(groupId, item) {
+            if(!groupId || !item) {
+                return false;
+            }
+            var group = this.getGroups(groupId);
+            if(!group) {
+                return false;
+            }
+            var itemIndex = this._getItemIndex('id', item.id, group.items);
+            if(itemIndex !== -1) {
+                // not found
+                _log.debug('Item already exists "' + item.id + '" in group"' + groupId + '".');
+                return false;
+            }
+            group.items.push(item);
+            this.trigger('change');
+            return true;
+        },
+        _getItemIndex: function (key, value, list) {
+            list = list || [];
+            var len = list.length;
+            for (var i = 0; i < len; ++i) {
+                if(list[i][key] === value) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+    }, {
+        'protocol': ['Oskari.mapframework.service.Service']
+    });
+}(Oskari));

--- a/bundles/mapping/mapmodule/plugin/logo/DataProviderInfoService.js
+++ b/bundles/mapping/mapmodule/plugin/logo/DataProviderInfoService.js
@@ -7,9 +7,9 @@ service.on('change', function() {
     console.log('groups for ui', this._service.getNonEmptyGroups());
 });
 service.addGroup('map.layers', 'Map layers');
-service.addGroup('statsgrid.indicators', 'Statistics indicators', [{ 'id' : 'dummy id'}]);
+service.addGroup('statsgrid.indicators', 'Statistics indicators', [{ 'id' : 'dummy id', 'name' : 'indicator name', 'source' : 'Data provider for indicator'}]);
 service.removeItemFromGroup('statsgrid.indicators', 'dummy id');
-service.addItemFromGroup('map.layers', { 'id' : 'dummy id the second'});
+service.addItemToGroup('map.layers', { 'id' : 'dummy id the second', 'name' : 'indicator name', 'source' : 'Data provider for indicator'});
  */
 (function(Oskari) {
     var _log = Oskari.log('Oskari.map.DataProviderInfoService');

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -45,7 +45,7 @@ Oskari.clazz.define(
                     var layers = me.getSandbox().findAllSelectedMapLayers();
                     // add initial layers
                     layers.forEach(function(layer) {
-                        me._service.addItemFromGroup(me.constLayerGroupId, {
+                        me._service.addItemToGroup(me.constLayerGroupId, {
                             'id' : layer.getId(),
                             'name' : layer.getName(),
                             // AH-2182 Show source for user layers
@@ -84,19 +84,13 @@ Oskari.clazz.define(
                     if(!service || !layer) {
                         return;
                     }
-                    service.addItemFromGroup(this.constLayerGroupId, {
+                    service.addItemToGroup(this.constLayerGroupId, {
                         'id' : layer.getId(),
                         'name' : layer.getName(),
                         // AH-2182 Show source for user layers
                         'source' : layer.getSource && layer.getSource() ? layer.getSource() : layer.getOrganizationName()
                     });
                 },
-                'StatsGrid.IndicatorsEvent': function (event) {
-                    this._addIndicatorsToDataSourcesDialog(
-                        event.getIndicators()
-                    );
-                },
-
                 'MapSizeChangedEvent': function (event) {
                     if (this.dataSourcesDialog) {
                         var target = this.getElement().find('.data-sources');
@@ -226,7 +220,6 @@ Oskari.clazz.define(
                 dataSources.click(function (e) {
                     if (!me.inLayerToolsEditMode() && !me.dataSourcesDialog) {
                         me._openDataSourcesDialog(e.target);
-                        me._requestDataSources();
                     } else if (me.dataSourcesDialog) {
                         me.dataSourcesDialog.close(true);
                         me.dataSourcesDialog = null;
@@ -259,27 +252,6 @@ Oskari.clazz.define(
             this.changeCssClasses(classToAdd, testRegex, [div]);
         },
 
-        /**
-         * @private @method _requestDataSources
-         * Sends a request for indicators. If the statsgrid bundle is not
-         * available (and consequently there aren't any indicators) it opens the
-         * data sources dialog and just shows the data sources of the layers.
-         *
-         *
-         * @return {undefined}
-         */
-        _requestDataSources: function () {
-            var me = this,
-                reqBuilder = me.getSandbox().getRequestBuilder(
-                    'StatsGrid.IndicatorsRequest'
-                ),
-                request;
-
-            if (reqBuilder) {
-                request = reqBuilder();
-                me.getSandbox().request(me, request);
-            }
-        },
         updateDialog : function() {
             if(!this.dataSourcesDialog) {
                 return;
@@ -353,7 +325,7 @@ Oskari.clazz.define(
             this._service.addGroup('indicators', me._loc.indicatorsHeader);
             // add initial layers
             Object.keys(indicators).forEach(function(id) {
-                me._service.addItemFromGroup('indicators', {
+                me._service.addItemToGroup('indicators', {
                     'id' : id,
                     'name' : indicators[id].title,
                     'source' : indicators[id].organization

--- a/bundles/mapping/mapmodule/resources/css/logoplugin.css
+++ b/bundles/mapping/mapmodule/resources/css/logoplugin.css
@@ -31,9 +31,9 @@
 
 .data-sources-dialog {
   max-width: 400px; }
-  .data-sources-dialog .layers h4, .data-sources-dialog .data-sources-dialog .indicators h4 {
+  .data-sources-dialog h4.data-sources-heading {
     padding-bottom: 5px; }
-  .data-sources-dialog .indicators {
+  .data-sources-dialog .data-sources-group {
     margin-top: 10px; }
 
 /*# sourceMappingURL=logoplugin.css.map */

--- a/bundles/mapping/mapmodule/resources/locale/de.js
+++ b/bundles/mapping/mapmodule/resources/locale/de.js
@@ -23,8 +23,7 @@ Oskari.registerLocalization(
             "LogoPlugin": {
                 "terms": "Nutzungsbedingungen",
                 "dataSources": "Datenquellen",
-                "layersHeader": "Kartenebenen",
-                "indicatorsHeader": "Indikatoren"
+                "layersHeader": "Kartenebenen"
             },
             "DataSourcePlugin": {
                 "link": "Datenquelle",

--- a/bundles/mapping/mapmodule/resources/locale/en.js
+++ b/bundles/mapping/mapmodule/resources/locale/en.js
@@ -23,8 +23,7 @@ Oskari.registerLocalization(
             "LogoPlugin": {
                 "terms": "Terms of Use",
                 "dataSources": "Data Sources",
-                "layersHeader": "Map Layers",
-                "indicatorsHeader": "Indicators"
+                "layersHeader": "Map Layers"
             },
             "DataSourcePlugin": {
                 "link": "Data source",

--- a/bundles/mapping/mapmodule/resources/locale/es.js
+++ b/bundles/mapping/mapmodule/resources/locale/es.js
@@ -23,8 +23,7 @@ Oskari.registerLocalization(
             "LogoPlugin": {
                 "terms": "Términos de uso",
                 "dataSources": "Fuente de datos",
-                "layersHeader": "Capas de mapa",
-                "indicatorsHeader": "Indicadores"
+                "layersHeader": "Capas de mapa"
             },
             "DataSourcePlugin": {
                 "link": "Fuente de datos",

--- a/bundles/mapping/mapmodule/resources/locale/et.js
+++ b/bundles/mapping/mapmodule/resources/locale/et.js
@@ -23,8 +23,7 @@ Oskari.registerLocalization(
             "LogoPlugin": {
                 "terms": "Kasutustingimused",
                 "dataSources": "Andmeallikad",
-                "layersHeader": "Kaardikihid",
-                "indicatorsHeader": "Märksõnad"
+                "layersHeader": "Kaardikihid"
             },
             "DataSourcePlugin": {
                 "link": "Andmeallikas",

--- a/bundles/mapping/mapmodule/resources/locale/fi.js
+++ b/bundles/mapping/mapmodule/resources/locale/fi.js
@@ -23,8 +23,7 @@ Oskari.registerLocalization(
             "LogoPlugin": {
                 "terms": "Käyttöehdot",
                 "dataSources": "Tietolähteet",
-                "layersHeader": "Karttatasot",
-                "indicatorsHeader": "Indikaattorit"
+                "layersHeader": "Karttatasot"
             },
             "DataSourcePlugin": {
                 "link": "Tietolähde",

--- a/bundles/mapping/mapmodule/resources/locale/fr.js
+++ b/bundles/mapping/mapmodule/resources/locale/fr.js
@@ -23,8 +23,7 @@ Oskari.registerLocalization(
             "LogoPlugin": {
                 "terms": "Conditions d’utilisation",
                 "dataSources": "Sources des données",
-                "layersHeader": "Couches cartographiques",
-                "indicatorsHeader": "Indicateurs"
+                "layersHeader": "Couches cartographiques"
             },
             "DataSourcePlugin": {
                 "link": "Source des données",

--- a/bundles/mapping/mapmodule/resources/locale/nl.js
+++ b/bundles/mapping/mapmodule/resources/locale/nl.js
@@ -23,8 +23,7 @@ Oskari.registerLocalization(
             "LogoPlugin": {
                 "terms": "Gebruiksvoorwaarden",
                 "dataSources": "Gegevensbronnen",
-                "layersHeader": "Kaartlagen",
-                "indicatorsHeader": "Indicatoren"
+                "layersHeader": "Kaartlagen"
             },
             "DataSourcePlugin": {
                 "link": "Gegevensbron",

--- a/bundles/mapping/mapmodule/resources/locale/sk.js
+++ b/bundles/mapping/mapmodule/resources/locale/sk.js
@@ -23,8 +23,7 @@ Oskari.registerLocalization(
             "LogoPlugin": {
                 "terms": "Podmienky používania",
                 "dataSources": "Zdroje údajov",
-                "layersHeader": "Mapové vrstvy",
-                "indicatorsHeader": "Indikátory"
+                "layersHeader": "Mapové vrstvy"
             },
             "DataSourcePlugin": {
                 "link": "Zdroj údajov",

--- a/bundles/mapping/mapmodule/resources/locale/sl.js
+++ b/bundles/mapping/mapmodule/resources/locale/sl.js
@@ -23,8 +23,7 @@ Oskari.registerLocalization(
             "LogoPlugin": {
                 "terms": "Pogoji uporabe",
                 "dataSources": "Viri podatkov",
-                "layersHeader": "Sloji karte",
-                "indicatorsHeader": "Indikatorji"
+                "layersHeader": "Sloji karte"
             },
             "DataSourcePlugin": {
                 "link": "Vir podatkov",

--- a/bundles/mapping/mapmodule/resources/locale/sv.js
+++ b/bundles/mapping/mapmodule/resources/locale/sv.js
@@ -23,8 +23,7 @@ Oskari.registerLocalization(
             "LogoPlugin": {
                 "terms": "Användarvillkor",
                 "dataSources": "Datakällor",
-                "layersHeader": "Kartlager",
-                "indicatorsHeader": "Indikatorer"
+                "layersHeader": "Kartlager"
             },
             "DataSourcePlugin": {
                 "link": "Datakälla",

--- a/bundles/mapping/mapmodule/scss/logoplugin.scss
+++ b/bundles/mapping/mapmodule/scss/logoplugin.scss
@@ -40,11 +40,11 @@
 
 .data-sources-dialog {
   max-width: 400px;
-  .layers h4, .data-sources-dialog .indicators h4 {
+  h4.data-sources-heading {
     padding-bottom: 5px;
   }
 
-  .indicators {
+  .data-sources-group {
     margin-top: 10px;
   }
 }

--- a/bundles/statistics/statsgrid/plugin/ManageStatsPlugin.js
+++ b/bundles/statistics/statsgrid/plugin/ManageStatsPlugin.js
@@ -1346,6 +1346,45 @@ Oskari.clazz.define(
             var columnId = 'indicator' + indicatorId + year + gender;
             return columnId;
         },
+        /**
+         * Initialize group for indicators in DataProviderInfoService
+         */
+        initDatasourceInfo : function() {
+            if(this.___DataProviderInfoServiceInitDone) {
+                return;
+            }
+            var service = this.getSandbox().getService('Oskari.map.DataProviderInfoService');
+            if(!service) {
+                return;
+            }
+            service.addGroup('indicators', this._locale.dataProviderInfoTitle || 'Indicators');
+            this.___DataProviderInfoServiceInitDone = true;
+        },
+        /**
+         * Notify DataProviderInfoService that indicator was added
+         */
+        notifyIndicatorAdded : function(id, name, source) {
+            this.initDatasourceInfo();
+            var service = this.getSandbox().getService('Oskari.map.DataProviderInfoService');
+            if(!service) {
+                return;
+            }
+            service.addItemToGroup('indicators', {
+                'id' : id,
+                'name' : name,
+                'source' : source
+            });
+        },
+        /**
+         * Notify DataProviderInfoService that indicator was removed
+         */
+        notifyIndicatorRemoved : function(id) {
+            var service = this.getSandbox().getService('Oskari.map.DataProviderInfoService');
+            if(!service) {
+                return;
+            }
+            service.removeItemFromGroup('indicators', id);
+        },
 
         /**
          * Add indicator data to the grid.
@@ -1361,7 +1400,7 @@ Oskari.clazz.define(
             var me = this,
                 columnId = me._getIndicatorColumnId(indicatorId, gender, year),
                 columns = me.grid.getColumns(),
-                indicatorName = meta.title[Oskari.getLang()] || meta.title;
+                indicatorName = Oskari.getLocalized(meta.title);
 
             if (me.isIndicatorInGrid(columnId)) {
                 return false;
@@ -1446,6 +1485,7 @@ Oskari.clazz.define(
 
             me.updateDemographicsButtons(indicatorId, gender, year);
             me.grid.setSortColumn(me._state.currentColumn, true);
+            this.notifyIndicatorAdded(indicatorId, indicatorName, Oskari.getLocalized(meta.organization.title));
         },
 
         _updateIndicatorDataToGrid: function (columnId, data, columns) {
@@ -1634,8 +1674,8 @@ Oskari.clazz.define(
 
             this.updateDemographicsButtons(indicatorId, gender, year);
 
-
             this.sendStatsData(undefined);
+            this.notifyIndicatorRemoved(indicatorId);
             /*
             if (columnId === this._state.currentColumn) {
                 // hide the layer, as we just removed the "selected"

--- a/bundles/statistics/statsgrid/resources/locale/de.js
+++ b/bundles/statistics/statsgrid/resources/locale/de.js
@@ -12,6 +12,7 @@ Oskari.registerLocalization(
             "title": "",
             "message": ""
         },
+        "dataProviderInfoTitle": "Indikatoren",
         "layertools": {
             "table_icon": {
                 "tooltip": "Thematische Karten ansehen",

--- a/bundles/statistics/statsgrid/resources/locale/en.js
+++ b/bundles/statistics/statsgrid/resources/locale/en.js
@@ -12,6 +12,7 @@ Oskari.registerLocalization(
             "title": "Patio",
             "message": "patiopoc"
         },
+        "dataProviderInfoTitle": "Indicators",
         "layertools": {
             "table_icon": {
                 "tooltip": "Go to thematic maps",

--- a/bundles/statistics/statsgrid/resources/locale/es.js
+++ b/bundles/statistics/statsgrid/resources/locale/es.js
@@ -12,6 +12,7 @@ Oskari.registerLocalization(
             "title": "Patio",
             "message": "patiopoc"
         },
+        "dataProviderInfoTitle": "Indicadores",
         "layertools": {
             "table_icon": {
                 "tooltip": "Ir a mapas temáticos",

--- a/bundles/statistics/statsgrid/resources/locale/et.js
+++ b/bundles/statistics/statsgrid/resources/locale/et.js
@@ -12,6 +12,7 @@ Oskari.registerLocalization(
             "title": "",
             "message": ""
         },
+        "dataProviderInfoTitle": "Märksõnad",
         "layertools": {
             "table_icon": {
                 "tooltip": "",

--- a/bundles/statistics/statsgrid/resources/locale/fi.js
+++ b/bundles/statistics/statsgrid/resources/locale/fi.js
@@ -12,6 +12,7 @@ Oskari.registerLocalization(
             "title": "Patio",
             "message": "patiopoc"
         },
+        "dataProviderInfoTitle": "Indikaattorit",
         "layertools": {
             "table_icon": {
                 "tooltip": "Siirry teemakarttoihin",

--- a/bundles/statistics/statsgrid/resources/locale/fr.js
+++ b/bundles/statistics/statsgrid/resources/locale/fr.js
@@ -12,6 +12,7 @@ Oskari.registerLocalization(
             "title": "Patio",
             "message": "patiopoc"
         },
+        "dataProviderInfoTitle": "Indicateurs",
         "layertools": {
             "table_icon": {
                 "tooltip": "Aller aux cartes thématiques",

--- a/bundles/statistics/statsgrid/resources/locale/nl.js
+++ b/bundles/statistics/statsgrid/resources/locale/nl.js
@@ -12,6 +12,7 @@ Oskari.registerLocalization(
             "title": "Patio",
             "message": "Patiopoc"
         },
+        "dataProviderInfoTitle": "Indicatoren",
         "layertools": {
             "table_icon": {
                 "tooltip": "Ga naar de thema kaarten",

--- a/bundles/statistics/statsgrid/resources/locale/sk.js
+++ b/bundles/statistics/statsgrid/resources/locale/sk.js
@@ -12,6 +12,7 @@ Oskari.registerLocalization(
             "title": "Patio",
             "message": "patiopoc"
         },
+        "dataProviderInfoTitle": "Indikátory",
         "layertools": {
             "table_icon": {
                 "tooltip": "Choď na tematické mapy",

--- a/bundles/statistics/statsgrid/resources/locale/sl.js
+++ b/bundles/statistics/statsgrid/resources/locale/sl.js
@@ -12,6 +12,7 @@ Oskari.registerLocalization(
             "title": "Patio",
             "message": "patiopoc"
         },
+        "dataProviderInfoTitle": "Indikatorji",
         "layertools": {
             "table_icon": {
                 "tooltip": "Pojdi na tematske karte",

--- a/bundles/statistics/statsgrid/resources/locale/sv.js
+++ b/bundles/statistics/statsgrid/resources/locale/sv.js
@@ -12,6 +12,7 @@ Oskari.registerLocalization(
             "title": "Patio",
             "message": "patiopoc"
         },
+        "dataProviderInfoTitle": "Indikatorer",
         "layertools": {
             "table_icon": {
                 "tooltip": "Gå till temakartor",

--- a/bundles/statistics/statsgrid2016/resources/locale/en.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/en.js
@@ -9,6 +9,7 @@ Oskari.registerLocalization(
         "flyout": {
             "title": "Thematic maps"
         },
+        "dataProviderInfoTitle": "Indicators",
         "layertools": {
             "table_icon": {
                 "tooltip": "Go to thematic maps",

--- a/bundles/statistics/statsgrid2016/resources/locale/fi.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/fi.js
@@ -9,6 +9,7 @@ Oskari.registerLocalization(
         "flyout": {
             "title": "Teemakartat"
         },
+        "dataProviderInfoTitle": "Indikaattorit",
         "layertools": {
             "table_icon": {
                 "tooltip": "Siirry teemakarttoihin",

--- a/bundles/statistics/statsgrid2016/resources/locale/sv.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/sv.js
@@ -9,6 +9,7 @@ Oskari.registerLocalization(
         "flyout": {
             "title": "Tematiska kartor"
         },
+        "dataProviderInfoTitle": "Indikatorer",
         "layertools": {
             "table_icon": {
                 "tooltip": "Gå till temakartor",

--- a/bundles/statistics/statsgrid2016/service/StateService.js
+++ b/bundles/statistics/statsgrid2016/service/StateService.js
@@ -125,7 +125,22 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
             }
             return null;
         },
-
+        /**
+         * Returns true if an indicator matching the datasource and id is still selected with any parameters.
+         * Can be used to check if we should show the dataprovider information for the indicator or not.
+         * @param  {Number}  ds datasource id
+         * @param  {String}  id Indicator id
+         * @return {Boolean} true if this indicator with any selections is still part of the selected indicators
+         */
+        isSelected : function(ds, id) {
+            for(var i = 0;i<this.indicators.length; i++) {
+                var ind = this.indicators[i];
+                if(ind.datasource === ds && ind.indicator === id) {
+                    return true;
+                }
+            }
+            return false;
+        },
         /**
          * Returns an array of objects containing details (datasource, id, selections) of currently selected indicators.
          * @return {Object[]} currently selected indicators

--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -118,6 +118,7 @@
                 var selectorsFormatted = '( ' +  preferredFormatting.join(' / ') + ' )';
                 callback({
                     indicator : name,
+                    source : Oskari.getLocalized(ind.source),
                     params : selectorsFormatted,
                     full : name + ' ' + selectorsFormatted,
                     paramsAsObject : uiLabels

--- a/packages/framework/bundle/mapmodule-plugin/bundle.js
+++ b/packages/framework/bundle/mapmodule-plugin/bundle.js
@@ -188,6 +188,9 @@ Oskari.clazz.define(
                     "type": "text/javascript",
                     "src": "../../../../bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js"
                 }, {
+                    "type": "text/javascript",
+                    "src": "../../../../bundles/mapping/mapmodule/plugin/logo/DataProviderInfoService.js"
+                }, {
                     "type": "text/css",
                     "src": "../../../../bundles/mapping/mapmodule/resources/css/logoplugin.css"
                 },

--- a/packages/mapping/ol3/mapmodule/bundle.js
+++ b/packages/mapping/ol3/mapmodule/bundle.js
@@ -161,6 +161,9 @@ Oskari.clazz.define(
                     "type": "text/javascript",
                     "src": "../../../../bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js"
                 }, {
+                    "type": "text/javascript",
+                    "src": "../../../../bundles/mapping/mapmodule/plugin/logo/DataProviderInfoService.js"
+                }, {
                     "type": "text/css",
                     "src": "../../../../bundles/mapping/mapmodule/resources/css/logoplugin.css"
                 },


### PR DESCRIPTION
Fixes an issue where data providers were not listed on the attribution listing.
LogoPlugin now has a service which can be used to push information to the data providers/attribution list.
LogoPlugin no longer references statistics data on its own.
Statsgrid bundles push the attribution data to the LogoPlugin via the new ´map.DataProviderInfoService´.