### PR TITLE
Feature/statistics datasource name and link

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -138,6 +138,8 @@ ol2 mapmodule now support fill.color -property when getting style.
 
 ol3 mapmodule getStyle also handle image.opacity same as than ol2 side. Opacity setted here in fill color.
 
+´map.DataProviderInfoService´ from LogoPlugin can now handle multiple sources for attribution data including an optional link in addition to name.
+
 ### publisher2
 
 Medium map height changed from 525 to 600 pixels.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -60,7 +60,9 @@ Can be activated with following bundle config (not production ready yet):
         vectorViewer: true
     }
 
-#### grid
+Indicator attribution data now include the datasource name and optional link in addition to indicator source.
+
+### divmanazer grid component
 
 ``setGroupingHeader`` function now allows also setting maxCols and pagingHandler. maxCols tells how many cols you allow to show before paging content. You can also define pagingHandler, it's called when paging is done, first param is title element and second parameter is object, what tells you visible information {visible: {start:1,end:3}, count:3}, paging object telss start and end page, count tells full count on cols.
 

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -274,12 +274,48 @@ Oskari.clazz.define(
                 tpl.find('h4').html(group.name);
                 group.items.forEach(function(item) {
                     var itemTpl = jQuery('<div></div>');
-                    itemTpl.append(item.name + ' - ' + item.source);
+                    itemTpl.append(item.name);
+                    itemTpl.append(me.__formatItemSources(item.source));
                     tpl.append(itemTpl);
                 });
                 content.append(tpl);
             });
             return content;
+        },
+        /**
+         * The parameter can be undefined, string, object with url and name keys or array of such objects.
+         * @param  {String|Object|Object[]} src datasources for item to show on the UI
+         * @return {String|jQuery} appendable presentation of datasources for an UI item.
+         */
+        __formatItemSources : function(src) {
+            if(!src) {
+                return '';
+            }
+            var SEPARATOR = ' - ';
+            var formatSrc = function(item) {
+                if(typeof item ==='string') {
+                    return item;
+                }
+                if(!item.url) {
+                    return item.name;
+                }
+                var link = jQuery('<a target="_blank"></a>');
+                link.attr('href', item.url);
+                link.append(item.name);
+                return link;
+            }
+            var tpl = jQuery('<span></span>');
+            if(typeof src.forEach !== 'function') {
+                tpl.append(SEPARATOR);
+                tpl.append(formatSrc(src));
+                return tpl;
+            }
+
+            src.forEach(function(item) {
+                tpl.append(SEPARATOR);
+                tpl.append(formatSrc(item));
+            })
+            return tpl;
         },
         /**
          * @method _openDataSourcesDialog

--- a/bundles/statistics/statsgrid2016/instance.js
+++ b/bundles/statistics/statsgrid2016/instance.js
@@ -108,10 +108,15 @@ Oskari.clazz.define(
                     indicator : id,
                     selections : selections
                 }, function(labels) {
+                    var datasource = me.statsService.getDatasource(ds);
+
                     var data = {
                         'id' : dsid,
                         'name' : labels.indicator,
-                        'source' : labels.source
+                        'source' : [labels.source, {
+                            name : datasource.name,
+                            url : datasource.info.url
+                        }]
                     };
                     if(!service.addItemToGroup('indicators', data)) {
                         // if adding failed, it might because group was not registered.

--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -64,6 +64,8 @@
                 });
                 return;
             }
+            // normalize to always have info-object (so far only holds optional description url of service with "url" key)
+            ds.info = ds.info || {};
             this.datasources.push(ds);
         },
 


### PR DESCRIPTION
- ´map.DataProviderInfoService´ from LogoPlugin can now handle multiple sources for attribution data including an optional link in addition to name.
- Indicator attribution data now include the datasource name and optional link in addition to indicator source.