### PR TITLE
Don't sort feature properties if user_layer fields is empty

### DIFF
--- a/bundles/mapping/mapuserlayers/domain/UserLayer.js
+++ b/bundles/mapping/mapuserlayers/domain/UserLayer.js
@@ -37,17 +37,21 @@ function() {
         return this.renderingElement;
     },
     setFeatureProperties: function(fields){
-            this.featureProperties = fields;
+        this.featureProperties = fields;
     },
     getFeatureProperties: function(){
-            return this.featureProperties;
+        return this.featureProperties;
     },
     setFeaturePropertyIndexes: function(indexes){
-            this.featurePropertyIndexes = indexes;
+        this.featurePropertyIndexes = indexes;
     },
     getFeaturePropertyIndexes: function(){
-            return this.featurePropertyIndexes;
+        return this.featurePropertyIndexes;
+    },
+    hasOrder: function(){
+        return this.featureProperties && this.featureProperties.length > 1;
     }
+
 }, {
     "extend": ["Oskari.mapframework.bundle.mapwfs2.domain.WFSLayer"]
 });

--- a/bundles/mapping/mapuserlayers/domain/UserLayerModelBuilder.js
+++ b/bundles/mapping/mapuserlayers/domain/UserLayerModelBuilder.js
@@ -30,7 +30,11 @@ Oskari.clazz.define(
             layer.setSource(mapLayerJson.source);
             layer.setRenderingElement(mapLayerJson.renderingElement);
             layer.addLayerUrl(mapLayerJson.renderingUrl);
-            layer.setFeatureProperties(this.addHiddenFields(mapLayerJson.fields));
+            if (mapLayerJson.fields && mapLayerJson.fields.length !== 0){
+                layer.setFeatureProperties(this.addHiddenFields(mapLayerJson.fields));
+            } else {
+                layer.setFeatureProperties([]);
+            }
         },
 
         addHiddenFields: function(fields){

--- a/bundles/mapping/mapwfs2/service/Mediator.js
+++ b/bundles/mapping/mapwfs2/service/Mediator.js
@@ -302,7 +302,7 @@ Oskari.clazz.category('Oskari.mapframework.bundle.mapwfs2.service.Mediator', 'ge
                 this.plugin.mapMoveHandler();
             }
 
-            if (typeof layer.getFeatureProperties === "function"){
+            if (typeof layer.getFeatureProperties === "function" && layer.hasOrder()){
                 this.setOrderForFeatureProperties(layer,data.data.fields);
                 layer.setFields(this.sortArrayByFeaturePropertyIndexes(layer, data.data.fields));
                 layer.setLocales (this.sortArrayByFeaturePropertyIndexes(layer, data.data.locales));
@@ -335,7 +335,7 @@ Oskari.clazz.category('Oskari.mapframework.bundle.mapwfs2.service.Mediator', 'ge
             feature;
         if (data.data.feature !== 'empty' && data.data.feature !== 'max') {
             feature = data.data.feature;
-            if (typeof layer.getFeatureProperties === "function"){
+            if (typeof layer.getFeatureProperties === "function" && layer.hasOrder()){
                 layer.setActiveFeature(this.sortArrayByFeaturePropertyIndexes(layer,feature));
             } else{
                 layer.setActiveFeature(feature);
@@ -392,7 +392,7 @@ Oskari.clazz.category('Oskari.mapframework.bundle.mapwfs2.service.Mediator', 'ge
             // FIXME: pass coordinates from server in response, but not like this
             data.data.lonlat = this.lonlat;
             me.WFSLayerService.emptyWFSFeatureSelections(layer);
-            if (typeof layer.getFeatureProperties === "function" && data.data.features !== 'empty'){
+            if (typeof layer.getFeatureProperties === "function" && layer.hasOrder() && data.data.features !== 'empty'){
                 features = data.data.features;
                 for (i=0; i<features.length; i++){
                     features [i] = this.sortArrayByFeaturePropertyIndexes (layer, features[i]);

--- a/bundles/mapping/mapwfs2/service/Mediator.js
+++ b/bundles/mapping/mapwfs2/service/Mediator.js
@@ -302,11 +302,13 @@ Oskari.clazz.category('Oskari.mapframework.bundle.mapwfs2.service.Mediator', 'ge
                 this.plugin.mapMoveHandler();
             }
 
-            if (typeof layer.getFeatureProperties === "function" && layer.hasOrder()){
+            if (typeof layer.getFeatureProperties === "function" && layer.hasOrder()) {
+                // this is a "userlayer" type layer
                 this.setOrderForFeatureProperties(layer,data.data.fields);
                 layer.setFields(this.sortArrayByFeaturePropertyIndexes(layer, data.data.fields));
                 layer.setLocales (this.sortArrayByFeaturePropertyIndexes(layer, data.data.locales));
-            }else{
+            } else {
+                // this is any other layer supported by transport
                 layer.setFields(data.data.fields);
                 layer.setLocales(data.data.locales);
             }
@@ -335,9 +337,11 @@ Oskari.clazz.category('Oskari.mapframework.bundle.mapwfs2.service.Mediator', 'ge
             feature;
         if (data.data.feature !== 'empty' && data.data.feature !== 'max') {
             feature = data.data.feature;
-            if (typeof layer.getFeatureProperties === "function" && layer.hasOrder()){
+            if (typeof layer.getFeatureProperties === "function" && layer.hasOrder()) {
+                // this is a "userlayer" type layer
                 layer.setActiveFeature(this.sortArrayByFeaturePropertyIndexes(layer,feature));
-            } else{
+            } else {
+                // this is any other layer supported by transport
                 layer.setActiveFeature(feature);
             }
         }
@@ -393,6 +397,7 @@ Oskari.clazz.category('Oskari.mapframework.bundle.mapwfs2.service.Mediator', 'ge
             data.data.lonlat = this.lonlat;
             me.WFSLayerService.emptyWFSFeatureSelections(layer);
             if (typeof layer.getFeatureProperties === "function" && layer.hasOrder() && data.data.features !== 'empty'){
+                // this is a "userlayer" type layer - props are sorted to match the original order
                 features = data.data.features;
                 for (i=0; i<features.length; i++){
                     features [i] = this.sortArrayByFeaturePropertyIndexes (layer, features[i]);


### PR DESCRIPTION
Function hasOrder() checks if featureProperties contains more than one property. FeatureProperties comes from user_layer table fields column.