### PR TITLE
Drawtools fix

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -12,13 +12,7 @@ Fixed an issue where the button to add layers in publisher didn't work.
 
 ### drawtools
 
-Fixed an issue where:
-
-1) Draw a shape (like Polygon) with functionality id 1
-2) Draw another type of shape (like LineString) with functionality id 2
-3) Draw the same shape as in step 1 with functionality id 3
-
-Resulted in DrawingEvents on step 3 NOT to be sent. They are now sent correctly.
+See [api/CHANGELOG.md](api/CHANGELOG.md) for changes.
 Refactored the code for the functionality to make it more accessible.
 
 ## 1.44.0

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -10,6 +10,17 @@ Fixed an error when ``MapModulePlugin.RemoveFeaturesFromMapRequest`` is used to 
 
 Fixed an issue where the button to add layers in publisher didn't work.
 
+### drawtools
+
+Fixed an issue where:
+
+1) Draw a shape (like Polygon) with functionality id 1
+2) Draw another type of shape (like LineString) with functionality id 2
+3) Draw the same shape as in step 1 with functionality id 3
+
+Resulted in DrawingEvents on step 3 NOT to be sent. They are now sent correctly.
+Refactored the code for the functionality to make it more accessible.
+
 ## 1.44.0
 
 ### layerselector2

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -13,6 +13,14 @@ Some extra tags:
 
 ### [mod] [rpc] DrawingEvent
 
+Fixed an issue where:
+
+1) Draw a shape (like Polygon) with functionality id 1
+2) Draw another type of shape (like LineString) with functionality id 2
+3) Draw the same shape as in step 1 with functionality id 3
+
+Resulted in DrawingEvents on step 3 to have an empty features array. Features the user draws are now sent correctly.
+
 DrawingEvent with isFinished = true is now correctly triggered also when user modifies the geometry.
 Previously isFinished was only ever "true" for the original draw and always false for any modifications.
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -36,7 +36,13 @@ The length/area is written to geojson properties per feature so if you need to a
     }
 ```
 
-To get the same information you can do `event.geojson.features[event.geojson.features.length - 1].properties.area`, but it makes more sense to have the sum on the data block instead of measures for the latest feature in a collection of features. Note! If you have just one feature ever this works like before.
+To get the same information you can do `event.geojson.features[event.geojson.features.length - 1].properties.area`, but it makes more sense to have the sum on the data block instead of measures for the latest feature in a collection of features.
+
+Notes:
+
+- If you have just one feature ever this works like before.
+- Only lines and polygons are counted for the area/length (circles/points with buffers are not).
+- The measurements are for non-buffered features.
 
 ## 1.44
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -9,6 +9,13 @@ Some extra tags:
 - [rpc] tag indicates that the change affects RPC API
 - [breaking] tag indicates that the change is not backwards compatible
 
+## 1.44.1
+
+### [mod] [rpc] DrawingEvent
+
+DrawingEvent with isFinished = true is now correctly triggered also when user modifies the geometry.
+Previously isFinished was only ever "true" for the original draw and always false for any modifications.
+
 ## 1.44
 
 ### [mod] [breaking] AddLayerListFilterRequest

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -16,6 +16,28 @@ Some extra tags:
 DrawingEvent with isFinished = true is now correctly triggered also when user modifies the geometry.
 Previously isFinished was only ever "true" for the original draw and always false for any modifications.
 
+Length and area information in the event are now the sum for all the LineStrings (for length) and (non-intersecting) Polygons instead of the last drawn shape.
+The length/area is written to geojson properties per feature so if you need to access measurement for the latest feature it's still there like this:
+
+```javascript
+    {
+        data : {
+             length : 0,
+             area : 39696895.99975586
+        },
+        geojson : {
+            features : [{ geometry: ..., properties : {
+                    area : 20396544
+                },
+                { geometry: ..., properties : {
+                    area : 19300351.99975586
+                }]
+        }
+    }
+```
+
+To get the same information you can do `event.geojson.features[event.geojson.features.length - 1].properties.area`, but it makes more sense to have the sum on the data block instead of measures for the latest feature in a collection of features. Note! If you have just one feature ever this works like before.
+
 ## 1.44
 
 ### [mod] [breaking] AddLayerListFilterRequest

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -668,6 +668,13 @@ Oskari.clazz.define(
                 me._showIntersectionWarning = true;
                 me._mode = '';
                 me._sketch = null;
+
+                // send isFinished when user stops modifying the feature
+                // (the user might make another edit, but at least he/she let go of the mouse button etc)
+                var opts = jQuery.extend({}, options);
+                opts.isFinished = true;
+                me.sendDrawingEvent(me._id, opts);
+
                 me.toggleDrawLayerChangeFeatureEventHandler(false);
                 me.modifyFeatureChangeEventCallback = null;
             });

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -124,10 +124,11 @@ Oskari.clazz.define(
             // creating layer for drawing (if layer not already added)
             if(!me.getCurrentDrawLayer()) {
                 me.addVectorLayer(me.getCurrentLayerId());
-                // BUG: this doesn't get assigned if drawlayer already exists!!!!!!!!
-                me._functionalityIds[id] = me._layerId;
-
             }
+
+            // always assign layerId for functionality id
+            me._functionalityIds[id] = me.getCurrentLayerId();
+
             //activate drawcontrols
             if(shape) {
                 me.drawShape(shape, options);

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -11,7 +11,6 @@ Oskari.clazz.define(
     function () {
         this._clazz = 'Oskari.mapping.drawtools.plugin.DrawPlugin';
         this._name = 'GenericDrawPlugin';
-        this._gfiReqBuilder = Oskari.requestBuilder('MapModulePlugin.GetFeatureInfoActivationRequest');
         this._bufferedFeatureLayerId = 'BufferedFeatureDrawLayer';
         this._styleTypes = ['draw', 'modify', 'intersect'];
         this._styles = {};
@@ -71,6 +70,16 @@ Oskari.clazz.define(
                 me._styles[type] = me.getMapModule().getStyle(styleDef);
             });
         },
+        setGFIEnabled : function(enabled) {
+            var reqBuilder = Oskari.requestBuilder('MapModulePlugin.GetFeatureInfoActivationRequest');
+            if (!reqBuilder) {
+                // GFI functionality not available
+                return;
+            }
+            // enable (resume showing gfi popups after drawing is completed)
+            // or disable (when drawing in progress to not generate popups on clicks)
+            this.getSandbox().request(this, reqBuilder(!!enabled));
+        },
         /**
          * @method draw
          * - activates draw and modify controls
@@ -98,9 +107,7 @@ Oskari.clazz.define(
             // use default style if options don't include custom style
             var me = this;
             //disable gfi
-            if (me._gfiReqBuilder) {
-                me.getSandbox().request(me, me._gfiReqBuilder(false));
-            }
+            me.setGFIEnabled(false);
             me.removeInteractions(me._draw, me._id);
             me.removeInteractions(me._modify, me._id);
 
@@ -217,11 +224,7 @@ Oskari.clazz.define(
                 me.setVariablesToNull();
                 me.getMap().un('pointermove', me.pointerMoveHandler, me);
                 //enable gfi
-                if (me._gfiReqBuilder) {
-                    me.getSandbox().request(me, me._gfiReqBuilder(true));
-                }
-
-
+                me.setGFIEnabled(true);
             }
         },
         /**

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -51,6 +51,7 @@ Oskari.clazz.define(
         };
 
         this.wgs84Sphere = new ol.Sphere(6378137);
+        this._loc = Oskari.getLocalization('DrawTools');
     },
     {
         /**
@@ -115,8 +116,6 @@ Oskari.clazz.define(
                 options.modifyControl = true;
             }
             me.setDefaultStyle(options.style);
-
-            me._loc = Oskari.getLocalization('DrawTools', Oskari.getLang() || Oskari.getDefaultLanguage());
 
             me._sandbox = me.getSandbox();
             me._map = me.getMapModule().getMap();

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -20,7 +20,8 @@ Oskari.clazz.define(
         this._mode = "";
         this._featuresValidity = {};
         // TODO: figure out why we have some variables that are "globally reset" and some that are functionality id specific.
-        // As some are "global" resuming a previous id will probably NOT work the way expected and storing these/id probably not needed.
+        // As some are "global"/shared between functionalities resuming a previous id will probably NOT work the way expected
+        //  and storing these for each id is probably not needed.
         this._draw = {};
         this._modify = {};
         this._functionalityIds = {};
@@ -72,6 +73,11 @@ Oskari.clazz.define(
                 me._styles[type] = me.getMapModule().getStyle(styleDef);
             });
         },
+        /**
+         * Used to toggle GFI functionality off when the user is drawing to not generate popups on clicks
+         * and on after the drawing is finished to resume showing GFI popups.
+         * @param {Boolean} enabled
+         */
         setGFIEnabled : function(enabled) {
             var reqBuilder = Oskari.requestBuilder('MapModulePlugin.GetFeatureInfoActivationRequest');
             if (!reqBuilder) {

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -99,7 +99,7 @@ Oskari.clazz.define(
             var me = this;
             //disable gfi
             if (me._gfiReqBuilder) {
-                me._sandbox.request(me, me._gfiReqBuilder(false));
+                me.getSandbox().request(me, me._gfiReqBuilder(false));
             }
             me.removeInteractions(me._draw, me._id);
             me.removeInteractions(me._modify, me._id);
@@ -117,12 +117,10 @@ Oskari.clazz.define(
             }
             me.setDefaultStyle(options.style);
 
-            me._sandbox = me.getSandbox();
-            me._map = me.getMapModule().getMap();
-
             // creating layer for drawing (if layer not already added)
             if(!me._drawLayers[me._layerId]) {
                 me.addVectorLayer(me._layerId);
+                // BUG: this doesn't get assigned if drawlayer already exists!!!!!!!!
                 me._functionalityIds[id] = me._layerId;
             }
             // creating layer for buffered features (if layer not already added)
@@ -177,10 +175,10 @@ Oskari.clazz.define(
                 me.removeInteractions(me._draw, id);
                 me.removeInteractions(me._modify, id);
                 me.setVariablesToNull();
-                me._map.un('pointermove', me.pointerMoveHandler, me);
+                me.getMap().un('pointermove', me.pointerMoveHandler, me);
                 //enable gfi
                 if (me._gfiReqBuilder) {
-                    me._sandbox.request(me, me._gfiReqBuilder(true));
+                    me.getSandbox().request(me, me._gfiReqBuilder(true));
                 }
 
 
@@ -237,8 +235,8 @@ Oskari.clazz.define(
                 isFinished = options.isFinished;
             }
 
-            var event = me._sandbox.getEventBuilder('DrawingEvent')(id, geojson, data, isFinished);
-            me._sandbox.notifyAll(event);
+            var event = me.getSandbox().getEventBuilder('DrawingEvent')(id, geojson, data, isFinished);
+            me.getSandbox().notifyAll(event);
         },
         /**
          * @method addVectorLayer
@@ -253,7 +251,7 @@ Oskari.clazz.define(
               source: new ol.source.Vector({features: new ol.Collection()}),
               style: me._styles['draw']
             });
-            me._map.addLayer(vector);
+            me.getMap().addLayer(vector);
             me._drawLayers[layerId] = vector;
         },
          /**
@@ -277,9 +275,9 @@ Oskari.clazz.define(
                 }
             }
             // remove overlays
-            me._map.getOverlays().forEach(function (o) {
+            me.getMap().getOverlays().forEach(function (o) {
               if(!id || o.id === id) {
-                  me._map.removeOverlay(o);
+                  me.getMap().removeOverlay(o);
               }
             });
             jQuery('.' + me._tooltipClassForMeasure).remove();
@@ -360,13 +358,13 @@ Oskari.clazz.define(
               maxPoints: maxPoints
             });
 
-            me._map.addInteraction(me._draw[me._id]);
+            me.getMap().addInteraction(me._draw[me._id]);
 
             me.drawStartEvent(options);
             me.drawingEndEvent(options, shape);
 
             if(options.showMeasureOnMap) {
-                me._map.on('pointermove', me.pointerMoveHandler, me);
+                me.getMap().on('pointermove', me.pointerMoveHandler, me);
             }
         },
          /**
@@ -496,7 +494,7 @@ Oskari.clazz.define(
                     tooltipCoord = geom.getLastCoordinate();
                 }
                 if(me._options.showMeasureOnMap && tooltipCoord) {
-                    me._map.getOverlays().forEach(function (o) {
+                    me.getMap().getOverlays().forEach(function (o) {
                         if(o.id === me._sketch.getId()) {
                             var ii = jQuery('div.' + me._tooltipClassForMeasure + "." + me._sketch.getId());
                             ii.html(output);
@@ -531,8 +529,8 @@ Oskari.clazz.define(
                });
            }
            me.modifyStartEvent(shape, options);
-           me._map.on('pointermove', me.pointerMoveHandler, me);
-           me._map.addInteraction(me._modify[me._id]);
+           me.getMap().on('pointermove', me.pointerMoveHandler, me);
+           me.getMap().addInteraction(me._modify[me._id]);
         },
         /**
          * @method isValidJstsGeometry
@@ -678,10 +676,10 @@ Oskari.clazz.define(
             var me = this;
             if(!id || id===undefined || id === '') {
                 _.each(iteraction, function (key) {
-                    me._map.removeInteraction(key);
+                    me.getMap().removeInteraction(key);
                 });
             } else {
-                me._map.removeInteraction(iteraction[id]);
+                me.getMap().removeInteraction(iteraction[id]);
             }
         },
         setVariablesToNull: function() {
@@ -742,7 +740,7 @@ Oskari.clazz.define(
         getPolygonArea: function(geometry) {
             var area = 0;
             if (geometry && geometry.getType()==='Polygon') {
-                var sourceProj = this._map.getView().getProjection();
+                var sourceProj = this.getMap().getView().getProjection();
                 if (sourceProj.getUnits() === "degrees") {
                     var geom = geometry.clone().transform(sourceProj, 'EPSG:4326');
                     var coordinates = geom.getLinearRing(0).getCoordinates();
@@ -767,7 +765,7 @@ Oskari.clazz.define(
         getLineLength: function(geometry) {
             var length = 0;
             if(geometry && geometry.getType()==='LineString') {
-                var sourceProj = this._map.getView().getProjection();
+                var sourceProj = this.getMap().getView().getProjection();
                 if (sourceProj.getUnits() === "degrees") {
                     var coordinates = geometry.getCoordinates();
                     for (var i = 0, ii = coordinates.length - 1; i < ii; ++i) {
@@ -909,7 +907,7 @@ Oskari.clazz.define(
            });
            tooltipElement.parentElement.style.pointerEvents = 'none';
            tooltip.id = id;
-           me._map.addOverlay(tooltip);
+           me.getMap().addOverlay(tooltip);
        },
        getLayerIdForFunctionality : function(id) {
            var me = this,

--- a/bundles/mapping/mapmodule/plugin/AbstractMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/AbstractMapModulePlugin.js
@@ -71,8 +71,10 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.AbstractMapModulePlugin',
                 this._mapModule = mapModule;
                 this._map = mapModule.getMap();
                 this._pluginName = mapModule.getName() + this._name;
-                this._loc =
-                    mapModule.getLocalization('plugin', true)[this._name];
+                if(Object.keys(this._loc).length === 0) {
+                    // don't blindly overwrite if localization already has some content
+                    this._loc = mapModule.getLocalization('plugin', true)[this._name] || {};
+                }
             }
         },
         /**


### PR DESCRIPTION
This PR does too much as there's a lot of code moved around, changed variable references to more meaningful names and method calls. Some of the weird variables are commented with TODOs.  Also solves these actual problems:

# Empty features after drawing

Fixed an issue where: 

1) Draw a shape (like Polygon) with functionality id 1
2) Draw another type of shape (like LineString) with functionality id 2
3) Draw the same shape as in step 1 with functionality id 3

Resulted in DrawingEvents on step 3 to have an empty features array. Features the user draws are now sent correctly.

# Measures for features

Length and area information in the event are now the sum for all the LineStrings (for length) and (non-intersecting) Polygons instead of the last drawn shape. To get the same information as before you can do `event.geojson.features[event.geojson.features.length - 1].properties.area`, but it makes more sense to have the sum on the data block instead of measures for the latest feature in a collection of features.

Notes:

- If you have just one feature ever this works like before.
- Only lines and polygons are counted for the area/length (circles/points with buffers are not).
- The measurements are for non-buffered features.