### PR TITLE
Change layer selector into dropdown if map is too narrow

### DIFF
--- a/bundles/mapping/mapmodule/plugin/layers/BackgroundLayerSelectionPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/layers/BackgroundLayerSelectionPlugin.js
@@ -130,26 +130,20 @@ Oskari.clazz.define(
                 },
 
                 /**
-                 * @method userinterface.ExtensionUpdatedEvent
+                 * @method MapSizeChangedEvent
+                 * 
+                 * Changes selector into dropdown if map is too narrow to fit buttons
                  */
-                'userinterface.ExtensionUpdatedEvent': function (event) {
-                    // Hide layer selection if a mode was activated
-                    if (jQuery.inArray(event.getExtension().getName(), ['Analyse', 'Publisher', 'StatsGrid', 'Printout']) > -1) {
-                        var me = this,
-                            isShown = event.getViewState() !== 'close';
-                        if (isShown) {
-                            // Mode opened, hide plugin
-                            if (!me.hiddenByMode) {
-                                me.hiddenByMode = true;
-                                me.setVisible(false);
-                            }
-                        } else if (me.hiddenByMode) {
-                            me.hiddenByMode = null;
-                            delete me.hiddenByMode;
-                            me.setVisible(true);
-                        }
+                MapSizeChangedEvent: function (evt) {
+                    if(this._config.showAsDropdown) {
+                        return; // already shown as dropdown
                     }
-                }
+                    var el = this.getElement();
+                    var buttonWidth = el.find('div.content li').outerWidth() || 0;
+                    var showAsDropdown = buttonWidth * this._config.baseLayers.length > evt.getWidth() - 300; /// 150px margin on each side -> -300
+                    
+                    el.find('div.content').toggleClass('dropdown', showAsDropdown);
+                },
             };
         },
 

--- a/bundles/mapping/mapmodule/resources/css/backgroundlayerselection.css
+++ b/bundles/mapping/mapmodule/resources/css/backgroundlayerselection.css
@@ -86,21 +86,21 @@ div.mapplugin.backgroundLayerSelectionPlugin div.content {
     border-bottom-right-radius: 2px; }
   div.mapplugin.backgroundLayerSelectionPlugin div.content ul li:hover {
     color: #ff9100; }
-  div.mapplugin.backgroundLayerSelectionPlugin div.content .dropdown div.currentSelection {
+  div.mapplugin.backgroundLayerSelectionPlugin div.content.dropdown div.currentSelection {
     display: block; }
-    div.mapplugin.backgroundLayerSelectionPlugin div.content .dropdown div.currentSelection div.header-icon {
+    div.mapplugin.backgroundLayerSelectionPlugin div.content.dropdown div.currentSelection div.header-icon {
       float: left;
       clear: none;
       margin-left: -5px;
       margin-top: 7px; }
-  div.mapplugin.backgroundLayerSelectionPlugin div.content .dropdown ul {
+  div.mapplugin.backgroundLayerSelectionPlugin div.content.dropdown ul {
     display: none;
     width: 151px;
     margin: 0 auto;
     height: auto;
     border: 1px solid #3c3c3c;
     border-bottom-width: 0; }
-    div.mapplugin.backgroundLayerSelectionPlugin div.content .dropdown ul li {
+    div.mapplugin.backgroundLayerSelectionPlugin div.content.dropdown ul li {
       background-color: #fafafa;
       color: #3c3c3c;
       display: block;
@@ -114,11 +114,11 @@ div.mapplugin.backgroundLayerSelectionPlugin div.content {
       -o-border-radius: 0;
       -ms-border-radius: 0;
       border-radius: 0; }
-    div.mapplugin.backgroundLayerSelectionPlugin div.content .dropdown ul li.selected {
+    div.mapplugin.backgroundLayerSelectionPlugin div.content.dropdown ul li.selected {
       display: none; }
-  div.mapplugin.backgroundLayerSelectionPlugin div.content .dropdown .open ul {
+  div.mapplugin.backgroundLayerSelectionPlugin div.content.dropdown.open ul {
     display: block; }
-  div.mapplugin.backgroundLayerSelectionPlugin div.content .dropdown .open div.currentSelection {
+  div.mapplugin.backgroundLayerSelectionPlugin div.content.dropdown.open div.currentSelection {
     -webkit-border-top-left-radius: 0;
     -webkit-border-top-right-radius: 0;
     -moz-border-radius-topleft: 0;

--- a/bundles/mapping/mapmodule/scss/backgroundlayerselection.scss
+++ b/bundles/mapping/mapmodule/scss/backgroundlayerselection.scss
@@ -109,7 +109,7 @@ div.mapplugin.backgroundLayerSelectionPlugin {
       color: #ff9100; 
     }
     
-    .dropdown {
+    &.dropdown {
       div.currentSelection {
         display: block;
         div.header-icon {
@@ -145,7 +145,7 @@ div.mapplugin.backgroundLayerSelectionPlugin {
           display: none; 
         }
       }
-      .open {
+      &.open {
         ul {
           display: block; 
         }


### PR DESCRIPTION
Currently the layer selector UI is hidden if user opens Analysis, Thematic or Publish map modes. This change keeps the layer selector visible always (except Publish map), but turns the selector into a dropdown menu if the map is too narrow to fit the buttons.

In reference to: https://jira.nls.fi/browse/AH-3890