### PR TITLE
Fix for editing published maps with thematic maps functionality

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -11,6 +11,8 @@ Fixed issues:
 #### VectorLayerPlugin ol2/ol3
 
 Fixed an error when ``MapModulePlugin.RemoveFeaturesFromMapRequest`` is used to remove features from layer which has none.
+Fixed an error when ``MapModulePlugin.RemoveFeaturesFromMapRequest`` is used to remove features from layer that is not on the map (now ignores the call, previously cleared all features from all layers).
+Fixed an error introduced in 1.44.0 where ``MapModulePlugin.AddFeaturesToMapRequest`` with priority value resulted in a JavaScript error.
 
 ### publisher2
 
@@ -32,6 +34,11 @@ Refactored the code for the functionality to make it more accessible.
 ### Data sanitation
 
 Improved security by sanitizing values.
+
+### statistics/statsgrid2016
+
+Fixed an issue where publisher tools couldn't restore thematic maps functionality (for editing) from a previously saved published map.
+This resulted in thematic maps functionality being removed from the published map on edit.
 
 ## 1.44.0
 

--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -125,7 +125,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
 
             _.each(me.tools, function(tool){
 
-                if (tool.isDisplayed()) {
+                if (tool.isDisplayed(me.data)) {
                     var value = tool.getValues();
                     if (value !== undefined && value !== null) {
                         me._extendRecursive(values, value);
@@ -161,7 +161,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
             var me = this;
             _.each(me.tools, function(tool) {
                 //don't call for tools that already have been set enabled (=plugin has already been created.)
-                if (tool.isDisplayed() && !tool.isShownInToolsPanel() && !tool.state.enabled) {
+                if (tool.isDisplayed(me.data) && !tool.isShownInToolsPanel() && !tool.state.enabled) {
                     tool.setEnabled(true);
                 }
             });
@@ -644,7 +644,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
                 tools = me.tools;
 
             _.each(me.tools, function(tool) {
-                if (tool.isDisplayed() && tool.isStarted()) {
+                if (tool.isDisplayed(me.data) && tool.isStarted()) {
                     //reset
                     tool.setEnabled(false);
                     tool.setEnabled(true);

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -295,7 +295,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
             // group tools per tool-group
             _.each(definedTools, function(ignored, toolname) {
                 var tool = Oskari.clazz.create(toolname, sandbox, mapmodule, me.loc, me.instance, me.getHandlers());
-                if(tool.isDisplayed() === true && tool.isShownInToolsPanel()) {
+                if(tool.isDisplayed(me.data) === true && tool.isShownInToolsPanel()) {
                     var group = tool.getGroup();
                     if(!grouping[group]) {
                         grouping[group] = [];
@@ -304,7 +304,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                     grouping[group].push(tool);
                 }
 
-                if (tool.isDisplayed() === true) {
+                if (tool.isDisplayed(me.data) === true) {
                     allTools.push(tool);
                 }
             });

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol2.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol2.js
@@ -231,8 +231,8 @@ Oskari.clazz.define(
                     delete this._features[layerId];
                 }
             }
-            // Removes all features from all layers
-            else {
+            // Removes all features from all layers if layer is not specified
+            else if(!layer) {
                 for (layerId in me._olLayers) {
                     if (me._olLayers.hasOwnProperty(layerId)) {
                         olLayer = me._olLayers[layerId];

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol3.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol3.js
@@ -487,6 +487,8 @@ Oskari.clazz.define(
                 });
 
                 if (options.prio && !isNaN(options.prio)) {
+                    // clear any features since we are re-adding the same features sorted by priority
+                    vectorSource.clear();
                     me._features[options.layerId].sort(function(a, b) {
                         return b.prio - a.prio;
                     });

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol3.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol3.js
@@ -239,8 +239,8 @@ Oskari.clazz.define(
                     delete this._features[layerId];
                 }
             }
-            // Removes all features from all layers
-            else {
+            // Removes all features from all layers if layer is not specified
+            else if(!layer) {
                 for (layerId in me._olLayers) {
                     if (me._olLayers.hasOwnProperty(layerId)) {
                         olLayer = me._olLayers[layerId];

--- a/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
+++ b/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
@@ -244,6 +244,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function(inst
         });
 
         me.service.on('StatsGrid.RegionSelectedEvent', function(event){
+            // FIXME: this needs some serious optimization
+            // we need previous selection from event so we can update the style
+            //  for 2 features instead of ALL the regions
             me.render(event.getRegion());
         });
 

--- a/bundles/statistics/statsgrid2016/instance.js
+++ b/bundles/statistics/statsgrid2016/instance.js
@@ -344,6 +344,7 @@ Oskari.clazz.define(
         },
         /**
          * @method  @public showLegendOnMap Render published  legend
+         * This method is also used to setup functionalities for publisher preview
          */
         showLegendOnMap: function(enabled){
             var me = this;
@@ -375,7 +376,7 @@ Oskari.clazz.define(
 
         /**
          * @method  @public enableClassification change published map classification visibility.
-         * @param  {Boolean} visible visible or not
+         * @param  {Boolean} enabled allow user to change classification or not
          */
         enableClassification: function(enabled) {
             if(!this.plugin) {

--- a/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
@@ -23,7 +23,7 @@ function() {
         var me = this;
 
         var stats = Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid');
-        if(stats && this.isDisplayed()) {
+        if(stats && this.isDisplayed(pdata)) {
             stats.showLegendOnMap(true);
         }
         if (pdata && Oskari.util.keyExists(pdata, 'configuration.statsgrid.conf') && pdata.configuration.statsgrid.conf.allowClassification !== false) {
@@ -107,10 +107,18 @@ function() {
     *
     * @returns {Boolean} is tool displayed
     */
-    isDisplayed: function() {
-        var me = this,
-            statsLayer = me._getStatsLayer();
-        return statsLayer !== null;
+    isDisplayed: function(data) {
+        var configExists = Oskari.util.keyExists(data, 'configuration.statsgrid.conf');
+        if(!configExists) {
+            return false;
+        }
+        if(!Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid')) {
+            Oskari.log('Oskari.mapframework.publisher.tool.ClassificationTool')
+                .warn("Published map had config, but current appsetup doesn't include StatsGrid! " +
+                  "The thematic map functionality will be removed if user saves the map!!");
+            return false;
+        }
+        return true;
     },
     getValues: function() {
         var me = this,

--- a/bundles/statistics/statsgrid2016/publisher/StatsTableTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/StatsTableTool.js
@@ -99,10 +99,18 @@ function() {
     *
     * @returns {Boolean} is tool displayed
     */
-    isDisplayed: function() {
-        var me = this,
-            statsLayer = me._getStatsLayer();
-        return statsLayer !== null;
+    isDisplayed: function(data) {
+        var configExists = Oskari.util.keyExists(data, 'configuration.statsgrid.conf');
+        if(!configExists) {
+            return false;
+        }
+        if(!Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid')) {
+            Oskari.log('Oskari.mapframework.publisher.tool.ClassificationTool')
+                .warn("Published map had config, but current appsetup doesn't include StatsGrid! " +
+                  "The thematic map functionality will be removed if user saves the map!!");
+            return false;
+        }
+        return true;
     },
     getValues: function() {
         var me = this,

--- a/bundles/statistics/statsgrid2016/service/StateService.js
+++ b/bundles/statistics/statsgrid2016/service/StateService.js
@@ -74,6 +74,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
          * @param {String} componentId component id
          */
         toggleRegion : function(region, componentId) {
+            // TODO: why does this need componentId?
             var me = this;
 
             // if region is same than previous then unselect region
@@ -86,6 +87,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
                 me.activeRegion = region;
                 // notify
                 var eventBuilder = Oskari.eventBuilder('StatsGrid.RegionSelectedEvent');
+                // TODO: send which region was deselected so implementations can optimize rendering!!!!
                 me.sandbox.notifyAll(eventBuilder(me.getRegionset(), region, null, componentId));
             }, 100);
         },


### PR DESCRIPTION
The thematic maps features were not restored properly when editing published maps.

Also fixes issues with VectorLayerPlugin:

- Fixed an error when ``MapModulePlugin.RemoveFeaturesFromMapRequest`` is used to remove features from layer that is not on the map (now ignores the call, previously cleared all features from all layers).
- Fixed an error introduced in 1.44.0 where ``MapModulePlugin.AddFeaturesToMapRequest`` with priority value resulted in a JavaScript error.