### PR TITLE
Fixed disappearing LogoPlugin

### DIFF
--- a/api/mapping/mapmodule/logopluginservice.md
+++ b/api/mapping/mapmodule/logopluginservice.md
@@ -1,7 +1,7 @@
 # LogoPluginService
 
 ## Description
-This service can be used to extend the Logo-plugin.
+This service can be used to extend the Logo-plugin. The same LogoPluginService instance is returned on repeated calls to Oskari.clazz.create (singleton pattern).
 
 ```javascript
 var logoService = Oskari.getSandbox().getService('Oskari.map.LogoPluginService');

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -54,15 +54,19 @@ Oskari.clazz.define(
             }
             return this._service;
         },
-        createExtendService: function(el) {
-          var me = this;
-          var element = el || this.getElement();
-          if(!this._extendService) {
-              this._extendService = Oskari.clazz.create('Oskari.map.LogoPluginService', this.getSandbox());
-          }
-          this._extendService.on('change', function() {
-              me.updateLabels(element);
-          });
+        registerForUpdateLabels: function (el) {
+            var me = this;
+            var element = el || this.getElement();
+            if (!this._extendService) {
+                this._extendService = Oskari.clazz.create('Oskari.map.LogoPluginService', this.getSandbox());
+                this._extendServiceHandler = function () {
+                    me._labelCallBack();
+                };
+                this._extendService.on('change', this._extendServiceHandler);
+            }
+            this._labelCallBack = function () {
+                me.updateLabels(element);
+            }
         },
         /**
          * @method _createEventHandlers
@@ -138,7 +142,7 @@ Oskari.clazz.define(
         _createControlElement: function () {
             var container = this.templates.main.clone();
             var conf = this.getConfig() || {};
-            this.createExtendService(container);
+            this.registerForUpdateLabels(container);
             this.changeFont(conf.font || this.getToolFontFromMapModule(), container);
             this._createServiceLink(container);
 
@@ -146,6 +150,14 @@ Oskari.clazz.define(
             this._createTermsLink(termsUrl, container);
             this._createDataSourcesLink(container);
             return container;
+        },
+
+        _stopPluginImpl: function () {
+            if (this._extendService) {
+                this._extendService.off('change', this._extendServiceHandler);
+                this._extendService = null;
+            }
+            this.removeFromPluginContainer(this.getElement());
         },
 
         _createServiceLink: function (el) {


### PR DESCRIPTION
The "Data sources" and "Terms" links in the lower left corner of the map produced by LogoPlugin will now recreate themselves after the plugin is removed and re-created. This happens for example when user goes to Publish map view and back to main map view.

In reference to: https://jira.nls.fi/browse/AH-3935