### PR TITLE
Remove env variables handling from mapfull bundle

### DIFF
--- a/bundles/admin/appsetup/instance.js
+++ b/bundles/admin/appsetup/instance.js
@@ -47,7 +47,7 @@ Oskari.clazz.define("Oskari.admin.bundle.appsetup.AppSetupAdminBundleInstance",
 
             var content = me._templates.tabContent.clone();
             var description = content.find('.appsetup__description');
-            var currentViewUrl = me.sandbox.getAjaxUrl('Views') + '&uuid=' + controlParams.uuid;
+            var currentViewUrl = me.sandbox.getAjaxUrl('Views') + '&uuid=' + Oskari.app.getUuid();
             description.html('<div>' + me._localization.description.fillJSON + ' ' +
                 '(<a href="' + currentViewUrl + '" target="_blank">' + me._localization.description.current + '</a>).</div>' +
                 '<div>' + this._localization.description.differentUuid + '</div>'

--- a/bundles/framework/feedbackService/instance.js
+++ b/bundles/framework/feedbackService/instance.js
@@ -97,8 +97,7 @@ function () {
         var me = this;
         params = params || {};
         // Add view uuid for the request for to access view metadata
-        //FIXME: Store current view uuid to Oskari globals and use it via Oskari.
-        params['uuid'] = window.controlParams['uuid'];
+        params['uuid'] = Oskari.app.getUuid();
         if(typeof params.payload === 'object') {
             params.payload = JSON.stringify(params.payload);
         }

--- a/bundles/framework/mapfull/instance.js
+++ b/bundles/framework/mapfull/instance.js
@@ -216,10 +216,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
                 me.contentMapDivId = conf.mapContainer;
             }
 
-            // Init user
-            Oskari.user(conf.user);
-            sandbox.setAjaxUrl(conf.globalMapAjaxUrl);
-
             // create services & enhancements
             var services = me._createServices(conf);
             services.forEach(function(service) {


### PR DESCRIPTION
Mapfull bundle no longer receives user or globalMapAjaxUrl in config after oskariorg/oskari-server#111 has been merged. Without this change the frontend won't function correctly as the mapfull bundle resets the variables set from appsetup.env.

Also updates bundles depending on a global controlParams variable to use the new Oskari.app.getUuid() method.