### PR TITLE
Fixed wrong params in request

### DIFF
--- a/bundles/framework/publisher2/view/PanelMapLayers.js
+++ b/bundles/framework/publisher2/view/PanelMapLayers.js
@@ -727,7 +727,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapLayers',
             var requestName = 'ShowFilteredLayerListRequest';
             this.instance.getSandbox().postRequestByName(
                 requestName,
-                [null, 'publishable', true]
+                ['publishable', true]
             );
         },
         /**


### PR DESCRIPTION
Layer selector now opens as expected in publisher.