### PR TITLE
Feature data button fixes: show/hide & styling

### DIFF
--- a/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
+++ b/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
@@ -71,9 +71,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
             el.mousedown(function (event) {
                 event.stopPropagation();
             });
-            if (!me._hasFeaturedataLayers()) {
-                el.hide();
-            }
+
             return el;
         },
         /**
@@ -118,6 +116,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
             } else {
                 me._element = me._createControlElement();
                 this.addToPluginContainer(me._element);
+                this.refresh();
             }
         },
 
@@ -185,7 +184,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
             me._resetMobileIcon(el, me._mobileDefs.buttons['mobile-featuredata'].iconCls);
         },
         /**
-         * @method _refresh
+         * @method refresh
          * Updates the plugins interface (hides if no featuredata layer selected)
          */
         refresh: function () {
@@ -193,12 +192,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
                 isVisible = me._hasFeaturedataLayers(),
                 conf = me._config;
 
-            if(this.getElement()) {
-                this.getElement().hide();
-            }
-            if(isVisible && this.getElement()){
-              this.getElement().show();
-            }
             me.setVisible(isVisible);
 
             // Change the style if in the conf


### PR DESCRIPTION
Feature data button now gets all of its styles when recreated. Removed unnecessary show/hide code (already handled by BasicMapModulePlugin setVisible()-method).

In reference to:
https://jira.nls.fi/browse/AH-4124