### PR TITLE
Autocomplete & search improvements

### DIFF
--- a/bundles/framework/divmanazer/component/FormInput.js
+++ b/bundles/framework/divmanazer/component/FormInput.js
@@ -378,7 +378,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormInput',
             var me = this,
                 input = this._field.find('input');
 
-            input.keyup(function () {
+            input.keyup(function (event) {
                 callback(event);
             });
         },
@@ -430,6 +430,10 @@ Oskari.clazz.define('Oskari.userinterface.component.FormInput',
             } else {
                 input.keyup(callback);
             }
+        },
+        bindAutocompleteSelect: function (callback) {
+            var input = this._field.find('input');
+            input.on("autocompleteselect", callback);
         },
         autocomplete: function (results) {
             var input = this._field.find('input');

--- a/bundles/framework/search/view/DefaultSearchView.js
+++ b/bundles/framework/search/view/DefaultSearchView.js
@@ -87,7 +87,10 @@ Oskari.clazz.define(
             	me.__doSearch();
             };
 
-            var doAutocompleteSearch = function() {
+            var doAutocompleteSearch = function(e) {
+                if(e.keyCode === 38 || e.keyCode === 40 ) { // arrow keys up/down
+                    return;
+                }
                 me.__doAutocompleteSearch();
             };
 
@@ -96,6 +99,7 @@ Oskari.clazz.define(
 
             if(this.instance.conf.autocomplete === true) {
                 field.bindUpKey(doAutocompleteSearch);
+                field.bindAutocompleteSelect(doSearch);
             }
 
             var controls = searchContainer.find('div.controls');
@@ -326,10 +330,6 @@ Oskari.clazz.define(
             if (result.totalCount === 1) {
                 // move map etc
                 me._resultClicked(result.locations[0]);
-                // close flyout
-                inst.sandbox.postRequestByName('userinterface.UpdateExtensionRequest',
-                    [me.instance, 'close']
-                );
             }
             // render results
             var table = jQuery(this.__templates.resultTable()),


### PR DESCRIPTION
- Search flyout no longer closes itself if only one result is found
- Clicking/pressing enter on autocomplete result starts search
- Arrow up/down keys for navigation of autocomplete menu
- Firefox now works

In reference to:
https://jira.nls.fi/browse/AH-3911