### PR TITLE
Search localization overrides for paikkatietoikkuna.fi

### DIFF
--- a/applications/paikkatietoikkuna.fi/full-map/minifierAppSetup.json
+++ b/applications/paikkatietoikkuna.fi/full-map/minifierAppSetup.json
@@ -1,5 +1,15 @@
 {
 	"startupSequence": [
+        {
+            "bundlename": "lang-overrides",
+            "metadata": {
+                "Import-Bundle": {
+                    "lang-overrides": {
+                        "bundlePath": "../../../packages/paikkatietoikkuna/"
+                    }
+                }
+            }
+        },
 		{
 			"bundlename": "openlayers-default-theme",
 			"metadata": {

--- a/applications/paikkatietoikkuna.fi/full-map_experimental/minifierAppSetup.json
+++ b/applications/paikkatietoikkuna.fi/full-map_experimental/minifierAppSetup.json
@@ -1,5 +1,15 @@
 {
 	"startupSequence": [
+        {
+            "bundlename": "lang-overrides",
+            "metadata": {
+                "Import-Bundle": {
+                    "lang-overrides": {
+                        "bundlePath": "../../../packages/paikkatietoikkuna/"
+                    }
+                }
+            }
+        },
 		{
 			"bundlename": "openlayers-default-theme",
 			"metadata": {

--- a/applications/paikkatietoikkuna.fi/full-map_guest/minifierAppSetup.json
+++ b/applications/paikkatietoikkuna.fi/full-map_guest/minifierAppSetup.json
@@ -1,6 +1,16 @@
 {
     "startupSequence": [
         {
+            "bundlename": "lang-overrides",
+            "metadata": {
+                "Import-Bundle": {
+                    "lang-overrides": {
+                        "bundlePath": "../../../packages/paikkatietoikkuna/"
+                    }
+                }
+            }
+        },
+        {
             "bundleinstancename": "openlayers-default-theme",
             "bundlename": "openlayers-default-theme",
             "metadata": {

--- a/applications/paikkatietoikkuna.fi/published-map_ol3/minifierAppSetup.json
+++ b/applications/paikkatietoikkuna.fi/published-map_ol3/minifierAppSetup.json
@@ -1,5 +1,15 @@
 {
-    "startupSequence": [{
+    "startupSequence": [
+        {
+            "bundlename": "lang-overrides",
+            "metadata": {
+                "Import-Bundle": {
+                    "lang-overrides": {
+                        "bundlePath": "../../../packages/paikkatietoikkuna/"
+                    }
+                }
+            }
+        }, {
         "bundlename": "mapfull",
         "metadata": {
             "Import-Bundle" : {

--- a/bundles/paikkatietoikkuna/lang-overrides/resources/locale/en.js
+++ b/bundles/paikkatietoikkuna/lang-overrides/resources/locale/en.js
@@ -1,0 +1,23 @@
+Oskari.registerLocalization(
+{
+    "lang": "en",
+    "key": "MapModule",
+    "value": {
+        "plugin": {
+            "SearchPlugin" : {
+                "column_region": "Municipality"
+            }
+        }
+    }
+}, true);
+
+Oskari.registerLocalization(
+{
+    "lang": "en",
+    "key": "Search",
+    "value": {
+        "grid": {
+            "region": "Municipality"
+        }
+    }
+}, true);

--- a/bundles/paikkatietoikkuna/lang-overrides/resources/locale/fi.js
+++ b/bundles/paikkatietoikkuna/lang-overrides/resources/locale/fi.js
@@ -1,0 +1,23 @@
+Oskari.registerLocalization(
+{
+    "lang": "fi",
+    "key": "MapModule",
+    "value": {
+        "plugin": {
+            "SearchPlugin" : {
+                "column_region": "Kunta"
+            }
+        }
+    }
+}, true);
+
+Oskari.registerLocalization(
+{
+    "lang": "fi",
+    "key": "Search",
+    "value": {
+        "grid": {
+            "region": "Kunta"
+        }
+    }
+}, true);

--- a/bundles/paikkatietoikkuna/lang-overrides/resources/locale/sv.js
+++ b/bundles/paikkatietoikkuna/lang-overrides/resources/locale/sv.js
@@ -1,0 +1,23 @@
+Oskari.registerLocalization(
+{
+    "lang": "sv",
+    "key": "MapModule",
+    "value": {
+        "plugin": {
+            "SearchPlugin" : {
+                "column_region": "Kommun"
+            }
+        }
+    }
+}, true);
+
+Oskari.registerLocalization(
+{
+    "lang": "sv",
+    "key": "Search",
+    "value": {
+        "grid": {
+            "region": "Kommun"
+        }
+    }
+}, true);

--- a/packages/paikkatietoikkuna/lang-overrides/bundle.js
+++ b/packages/paikkatietoikkuna/lang-overrides/bundle.js
@@ -1,0 +1,37 @@
+/**
+ * Definition for bundle. See source for details.
+ *
+ * @class Oskari.elf.lang.overrides.Bundle
+ */
+Oskari.clazz.define("Oskari.paikkis.language.Bundle", function() {
+
+}, {
+    "create" : function() {
+        return this;
+    },
+    "start": function() {},
+    "stop": function() {}
+}, {
+    "source" : {
+        "scripts" : [],
+        "locales" : [
+            {
+                "lang": "fi",
+                "type": "text/javascript",
+                "src": "../../../../bundles/paikkatietoikkuna/lang-overrides/resources/locale/fi.js"
+            },
+            {
+                "lang": "sv",
+                "type": "text/javascript",
+                "src": "../../../../bundles/paikkatietoikkuna/lang-overrides/resources/locale/sv.js"
+            },
+            {
+                "lang": "en",
+                "type": "text/javascript",
+                "src": "../../../../bundles/paikkatietoikkuna/lang-overrides/resources/locale/en.js"
+            }
+        ]
+    }
+});
+
+Oskari.bundle_manager.installBundleClass("lang-overrides", "Oskari.paikkis.language.Bundle");


### PR DESCRIPTION
This overrides the search user interface column labels for the new "region" label and restores the previously used "municipality" for paikkatietoikkuna.fi Oskari-application.

Application specific overrides should not be part of the official Oskari repository, but since the old ones have not yet been moved to community/app-specific repositories -> this app-specific bundle needs to be added for Paikkatietoikkuna.