### PR TITLE
Feature/statsgrid table paging

### DIFF
--- a/api/ui/divmanazer/grid.md
+++ b/api/ui/divmanazer/grid.md
@@ -35,7 +35,51 @@ grid.setVisibleFields([ 'id', 'afield', 'anotherfield' ]);
 grid.setColumnValueRenderer('id', idRenderer);
 grid.setColumnUIName('afield', localisations.afield);
 grid.setColumnUIName('anotherfield', localisations.anotherfield);
+
+// If you want use paging you can also define grid for this way
+// Set grouping header, only grouping headers allows use paging
+me.grid.setGroupingHeader([
+    {
+        // first grouping cell is same for all others cells, for example same title
+        // define grouping cell style class
+        cls: 'grouping-header-1',
+        // define grouping header text
+        text: 'Header 1'
+    },
+    {
+        // this we use at all others than first cell has own grouping header
+        // define grouping cell style class
+        cls:'grouping-header-2',
+        // define grouping header text
+        text: 'Header 2',
+        // define how many cells is maximum count. If cols are more than this then shows paging arrows
+        maxCols: 2,
+        /* define paging handler. Handler return text element and data obtains information on paging. data object is following:
+        {
+          visible: {
+            start: 2,
+            end: 3
+          },
+          count: 6,
+          page: 1,
+          maxPages: 3
+        }
+        Object tells:
+        - visible: tells at showing now cells 2 - 3
+        - count: tells at there is 6 cells
+        - page: tells at you are now page 1
+        - maxPages: tells at there is 3 pages
+        */
+        pagingHandler: function(element, data){
+            element.html('Data ' + '<span>('+data.visible.start + '-' + data.visible.end +'/' + data.count+')</span>');
+        }
+    }
+]);
+
+
 grid.renderTo(someElement);
+
+
 ```
 
 ## Dependencies

--- a/bundles/framework/divmanazer/component/Grid.js
+++ b/bundles/framework/divmanazer/component/Grid.js
@@ -531,11 +531,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Grid',
                     checkPagingButtonsVisiblity();
                 }
 
-                // IE fix
-                table.addClass('autoheight');
-                table.removeClass('autoheight');
-                table.hide();
-                table.show(0);
+
             }
         },
         /**

--- a/bundles/statistics/statsgrid2016/components/Datatable.js
+++ b/bundles/statistics/statsgrid2016/components/Datatable.js
@@ -426,15 +426,18 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function(sandbox, l
     setHeaderHeight: function(){
         var me = this;
         var statsTableEl = jQuery('.oskari-flyoutcontent.statsgrid .stats-table');
+
+        // IE fix
         if(statsTableEl.length > 0) {
-            statsTableEl.addClass('autoheight');
+            var latestCell = statsTableEl.find('tbody tr').last();
+            latestCell.addClass('autoheight');
             // hack is needed by IE 11. Otherwise header elements with css like
             //   position : absolute, bottom : 0
             // will render in wrong location.
             // This will force a repaint which will fix the locations.
-            statsTableEl.removeClass('autoheight');
-            statsTableEl.hide();
-            statsTableEl.show(0);
+            latestCell.removeClass('autoheight');
+            latestCell.hide();
+            latestCell.show(0);
         }
     },
 

--- a/bundles/statistics/statsgrid2016/components/Datatable.js
+++ b/bundles/statistics/statsgrid2016/components/Datatable.js
@@ -337,6 +337,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function(sandbox, l
         var log = Oskari.log('Oskari.statistics.statsgrid.Datatable');
         var src = this.service.getDatasource(datasrc);
         log.info('Indicator added ', src, indId, selections);
+        var state = this.service.getStateService();
+        var hash = this.service.getStateService().getHash(datasrc, indId, selections);
+
+        state.setActiveIndicator(hash);
         this._handleRegionsetChanged(this.getCurrentRegionset());
     },
     /**

--- a/bundles/statistics/statsgrid2016/components/Datatable.js
+++ b/bundles/statistics/statsgrid2016/components/Datatable.js
@@ -13,6 +13,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function(sandbox, l
         descending: false
     };
 
+    this._maxCols = 3;
+
     // Keep latest sorting on memory
     this._sortOrder = null;
 }, {
@@ -90,7 +92,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function(sandbox, l
             {
                 cls:'statsgrid-grouping-header sources',
                 text: gridLoc.title + ' <span>('+indicators.length+')</span>',
-                maxCols: 3,
+                maxCols: me._maxCols,
                 pagingHandler: function(element, data){
                     element.html(gridLoc.title + ' <span>('+data.visible.start + '-' + data.visible.end +'/' + data.count+')</span>');
                     me.setHeaderHeight();
@@ -195,7 +197,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function(sandbox, l
                 sortBy.find('.orderTitle').attr('title', gridLoc.orderByAscending);
             }
 
-            content.css('width', '180px');
+            content.css('width', '30%');
         });
 
 
@@ -319,6 +321,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function(sandbox, l
                     me.service.getStateService().setActiveIndicator(ind.hash);
                 });
 
+                // calculate cell width
+                var visibleCells = (indicators.length > me._maxCols) ? me._maxCols : indicators.length;
+                var cellWidth = 70 / visibleCells;
+                content.css('width', cellWidth + '%');
                 content.append(tableHeader);
             });
             if(indicators.length - 1 === id) {

--- a/bundles/statistics/statsgrid2016/resources/css/style.css
+++ b/bundles/statistics/statsgrid2016/resources/css/style.css
@@ -29,7 +29,7 @@
     margin-bottom: 6px; }
   .statsgrid-grid-table-header .selection {
     margin-bottom: 6px;
-    width: 94%; }
+    width: 98%; }
   .statsgrid-grid-table-header .sortby {
     cursor: pointer;
     position: absolute;
@@ -104,6 +104,13 @@ div.oskari-flyoutcontent.statsgrid {
   /* TODO: limits the table from blowing up the flyout, but this needs to be handled in some other way */
   max-width: 700px;
   /* Chosen fixes */ }
+  div.oskari-flyoutcontent.statsgrid table.oskari-grid th.selected {
+    background-color: #FDF8D9;
+    animation-name: statsgridcolumnselection;
+    animation-duration: 0.5s;
+    animation-iteration-count: 3; }
+  div.oskari-flyoutcontent.statsgrid table.oskari-grid td {
+    text-align: left; }
   div.oskari-flyoutcontent.statsgrid label span {
     /* Indicator selection form */
     width: 200px;
@@ -140,11 +147,6 @@ div.oskari-flyoutcontent.statsgrid {
       font-style: italic; }
     div.oskari-flyoutcontent.statsgrid .statsgrid-ds-selections input.oskari-button {
       margin-left: 10px; }
-  div.oskari-flyoutcontent.statsgrid table.oskari-grid th.selected {
-    background-color: #FDF8D9;
-    animation-name: statsgridcolumnselection;
-    animation-duration: 0.5s;
-    animation-iteration-count: 3; }
   div.oskari-flyoutcontent.statsgrid .chosen-container.chosen-drop-up .chosen-drop {
     border-bottom: 0;
     border-radius: 4px 4px 0 0;
@@ -180,21 +182,21 @@ div.oskari-flyoutcontent.statsgrid {
     width: 336px; }
   div.oskari-flyoutcontent.statsgrid div.parameter div.clear {
     clear: both; }
-div.oskari-flyoutcontent.statsgrid thead th {
-  border: none;
-  border-bottom: 1px solid #E6E6E6;
-  border-left: 1px solid #E6E6E6;
-  border-right: 1px solid #E6E6E6; }
-div.oskari-flyoutcontent .statsgrid-grouping-header {
-  text-align: left;
-  padding: 6px;
-  border-bottom: none !important;
-  border-top: 1px solid #E6E6E6; }
-  div.oskari-flyoutcontent .statsgrid-grouping-header.sources {
-    color: #ffffff;
-    background-color: #000000; }
-    div.oskari-flyoutcontent .statsgrid-grouping-header.sources span {
-      font-weight: normal; }
+  div.oskari-flyoutcontent.statsgrid thead th {
+    border: none;
+    border-bottom: 1px solid #E6E6E6;
+    border-left: 1px solid #E6E6E6;
+    border-right: 1px solid #E6E6E6; }
+  div.oskari-flyoutcontent.statsgrid .statsgrid-grouping-header {
+    text-align: left;
+    padding: 6px;
+    border-bottom: none !important;
+    border-top: 1px solid #E6E6E6; }
+    div.oskari-flyoutcontent.statsgrid .statsgrid-grouping-header.sources {
+      color: #ffffff;
+      background-color: #000000; }
+      div.oskari-flyoutcontent.statsgrid .statsgrid-grouping-header.sources span {
+        font-weight: normal; }
 
 /* ********************************************
  * Statsgrid legend
@@ -203,8 +205,8 @@ div.oskari-flyoutcontent .statsgrid-grouping-header {
   border: 1px solid rgba(0, 0, 0, 0.2);
   pointer-events: auto;
   text-align: left;
-    /* Float right to not overlap with other plugins */
-    float: right; }
+  /* Float right to not overlap with other plugins */
+  float: right; }
 
 .statsgrid-legend-container {
   background-color: #FFFFFF;
@@ -273,29 +275,28 @@ div.mapplugins .mappluginsContainer .mappluginsContent .mapplugin.statsgrid-publ
   border: 1px solid rgba(0, 0, 0, 0.2);
   float: right;
   z-index: 100000;
-  margin: 10px;
-   }
-  .statsgrid-published-toggle-buttons .map {
+  margin: 10px; }
+  div.mapplugins .mappluginsContainer .mappluginsContent .mapplugin.statsgrid-published-toggle-buttons .map {
     background-color: #3c3c3c;
     float: left;
     height: 36px;
     width: 36px;
     background-image: url("../images/map_dark.png");
     cursor: pointer; }
-    .statsgrid-published-toggle-buttons .map.active {
+    div.mapplugins .mappluginsContainer .mappluginsContent .mapplugin.statsgrid-published-toggle-buttons .map.active {
       background-color: #ffffff;
       background-image: url("../images/map_light.png"); }
-  .statsgrid-published-toggle-buttons .table {
+  div.mapplugins .mappluginsContainer .mappluginsContent .mapplugin.statsgrid-published-toggle-buttons .table {
     background-color: #3c3c3c;
     float: left;
     height: 36px;
     width: 36px;
     background-image: url("../images/table_dark.png");
     cursor: pointer; }
-    .statsgrid-published-toggle-buttons .table.active {
+    div.mapplugins .mappluginsContainer .mappluginsContent .mapplugin.statsgrid-published-toggle-buttons .table.active {
       background-color: #ffffff;
       background-image: url("../images/table_light.png"); }
-  .statsgrid-published-toggle-buttons .clear {
+  div.mapplugins .mappluginsContainer .mappluginsContent .mapplugin.statsgrid-published-toggle-buttons .clear {
     clear: both; }
 
 /*# sourceMappingURL=style.css.map */

--- a/bundles/statistics/statsgrid2016/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/scss/style.scss
@@ -54,7 +54,7 @@ $buttonWidth: 86%;
 
     .selection {
         margin-bottom: 6px;
-        width: 94%;
+        width: 98%;
     }
 
     .sortby {
@@ -160,11 +160,17 @@ div.oskari-flyoutcontent{
         /* TODO: limits the table from blowing up the flyout, but this needs to be handled in some other way */
         max-width: 700px;
 
-        table.oskari-grid th.selected {
-          background-color: #FDF8D9;
-            animation-name: statsgridcolumnselection;
-            animation-duration: 0.5s;
-            animation-iteration-count: 3;
+        table.oskari-grid {
+            th.selected {
+                background-color: #FDF8D9;
+                animation-name: statsgridcolumnselection;
+                animation-duration: 0.5s;
+                animation-iteration-count: 3;
+            }
+
+            td {
+                text-align: left;
+            }
         }
 
         label span {

--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -86,7 +86,9 @@
                     });
                     return;
                 }
+
                 var uiLabels = [];
+                var preferredFormatting = [];
                 for(var sel in indicator.selections){
                     var val = indicator.selections[sel];
 
@@ -107,15 +109,14 @@
                                 id : value.id || value,
                                 label : name
                             });
+
+                            preferredFormatting.push(name);
                         });
                     });
                 }
-                var preferredFormatting = [];
-                uiLabels.forEach(function(param) {
-                    preferredFormatting.push(param.label);
-                });
+
                 var name = Oskari.getLocalized(ind.name);
-                var selectorsFormatted = '( ' +  preferredFormatting.join(' / ') + ' )';
+                var selectorsFormatted = '(' +  preferredFormatting.join(' / ') + ')';
                 callback({
                     indicator : name,
                     source : Oskari.getLocalized(ind.source),


### PR DESCRIPTION
Some fixes for Grid/statsgrid2016:

- Grid:
  - paging: now arrows change pages (before changed previous/next column).
- Statsgrid2016: 
  - empty cells: now columns have the same width even if the cells are empty values.
  - published maps: datatable now looks same than normal map side. Previously published map statsgrid2016/datatable columns was centered text.
  - flyout scrolling: fixed flyout scrolling to top when pressing paging buttons
  - adding new indicator: now added new indicator go to latest indicator and also selected as an active
  - selector formatted text: removed space before and after the brackets 
  - speed-up: removed unnecessary forEach when getting ui labels