### PR TITLE
Feature/logopluginservice

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,9 @@
 # Release Notes
+## 1.43.0
+
+### LogoPluginService
+
+Logo-plugin provides a new service which constructs new items to the plugin. (links, texts)
 
 ## 1.42.1
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -3,7 +3,20 @@
 
 ### LogoPluginService
 
-Logo-plugin provides a new service which constructs new items to the plugin. (links, texts)
+Logo-plugin now provides a new service which can be used to add new items next to the logo (links, texts):
+
+	var logoService = Oskari.getSandbox().getService('Oskari.map.LogoPluginService');
+	// just adding a text
+	logoService.addLabel('Hello');
+
+	// providing a callback and an id (to identify the label later on)
+	var options = {
+		id:'hello',
+		callback: function() {
+			alert("Hello");
+		}
+	};
+	logoService.addLabel('Alert', options);
 
 ## 1.42.1
 

--- a/api/mapping/mapmodule/logopluginservice.md
+++ b/api/mapping/mapmodule/logopluginservice.md
@@ -4,6 +4,7 @@
 This service can be used to extend the Logo-plugin.
 
 ```javascript
+var info = 'About'
 var link = [
   {
     link: 'http://arctic-sdi.org/wp-content/uploads/2016/09/fact-sheet-copy-Sept-2016.pdf',
@@ -15,6 +16,6 @@ var link = [
   }
 ];
 
-var logoService = Oskari.clazz.create('Oskari.map.LogoPluginService', link);
+var logoService = Oskari.clazz.create('Oskari.map.LogoPluginService', info, link);
 logoService.extend();
 ```

--- a/api/mapping/mapmodule/logopluginservice.md
+++ b/api/mapping/mapmodule/logopluginservice.md
@@ -1,0 +1,20 @@
+# LogoPluginService
+
+## Description
+This service can be used to extend the Logo-plugin.
+
+```javascript
+var link = [
+  {
+    link: 'http://arctic-sdi.org/wp-content/uploads/2016/09/fact-sheet-copy-Sept-2016.pdf',
+    title: 'Arctic SDI Fact Sheet'
+  },
+  {
+    link: 'https://auth0.com/',
+    title: 'Auth0'
+  }
+];
+
+var logoService = Oskari.clazz.create('Oskari.map.LogoPluginService', link);
+logoService.extend();
+```

--- a/api/mapping/mapmodule/logopluginservice.md
+++ b/api/mapping/mapmodule/logopluginservice.md
@@ -4,18 +4,19 @@
 This service can be used to extend the Logo-plugin.
 
 ```javascript
-var info = 'About'
-var link = [
-  {
-    link: 'http://arctic-sdi.org/wp-content/uploads/2016/09/fact-sheet-copy-Sept-2016.pdf',
-    title: 'Arctic SDI Fact Sheet'
-  },
-  {
-    link: 'https://auth0.com/',
-    title: 'Auth0'
+var logoService = Oskari.getSandbox().getService('Oskari.map.LogoPluginService');
+var options = {
+  id:'links',
+  callback: function() {
+    var links = [
+      {
+        link: 'http://arctic-sdi.org/wp-content/uploads/2016/09/fact-sheet-copy-Sept-2016.pdf',
+        title: 'Arctic SDI Fact Sheet'
+      }
+    ];
+    alert(links);
   }
-];
-
-var logoService = Oskari.clazz.create('Oskari.map.LogoPluginService', info, link);
-logoService.extend();
+}
+logoService.addLabel('Title', options);
+logoService.trigger("change");
 ```

--- a/api/mapping/mapmodule/logopluginservice.md
+++ b/api/mapping/mapmodule/logopluginservice.md
@@ -7,10 +7,11 @@ This service can be used to extend the Logo-plugin.
 var logoService = Oskari.getSandbox().getService('Oskari.map.LogoPluginService');
 var options = {
   id:'links',
-  callback: function() {
+  callback: function(event) {
     //here you can construct you popup
     alert("Hello world");
   }
 }
 logoService.addLabel('Title', options);
 ```
+The callback is optional and will receive the click event from the link in the plugin.

--- a/api/mapping/mapmodule/logopluginservice.md
+++ b/api/mapping/mapmodule/logopluginservice.md
@@ -8,15 +8,9 @@ var logoService = Oskari.getSandbox().getService('Oskari.map.LogoPluginService')
 var options = {
   id:'links',
   callback: function() {
-    var links = [
-      {
-        link: 'http://arctic-sdi.org/wp-content/uploads/2016/09/fact-sheet-copy-Sept-2016.pdf',
-        title: 'Arctic SDI Fact Sheet'
-      }
-    ];
-    alert(links);
+    //here you can construct you popup
+    alert("Hello world");
   }
 }
 logoService.addLabel('Title', options);
-logoService.trigger("change");
 ```

--- a/bundles/asdi/asdi-logo-plugin/instance.js
+++ b/bundles/asdi/asdi-logo-plugin/instance.js
@@ -13,12 +13,15 @@ Oskari.clazz.define("Oskari.asdi.logo.BundleInstance",
         },
 
         start: function() {
+          var errorCb = function (xhr, errorText) {
+            Oskari.log(this.getName(), errorText);
+          };
           this._loc = Oskari.getLocalization('asdi-logo-plugin', Oskari.getLang());
-          this.getAboutLinkContent();
+          this.getAboutLinkContent(errorCb);
           this.createLogoPlugin();
         },
 
-        getAboutLinkContent: function() {
+        getAboutLinkContent: function(errorCb) {
           var me = this;
           jQuery.ajax({
             url:Oskari.getSandbox().getAjaxUrl('GetArticlesByTag'),

--- a/bundles/asdi/asdi-logo-plugin/instance.js
+++ b/bundles/asdi/asdi-logo-plugin/instance.js
@@ -26,7 +26,9 @@ Oskari.clazz.define("Oskari.asdi.logo.BundleInstance",
               tags: 'asdi-about'
             },
             success: function (response) {
-              me.data = response;
+              if( response.articles instanceof Array ) {
+                  me.data = response.articles[0].content.body;
+              }
             },
             error: function (jqXHR, textStatus) {
                 if(typeof errorCb === 'function' && jqXHR.status !== 0) {
@@ -56,9 +58,9 @@ Oskari.clazz.define("Oskari.asdi.logo.BundleInstance",
             return;
           }
           var content = jQuery('<div></div>');
-          this.data.articles.forEach( function (article) {
-            content.append(article.content.body);
-          });
+          if( this.data ){
+            content.append( this.data );
+          }
           var me = this;
           var popupTitle = this._loc.title;
           var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');

--- a/bundles/asdi/asdi-logo-plugin/instance.js
+++ b/bundles/asdi/asdi-logo-plugin/instance.js
@@ -1,0 +1,78 @@
+/**
+ * @class Oskari.asdi.login.BundleInstance
+ */
+Oskari.clazz.define("Oskari.asdi.logo.BundleInstance",
+    function() {
+      this.dialog = null;
+      this.data = null;
+    }, {
+        __name : 'asdi-logo-plugin',
+        getName : function () {
+            return this.__name;
+        },
+
+        start: function() {
+          this.getAboutLinkContent();
+          this.createLogoPlugin();
+        },
+
+        getAboutLinkContent: function() {
+          var me = this;
+          jQuery.ajax({
+            url:Oskari.getSandbox().getAjaxUrl('GetArticlesByTag'),
+            data: {
+              tags: 'asdi-about, termsofuse_mappublication'
+            },
+            success: function (response) {
+              me.data = response;
+            },
+            error: function (jqXHR, textStatus) {
+                if(typeof errorCb === 'function' && jqXHR.status !== 0) {
+                    errorCb(jqXHR, textStatus);
+                }
+            }
+          });
+        },
+
+        createLogoPlugin(response) {
+          var me = this;
+          var logoService = Oskari.getSandbox().getService('Oskari.map.LogoPluginService');
+          var options = {
+            id:'About',
+            callback: function(event) {
+              me.createAboutDialog(event);
+            }
+          }
+          logoService.addLabel('About', options);
+          logoService.trigger("change");
+        },
+
+        createAboutDialog(event) {
+          var me = this;
+          if(this.dialog) {
+            this.dialog.close(true);
+            this.dialog = null;
+            return;
+          }
+          var content = jQuery('<div></div>');
+          this.data.articles.forEach( function (article) {
+            content.append(article.content.body);
+          });
+          var me = this;
+          var popupTitle = 'About';
+          var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+
+          var closeButton = Oskari.clazz.create('Oskari.userinterface.component.buttons.OkButton');
+          closeButton.setHandler(function () {
+            me.dialog.close(true);
+            me.dialog = null;
+          });
+          this.dialog = dialog;
+          dialog.show(popupTitle, content, [closeButton]);
+          dialog.moveTo(event.target, 'top');
+        }
+
+    }, {
+        "extend" : ["Oskari.userinterface.extension.DefaultExtension"]
+    }
+);

--- a/bundles/asdi/asdi-logo-plugin/instance.js
+++ b/bundles/asdi/asdi-logo-plugin/instance.js
@@ -21,7 +21,7 @@ Oskari.clazz.define("Oskari.asdi.logo.BundleInstance",
           jQuery.ajax({
             url:Oskari.getSandbox().getAjaxUrl('GetArticlesByTag'),
             data: {
-              tags: 'asdi-about, termsofuse_mappublication'
+              tags: 'asdi-about'
             },
             success: function (response) {
               me.data = response;

--- a/bundles/asdi/asdi-logo-plugin/instance.js
+++ b/bundles/asdi/asdi-logo-plugin/instance.js
@@ -5,6 +5,7 @@ Oskari.clazz.define("Oskari.asdi.logo.BundleInstance",
     function() {
       this.dialog = null;
       this.data = null;
+      this._loc;
     }, {
         __name : 'asdi-logo-plugin',
         getName : function () {
@@ -12,6 +13,7 @@ Oskari.clazz.define("Oskari.asdi.logo.BundleInstance",
         },
 
         start: function() {
+          this._loc = Oskari.getLocalization('asdi-logo-plugin', Oskari.getLang());
           this.getAboutLinkContent();
           this.createLogoPlugin();
         },
@@ -43,8 +45,7 @@ Oskari.clazz.define("Oskari.asdi.logo.BundleInstance",
               me.createAboutDialog(event);
             }
           }
-          logoService.addLabel('About', options);
-          logoService.trigger("change");
+          logoService.addLabel(this._loc.title, options);
         },
 
         createAboutDialog(event) {
@@ -59,7 +60,7 @@ Oskari.clazz.define("Oskari.asdi.logo.BundleInstance",
             content.append(article.content.body);
           });
           var me = this;
-          var popupTitle = 'About';
+          var popupTitle = this._loc.title;
           var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
 
           var closeButton = Oskari.clazz.create('Oskari.userinterface.component.buttons.OkButton');

--- a/bundles/asdi/asdi-logo-plugin/resources/locale/en.js
+++ b/bundles/asdi/asdi-logo-plugin/resources/locale/en.js
@@ -1,0 +1,8 @@
+Oskari.registerLocalization(
+{
+    "lang": "en",
+    "key": "asdi-logo-plugin",
+    "value": {
+        "title": "About",
+    }
+});

--- a/bundles/asdi/asdi-logo-plugin/resources/locale/fi.js
+++ b/bundles/asdi/asdi-logo-plugin/resources/locale/fi.js
@@ -1,0 +1,8 @@
+Oskari.registerLocalization(
+{
+    "lang": "fi",
+    "key": "asdi-logo-plugin",
+    "value": {
+        "title": "About",
+    }
+});

--- a/bundles/asdi/asdi-logo-plugin/resources/locale/se.js
+++ b/bundles/asdi/asdi-logo-plugin/resources/locale/se.js
@@ -1,0 +1,8 @@
+Oskari.registerLocalization(
+{
+    "lang": "en",
+    "key": "asdi-logo-plugin",
+    "value": {
+        "title": "About",
+    }
+});

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -195,20 +195,22 @@ Oskari.clazz.define(
             if(!el) {
                 return;
             }
+            if(termsUrl) {
+              var options = {
+                id:'terms',
+                callback: function (evt) {
+                    evt.preventDefault();
+                    if (!me.inLayerToolsEditMode()) {
+                        window.open(termsUrl, '_blank');
+                    }
+                }
+              };
 
-            var options = {
-              id:'terms',
-              callback: function (evt) {
-                  evt.preventDefault();
-                  if (!me.inLayerToolsEditMode()) {
-                      window.open(termsUrl, '_blank');
-                  }
-              }
-            };
-
-            me._extendService.addLabel(me._loc.terms, options);
-            me._extendService.trigger('change');
-
+              me._extendService.addLabel(me._loc.terms, options);
+              me._extendService.trigger('change');
+            } else {
+              return;
+            }
         },
 
         _createDataSourcesLink: function (el) {
@@ -216,9 +218,6 @@ Oskari.clazz.define(
                 conf = me.getConfig() || {},
                 el = el || me.getElement();
 
-            if( conf.hideDataSourceLink ) {
-              return;
-            }
             var options = {
               id:'data-sources',
               callback: function(e) {
@@ -385,14 +384,13 @@ Oskari.clazz.define(
         updateExtended: function () {
           var me = this;
           var template = this.getElement();
-          var links = this._extendService.getLabels();
+          var labels = this._extendService.getLabels();
 
-          links.forEach( function( link ) {
+          labels.forEach( function( link ) {
             var extend = me.templates.extend.clone();
             extend.addClass(link.options.id.toLowerCase());
             extend.find('a').text(link.title);
             template.append(extend);
-            this.extended = undefined;
             extend.on("click", function(e) {
               var result = link.options.callback(e);
             });

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -145,7 +145,6 @@ Oskari.clazz.define(
             var termsUrl = this.getSandbox().getLocalizedProperty(conf.termsUrl);
             this._createTermsLink(termsUrl, container);
             this._createDataSourcesLink(container);
-            this._extendService.trigger("change");
             return container;
         },
 
@@ -391,7 +390,9 @@ Oskari.clazz.define(
             extend.find('a').text(link.title);
             template.append(extend);
             extend.on("click", function(e) {
-              var result = link.options.callback(e);
+              if(link.options.callback) {
+                var result = link.options.callback(e);
+              }
             });
           });
         }

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -64,7 +64,7 @@ Oskari.clazz.define(
         },
         createExtendService: function(el) {
           var me = this;
-          var element = el;
+          var element = el || this.getElement();
           if(!this._extendService) {
               this._extendService = Oskari.clazz.create('Oskari.map.LogoPluginService', this.getSandbox());
           }
@@ -153,7 +153,7 @@ Oskari.clazz.define(
             var termsUrl = this.getSandbox().getLocalizedProperty(conf.termsUrl);
             this._createTermsLink(termsUrl, container);
             this._createDataSourcesLink(container);
-
+            this._extendService.trigger("change");
             return container;
         },
 
@@ -208,7 +208,6 @@ Oskari.clazz.define(
               };
 
               me._extendService.addLabel(me._loc.terms, options);
-              me._extendService.trigger('change');
             } else {
               return;
             }
@@ -235,7 +234,6 @@ Oskari.clazz.define(
             };
 
             me._extendService.addLabel(me._loc.dataSources, options);
-            me._extendService.trigger('change');
         },
 
         /**
@@ -387,7 +385,7 @@ Oskari.clazz.define(
          */
         updateExtended: function (el) {
           var me = this;
-          if(!el || this.getElement()) {
+          if(!el && !this.getElement()) {
             return;
           }
           var template = el;

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -62,13 +62,14 @@ Oskari.clazz.define(
             }
             return this._service;
         },
-        createExtendService: function() {
+        createExtendService: function(el) {
           var me = this;
+          var element = el;
           if(!this._extendService) {
               this._extendService = Oskari.clazz.create('Oskari.map.LogoPluginService', this.getSandbox());
           }
           this._extendService.on('change', function() {
-              me.updateExtended();
+              me.updateExtended(element);
           });
         },
         /**
@@ -145,8 +146,8 @@ Oskari.clazz.define(
         _createControlElement: function () {
             var container = this.templates.main.clone();
             var conf = this.getConfig() || {};
+            this.createExtendService(container);
             this.changeFont(conf.font || this.getToolFontFromMapModule(), container);
-            this.createExtendService();
             this._createServiceLink(container);
 
             var termsUrl = this.getSandbox().getLocalizedProperty(conf.termsUrl);
@@ -218,6 +219,9 @@ Oskari.clazz.define(
                 conf = me.getConfig() || {},
                 el = el || me.getElement();
 
+            if(!el || conf.hideDataSourceLink) {
+              return;
+            }
             var options = {
               id:'data-sources',
               callback: function(e) {
@@ -381,9 +385,12 @@ Oskari.clazz.define(
          * @param {Object} content
          *
          */
-        updateExtended: function () {
+        updateExtended: function (el) {
           var me = this;
-          var template = this.getElement();
+          if(!el || this.getElement()) {
+            return;
+          }
+          var template = el;
           var labels = this._extendService.getLabels();
 
           labels.forEach( function( link ) {

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -382,7 +382,9 @@ Oskari.clazz.define(
 
            labels.forEach( function( link ) {
              var extend = me.templates.extend.clone();
-             extend.addClass(link.options.id.toLowerCase());
+             if(link.options.id) {
+               extend.addClass(link.options.id.toLowerCase());
+             }
              extend.find('a').text(link.title);
              template.append(extend);
              if(typeof link.options.callback === 'function') {

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -216,6 +216,9 @@ Oskari.clazz.define(
                 conf = me.getConfig() || {},
                 el = el || me.getElement();
 
+            if( conf.hideDataSourceLink ) {
+              return;
+            }
             var options = {
               id:'data-sources',
               callback: function(e) {
@@ -227,7 +230,7 @@ Oskari.clazz.define(
                 }
               }
             };
-            
+
             me._extendService.addLabel(me._loc.dataSources, options);
             me._extendService.trigger('change');
         },

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -379,10 +379,10 @@ Oskari.clazz.define(
          */
         updateExtended: function (el) {
           var me = this;
-          if(!el && !this.getElement()) {
+          var template = el || this.getElement();
+          if(!template) {
             return;
           }
-          var template = el;
           var labels = this._extendService.getLabels();
 
           labels.forEach( function( link ) {

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -390,7 +390,7 @@ Oskari.clazz.define(
             extend.find('a').text(link.title);
             template.append(extend);
             extend.on("click", function(e) {
-              if(link.options.callback) {
+              if(typeof link.options.callback === 'function') {
                 var result = link.options.callback(e);
               }
             });

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -31,7 +31,7 @@ Oskari.clazz.define(
             ),
             dataSourcesDialog: jQuery('<div class="data-sources-dialog"></div>'),
             dataSourceGroup: jQuery('<div class="data-sources-group"><h4 class="data-sources-heading"></h4></div>'),
-            extend: jQuery('<div style="display: inline-block"><a href="#"></a></div>')
+            extend: jQuery('<div style="display: inline-block; margin: 5px"><a href="#"></a></div>')
         },
         _initImpl : function() {
             this._loc = Oskari.getLocalization('MapModule', Oskari.getLang() || Oskari.getDefaultLanguage()).plugin.LogoPlugin;
@@ -377,11 +377,11 @@ Oskari.clazz.define(
          * @param {Object} content
          *
          */
-        addContentFromService: function (links) {
+        addContentFromService: function (info, links) {
           var template = jQuery(".logoplugin");
           var extend = this.templates.extend.clone();
-          extend.addClass('about');
-          extend.text("About");
+          extend.addClass(info.toLowerCase());
+          extend.find('a').text(info);
           template.append(extend);
           this.extended = undefined;
           extend.on("click", function() {
@@ -391,7 +391,7 @@ Oskari.clazz.define(
               return;
             }
             var me = this;
-            var popupTitle = "About";
+            var popupTitle = info;
             var content = jQuery('<div></div>');
             var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
             this.extended = dialog;
@@ -406,7 +406,7 @@ Oskari.clazz.define(
             })
             dialog.show(popupTitle, content, [closeButton]);
 
-            var target = jQuery('div.about');
+            var target = jQuery('div.'+info.toLowerCase()+'');
             dialog.moveTo(target, 'top');
           });
         }

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -61,7 +61,7 @@ Oskari.clazz.define(
               this._extendService = Oskari.clazz.create('Oskari.map.LogoPluginService', this.getSandbox());
           }
           this._extendService.on('change', function() {
-              me.updateExtended(element);
+              me.updateLabels(element);
           });
         },
         /**
@@ -186,10 +186,9 @@ Oskari.clazz.define(
         _createTermsLink: function (termsUrl, el) {
             var me = this,
                 el = el || me.getElement();
-            if(!el) {
+            if(!el || !termsUrl) {
                 return;
             }
-            if(termsUrl) {
               var options = {
                 id:'terms',
                 callback: function (evt) {
@@ -201,9 +200,6 @@ Oskari.clazz.define(
               };
 
               me._extendService.addLabel(me._loc.terms, options);
-            } else {
-              return;
-            }
         },
 
         _createDataSourcesLink: function (el) {
@@ -370,32 +366,32 @@ Oskari.clazz.define(
             });
         },
         /**
-         * @method addContentFromService
+         * @method updateLabels
          * Adds functionality to plugin
          *
-         * @param {Object} content
+         * @param {jQuery} el
          *
          */
-        updateExtended: function (el) {
-          var me = this;
-          var template = el || this.getElement();
-          if(!template) {
-            return;
-          }
-          var labels = this._extendService.getLabels();
+         updateLabels: function (el) {
+           var me = this;
+           var template = el || this.getElement();
+           if(!template) {
+             return;
+           }
+           var labels = this._extendService.getLabels();
 
-          labels.forEach( function( link ) {
-            var extend = me.templates.extend.clone();
-            extend.addClass(link.options.id.toLowerCase());
-            extend.find('a').text(link.title);
-            template.append(extend);
-            extend.on("click", function(e) {
-              if(typeof link.options.callback === 'function') {
-                var result = link.options.callback(e);
-              }
-            });
-          });
-        }
+           labels.forEach( function( link ) {
+             var extend = me.templates.extend.clone();
+             extend.addClass(link.options.id.toLowerCase());
+             extend.find('a').text(link.title);
+             template.append(extend);
+             if(typeof link.options.callback === 'function') {
+               extend.on("click", function(e) {
+                 link.options.callback(e);
+               });
+             }
+           });
+         }
     }, {
         extend: ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],
         /**

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -38,6 +38,7 @@ Oskari.clazz.define(
         getService : function() {
             if(!this._service) {
                 this._service = Oskari.clazz.create('Oskari.map.DataProviderInfoService', this.getSandbox());
+
                 if(this._service) {
                     var me = this;
                     // init group for layers
@@ -367,6 +368,39 @@ Oskari.clazz.define(
                     'source' : indicators[id].organization
                 });
             });
+        },
+        /**
+         * @method addContentFromService
+         * Adds functionality to plugin
+         *
+         * @param {Object} content
+         *
+         */
+        addContentFromService: function (content, obj) {
+          var template = jQuery(".logoplugin");
+          template.append(content);
+          this.extended = undefined;
+          content.on("click", function() {
+            if(typeof this.extended !== 'undefined') {
+              this.extended.close(true);
+              this.extended = undefined;
+              return;
+            }
+            var me = this;
+            var popupTitle = obj.title;
+            var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+            this.extended = dialog;
+
+            var closeButton = Oskari.clazz.create('Oskari.userinterface.component.buttons.OkButton');
+            closeButton.setHandler(function () {
+                dialog.close(true);
+            });
+            var content = jQuery('<div><a target="_blank" href="'+obj.link+'">'+obj.linkTitle+'</a></div>');
+            dialog.show(popupTitle, content, [closeButton]);
+
+            var target = jQuery('div.about');
+            dialog.moveTo(target, 'top');
+          });
         }
     }, {
         extend: ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -30,7 +30,8 @@ Oskari.clazz.define(
                 '</div>'
             ),
             dataSourcesDialog: jQuery('<div class="data-sources-dialog"></div>'),
-            dataSourceGroup: jQuery('<div class="data-sources-group"><h4 class="data-sources-heading"></h4></div>')
+            dataSourceGroup: jQuery('<div class="data-sources-group"><h4 class="data-sources-heading"></h4></div>'),
+            extend: jQuery('<div style="display: inline-block"><a href="#"></a></div>')
         },
         _initImpl : function() {
             this._loc = Oskari.getLocalization('MapModule', Oskari.getLang() || Oskari.getDefaultLanguage()).plugin.LogoPlugin;
@@ -376,18 +377,22 @@ Oskari.clazz.define(
          * @param {Object} content
          *
          */
-        addContentFromService: function (content, obj) {
+        addContentFromService: function (links) {
           var template = jQuery(".logoplugin");
-          template.append(content);
+          var extend = this.templates.extend.clone();
+          extend.addClass('about');
+          extend.text("About");
+          template.append(extend);
           this.extended = undefined;
-          content.on("click", function() {
+          extend.on("click", function() {
             if(typeof this.extended !== 'undefined') {
               this.extended.close(true);
               this.extended = undefined;
               return;
             }
             var me = this;
-            var popupTitle = obj.title;
+            var popupTitle = "About";
+            var content = jQuery('<div></div>');
             var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
             this.extended = dialog;
 
@@ -395,7 +400,10 @@ Oskari.clazz.define(
             closeButton.setHandler(function () {
                 dialog.close(true);
             });
-            var content = jQuery('<div><a target="_blank" href="'+obj.link+'">'+obj.linkTitle+'</a></div>');
+            links.forEach(function(link){
+              var anchorLink = jQuery('<div><a target="blank" href="'+link.link+'">'+link.title+'</a></div>');
+              content.append(anchorLink);
+            })
             dialog.show(popupTitle, content, [closeButton]);
 
             var target = jQuery('div.about');

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -19,15 +19,7 @@ Oskari.clazz.define(
         constLayerGroupId : 'layers',
         templates: {
             main :  jQuery(
-                '<div class="mapplugin logoplugin">' +
-                '  <div class="icon"></div>' +
-                '  <div class="terms">' +
-                '    <a href="#" target="_blank"></a>' +
-                '  </div>' +
-                '  <div class="data-sources">' +
-                '    <a href="#"></a>' +
-                '  </div>' +
-                '</div>'
+                '<div class="mapplugin logoplugin"></div>'
             ),
             dataSourcesDialog: jQuery('<div class="data-sources-dialog"></div>'),
             dataSourceGroup: jQuery('<div class="data-sources-group"><h4 class="data-sources-heading"></h4></div>'),
@@ -167,15 +159,17 @@ Oskari.clazz.define(
                 return;
             }
 
-            link = el.find('.icon');
-            link.unbind('click');
+            var options = {
+              id:'icon',
+              callback: function (event) {
+                  if (!me.inLayerToolsEditMode()) {
+                      linkParams = me.getSandbox().generateMapLinkParameters({});
+                      window.open(mapUrl + linkParams, '_blank');
+                  }
+              }
+            };
 
-            link.click(function (event) {
-                if (!me.inLayerToolsEditMode()) {
-                    linkParams = me.getSandbox().generateMapLinkParameters({});
-                    window.open(mapUrl + linkParams, '_blank');
-                }
-            });
+            me._extendService.addLabel('', options);
         },
 
         /**

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -378,6 +378,7 @@ Oskari.clazz.define(
          *
          */
         addContentFromService: function (info, links) {
+          var me = this;
           var template = jQuery(".logoplugin");
           var extend = this.templates.extend.clone();
           extend.addClass(info.toLowerCase());
@@ -398,7 +399,8 @@ Oskari.clazz.define(
 
             var closeButton = Oskari.clazz.create('Oskari.userinterface.component.buttons.OkButton');
             closeButton.setHandler(function () {
-                dialog.close(true);
+                me.extended.close(true);
+                me.extended = undefined;
             });
             links.forEach(function(link){
               var anchorLink = jQuery('<div><a target="blank" href="'+link.link+'">'+link.title+'</a></div>');

--- a/bundles/mapping/mapmodule/plugin/logo/logo.service.js
+++ b/bundles/mapping/mapmodule/plugin/logo/logo.service.js
@@ -6,10 +6,18 @@ Oskari.clazz.define('Oskari.map.LogoPluginService',
  * @method create called automatically on construction
  * @static
  */
-function(info, link) {
-    this._info = info;
-    this._link = link;
-    this._plugin = Oskari.clazz.create('Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin');
+function(sandbox) {
+  if(!sandbox) {
+      return null;
+  }
+  this.sandbox = sandbox;
+  var me = sandbox.getService(this.getQName());
+  if(me) {
+      return me;
+  }
+  this.labels = [];
+  sandbox.registerService(this);
+  Oskari.makeObservable(this);
 }, {
   __name: "map.logo.service",
   __qname : "Oskari.map.LogoPluginService",
@@ -19,16 +27,17 @@ function(info, link) {
   getName: function() {
       return this.__name;
   },
-  extend: function() {
-    this._plugin.addContentFromService(this._info, this._link);
+  getLabels: function() {
+    return this.labels;
   },
   /**
-   * Initializes the service (does nothing atm).
-   *
-   * @method init
+   * @method addLabel
+   * @param {String} title
+   * @param {Object} options {id, callback}
    */
-  init: function() {
-  },
+  addLabel: function( title, options) {
+    this.labels.push({ title: title, options: options });
+  }
 },{
     'protocol' : ['Oskari.framework.service.Service']
 });

--- a/bundles/mapping/mapmodule/plugin/logo/logo.service.js
+++ b/bundles/mapping/mapmodule/plugin/logo/logo.service.js
@@ -6,9 +6,8 @@ Oskari.clazz.define('Oskari.map.LogoPluginService',
  * @method create called automatically on construction
  * @static
  */
-function(sandbox, link) {
+function(link) {
     this._link = link;
-    this._sandbox = sandbox;
     this._plugin = Oskari.clazz.create('Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin');
 }, {
   __name: "map.logo.service",
@@ -19,13 +18,8 @@ function(sandbox, link) {
   getName: function() {
       return this.__name;
   },
-  extend: function(div) {
-    var extend = {
-      link: this._link.link,
-      linkTitle: this._link.title,
-      title: 'About'
-    }
-    this._plugin.addContentFromService(div, extend);
+  extend: function() {
+    this._plugin.addContentFromService(this._link);
   },
   /**
    * Initializes the service (does nothing atm).

--- a/bundles/mapping/mapmodule/plugin/logo/logo.service.js
+++ b/bundles/mapping/mapmodule/plugin/logo/logo.service.js
@@ -38,7 +38,10 @@ function(sandbox) {
    * @param {Object} options {id, callback}
    */
   addLabel: function( title, options) {
-    this.labels.push({ title: title, options: options });
+    if(!title) {
+        return;
+    }
+    this.labels.push({ title: title, options: options || {} });
     this.trigger("change");
   }
 },{

--- a/bundles/mapping/mapmodule/plugin/logo/logo.service.js
+++ b/bundles/mapping/mapmodule/plugin/logo/logo.service.js
@@ -28,7 +28,9 @@ function(sandbox) {
       return this.__name;
   },
   getLabels: function() {
-    return this.labels;
+    var currentLabels = this.labels;
+    this.labels = [];
+    return currentLabels;
   },
   /**
    * @method addLabel

--- a/bundles/mapping/mapmodule/plugin/logo/logo.service.js
+++ b/bundles/mapping/mapmodule/plugin/logo/logo.service.js
@@ -6,7 +6,8 @@ Oskari.clazz.define('Oskari.map.LogoPluginService',
  * @method create called automatically on construction
  * @static
  */
-function(link) {
+function(info, link) {
+    this._info = info;
     this._link = link;
     this._plugin = Oskari.clazz.create('Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin');
 }, {
@@ -19,7 +20,7 @@ function(link) {
       return this.__name;
   },
   extend: function() {
-    this._plugin.addContentFromService(this._link);
+    this._plugin.addContentFromService(this._info, this._link);
   },
   /**
    * Initializes the service (does nothing atm).

--- a/bundles/mapping/mapmodule/plugin/logo/logo.service.js
+++ b/bundles/mapping/mapmodule/plugin/logo/logo.service.js
@@ -39,6 +39,7 @@ function(sandbox) {
    */
   addLabel: function( title, options) {
     this.labels.push({ title: title, options: options });
+    this.trigger("change");
   }
 },{
     'protocol' : ['Oskari.framework.service.Service']

--- a/bundles/mapping/mapmodule/plugin/logo/logo.service.js
+++ b/bundles/mapping/mapmodule/plugin/logo/logo.service.js
@@ -1,0 +1,39 @@
+/**
+ * @class Oskari.map.LogoPluginService
+ */
+Oskari.clazz.define('Oskari.map.LogoPluginService',
+/**
+ * @method create called automatically on construction
+ * @static
+ */
+function(sandbox, link) {
+    this._link = link;
+    this._sandbox = sandbox;
+    this._plugin = Oskari.clazz.create('Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin');
+}, {
+  __name: "map.logo.service",
+  __qname : "Oskari.map.LogoPluginService",
+  getQName : function() {
+      return this.__qname;
+  },
+  getName: function() {
+      return this.__name;
+  },
+  extend: function(div) {
+    var extend = {
+      link: this._link.link,
+      linkTitle: this._link.title,
+      title: 'About'
+    }
+    this._plugin.addContentFromService(div, extend);
+  },
+  /**
+   * Initializes the service (does nothing atm).
+   *
+   * @method init
+   */
+  init: function() {
+  },
+},{
+    'protocol' : ['Oskari.framework.service.Service']
+});

--- a/bundles/mapping/mapmodule/resources/css/logoplugin.css
+++ b/bundles/mapping/mapmodule/resources/css/logoplugin.css
@@ -17,7 +17,7 @@
     vertical-align: bottom;
     cursor: pointer; }
   .logoplugin .data-sources, .logoplugin .terms {
-    display: inline-block !important;
+    display: inline-block;
     margin: 5px;
     cursor: pointer; }
     .logoplugin .data-sources .data-sources a, .logoplugin .data-sources .terms a, .logoplugin .terms .data-sources a, .logoplugin .terms .terms a {

--- a/bundles/mapping/mapmodule/resources/css/logoplugin.css
+++ b/bundles/mapping/mapmodule/resources/css/logoplugin.css
@@ -17,7 +17,7 @@
     vertical-align: bottom;
     cursor: pointer; }
   .logoplugin .data-sources, .logoplugin .terms {
-    display: inline-block;
+    display: inline-block !important;
     margin: 5px;
     cursor: pointer; }
     .logoplugin .data-sources .data-sources a, .logoplugin .data-sources .terms a, .logoplugin .terms .data-sources a, .logoplugin .terms .terms a {

--- a/packages/asdi/bundle/asdi-logo-plugin/bundle.js
+++ b/packages/asdi/bundle/asdi-logo-plugin/bundle.js
@@ -1,0 +1,66 @@
+/**
+ * Definition for bundle. See source for details.
+ *
+ * @class Oskari.elf.geolocator.Bundle
+ */
+Oskari.clazz.define("Oskari.asdi.logo.Bundle", function() {
+
+}, {
+    "create" : function() {
+        return Oskari.clazz.create(
+            "Oskari.asdi.logo.BundleInstance",
+            "asdi-logo-plugin");
+    },
+    "update" : function(manager, bundle, bi, info) {
+    }
+}, {
+    "protocol" : [
+        "Oskari.bundle.Bundle",
+        "Oskari.mapframework.bundle.extension.ExtensionBundle"
+    ],
+    "source" : {
+
+        "scripts" : [{
+            "type" : "text/javascript",
+            "src" : "../../../../bundles/asdi/asdi-logo-plugin/instance.js"
+        }]
+    },
+    "bundle" : {
+        "manifest" : {
+            "Bundle-Identifier" : "asdi-logo-plugin",
+            "Bundle-Name" : "asdi-logo-plugin;",
+            "Bundle-Author" : [{
+                "Name" : "jjk",
+                "Organisation" : "nls.fi",
+                "Temporal" : {
+                    "Start" : "2017"
+                },
+                "Copyleft" : {
+                    "License" : {
+                        "License-Name" : "EUPL",
+                        "License-Online-Resource" : "http://www.oskari.org/documentation/development/license"
+                    }
+                }
+            }],
+            "Bundle-Name-Locale" : {
+                "fi" : {
+                    "Name" : "logo",
+                    "Title" : "logo"
+                },
+                "en" : {}
+            },
+            "Bundle-Version" : "1.0.0",
+            "Import-Namespace" : ["Oskari", "jquery"],
+            "Import-Bundle" : {}
+        }
+    },
+    /**
+     * @static
+     * @property dependencies
+     */
+    "dependencies" : ["jquery"]
+
+});
+
+Oskari.bundle_manager.installBundleClass("asdi-logo-plugin",
+    "Oskari.asdi.logo.Bundle");

--- a/packages/asdi/bundle/asdi-logo-plugin/bundle.js
+++ b/packages/asdi/bundle/asdi-logo-plugin/bundle.js
@@ -20,10 +20,21 @@ Oskari.clazz.define("Oskari.asdi.logo.Bundle", function() {
     ],
     "source" : {
 
-        "scripts" : [{
+        "scripts" : [
+          {
             "type" : "text/javascript",
             "src" : "../../../../bundles/asdi/asdi-logo-plugin/instance.js"
-        }]
+          }, {
+            "type" : "text/javascript",
+            "src" : "../../../../bundles/asdi/asdi-logo-plugin/resources/locale/en.js"
+          }, {
+            "type" : "text/javascript",
+            "src" : "../../../../bundles/asdi/asdi-logo-plugin/resources/locale/fi.js"
+          }, {
+            "type" : "text/javascript",
+            "src" : "../../../../bundles/asdi/asdi-logo-plugin/resources/locale/se.js"
+          }
+        ]
     },
     "bundle" : {
         "manifest" : {

--- a/packages/framework/bundle/mapmodule-plugin/bundle.js
+++ b/packages/framework/bundle/mapmodule-plugin/bundle.js
@@ -191,6 +191,9 @@ Oskari.clazz.define(
                     "type": "text/javascript",
                     "src": "../../../../bundles/mapping/mapmodule/plugin/logo/DataProviderInfoService.js"
                 }, {
+                    "type": "text/javascript",
+                    "src": "../../../../bundles/mapping/mapmodule/plugin/logo/logo.service.js"
+                }, {
                     "type": "text/css",
                     "src": "../../../../bundles/mapping/mapmodule/resources/css/logoplugin.css"
                 },

--- a/packages/mapping/ol3/mapmodule/bundle.js
+++ b/packages/mapping/ol3/mapmodule/bundle.js
@@ -164,6 +164,9 @@ Oskari.clazz.define(
                     "type": "text/javascript",
                     "src": "../../../../bundles/mapping/mapmodule/plugin/logo/DataProviderInfoService.js"
                 }, {
+                    "type": "text/javascript",
+                    "src": "../../../../bundles/mapping/mapmodule/plugin/logo/logo.service.js"
+                }, {
                     "type": "text/css",
                     "src": "../../../../bundles/mapping/mapmodule/resources/css/logoplugin.css"
                 },


### PR DESCRIPTION
New service to extend the Logo-plugin.

- find reference to the new service:
`var logoService = Oskari.getSandbox().getService('Oskari.map.LogoPluginService');
`
- create a options object with id & callback: 
` var options = { id:'links',
              callback: function() {
                alert("hello");
              }
            }`

- add the options and a title to the service:
 `logoService.addLabel('Hello', options);`
