### PR TITLE
Fix for bundles that assume receiving configuration

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -95,6 +95,25 @@ New event (ProgressEvent) that tracks if something is progressing or not. Ex. us
 
 Medium map height changed from 525 to 600 pixels.
 
+### myplacesimport
+
+Default config is now included in the code so configuration is optional.
+
+### timeseries
+
+Default config is now included in the code so configuration is optional.
+
+### promote
+
+UI text for bundle now uses Oskari.getLocalized() when parsing configuration.
+This means that for example URLs in localization can be presented as single value or a localized object:
+
+      "signupUrl": "/user",
+      "registerUrl": {
+        "en": "/user",
+        "fi": "/user"
+      }
+
 ## 1.41.3
 
 ### coordinatetool

--- a/bundles/framework/myplacesimport/instance.js
+++ b/bundles/framework/myplacesimport/instance.js
@@ -6,10 +6,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportBun
  * @static constructor function
  */
 function () {
-    this.conf = {
-        "name": "MyPlacesImport",
-        "sandbox": "sandbox",
-        "flyoutClazz": "Oskari.mapframework.bundle.myplacesimport.Flyout"
+    // these will be used for this.conf if nothing else is specified (handled by DefaultExtension)
+    this.defaultConf = {
+        name: 'MyPlacesImport',
+        sandbox: 'sandbox',
+        stateful: true,
+        flyoutClazz: 'Oskari.mapframework.bundle.myplacesimport.Flyout'
     };
     this.buttonGroup = 'myplaces';
     this.toolName = 'import';
@@ -29,7 +31,7 @@ function () {
      */
     start: function () {
         var me = this,
-            conf = this.conf,
+            conf = this.getConfiguration() || {},
             sandboxName = (conf ? conf.sandbox : null) || 'sandbox',
             sandbox = Oskari.getSandbox(sandboxName),
             request;

--- a/bundles/framework/promote/instance.js
+++ b/bundles/framework/promote/instance.js
@@ -19,7 +19,6 @@ function() {
     this.started = false;
     this.plugins = {};
     this.localization = null;
-    this.userInterfaceLanguage = null;
     this.service = null;
 }, {
     /**
@@ -64,7 +63,7 @@ function() {
      */
     getLocalization: function(key) {
         if (this.conf && this.conf[key]) {
-            return this.conf[key][this.userInterfaceLanguage];
+            return Oskari.getLocalized(this.conf[key]);
         }
         if(!this._localization) {
             this._localization = Oskari.getLocalization(this.__name);
@@ -95,7 +94,6 @@ function() {
         var sandbox = Oskari.getSandbox(sandboxName);
 
         me.sandbox = sandbox;
-        me.userInterfaceLanguage = Oskari.getLang();
 
         this.localization = Oskari.getLocalization(this.getName());
 
@@ -117,7 +115,7 @@ function() {
                 for(var tool in this.conf.toolbarButtons[group]) {
                     var toolConfig = this.conf.toolbarButtons[group][tool];
                     // pick the tooltip in the current language
-                    toolConfig.tooltip = toolConfig.tooltip[me.userInterfaceLanguage];
+                    toolConfig.tooltip = Oskari.getLocalized(toolConfig.tooltip);
                     // disable button
                     toolConfig.enabled = false;
                     // set null

--- a/bundles/framework/timeseries/TimeseriesPlayback.js
+++ b/bundles/framework/timeseries/TimeseriesPlayback.js
@@ -18,6 +18,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.timeseries.TimeseriesPlayback",
         this.sandbox = sandbox;
         this.loc = locale;
         this.mapmodule = mapmodule;
+        conf = conf || {};
         this.conf = conf;
         this.template = {};
 

--- a/bundles/framework/timeseries/instance.js
+++ b/bundles/framework/timeseries/instance.js
@@ -79,7 +79,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.timeseries.TimeseriesToolBundleI
             }
             me.started = true;
 
-            var conf = me.conf,
+            var conf = me.conf || {},
                 sandboxName = (conf ? conf.sandbox : null) || 'sandbox',
                 sandbox = Oskari.getSandbox(sandboxName);
             me.setSandbox(sandbox);


### PR DESCRIPTION
### myplacesimport

Default config is now included in the code so configuration is optional.

### timeseries

Default config is now included in the code so configuration is optional.

### promote

UI text for bundle now uses Oskari.getLocalized() when parsing configuration.
This means that for example URLs in localization can be presented as single value or a localized object:

      "signupUrl": "/user",
      "registerUrl": {
        "en": "/user",
        "fi": "/user"
      }
