### PR TITLE
Fix map size handling when moving from desktop to mobile view

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1169,11 +1169,13 @@ Oskari.clazz.define(
                 }
             }
 
-
             // Adjust map size always if in mobile mode because otherwise bottom tool drop out of screen
             // only reduce size if div is visible, otherwise padding will make the map smaller than it should be
             if (Oskari.util.isMobile() && mobileDiv.is(':visible')) {
-                mapDivHeight -= mobileDiv.outerHeight();
+                var totalHeight = jQuery('#contentMap').height();
+                if(totalHeight < mapDivHeight + mobileDiv.outerHeight()) {
+                    mapDivHeight -= mobileDiv.outerHeight();
+                }
                 if((mobileDiv.attr('data-height')) !== mapDivHeight.toString()) {
                     jQuery('#' + this.getMapElementId()).css('height', mapDivHeight + 'px');
                     this.updateDomain();


### PR DESCRIPTION
Fixes an issue introduced in #163 where map was resized in a loop until it was the size of the mobilebar.