### PR TITLE
history tools can now be published only together

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,10 @@
 
 ## 1.43.0
 
+### Publisher2/history tools
+
+History tools (moving to previous or next view) can no be published only together. If there are published maps with only one of history tools, the other one will be added there as well. This is done because moving to next view is useless without possibility to move to previous view.
+
 ### Grid
 
 Fixed subtable sorting.

--- a/bundles/framework/publisher2/resources/locale/en.js
+++ b/bundles/framework/publisher2/resources/locale/en.js
@@ -68,6 +68,7 @@ Oskari.registerLocalization(
                 "MapRotator":"Enable map rotation",
                 "CrosshairTool": "Show map focal point",
                 "toolbarToolNames": {
+                    "history": "Move to previous or next view",
                     "history_back": "Move to previous view",
                     "history_forward": "Move to next view",
                     "measureline": "Measure distance",

--- a/bundles/framework/publisher2/resources/locale/et.js
+++ b/bundles/framework/publisher2/resources/locale/et.js
@@ -66,6 +66,7 @@ Oskari.registerLocalization(
                 "CrosshairTool": "Näita kaardi keskpunkti",
                 "FeedbackServiceTool": "",
                 "toolbarToolNames": {
+                    "history": "Liigu eelmisesse või järgmisesse",
                     "history_back": "Liigu eelmisesse vaatesse",
                     "history_forward": "Liigu järgmisesse vaatesse",
                     "measureline": "Mõõda vahemaad",

--- a/bundles/framework/publisher2/resources/locale/fi.js
+++ b/bundles/framework/publisher2/resources/locale/fi.js
@@ -68,6 +68,7 @@ Oskari.registerLocalization(
                 "MapRotator": "Salli kartan pyörittäminen",
                 "CrosshairTool": "Näytä kartan keskipiste",
                 "toolbarToolNames": {
+                    "history": "Siirtyminen edelliseen ja seuraavaan näkymään",
                     "history_back": "Siirtyminen edelliseen näkymään",
                     "history_forward": "Siirtyminen seuraavaan näkymään",
                     "measureline": "Matkan mittaus",

--- a/bundles/framework/publisher2/resources/locale/sv.js
+++ b/bundles/framework/publisher2/resources/locale/sv.js
@@ -67,6 +67,7 @@ Oskari.registerLocalization(
                 "MapRotator":"Tillåt kartrotation",
                 "CrosshairTool": "Visa kartans mittpunkt",
                 "toolbarToolNames": {
+                    "history": "Gå bakåt eller framåt",
                     "history_back": "Gå bakåt",
                     "history_forward": "Gå framåt",
                     "measureline": "Mät avstånd",


### PR DESCRIPTION
History tools (moving to previous or next view) can no be published only together. If there are published maps with only one of history tools, the other one will be added there as well. This is done because moving to next view is useless without possibility to move to previous view.