### PR TITLE
Fix for analysis layer union with english translations.

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -86,6 +86,10 @@ User can select "no stroke" and "no fill" as stroke and fill colors. This result
 Previously the layer selector UI was hidden if user opened Analysis, Thematic or Publish map modes.
 This change keeps the layer selector visible always (except Publish map), but turns the selector into a dropdown menu if the map is too narrow to fit the buttons.
 
+### Analysis
+
+Fixed an issue with english translations where selecting analysis method "Analysis Layer Union" showed the parameters for "Buffers and sector".
+
 ## 1.43.0
 
 ### Minifier script

--- a/bundles/analysis/analyse/resources/locale/en.js
+++ b/bundles/analysis/analyse/resources/locale/en.js
@@ -129,7 +129,7 @@ Oskari.registerLocalization(
                         "tooltip": "Select features from the layer to be intersected. The features partially or totally inside the features on the intersecting layer are selected."
                     },
                     {
-                        "id": "oskari_analyse_areas_and_sectors",
+                        "id": "oskari_analyse_layer_union",
                         "label": "Analysis Layer Union",
                         "classForPreview": "layer_union",
                         "tooltip": "Combine the selected map layers. You can combine them only if they have same attributes."


### PR DESCRIPTION
Fixes oskariorg/oskari-docs#51

Localization shouldn't be used for such purposes as it is for this feature, but a quick fix for the problem.