### PR TITLE
Publisher now sends UUID of the appsetup it was used in

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -15,6 +15,11 @@ Some extra tags:
 
 Timeseries functionality rewrite. Old event & request removed.
 
+### [rem] [breaking] mapfull configuration
+
+Mapfull no longer receives or handles "globalMapAjaxUrl" and "user" in bundle configuration. Handling has been moved to Oskari.app.init().
+If you haven't implemented a custom version of "mapfull" bundle or the Oskari-global this has no effect.
+
 ## 1.44.1
 
 ### [mod] [rpc] DrawingEvent

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -378,7 +378,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
             draggables.draggable('destroy');
             jQuery('.mappluginsContent.ui-droppable').droppable('destroy');
 
-            var event = sandbox.getEventBuilder('LayerToolsEditModeEvent')(false);
+            var event = Oskari.eventBuilder('LayerToolsEditModeEvent')(false);
             sandbox.notifyAll(event);
         },
 
@@ -474,17 +474,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                 type: 'POST',
                 dataType: 'json',
                 data: {
+                    publishedFrom: Oskari.app.getUuid(),
                     uuid: (me.data && me.data.uuid) ? me.data.uuid : undefined,
                     pubdata: JSON.stringify(selections)
                 },
-                beforeSend: function (x) {
-                    if (x && x.overrideMimeType) {
-                        x.overrideMimeType('application/j-son;charset=UTF-8');
-                    }
-                },
                 success: function (response) {
                     if (response.id > 0) {
-                        var event = sandbox.getEventBuilder(
+                        var event = Oskari.eventBuilder(
                             'Publisher.MapPublishedEvent'
                         )(
                             response.id,


### PR DESCRIPTION
In preparation of enabling multiple projection support. After this the server can use mapOptions (projection, zoomlevels etc) from the appsetup sent as "publishedFrom" parameter instead of using the ones in "publish template" appsetup.