### PR TITLE
Vectorlayer handling improvement

### DIFF
--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol2.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol2.js
@@ -522,7 +522,7 @@ Oskari.clazz.define(
                     center = new OpenLayers.LonLat((right - ((right - left) / 2)), (top - ((top - bottom) / 2)));
                 }
 
-                mapmoveRequest = me._sandbox.getRequestBuilder('MapMoveRequest')(center.x, center.y, bounds);
+                mapmoveRequest = Oskari.requestBuilder('MapMoveRequest')(center.x, center.y, bounds);
                 me._sandbox.request(me, mapmoveRequest);
 
                 // Check scale if defined so. Scale decreases when the map is zoomed in. Scale increases when the map is zoomed out.
@@ -534,20 +534,15 @@ Oskari.clazz.define(
                 }
             }
 
-            if(options.showLayer && !mapLayerService.findMapLayer(options.layerId)) {
-                mapLayerService.addLayer(layer);
-
-                var requestBuilder = me._sandbox.getRequestBuilder(
-                    'AddMapLayerRequest'
-                );
-                if (requestBuilder) {
-                    var request = requestBuilder(layer.getId());
+            if(options.showLayer) {
+                if(!mapLayerService.findMapLayer(options.layerId)) {
+                    mapLayerService.addLayer(layer);
+                }
+                if(!me._sandbox.findMapLayerFromSelectedMapLayers(options.layerId)) {
+                    var request = Oskari.requestBuilder('AddMapLayerRequest')(layer.getId());
                     me._sandbox.request(me, request);
                 }
-
-            }
-
-            if(options.showLayer) {
+                // not too sure about this logic and if we can assume AddMapLayerRequest is sync
                 olLayer.display(!!me._sandbox.findMapLayerFromSelectedMapLayers(options.layerId) && layer.isVisible());
             }
         },

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol3.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol3.js
@@ -524,8 +524,8 @@ Oskari.clazz.define(
             // notify other components that features have been added
             var formatter = this._supportedFormats.GeoJSON;
             var sandbox = this.getSandbox();
-            var addEvent = sandbox.getEventBuilder('FeatureEvent')().setOpAdd();
-            var errorEvent = sandbox.getEventBuilder('FeatureEvent')().setOpError('feature has no geometry');
+            var addEvent = Oskari.eventBuilder('FeatureEvent')().setOpAdd();
+            var errorEvent = Oskari.eventBuilder('FeatureEvent')().setOpError('feature has no geometry');
 
             _.forEach(features, function(feature) {
                 var geojson = formatter.writeFeaturesObject([feature]);
@@ -555,21 +555,18 @@ Oskari.clazz.define(
                 }
             }
 
-            if(options.showLayer && !mapLayerService.findMapLayer(options.layerId)) {
-                mapLayerService.addLayer(layer);
-
-                var requestBuilder = me._sandbox.getRequestBuilder(
-                    'AddMapLayerRequest'
-                );
-                if (requestBuilder) {
-                    var request = requestBuilder(layer.getId());
+            if(options.showLayer) {
+                if(!mapLayerService.findMapLayer(options.layerId)) {
+                    mapLayerService.addLayer(layer);
+                }
+                if(!me._sandbox.findMapLayerFromSelectedMapLayers(options.layerId)) {
+                    var request = Oskari.requestBuilder('AddMapLayerRequest')(layer.getId());
                     me._sandbox.request(me, request);
                 }
-            }
-
-            if(options.showLayer) {
+                // not too sure about this logic and if we can assume AddMapLayerRequest is sync
                 olLayer.setVisible(!!me._sandbox.findMapLayerFromSelectedMapLayers(options.layerId) && layer.isVisible());
             }
+
         },
          /**
          * @method _updateFeature


### PR DESCRIPTION
Vectorlayer that has been removed from the map (with for example RemoveMapLayerRequest) is now correcly re-added with AddFeaturesToMapRequest when using showLayer=true. This fixes an issue where the vectorlayer was previously shown on the map, but wasn't part of the selected layers state if the layer was removed from the map.