### PR TITLE
Small fixes

### DIFF
--- a/bundles/framework/myplaces2/CategoryHandler.js
+++ b/bundles/framework/myplaces2/CategoryHandler.js
@@ -329,6 +329,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces2.CategoryHandler',
             cancelBtn.setTitle(btnLoc.cancel);
             cancelBtn.setHandler(function () {
                 dialog.close();
+                me.instance.sandbox.postRequestByName('EnableMapKeyboardMovementRequest');
             });
             buttons.push(cancelBtn);
             buttons.push(saveBtn);

--- a/bundles/framework/myplaces2/view/PlaceForm.js
+++ b/bundles/framework/myplaces2/view/PlaceForm.js
@@ -26,7 +26,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces2.view.PlaceForm",
             '    <input type="text" data-name="placename" placeholder="' + loc.placename.placeholder + '" />' +
             '  </div>' +
             '  <div class="field">' +
-            '    <textarea data-name="placedesc" placeholder="' + loc.placedesc.placeholder + '"></textarea>' +
+            '    <input type="text" data-name="placedesc" placeholder="' + loc.placedesc.placeholder + '" />' +
             '  </div>' +
             '  <div class="field">' +
             '    <input type="text" data-name="placeAttention" placeholder="' + loc.placeAttention.placeholder + '"/>' +
@@ -105,7 +105,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces2.view.PlaceForm",
 
             if (this.initialValues) {
                 ui.find('input[data-name=placename]').attr('value', this.initialValues.place.name);
-                ui.find('textarea[data-name=placedesc]').append(this.initialValues.place.desc);
+                ui.find('input[data-name=placedesc]').attr('value', this.initialValues.place.desc);
                 ui.find('input[data-name=placeAttention]').attr('value', this.initialValues.place.attention_text);
                 ui.find('input[data-name=placelink]').attr('value', this.initialValues.place.link);
                 ui.find('input[data-name=imagelink]').attr('value', this.initialValues.place.imageLink);
@@ -136,7 +136,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces2.view.PlaceForm",
             if (onScreenForm.length > 0) {
                 // found form on screen
                 var placeName = onScreenForm.find('input[data-name=placename]').val(),
-                    placeDesc = onScreenForm.find('textarea[data-name=placedesc]').val(),
+                    placeDesc = onScreenForm.find('input[data-name=placedesc]').val(),
                     placeAttention = onScreenForm.find('input[data-name=placeAttention]').val(),
                     placeLink = onScreenForm.find('input[data-name=placelink]').val();
                 if (placeLink) {
@@ -181,7 +181,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces2.view.PlaceForm",
             if (onScreenForm.length > 0) {
                 // found form on screen
                 onScreenForm.find('input[name=placename]').val(data.place.name);
-                onScreenForm.find('textarea[name=placedesc]').val(data.place.desc);
+                onScreenForm.find('input[name=placedesc]').val(data.place.desc);
                 onScreenForm.find('input[name=placeAttention]').val(data.place.attention_text);
                 onScreenForm.find('input[name=placelink]').val(data.place.link);
                 onScreenForm.find('input[name=imagelink]').val(data.place.imageLink);

--- a/bundles/mapping/mapmodule/mapmodule.ol2.js
+++ b/bundles/mapping/mapmodule/mapmodule.ol2.js
@@ -202,7 +202,8 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.MapModule',
          *     wanting to notify at end of the chain for performance reasons or similar) (optional)
          */
         zoomToExtent: function (bounds, suppressStart, suppressEnd) {
-            this.getMap().zoomToExtent(bounds);
+            // OpenLayers.Bounds or Array (left, bottom, right, top)
+            this.getMap().zoomToExtent(new OpenLayers.Bounds(bounds.left, bounds.bottom, bounds.right, bounds.top));
             this.updateDomain();
             // send note about map change
             if (suppressStart !== true) {


### PR DESCRIPTION
Changed place description textarea to input because Internet Explorer (10&11) can't handle textarea placeholder correctly. A textarea's placeholder text becomes it's actual value in IE.

Added missing EnableMapKeyboardMovementRequest when edit category popup is closed.

zoomToExtent function's bounds parameter should be OpenLayers.Bounds object.