### PR TITLE
Fixed disappearing mesurement after drawn shape modification

### DIFF
--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -632,6 +632,7 @@ Oskari.clazz.define(
             me._modify[me._id].on('modifyend', function() {
                 me._showIntersectionWarning = true;
                 me._mode = '';
+                me._sketch = null;
                 me.toggleDrawLayerChangeFeatureEventHandler(false);
                 me.modifyFeatureChangeEventCallback = null;
             });


### PR DESCRIPTION
If drawRequest was made with "showMeasureOnMap" option and user modified measurement line string / polygon and then stopped drawing, the most recently edited shape lost its measurement label.

In reference to:
https://jira.nls.fi/browse/AH-3876