### PR TITLE
Maplegend fixes

### DIFF
--- a/bundles/framework/maplegend/plugin/MapLegendPlugin.js
+++ b/bundles/framework/maplegend/plugin/MapLegendPlugin.js
@@ -188,7 +188,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
                 legendContainer.find('div.oskari-select').trigger('change');
             });
             return legend;
-        }
+        },
         getLayerLegend: function(successCb, errorCb, singleLegend) {
 
             var layer,
@@ -247,7 +247,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
             };
             var dropdown = select.create(legendLayers, options);
             dropdown.css({
-                width: '96%'
+                width: '96%',
+                paddingBottom: '1em'
             });
             select.adjustChosen();
             select.selectFirstValue();

--- a/bundles/framework/maplegend/plugin/MapLegendPlugin.js
+++ b/bundles/framework/maplegend/plugin/MapLegendPlugin.js
@@ -62,17 +62,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
             }
             var title = singleLegend ? me._loc.singleLegend + legends[0].title : me._loc.title;
 
-            me._popup.addClass('maplegend__popup');
-            me._popup.addClass('mobile-popup');
-            me._popup.setColourScheme({
-                "bgColour": "#e6e6e6"
-            });
-            me._popup.createCloseIcon();
-
-            me._popup.onClose(function() {
-                me._isVisible = false;
-                me._resetMobileIcon(el, me._mobileDefs.buttons['mobile-maplegend'].iconCls);
-            });
             var legendContainer = me.getLayerLegend(function() {
                 // move popup if el and topOffsetElement
                 if (el && el.length > 0 && topOffsetElement && topOffsetElement.length > 0) {
@@ -91,16 +80,23 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
                 me._popup.getJqueryContent().find('.error').remove();
                 me._popup.getJqueryContent().append('<div class="error">' + me._loc.invalidLegendUrl + '</div>');
             }, singleLegend);
+
             legendContainer.find('div.oskari-select').trigger('change');
+
             if (me._isVisible) {
                 me._popup.show(title, legendContainer);
-
                 popupCloseIcon = (Oskari.util.isDarkColor(themeColours.activeColour)) ? 'icon-close-white' : undefined;
+                me._popup.createCloseIcon();
+                me._popup.onClose(function() {
+                    me._isVisible = false;
+                    me._resetMobileIcon(el, me._mobileDefs.buttons['mobile-maplegend'].iconCls);
+                });
                 me._popup.setColourScheme({
                     'bgColour': themeColours.activeColour,
                     'titleColour': themeColours.activeTextColour,
                     'iconCls': popupCloseIcon
                 });
+                me._popup.addClass('maplegend__popup');
                 me._popup.addClass('mobile-popup');
             }
             return false;
@@ -141,10 +137,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
             popupService.closeAllPopups(true);
 
             legend.on("click", function() {
-                if (me.isOpen()) {
-                    me._isVisible = false;
-                    me._popup.dialog.children().empty();
-                    me._popup.close(true);
+                if( me._toggleToolState() === false){
                     return;
                 }
                 var legends = me.getLegends();
@@ -170,6 +163,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
                 me._popup.onClose(function() {
                     me._popup.dialog.children().empty();
                     me._isVisible = false;
+                    me._popup.close();
                 });
                 me._popup.adaptToMapSize(me.getSandbox(), 'maplegend');
                 me._isVisible = true;
@@ -367,7 +361,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
                 me._popup.dialog.children().empty();
                 me._isVisible = false;
                 me._popup.close(true);
-                return;
+                return me.isOpen();
             } else {
                 me._isVisible = true;
                 if (isMobile) {

--- a/bundles/framework/maplegend/publisher/MapLegend.js
+++ b/bundles/framework/maplegend/publisher/MapLegend.js
@@ -35,10 +35,34 @@ function() {
    */
   init: function(data) {
       var me = this;
+
       if (!data || !data.configuration[me.bundleName]) {
           return;
       }
-      me.setEnabled(true);
+
+
+      me.setEnabled( true );
+  },
+  isDisplayed: function() {
+      var legendLayers = [];
+      var layers = this.__sandbox.findAllSelectedMapLayers().slice(0); 
+           layers.forEach(function(layer) {
+              if (!layer.getLegendImage()) {
+                  return;
+              }
+
+              var layerObject = {
+                id: layer.getId(),
+                title: layer.getName()
+              };
+              
+              legendLayers.push(layerObject);
+            });
+
+      if (legendLayers === undefined || legendLayers.length == 0) {
+        return false;
+      }
+      return true;
   },
   /**
   * Set enabled.

--- a/bundles/framework/maplegend/resources/css/style.css
+++ b/bundles/framework/maplegend/resources/css/style.css
@@ -84,5 +84,7 @@
 .legendSelector .accordion {
   max-height: 400px;
   overflow: auto; }
-
+.popup-body .content {
+  overflow-y:hidden !important;
+}
 /*# sourceMappingURL=style.css.map */

--- a/bundles/framework/maplegend/resources/css/style.css
+++ b/bundles/framework/maplegend/resources/css/style.css
@@ -85,6 +85,5 @@
   max-height: 400px;
   overflow: auto; }
 .popup-body .content {
-  overflow-y:hidden !important;
-}
+  overflow-y:hidden !important;}
 /*# sourceMappingURL=style.css.map */

--- a/bundles/framework/maplegend/resources/locale/en.js
+++ b/bundles/framework/maplegend/resources/locale/en.js
@@ -8,6 +8,7 @@ Oskari.registerLocalization(
         "noLegendsText": "No map legends available",
         "invalidLegendUrl": "Map legend not available",
         "tooltip":"Show map legends",
+        "singleLegend":"Map legend: ",
         "infotext": "Choose the map layer, for which legend is shown:",
         "newtab":"Open in a new tab"
     }

--- a/bundles/framework/maplegend/resources/locale/fi.js
+++ b/bundles/framework/maplegend/resources/locale/fi.js
@@ -8,6 +8,7 @@ Oskari.registerLocalization(
         "noLegendsText": "Karttaselitteitä ei ole saatavilla avoinna oleville karttatasoille.",
         "invalidLegendUrl": "Karttaselitettä ei voi näyttää",
         "tooltip":"Näytä karttaselitteet",
+        "singleLegend":"Karttaselite: ",
         "infotext":"Valitse selitettävä karttataso:",
         "newtab":"Avaa uudessa välilehdessä"
     }

--- a/bundles/framework/maplegend/resources/locale/sv.js
+++ b/bundles/framework/maplegend/resources/locale/sv.js
@@ -7,7 +7,8 @@ Oskari.registerLocalization(
         "desc": "",
         "noLegendsText": "Inga kartförklaringar tillgängliga",
         "invalidLegendUrl": "kartförklaringen är inte tillgängliga",
-        "tooltip":"Vis förklaringar",
+        "tooltip":"Visa förklaringar",
+        "singleLegend":"Förklaring: ",
         "infotext":"Välj kartlager, vars förklaringar visas:",
         "newtab": "Öppna i ny flik"
     }

--- a/bundles/framework/maplegend/scss/style.scss
+++ b/bundles/framework/maplegend/scss/style.scss
@@ -128,4 +128,7 @@ $lightIcon: url("../images/Question-mark-light.png");
     max-height: 400px;
     overflow:auto;
   }
+  .popup-body .content {
+  overflow-y:hidden !important;
+  }
 }

--- a/bundles/framework/maplegend/scss/style.scss
+++ b/bundles/framework/maplegend/scss/style.scss
@@ -129,6 +129,6 @@ $lightIcon: url("../images/Question-mark-light.png");
     overflow:auto;
   }
   .popup-body .content {
-  overflow-y:hidden !important;
+    overflow-y:hidden !important;
   }
 }


### PR DESCRIPTION
- Plugin won't be choosable in the publisher if no layers support legend.

- Fix double scrollbar issue.

- Doesn't show dropdown anymore if one layer with legend.