### PR TITLE
Feature/add marker fix

### DIFF
--- a/bundles/framework/layerselector2/view/LayersTab.js
+++ b/bundles/framework/layerselector2/view/LayersTab.js
@@ -255,7 +255,6 @@ Oskari.clazz.define(
                 layerWrapper,
                 layerContainer,
                 selectedLayers;
-console.log(me.accordion.ui);
             me.accordion.removeAllPanels();
             me.layerContainers = {};
             me.layerGroups = groups;

--- a/bundles/framework/maplegend/Flyout.js
+++ b/bundles/framework/maplegend/Flyout.js
@@ -267,14 +267,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.Flyout',
                 invalidLegendUrl = this.instance.getLocalization('invalidLegendUrl'),
                 noLegendContainer = me.templateNoLegend.clone();
 
-
             if (legendDiv && layer) {
                 var legendUrl = layer.getLegendImage ? layer.getLegendImage() : null;
                 if(legendUrl){
                     noLegendContainer.html(invalidLegendUrl);
-                    if(window.console !== undefined) {
-                        console.log(invalidLegendUrl + ": " + legendUrl);
-                    }
+                    Oskari.log(me.instance.getName()).debug(invalidLegendUrl + ": " + legendUrl);
                 }
                 legendDiv.append(noLegendContainer);
             }

--- a/bundles/framework/myplacesimport/Flyout.js
+++ b/bundles/framework/myplacesimport/Flyout.js
@@ -209,7 +209,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.Flyout',
                 // Prevent from sending if there were missing fields
                 if (me.__validateForm (form, locale)){
                     return; //e.preventDefault()
-                };
+                }
 
                 jQuery.ajax({
                     url: action,
@@ -249,7 +249,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.Flyout',
                         if (textStatus === "error"){
                             try {
                                 err = JSON.parse(jqXHR.responseText);
-                                console.log(err);
                                 if (err.error !== null && err.error !== undefined) {
                                     error = err.error;
                                     if (err.error.warning !== undefined && err.error.warning.featuresSkipped){
@@ -364,7 +363,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.Flyout',
             var title = locale.finish.success.title,
                 msg = locale.finish.success.message,
                 json,
-                me=this
+                me=this,
                 fadeout = true;
              try {
                 json = JSON.parse(response);

--- a/bundles/hsy/download-basket/Cropping.js
+++ b/bundles/hsy/download-basket/Cropping.js
@@ -296,8 +296,6 @@ Oskari.clazz.define(
             layerCroppingMode = jQuery('.cropping-btn.selected').data('croppingMode'),
             layerNameLang = jQuery('.cropping-btn.selected').val();
 
-            console.info();
-
             jQuery.ajax({
                 type: "POST",
                 dataType: 'json',

--- a/bundles/liikennevirasto/lakapa-metadataflyout/instance.js
+++ b/bundles/liikennevirasto/lakapa-metadataflyout/instance.js
@@ -242,8 +242,6 @@ Oskari.clazz.define("Oskari.catalogue.bundle.metadataflyout.MetadataFlyoutBundle
             feats.push(ef);
         }
 
-//        console.log("metadataflyout.showExtentOnMap", Oskari.getSandbox().getMap().getSrsName(), "should match", "EPSG:3067");
-
         var eventBuilder = me.getSandbox().getEventBuilder("FeaturesAvailableEvent");
         // FIXME: FeaturesAvailableEvent has been removed. Use MapModulePlugin.AddFeaturesToMapRequest instead.
         if(eventBuilder) {

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -312,7 +312,7 @@ Oskari.clazz.define(
                       me.pointerMoveHandler();
                       me.sendDrawingEvent(me._id, optionsForDrawingEvent);
                       return geometry;
-                  }
+                  };
             } else if (shape === 'Box') {
                  maxPoints = 2;
                  geometryType = 'LineString';
@@ -326,7 +326,7 @@ Oskari.clazz.define(
                    me.pointerMoveHandler();
                    me.sendDrawingEvent(me._id, optionsForDrawingEvent);
                    return geometry;
-                 }
+                 };
             } else if (shape === 'Square') {
                 geometryType = 'Circle';
                 geometryFunction = ol.interaction.Draw.createRegularPolygon(4);
@@ -339,7 +339,7 @@ Oskari.clazz.define(
                      me.pointerMoveHandler();
                      me.sendDrawingEvent(me._id, optionsForDrawingEvent);
                      return geometry;
-                 }
+                 };
             } else if(shape === 'Polygon') {
                 geometryFunction = function(coordinates, geometry) {
                     if (!geometry) {
@@ -350,7 +350,7 @@ Oskari.clazz.define(
                     me.pointerMoveHandler();
                     me.sendDrawingEvent(me._id, optionsForDrawingEvent);
                     return geometry;
-                 }
+                 };
             }
 
             me._draw[me._id] = new ol.interaction.Draw({
@@ -502,7 +502,7 @@ Oskari.clazz.define(
                             var ii = jQuery('div.' + me._tooltipClassForMeasure + "." + me._sketch.getId());
                             ii.html(output);
                             if(output==="") {
-                                ii.addClass('withoutText')
+                                ii.addClass('withoutText');
                             } else {
                                 ii.removeClass('withoutText');
                             }
@@ -713,25 +713,25 @@ Oskari.clazz.define(
 
             if(me._draw[me._id]) {
                 me._draw.on('drawstart', function() {
-                    console.log("drawstart");
+                    Oskari.log('DrawPlugin').debug('drawstart');
                 });
                 me._draw[me._id].on('drawend', function() {
-                    console.log("drawend");
+                    Oskari.log('DrawPlugin').debug('drawend');
                 });
                 me._draw[me._id].on('change:active', function() {
-                    console.log("drawchange");
+                    Oskari.log('DrawPlugin').debug('drawchange');
                 });
             }
             if(me._modify[me._id]) {
                 me._modify[me._id].on('modifystart', function() {
-                    console.log("modifystart");
+                    Oskari.log('DrawPlugin').debug('modifystart');
                 });
                 me._modify[me._id].on('change', function() {
-                    console.log("modifychange");
+                    Oskari.log('DrawPlugin').debug('modifychange');
                 });
 
                 me._modify[me._id].on('modifyend', function() {
-                    console.log("modifyend");
+                    Oskari.log('DrawPlugin').debug('modifyend');
                 });
             }
         },

--- a/bundles/mapping/mapmodule/mapmodule.ol2.js
+++ b/bundles/mapping/mapmodule/mapmodule.ol2.js
@@ -458,12 +458,21 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.MapModule',
          * @return {Object} ol2 specific style hash
          */
         getStyle : function(styleDef) {
-            var me = this;
-            var style = jQuery.extend(true, {}, styleDef);
+            var me = this,
+                style = jQuery.extend(true, {}, styleDef),
+                size;
             //create a blank style with default values
             var olStyle = OpenLayers.Util.applyDefaults({}, OpenLayers.Feature.Vector.style["default"]);
-            var size = (style.image) ? style.image.size | style.image.sizePx : this._defaultMarker.size;
-            if(!size || typeof size !== 'number'){
+            // use sizePx if given
+            if (style.image && style.image.sizePx){
+                size = style.image.sizePx;
+            } else if (style.image && style.image.size){
+                size = this.getPixelForSize(style.image.size);
+            } else {
+                size = this._defaultMarker.size;
+            }
+
+            if(typeof size !== 'number'){
                 size = this._defaultMarker.size;
             }
 

--- a/bundles/mapping/mapmodule/mapmodule.ol3.js
+++ b/bundles/mapping/mapmodule/mapmodule.ol3.js
@@ -651,11 +651,19 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.MapModule',
          * @return {ol.style.Circle}
          */
         __getImageStyle: function(styleDef) {
-            var me = this;
-            var image = {};
+            var me = this,
+                image = {},
+                size;
 
-            var size = (styleDef.image) ? styleDef.image.size | styleDef.image.sizePx : this._defaultMarker.size;
-            if(!size || typeof size !== 'number'){
+            if (styleDef.image && styleDef.image.sizePx){
+                size = styleDef.image.sizePx;
+            } else if (styleDef.image && styleDef.image.size){
+                size = this.getPixelForSize(styleDef.image.size);
+            } else {
+                size = this._defaultMarker.size;
+            }
+
+            if(typeof size !== 'number'){
                 size = this._defaultMarker.size;
             }
 

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -239,7 +239,6 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
          *            json conf for the layer. NOTE! Only updates name for now
          */
         updateLayer: function (layerId, newLayerConf) {
-            //console.log("MapLayerService: updateLayer");
             var layer = this.findMapLayer(layerId);
             if (!layer) {
                 // couldn't find layer to update
@@ -355,7 +354,6 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
          * @param {Function} callbackFailure method to be called when something went wrong
          */
         loadAllLayersAjax: function (callbackSuccess, callbackFailure) {
-            //console.log("loadAllLayersAjax");
             var me = this,
                 epsg = me._sandbox.getMap().getSrsName();
             // Used to bypass browsers' cache especially in IE, which seems to cause

--- a/bundles/mapping/mapwfs2/service/StatusHandler.js
+++ b/bundles/mapping/mapwfs2/service/StatusHandler.js
@@ -17,18 +17,8 @@ Oskari.clazz.define(
     this.status = status;
     this._errorLayer = null;
     this._errorLayers = [];
-    this.timer;
-    // TODO: For debugging, remove when stable
-    Oskari.___getWFSStatus = function() {
-      console.log(status);
-    };
+    this.timer = null;
   }, {
-    __log : function() {
-      // TODO: For debugging, remove when stable
-      if(Oskari.__debugWFS === true) {
-        console.log.apply(console, arguments);
-      }
-    },
     getMapLayer : function(layerId) {
       var service = this.sandbox.getService('Oskari.mapframework.service.MapLayerService');
       return service.findMapLayer(layerId);
@@ -54,7 +44,7 @@ Oskari.clazz.define(
     },
     handleChannelRequest : function(layerId, type, reqId) {
       var status = this.getLayerStatus(layerId);
-      this.__log('Request data for layer: ' + layerId + ' (req:' + reqId + ')');
+      Oskari.log('mapwfs2').debug('Request data for layer: ' + layerId + ' (req:' + reqId + ')');
       status.inProgress.push({
         type: type,
         reqId : reqId
@@ -83,7 +73,7 @@ Oskari.clazz.define(
       loadEvent.setRequestType(loadEvent.type.image);
 
       if(data.success) {
-        this.__log('Back to normal for layer:', data.layerId, status.error);
+        Oskari.log('mapwfs2').debug('Back to normal for layer:', data.layerId, status.error);
         status.error = [];
         loadEvent.setStatus(loadEvent.status.complete);
         // No operations for wfs layer in case of true, e.g. manual refresh / feature data refresh
@@ -94,17 +84,17 @@ Oskari.clazz.define(
         loadEvent.setStatus(loadEvent.status.error);
       }
       sb.notifyAll(loadEvent);
-      this.__log('WFS complete', data);
+      Oskari.log('mapwfs2').debug('WFS complete', data);
     },
     handleChannelStatus : function(data) {
       var me = this;
       // {"layerId":"5","message":"started","reqId":9}
       // {"layerId":"15","success":true,"message":"completed","reqId":3}
       if(data.message === 'started') {
-        this.__log('Processing started for layer ' + data.layerId + ' (req: ' + data.reqId + ')');
+        Oskari.log('mapwfs2').debug('Processing started for layer ' + data.layerId + ' (req: ' + data.reqId + ')');
         if(typeof this.timer === 'undefined'){
           this.timer = setTimeout(function(){
-            me.__log('Processing layer ' + data.layerId + ' takes longer than excpected');
+            Oskari.log('mapwfs2').debug('Processing layer ' + data.layerId + ' takes longer than excpected');
           }, 4000);
         }
         return;
@@ -112,16 +102,16 @@ Oskari.clazz.define(
       else if(data.message === 'completed') {
         clearTimeout(this.timer);
         if(data.success) {
-          this.__log('Processing finished for layer ' + data.layerId + ' (req: ' + data.reqId + ')');
+          Oskari.log('mapwfs2').debug('Processing finished for layer ' + data.layerId + ' (req: ' + data.reqId + ')');
         }
         else {
-          this.__log('Processing error for layer ' + data.layerId + ' (req: ' + data.reqId + ')');
+          Oskari.log('mapwfs2').debug('Processing error for layer ' + data.layerId + ' (req: ' + data.reqId + ')');
         }
         this.__handleCompleted(data);
       }
     },
     handleError : function(error, plugin) {
-      this.__log('Error on layer ' +  error.layerId + ':' + error.message);
+      Oskari.log('mapwfs2').debug('Error on layer ' +  error.layerId + ':' + error.message);
       var status = this.getLayerStatus(error.layerId);
       status.error.push(error.message);
       var requestBuilder = Oskari.requestBuilder('ShowMessageRequest');

--- a/bundles/mapping/mapwmts/plugin/WmtsLayerPlugin.ol2.js
+++ b/bundles/mapping/mapwmts/plugin/WmtsLayerPlugin.ol2.js
@@ -90,7 +90,6 @@ Oskari.clazz.define('Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin',
                 map.addLayer(wmtsLayer);
                 map.setLayerIndex(wmtsLayer, oldLayerIndex);
             }, function() {
-//                console.log("Error updating WMTS layer");
             });
         },
         /**
@@ -160,7 +159,6 @@ Oskari.clazz.define('Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin',
                         map.setLayerIndex(wmtsLayer, 0);
                     }
             }, function() {
-//                console.log("Error loading capabilitiesXML");
             });
         },
 

--- a/bundles/mapping/mapwmts/plugin/WmtsLayerPlugin.ol3.js
+++ b/bundles/mapping/mapwmts/plugin/WmtsLayerPlugin.ol3.js
@@ -67,7 +67,6 @@ Oskari.clazz.define('Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin',
                     }
                     me.setOLMapLayers(layer.getId(), wmtsLayer);
             }, function() {
-//                console.log("Error loading capabilitiesXML");
             });
 
 

--- a/bundles/statistics/statsgraphs/Chart1Tab.js
+++ b/bundles/statistics/statsgraphs/Chart1Tab.js
@@ -38,8 +38,6 @@ Oskari.clazz.define('Oskari.mapframework.statsgraphs.Chart1Tab',
                     type:'bar',
                     onclick: function (d, element) {
                         //give the id and index of the latest data set.
-
-                        console.log("onclick latest data", element);
                     },
                     onmouseover: function (d) {
 
@@ -47,7 +45,6 @@ Oskari.clazz.define('Oskari.mapframework.statsgraphs.Chart1Tab',
                         //make the bar red
                         //d3.selectAll(k).style("fill", "red");
                         //event.stopPropagation();
-                        console.log("onmouseover latest data d", d);
 
                         //make all teh bar opacity 0.1
                         d3.selectAll(".c3-shape").style("opacity", 0.5);
@@ -63,7 +60,6 @@ Oskari.clazz.define('Oskari.mapframework.statsgraphs.Chart1Tab',
                         //var k = ".c3-shape-" + d.index;
                         //make the clicked bar opacity
                         //d3.selectAll(k).style("fill",'#1f77b4');
-                        console.log("onmouseout latest data", d);
                     }
                 },
                 grid: {

--- a/bundles/statistics/statsgraphs/instance.js
+++ b/bundles/statistics/statsgraphs/instance.js
@@ -24,18 +24,6 @@ Oskari.clazz.define(
         afterStart: function (sandbox) {
             var me = this;
             this.service = sandbox.getService('Oskari.statistics.statsgrid.StatisticsService');
-            /*
-            // FOR DEBUGGING
-            var sb = this.getSandbox();
-            var events = Oskari.clazz.protocol('Oskari.mapframework.event.Event')
-            for(var event in events) {
-                var name = events[event]._class.prototype.getName();
-                console.log(name);
-                if(name != 'MouseHoverEvent') {
-                    sb.registerForEventByName(me, name);
-                }
-            }
-            */
         },
         eventHandlers: {
             'StatsGrid.IndicatorEvent' : function(evt) {
@@ -76,48 +64,15 @@ Oskari.clazz.define(
             this.sandbox.unregisterFromEventByName(this, 'MapClickedEvent');
         },
 
-        /*
-        // FOR DEBUGGING
-        onEvent: function(event) {
-            console.log(event.getName(), event);
-        },
-*/
         _handleDataChangeEvent: function () {
 
             var me = this;
             this.service.getCurrentDataset(function(err, data) {
                 if(err) {
-                    console.warn(err);
                     return;
                 }
                 me.getFlyout().chartDataChanged(data);
             });
-
-/*
-            var regionSetId = this.service.getStateService().getRegionset();
-            //var regionset = this.service.getRegionsets(regionSetId);
-            var selectedList = this.service.getStateService().getIndicators();
-            if(!selectedList.length) {
-                // TODO: teardown any existing charts
-                return;
-            }
-            // latest indicator
-            var ind = selectedList[selectedList.length -1];
-            this.service.getRegions(regionSetId, function(err, regions) {
-                me.service.getIndicatorData(ind.datasource, ind.indicator, ind.selections, regionSetId, function(err, indicatorData) {
-                    var values = [];
-                    regions.forEach(function(reg) {
-                        values.push(indicatorData[reg.id]);
-                    });
-
-                    me.service.getIndicatorMetadata(ind.datasource, ind.indicator, function(err, indicator) {
-                        var ds = me.service.getDatasource(ind.datasource).name;
-                        var name = ds + ' - ' + Oskari.getLocalized(indicator.name);
-                        me.getFlyout().updateUI(name, regions, values);
-                    });
-                });
-            });
-*/
         }
     }, {
         extend: ['Oskari.userinterface.extension.DefaultExtension']


### PR DESCRIPTION
Fixes issue where icon size wasn't calculated correctly. Size (1-5) must use getPixelForSize to calculate pixels for icon size.

Now icon size is sizePx if given. If not uses getPixelForSize. If sizePx or size aren't given then use defaultSize.

Also deleted one logging line from layerTab  