### PR TITLE
Indexmap/statslayer interoperability

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,13 @@
 
 ## 1.42.0
 
+### statslayer/index map interoperability
+
+Fixed an issue where opening index map with statslayer as base resulted in:
+
+- the normal map not refreshing on move after indexmap is opened
+- in some cases indexmap + normal map going to an infinite update-loop when zooming out
+
 ### coordinatetool
 
 Fixed extra coordinate server transform calls.

--- a/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol3.js
+++ b/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol3.js
@@ -68,6 +68,14 @@ Oskari.clazz.define(
                     // get/Set only base layer to index map
                     var layer = me._getBaseLayer();
                     if (layer) {
+                        if(typeof layer.createIndexMapLayer === 'function') {
+                            // this is used for statslayer to create a copied layer as indexmap
+                            // as using it directly results in weird behavior:
+                            // - the normal map not refreshing on move after indexmap is opened
+                            // - in some cases indexmap + normal map going to an infinite update-loop when zooming out
+                            layer = layer.createIndexMapLayer();
+                        }
+
                         var controlOptions = {
                             target: me._indElement[0],
                             layers: [ layer ],

--- a/bundles/mapping/mapstats/plugin/StatsLayerPlugin2016.ol3.js
+++ b/bundles/mapping/mapstats/plugin/StatsLayerPlugin2016.ol3.js
@@ -26,6 +26,24 @@ Oskari.clazz.define(
 
             var me = this;
 
+            var openlayer = this.__createLayer(layer);
+            // this is used for statslayer to create a copied layer as indexmap
+            // as using it directly results in weird behavior:
+            // - the normal map not refreshing on move after indexmap is opened
+            // - in some cases indexmap + normal map going to an infinite update-loop when zooming out
+            openlayer.createIndexMapLayer = function() {
+                return me.__createLayer(layer);
+            };
+            this.getMapModule().addLayer(openlayer, !keepLayerOnTop);
+
+            me.getSandbox().printDebug('#!#! CREATED OPENLAYER.LAYER.WMS for StatsLayer ' + layer.getId());
+
+            // store reference to layers
+            this.setOLMapLayers(layer.getId(), openlayer);
+            this.renderActiveIndicator();
+        },
+        __createLayer: function(layer) {
+            var me = this;
             var openlayer = new ol.layer.Image({
                     source: new ol.source.ImageWMS({
                         url: me.ajaxUrl + '&LAYERID=' + layer.getId(),
@@ -50,13 +68,7 @@ Oskari.clazz.define(
             if (layer.getMinScale()  && layer.getMinScale() !== -1 && (layer.getMinScale() < this.getMapModule().getScaleArray()[0] )) {
                 openlayer.setMaxResolution(this.getMapModule().getResolutionForScale(layer.getMinScale()));
             }
-            this.getMapModule().addLayer(openlayer, !keepLayerOnTop);
-
-            me.getSandbox().printDebug('#!#! CREATED OPENLAYER.LAYER.WMS for StatsLayer ' + layer.getId());
-
-            // store reference to layers
-            this.setOLMapLayers(layer.getId(), openlayer);
-            this.renderActiveIndicator();
+            return openlayer;
         },
         __updateLayerParams : function(layer, params) {
             layer.getSource().updateParams(params);


### PR DESCRIPTION

Fixed an issue where opening index map with statslayer as base resulted in:

- the normal map not refreshing on move after indexmap is opened
- in some cases indexmap + normal map going to an infinite update-loop when zooming out