### PR TITLE
FormInput floating label fixes

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -10,6 +10,14 @@ Fixed an error when ``MapModulePlugin.RemoveFeaturesFromMapRequest`` is used to 
 
 Fixed an issue where the button to add layers in publisher didn't work.
 
+### FormInput
+
+Floating labels were created to all FormInput components which used setPlaceHolder method. Now floating labels are created by calling setFloatingLabel. If you want to use floating labels with FormInput component, you have to use new method. Floating label position can be adjusted with topPosition, which adds a value to the css-directive "top".
+
+Optionally tooltip can be bound to input (default binds to label).
+
+Now floating label is floated when input is selected instead of typing text.
+
 ## 1.44.0
 
 ### layerselector2

--- a/bundles/framework/divmanazer/component/FormInput.js
+++ b/bundles/framework/divmanazer/component/FormInput.js
@@ -14,16 +14,16 @@ Oskari.clazz.define('Oskari.userinterface.component.FormInput',
             input;
         Oskari.log('Oskari.userinterface.component.FormInput').warn('Deprecated - please use Oskari.userinterface.component.TextInput instead.');
         this.sandbox = sandbox;
-        this.template = jQuery('<div class="oskarifield"><label class="oskarifield_label"></label><input id="oskari_input" class="oskarifield_input" type="text" /></div>');
+        this.template = jQuery('<div class="oskarifield"><label></label><input type="text"/></div>');
         this.templateErrors = jQuery('<div class="error"></div>');
         this.templateTooltip = jQuery('<div class="icon-info"></div>');
         this.templateClearButton = jQuery('<div class="icon-close"></div>');
         this._field = this.template.clone();
 
-        label = this._field.find('.oskarifield_label');
+        label = this._field.find('label');
         label.attr('for', name);
 
-        input = this._field.find('.oskarifield_input').focus();
+        input = this._field.find('input').focus();
 
         input.attr('name', name);
         this._name = name;
@@ -32,23 +32,24 @@ Oskari.clazz.define('Oskari.userinterface.component.FormInput',
         this._requiredMsg = 'required';
         this._contentCheck = false;
         this._contentCheckMsg = 'illegal characters';
-        this._labelMargin = null;
-
         this._bindFocusAndBlur();
         // word characters, digits, whitespace and chars '-,.?!' allowed
         this._regExp = /[\s\w\d\.\,\?\!\-äöåÄÖÅ]*/;
         this._colorRegExp = /^([A-Fa-f0-9]{6})$/;
     }, {
-        bindOnInput: function() {
-            var me = this;
-            this._field.find('.oskarifield_input').on('input', function() {
+        /**
+         * @method bindOnFloatingLabelInput
+         * binds floating label functionality.
+         */
+        bindOnFloatingLabelInput: function() {
+            this._field.find('.oskarifield_floating_input').on('focus', function() {
                 var $field = jQuery(this).closest('.oskarifield');
-                if (this.value) {
-                    $field.addClass('oskarifield--not-empty');
-                    if(me._labelMargin !== null) {
-                        $field.find('.oskarifield_label').css('top', me._labelMargin + 'px');
-                    }
-                } else {
+                $field.addClass('oskarifield--not-empty');
+            });
+
+            this._field.find('.oskarifield_floating_input').on('blur', function() {
+                var $field = jQuery(this).closest('.oskarifield');
+                if (!this.value) {
                     $field.removeClass('oskarifield--not-empty');
                 }
             });
@@ -93,18 +94,24 @@ Oskari.clazz.define('Oskari.userinterface.component.FormInput',
          * Sets the fields tooltip and possible help tags
          * @param {String} pTooltip tooltip text
          * @param {String} pDataTags comma separated list of article tags identifying the help article for this field
+         * @param {Boolean} bindToInput (optional) true to add tooltip before input instead of label. Useful with floating labels.
          */
-        setTooltip: function (pTooltip, pDataTags) {
+        setTooltip: function (pTooltip, pDataTags, bindToInput) {
+            bindToInput = bindToInput || false;
             // TODO: check existing tooltip
             var tooltip = this.templateTooltip.clone(),
-                label;
+                place;
             tooltip.attr('title', pTooltip);
             if (pDataTags) {
                 tooltip.addClass('help');
                 tooltip.attr('helptags', pDataTags);
             }
-            label = this._field.find('label');
-            label.before(tooltip);
+            if (bindToInput){
+                place = this._field.find('input');
+            }else{
+                place = this._field.find('label');
+            }
+            place.before(tooltip);
         },
         /**
          * @method setPlaceholder
@@ -114,12 +121,36 @@ Oskari.clazz.define('Oskari.userinterface.component.FormInput',
         setPlaceholder: function (pLabel) {
             var input = this._field.find('input');
             input.attr('placeholder', pLabel);
+        },
+        /**
+         * @method setFloatingLabel
+         * Sets the fields floating label
+         * @param {String} pLabel
+         * @param {Integer} topPosition (optional) to adjust floating label in pixels. In CSS oskarifield_floating_label default top value 20px.
+         */
+        setFloatingLabel: function (pLabel, topPosition) {
+            var input = this._field.find('input'),
+                label = this._field.find('label');
+            if (topPosition){
+                this._setTopPosition(label, topPosition);
+            }
+            label.addClass('oskarifield_floating_label');
+            input.addClass('oskarifield_floating_input');
+            input.attr('placeholder', pLabel);
             // if we set placeholder we can set the label aswell for floating label
             this.setLabel(pLabel);
-            this.bindOnInput();
+            this.bindOnFloatingLabelInput();
         },
-        addMarginToLabel: function ( margin ) {
-           this._labelMargin = margin;
+        /**
+         * @method _setTopPosition
+         * Adds a value (px) to the element's css-directive top to override CSS default top value.
+         * @param {Object} elem HTML element
+         * @param {Integer} top value in px
+         */
+        _setTopPosition: function (elem, top) {
+            if (typeof top === "number"){
+                elem.css('top', top + 'px');
+            }
         },
         /**
          * @method setRequired
@@ -206,7 +237,11 @@ Oskari.clazz.define('Oskari.userinterface.component.FormInput',
          * @param {String} value
          */
         setValue: function (value) {
-            this._field.find('input').attr('value', value);
+            var input = this._field.find('input');
+            input.attr('value', value);
+            if(value && input.hasClass("oskarifield_floating_input")){
+                this._field.addClass('oskarifield--not-empty');
+            }
         },
 
         /**
@@ -454,7 +489,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormInput',
          */
         addClearButton: function (id) {
             var clearButton = this.templateClearButton.clone(),
-                input = this._field.find('.oskarifield_input');
+                input = this._field.find('input');
 
             clearButton.attr('id', id);
             clearButton.bind('click', function () {

--- a/bundles/framework/divmanazer/component/FormInput.js
+++ b/bundles/framework/divmanazer/component/FormInput.js
@@ -126,7 +126,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormInput',
          * @method setFloatingLabel
          * Sets the fields floating label
          * @param {String} pLabel
-         * @param {Integer} topPosition (optional) to adjust floating label in pixels. In CSS oskarifield_floating_label default top value 20px.
+         * @param {Integer} topPosition (optional) to adjust floating label in pixels. In CSS oskarifield_floating_label default top value 0px.
          */
         setFloatingLabel: function (pLabel, topPosition) {
             var input = this._field.find('input'),

--- a/bundles/framework/divmanazer/resources/css/forminput.css
+++ b/bundles/framework/divmanazer/resources/css/forminput.css
@@ -11,7 +11,7 @@ div.oskarifield div.icon-close {
     position: relative;
 }
 
-.oskarifield_label {
+.oskarifield_floating_label {
     color: #919293;
     box-sizing: border-box;
     display: block;
@@ -23,7 +23,7 @@ div.oskarifield div.icon-close {
     pointer-events: none;
     position: absolute;
     text-overflow: ellipsis;
-    top: 0;
+    top: 0px;
     text-align: left;
     transform: translateY(0.1875em);
     transition: all .2s ease-out;
@@ -33,12 +33,12 @@ div.oskarifield div.icon-close {
     z-index: 1;
 }
 
-.oskarifield--not-empty .oskarifield_label {
+.oskarifield--not-empty .oskarifield_floating_label {
     opacity: 1;
     transform: none;
 }
 
-.oskarifield_input {
+.oskarifield_floating_input {
     background-color: #f5f5f5;
     border: 2px solid #e9e9e9;
     color: #333;
@@ -48,13 +48,13 @@ div.oskarifield div.icon-close {
     width: 100%;
 }
 
-.oskarifield_input:hover, .oskarifield_input:focus {
+.oskarifield_floating_input:hover, .oskarifield_floating_input:focus {
     /* inset | offset-x | offset-y | blur-radius | spread-radius | color */
     box-shadow: inset 0 0 10px 0 rgba(85, 85, 85, 0.1);
     outline: 0;
 }
 
-.oskarifield--not-empty .oskarifield_input {
+.oskarifield--not-empty .oskarifield_floating_input {
     padding-top: 18px;
 }
 
@@ -77,5 +77,20 @@ div.oskarifield div.icon-close {
     /* Firefox 18- */
     color: #919293;
 }
-
+/* With floating labels hide placeholder on focus */
+.oskarifield_floating_input:focus::-webkit-input-placeholder {
+    color:transparent;
+}
+/* FF 4-18 */
+.oskarifield_floating_input:focus:-moz-placeholder {
+    color:transparent;
+}
+/* FF 19+ */
+.oskarifield_floating_input:focus::-moz-placeholder {
+    color:transparent;
+}
+/* IE 10+ */
+.oskarifield_floating_input:focus:-ms-input-placeholder {
+    color:transparent;
+}
 /*# sourceMappingURL=forminput.css.map */

--- a/bundles/framework/divmanazer/scss/forminput.scss
+++ b/bundles/framework/divmanazer/scss/forminput.scss
@@ -11,7 +11,7 @@ div.oskarifield div.icon-close {
     position: relative;
 }
 
-.oskarifield_label {
+.oskarifield_floating_label {
     color: #919293;
     box-sizing: border-box;
     display: block;
@@ -23,7 +23,7 @@ div.oskarifield div.icon-close {
     pointer-events: none;
     position: absolute;
     text-overflow: ellipsis;
-    top: 0;
+    top: 0px;
     text-align: left;
     transform: translateY(0.1875em);
     transition: all .2s ease-out;
@@ -38,7 +38,7 @@ div.oskarifield div.icon-close {
     }
 }
 
-.oskarifield_input {
+.oskarifield_floating_input {
     background-color: #f5f5f5;
     border: 2px solid #e9e9e9;
     color: #333;
@@ -76,4 +76,25 @@ div.oskarifield div.icon-close {
 :-moz-placeholder {
     /* Firefox 18- */
     color: #919293;
+}
+
+/* With floating labels hide placeholder on focus */
+/* Chrome/Opera/Safari */
+.oskarifield_floating_input:focus::-webkit-input-placeholder {
+    color:transparent;
+}
+
+/* FF 4-18 */
+.oskarifield_floating_input:focus:-moz-placeholder {
+    color:transparent;
+}
+
+/* FF 19+ */
+.oskarifield_floating_input:focus::-moz-placeholder {
+    color:transparent;
+}
+
+/* IE 10+ */
+.oskarifield_floating_input:focus:-ms-input-placeholder {
+    color:transparent;
 }

--- a/bundles/framework/personaldata/MyViewsTab.js
+++ b/bundles/framework/personaldata/MyViewsTab.js
@@ -195,7 +195,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.MyViewsTab',
             var form = Oskari.clazz.create('Oskari.userinterface.component.Form');
             var nameInput = Oskari.clazz.create('Oskari.userinterface.component.FormInput', 'name');
             nameInput.setPlaceholder(this.loc('tabs.myviews.popup.name_placeholder'));
-            nameInput.addMarginToLabel(9);
             var title = this.loc('tabs.myviews.popup.title');
             if (viewName) {
                 title = this.loc('tabs.myviews.popup.edit');

--- a/bundles/framework/publisher2/view/PanelGeneralInfo.js
+++ b/bundles/framework/publisher2/view/PanelGeneralInfo.js
@@ -59,7 +59,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelGeneralInfo
                     field.setLabel(data.label);
                     field.setTooltip(data.tooltip, data.helptags);
                     field.setPlaceholder(data.placeholder);
-                    field.addMarginToLabel(20);
                     data.field = field;
                 }
             }

--- a/bundles/paikkatietoikkuna/routesearch/Flyout.js
+++ b/bundles/paikkatietoikkuna/routesearch/Flyout.js
@@ -181,7 +181,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.routesearch.Flyout',
                     field
                 );
                 tmp.addClearButton();
-                tmp.setPlaceholder(me.locale[field]);
+                tmp.setFloatingLabel(me.locale[field]);
 
                 tmp.getField().find('input[type=text]').autocomplete({
                     delay: 300,


### PR DESCRIPTION
Hotfix for pull request #108.
Floating labels were created to all FormInput components which used setPlaceHolder method.

Added setFloatingLabel method. Now floating labels are created by calling new method. setLabel, setPlaceholder, setTooltip works now as in Oskari 1.43.

Floating label positioning can be adjusted by topPostion (optional).
	setFloatingLabel(label/placeholder, topPosition)

Floating functionality is created by styling HTML element classes oskarifield_floating_label and oskarifield_floating_input. Actual floating functionality is handled with oskarifield--not-empty class. This class is added on focus and removed on blur (if no value), because IE hides placeholder on focus instead of input.val.

FormInput css (for floating labels) looks like it is based on Paikkatietoikkuna's routeservice css. If the FormInput div is higher, then floating placeholder is placed incorrectly. For this reason topPosition (formerly addMarginToLabel) is added and floating label can be placed correctly. Needs manual handling in setFloatingLabel method. This isn't good solution and may need further improvement. Also forminput.css may affect to other components (.oskarifield).