### PR TITLE
Timeseries improvements

### DIFF
--- a/api/mapping/timeseries/bundle.md
+++ b/api/mapping/timeseries/bundle.md
@@ -62,6 +62,18 @@ After registering the new type, TimeseriesLayerService will create delegates aut
 No configuration is required.
 
 
+## Requests the bundle sends out
+
+<table class="table">
+  <tr>
+    <th> Request </th><th> Where/why it's used</th>
+  </tr>
+  <tr>
+    <td>MapModulePlugin.MapLayerUpdateRequest</td><td> When WMSAnimator changes the current TIME parameter in the WMS url</td>
+  </tr>
+</table>
+
+
 ## Events the bundle listens to
 
 <table class="table">

--- a/bundles/framework/timeseries/WMSAnimator.js
+++ b/bundles/framework/timeseries/WMSAnimator.js
@@ -9,13 +9,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.WMSAnimator',
         this._layer = this._sandbox.findMapLayerFromSelectedMapLayers(layerId);
 
         var times = this.getTimes();
-        this._currentTime = times[times.length - 1];
+        this._currentTime = times[0];
         this._subsetRange = [times[0], times[times.length - 1]];
 
         this._doneCallback = null;
         this._isBuffering = false;
         this._isLoading = false;
-
+        
         this._sandbox.register(this);
         var p;
         for (p in this.__eventHandlers) {
@@ -23,6 +23,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.WMSAnimator',
                 sandbox.registerForEventByName(this, p);
             }
         }
+        this.requestNewTime(this._currentTime, null, function(){});
     }, {
         __name: 'WMSAnimator',
         getName: function () {

--- a/bundles/framework/timeseries/resources/css/timeseriesplayback.css
+++ b/bundles/framework/timeseries/resources/css/timeseriesplayback.css
@@ -30,6 +30,9 @@
   fill: #333;
   stroke: none;
 }
+.timeline-svg g.tick text.bold {
+  font-weight: 600;
+}
 .timeseries-menus label.oskari-select {
   color: #333;
 }

--- a/bundles/framework/timeseries/resources/css/timeseriesplayback.css
+++ b/bundles/framework/timeseries/resources/css/timeseriesplayback.css
@@ -177,8 +177,8 @@
   height: 40px;
   margin: 0 0 0 10px;
   text-align: left;
-  line-height: 40px;
-  font-size: 15px;
+  line-height: 42px;
+  font-size: 13px;
 }
 .timeseries-timelines{
   display: inline-block;

--- a/bundles/framework/timeseries/resources/css/timeseriesplayback.css
+++ b/bundles/framework/timeseries/resources/css/timeseriesplayback.css
@@ -191,6 +191,7 @@
 }
 svg.timeline-svg{
   display: block;
+  overflow: hidden;
 }
 
 /* mobile mode */

--- a/bundles/framework/timeseries/resources/locale/en.js
+++ b/bundles/framework/timeseries/resources/locale/en.js
@@ -22,7 +22,7 @@ Oskari.registerLocalization(
             "week": "1 week",
             "month": "1 month"
         },
-        "dateRender": "{val, date, short} {val, time, short}",
+        "dateRender": "{val, date} {val, time, short}",
         "alert": {
             "title": "Warning",
             "message": "Multiple layers with timeseries selected. Only topmost can be controlled.",

--- a/bundles/framework/timeseries/resources/locale/en.js
+++ b/bundles/framework/timeseries/resources/locale/en.js
@@ -24,8 +24,8 @@ Oskari.registerLocalization(
         },
         "dateRender": "{val, date} {val, time, short}",
         "alert": {
-            "title": "Warning",
-            "message": "Multiple layers with timeseries selected. Only topmost can be controlled.",
+            "title": "Multiple layers with timeseries in use",
+            "message": "You can only control the topmost layer.",
             "ok": "OK"
         }
     }

--- a/bundles/framework/timeseries/resources/locale/fi.js
+++ b/bundles/framework/timeseries/resources/locale/fi.js
@@ -22,7 +22,7 @@ Oskari.registerLocalization(
             "week": "1 viikko",
             "month": "1 kuukausi"
         },
-        "dateRender": "{val, date, short} {val, time, short}",
+        "dateRender": "{val, date} {val, time, short}",
         "alert": {
             "title": "Huom!",
             "message": "Useita aikasarjatasoja valittu. Vain päällimmäistä voi ohjata.",

--- a/bundles/framework/timeseries/resources/locale/fi.js
+++ b/bundles/framework/timeseries/resources/locale/fi.js
@@ -24,8 +24,8 @@ Oskari.registerLocalization(
         },
         "dateRender": "{val, date} {val, time, short}",
         "alert": {
-            "title": "Huom!",
-            "message": "Useita aikasarjatasoja valittu. Vain päällimmäistä voi ohjata.",
+            "title": "Useita aikasarjatasoja valittu",
+            "message": "Voit ohjata vain päällimmäistä tasoa.",
             "ok": "OK"
         },
         "d3TimeDef": {

--- a/bundles/framework/timeseries/resources/locale/sv.js
+++ b/bundles/framework/timeseries/resources/locale/sv.js
@@ -22,7 +22,7 @@ Oskari.registerLocalization(
             "week": "1 vecka",
             "month": "1 månad"
         },
-        "dateRender": "{val, date, short} {val, time, short}",
+        "dateRender": "{val, date} {val, time, short}",
         "alert": {
             "title": "Obs!",
             "message": "Flera kartlager med tidsserier är valda. Bara den översta kan kotrolleras.",

--- a/bundles/framework/timeseries/resources/locale/sv.js
+++ b/bundles/framework/timeseries/resources/locale/sv.js
@@ -24,8 +24,8 @@ Oskari.registerLocalization(
         },
         "dateRender": "{val, date} {val, time, short}",
         "alert": {
-            "title": "Obs!",
-            "message": "Flera kartlager med tidsserier är valda. Bara den översta kan kotrolleras.",
+            "title": "Flera kartlager med tidsserier är valda",
+            "message": "Bara den översta kan kontrolleras.",
             "ok": "OK"
         },
         "d3TimeDef": {

--- a/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
@@ -13,13 +13,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
         conf = conf || {};
         var me = this;
         me._clazz = 'Oskari.mapframework.bundle.timeseries.TimeseriesControlPlugin';
-        me._defaultLocation = conf.location || 'bottom center';
+        me._defaultLocation = conf.location || 'top left';
         me._index = 90;
         me._name = 'TimeseriesControlPlugin';
         me._timelineWidth = 600;
         me.loc = Oskari.getMsg.bind(null, 'timeseries');
         me._d3TimeDef = Oskari.getLocalization('timeseries').d3TimeDef;
-        me._sideMargin = conf.sideMargin || 10;
+        me._widthMargin = conf.widthMargin || 130;
         me._waitingForFrame = false;
 
         me._delegate = delegate;
@@ -289,10 +289,18 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
                 me._setWidth(me.getSandbox().getMap().getWidth(), true);
                 me._element.prepend(aux);
                 me._initMenus();
+                me._makeDraggable();
             }
             me._initStepper();
             me._updateTimelines(isMobile);
             me._updateTimeDisplay();
+        },
+        _makeDraggable: function () {
+            this._element.prepend('<div class="timeseries-handle oskari-flyoutheading"></div>');
+            this._element.draggable({
+                scroll: false,
+                handle: '.timeseries-handle'
+            });
         },
         /**
          * @method _setWidth Set timeline width and update them if needed
@@ -301,7 +309,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
          * @param {Boolean} suppressUpdate true if no timelines update should be done
          */
         _setWidth: function (mapWidth, suppressUpdate) {
-            var targetWidth = Math.min(mapWidth - this._sideMargin, 860) - 260;
+            var targetWidth = Math.min(mapWidth - this._widthMargin, 860) - 260;
             if (!this._inMobileMode && this._timelineWidth !== targetWidth) {
                 this._timelineWidth = targetWidth;
                 if (!suppressUpdate) {

--- a/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
@@ -390,13 +390,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
                 formatYear = formatterFunction("%Y");
 
             return function multiFormat(date) {
+                var textEl = d3.select(this);
                 return (d3.timeSecond(date) < date ? formatMillisecond
                     : d3.timeMinute(date) < date ? formatSecond
                     : d3.timeHour(date) < date ? formatMinute
                     : d3.timeDay(date) < date ? formatHour
                     : d3.timeMonth(date) < date ? formatDay
                     : d3.timeYear(date) < date ? formatMonth
-                    : formatYear)(date);
+                    : (textEl.classed('bold', true), formatYear))(date);
             }
         },
         /**

--- a/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
@@ -35,12 +35,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
         };
         me._setFrameInterval(me._uiState.frameInterval); // sets throttle for animation, too
         me._throttleNewTime = Oskari.util.throttle(me._requestNewTime.bind(me), 500);
-
         this._uiState.times = delegate.getTimes();
         var range = delegate.getSubsetRange();
         this._uiState.rangeStart = range[0];
         this._uiState.rangeEnd = range[1];
         this._uiState.currentTime = delegate.getCurrentTime();
+        this._validSkipOptions = this._filterSkipOptions(this._uiState.times);
 
         me._isMobileVisible = false;
         me._inMobileMode = false;
@@ -68,6 +68,39 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
         };
     }, {
         __fullAxisYPos: 35,
+        __speedOptions: [
+            { key: 'fast', value: 1000 },
+            { key: 'normal', value: 2000 },
+            { key: 'slow', value: 3000 }
+        ],
+        __skipOptions : [
+            { key: 'none', value: '' },
+            { key: 'minute', value: 'minutes' },
+            { key: 'hour', value: 'hours' },
+            { key: 'day', value: 'days' },
+            { key: 'week', value: 'weeks' },
+            { key: 'month', value: 'months' }
+        ],
+        /**
+         * @method _filterSkipOptions Return animation skip options that are longer or as long than the shortest time interval in the series
+         * @private
+         * @param  {String[]} times time instants in timeseries, ISO-string
+         */
+        _filterSkipOptions: function (times) {
+            times = times.map(function (t) { return moment(t) }); // optimization: parse time strings once
+            var shortestInterval = Number.MAX_VALUE;
+            for (var i = 0; i < times.length - 1; i++) {
+                var current = times[i];
+                var next = times[i+1];
+                var difference = next.diff(current);
+                if(difference < shortestInterval) {
+                    shortestInterval = difference;
+                }
+            }
+            return this.__skipOptions.filter(function (option) {
+                return option.value === '' || moment.duration(1, option.value).asMilliseconds() >= shortestInterval;
+            });
+        },
         /**
          * @method _setFrameInterval Sets animation frame interval & updates associated throttle function
          * @private
@@ -301,11 +334,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
             var template = jQuery('<div class="timeseries-menus"><div class="timeseries-menus-half"></div><div class="timeseries-menus-half"></div></div>');
 
             var speedMenu = Oskari.clazz.create('Oskari.userinterface.component.Select');
-            speedMenu.setOptions(this._generateSelectOptions('animationSpeed.', [
-                { key: 'fast', value: 1000 },
-                { key: 'normal', value: 2000 },
-                { key: 'slow', value: 3000 }
-            ]));
+            speedMenu.setOptions(this._generateSelectOptions('animationSpeed.', this.__speedOptions));
             speedMenu.setTitle(this.loc('label.animationSpeed'));
             speedMenu.setValue(this._uiState.frameInterval);
             speedMenu.setHandler(function (value) {
@@ -315,14 +344,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
             template.find('.timeseries-menus-half').first().append(speedMenu.getElement());
 
             var skipMenu = Oskari.clazz.create('Oskari.userinterface.component.Select');
-            skipMenu.setOptions(this._generateSelectOptions('skip.', [
-                { key: 'none', value: '' },
-                { key: 'minute', value: 'minutes' },
-                { key: 'hour', value: 'hours' },
-                { key: 'day', value: 'days' },
-                { key: 'week', value: 'weeks' },
-                { key: 'month', value: 'months' }
-            ]));
+            skipMenu.setOptions(this._generateSelectOptions('skip.', this._validSkipOptions));
             skipMenu.setTitle(this.loc('label.skipAhead'));
             skipMenu.setValue(this._uiState.stepInterval);
             skipMenu.setHandler(function (value) {


### PR DESCRIPTION
- Default current time: start of time series
- Full year in date presentation
- Warning if multiple timeseries text updates
- Axis labels for years in bold
- Show only skip options that are longer than shortest time interval
- CSS fix for IE11
- Timeseries UI is now draggable

In reference to:
https://jira.nls.fi/browse/AH-3995

Depends on #169 