### PR TITLE
Featuredata2 feature selection by drawing fix

### DIFF
--- a/bundles/framework/featuredata2/instance.js
+++ b/bundles/framework/featuredata2/instance.js
@@ -414,25 +414,30 @@ Oskari.clazz.define("Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
             },
             'DrawingEvent': function(evt) {
                 var me = this;
-                if( evt._isFinished ) {
-                    if (!me.selectionPlugin) {
-                        me.selectionPlugin = me.sandbox.findRegisteredModuleInstance('MainMapModuleMapSelectionPlugin');
-                    }
-                    var geojson = evt.getGeoJson();
-                    var pixelTolerance = 15;
-                    if( geojson.features.length > 0 ) {
-                        geojson.features[0].properties.buffer_radius = me.selectionPlugin.getMapModule().getResolution() * pixelTolerance;
-                    } else {
-                        //no features
-                        return;
-                    }
-                    me.selectionPlugin.setFeatures(geojson.features);
-                    // me.selectionPlugin.setDrawing(evt.getOLDrawing());
-                    me.selectionPlugin.stopDrawing(true);
-
-                    var event = me.sandbox.getEventBuilder("WFSSetFilter")(geojson);
-                    me.sandbox.notifyAll(event);
+                if (!evt.getIsFinished()) {
+                    // only interested in finished drawings
+                    return;
                 }
+                if (!me.selectionPlugin) {
+                    me.selectionPlugin = me.sandbox.findRegisteredModuleInstance('MainMapModuleMapSelectionPlugin');
+                }
+                if (me.selectionPlugin.DRAW_REQUEST_ID !== evt.getId()) {
+                    // event is from some other functionality
+                    return;
+                }
+                var geojson = evt.getGeoJson();
+                var pixelTolerance = 15;
+                if( geojson.features.length > 0 ) {
+                    geojson.features[0].properties.buffer_radius = me.selectionPlugin.getMapModule().getResolution() * pixelTolerance;
+                } else {
+                    //no features
+                    return;
+                }
+                me.selectionPlugin.setFeatures(geojson.features);
+                me.selectionPlugin.stopDrawing(true);
+
+                var event = me.sandbox.getEventBuilder("WFSSetFilter")(geojson);
+                me.sandbox.notifyAll(event);
             },
             'AfterMapMoveEvent': function() {
                 var me = this;

--- a/bundles/framework/featuredata2/plugin/MapSelectionPlugin.js
+++ b/bundles/framework/featuredata2/plugin/MapSelectionPlugin.js
@@ -20,7 +20,6 @@ Oskari.clazz.define(
         me.prefix = 'Default.';
         me.sandbox = sandbox;
         me.WFSLayerService = me.sandbox.getService('Oskari.mapframework.bundle.mapwfs2.service.WFSLayerService');
-        me._currentRequestID = null;
         me._features;
         me._drawing;
 
@@ -34,9 +33,7 @@ Oskari.clazz.define(
         me.multipart = (me._config && me._config.multipart === true);
         Oskari.makeObservable(this);
     }, {
-        getCurrentDrawReqId: function () {
-            return this._currentRequestID;
-        },
+        DRAW_REQUEST_ID: 'FeatureData.featureselection',
         /**
          * @method startDrawing
          * Activates the selection tool
@@ -51,7 +48,7 @@ Oskari.clazz.define(
             var me = this;
             var sb = this.getSandbox();
             sb.postRequestByName('DrawTools.StopDrawingRequest', [
-                    me.getCurrentDrawReqId(),
+                    me.DRAW_REQUEST_ID,
                     true,
                     false
             ]);
@@ -115,36 +112,31 @@ Oskari.clazz.define(
 
             me.drawControls = {
                 point: function() {
-                    me._currentRequestID = me.getName() +'PointDrawRequest';
                     sb.postRequestByName('DrawTools.StartDrawingRequest', [
-                    me.getName() +'PointDrawRequest', 
+                    me.DRAW_REQUEST_ID,
                     'Point'
                     ]
                 )},
                 line: function() {
-                    me._currentRequestID = me.getName() +'LineStringDrawRequest';
                     sb.postRequestByName('DrawTools.StartDrawingRequest', [
-                    me.getName() +'LineStringDrawRequest', 
+                    me.DRAW_REQUEST_ID,
                     'LineString'
                     ]
                 )},
                 polygon: function() {
-                    me._currentRequestID = me.getName() +'PolygonDrawRequest';
                     sb.postRequestByName('DrawTools.StartDrawingRequest', [
-                    me.getName() +'PolygonDrawRequest', 
+                    me.DRAW_REQUEST_ID,
                     'Polygon'
                 ])},
                 square: function() {
-                    me._currentRequestID = me.getName() +'SquareDrawRequest';
                     sb.postRequestByName('DrawTools.StartDrawingRequest', [
-                    me.getName() +'SquareDrawRequest', 
+                    me.DRAW_REQUEST_ID,
                     'Square'
                     ]
                 )},
                 circle: function() {
-                    me._currentRequestID = me.getName() +'CircleDrawRequest';
                     sb.postRequestByName('DrawTools.StartDrawingRequest', [
-                    me.getName() +'CircleDrawRequest', 
+                    me.DRAW_REQUEST_ID,
                     'Circle'
                     ]
                 )}


### PR DESCRIPTION
Previously featuredata2 reacted to any DrawingEvent from the application. This fix limits it to only react to drawing events that it has initiated. Fixes an issue where doing a measurement in a OpenLayers 4 version of geoportal resulted in a Javascript error in featuredata2 bundle.