### PR TITLE
Added move map to extent functionality to MapMoveByLayerContentRequest

### DIFF
--- a/api/mapping/mapmodule/request/MapModulePlugin.MapMoveByLayerContentRequest.md
+++ b/api/mapping/mapmodule/request/MapModulePlugin.MapMoveByLayerContentRequest.md
@@ -1,17 +1,18 @@
 # MapModulePlugin.MapMoveByLayerContentRequest
 
-Allows the user to move the map by layer content.
+Allows the user to move the map by the layer content.
 
 ## Use cases
 
-- Focus the map to place where layer has content
-- Focus the map to layer extent
+- Focus the map to place where the layer has content
+- Focus the map to the layer extent
 
 ## Description
 Moves the map to zoom level that is in the scale with the requested maplayer.
-Also moves the map to given layers content if it has content and there is no layer content in the current viewport.
+Also moves the map to given layers center point if it has coverage data available and there is no layer content in the current viewport
 
-Optionally requests a map to be moved to layer extent (a bounding box that encloses the layer's geometries) which is the zoom level and location where whole layer content is in the viewport.
+Optionally zooms out to show as much of the layers content as possible. Without scale limitations on the layer the whole content is shown in the viewport.
+
 
 Triggers AfterMapMoveEvent and MapLayerVisibilityChangedEvent.
 
@@ -24,10 +25,10 @@ Triggers AfterMapMoveEvent and MapLayerVisibilityChangedEvent.
   <th> Name</th><th> Type</th><th> Description</th><th> Default value</th>
 </tr>
 <tr>
-  <td> \* layerId </td><td> String </td><td> id for map layer used in </td><td> </td>
+  <td> \* layerId </td><td> String </td><td> id for the layer used in </td><td> </td>
 </tr>
 <tr>
-  <td>  zoomToExtent </td><td> Boolean </td><td> should the map to be zoomed and moved to layer extent </td><td> false </td>
+  <td>  zoomToExtent </td><td> Boolean </td><td> should the map to be zoomed and moved to the layer extent </td><td> false </td>
 </tr>
 </table>
 

--- a/api/mapping/mapmodule/request/MapModulePlugin.MapMoveByLayerContentRequest.md
+++ b/api/mapping/mapmodule/request/MapModulePlugin.MapMoveByLayerContentRequest.md
@@ -1,0 +1,57 @@
+# MapModulePlugin.MapMoveByLayerContentRequest
+
+Allows the user to move the map by layer content.
+
+## Use cases
+
+- Focus the map to place where layer has content
+- Focus the map to layer extent
+
+## Description
+Moves the map to zoom level that is in the scale with the requested maplayer.
+Also moves the map to given layers content if it has content and there is no layer content in the current viewport.
+
+Optionally requests a map to be moved to layer extent (a bounding box that encloses the layer's geometries) which is the zoom level and location where whole layer content is in the viewport.
+
+Triggers AfterMapMoveEvent and MapLayerVisibilityChangedEvent.
+
+## Parameters
+
+(* means the parameter is required)
+
+<table class="table">
+<tr>
+  <th> Name</th><th> Type</th><th> Description</th><th> Default value</th>
+</tr>
+<tr>
+  <td> \* layerId </td><td> String </td><td> id for map layer used in </td><td> </td>
+</tr>
+<tr>
+  <td>  zoomToExtent </td><td> Boolean </td><td> should the map to be zoomed and moved to layer extent </td><td> false </td>
+</tr>
+</table>
+
+## Examples
+
+Move the map to the layer content
+```javascript
+var sb = Oskari.getSandbox();
+
+var layerId = layer.getId();
+
+sb.postRequestByName('MapModulePlugin.MapMoveByLayerContentRequest', [layerId]);
+```
+
+Move and zoom the map to the layer extent
+```javascript
+var sb = Oskari.getSandbox();
+
+var layerId = layer.getId();
+
+sb.postRequestByName('MapModulePlugin.MapMoveByLayerContentRequest', [layerId, true]);
+```
+
+## Related api
+
+- AfterMapMoveEvent
+- MapLayerVisibilityChangedEvent

--- a/bundles/mapping/mapmodule/plugin/layers/LayersPlugin.ol2.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayersPlugin.ol2.js
@@ -216,6 +216,28 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin',
             return false;
         },
         /**
+         * @method getGeometryCenter
+         *
+         * @param {OpenLayers.Geometry} geometry
+         * @return {Object} centroid
+         */
+        getGeometryCenter: function (geometry){
+            var center = geometry.getCentroid();
+            return {
+                lon: center.x,
+                lat: center.y
+            };
+        },
+        /**
+         * @method getGeometryBounds
+         *
+         * @param {OpenLayers.Geometry} geometry
+         * @return {OpenLayers.Bounds} bounds
+         */
+        getGeometryBounds: function (geometry){
+            return geometry.getBounds();
+        },
+        /**
          * @method notifyLayerVisibilityChanged
          * Notifies bundles about layer visibility changes by sending MapLayerVisibilityChangedEvent.
          * @param

--- a/bundles/mapping/mapmodule/plugin/layers/LayersPlugin.ol3.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayersPlugin.ol3.js
@@ -48,7 +48,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin',
                 me._scheduleVisiblityCheck();
             },
             AfterMapLayerAddEvent: function (event) {
-                console.log('parse geometry');
                 // parse geom if available
                 me._parseGeometryForLayer(event.getMapLayer());
                 me._scheduleVisiblityCheck();

--- a/bundles/mapping/mapmodule/request/MapMoveByLayerContentRequest.js
+++ b/bundles/mapping/mapmodule/request/MapMoveByLayerContentRequest.js
@@ -12,11 +12,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.MapMoveByLayer
  *
  * @param {String}
  *            mapLayerId id of map layer used in
+ * @param {boolean} zoomToExtent (optional) if true zooms map to layer extent, default false
  * Oskari.mapframework.service.MapLayerService
  */
-function(mapLayerId) {
+function(mapLayerId, zoomToExtent) {
     this._creator = null;
     this._mapLayerId = mapLayerId;
+    this._zoomToExtent = (zoomToExtent === true);
 }, {
     /** @static @property __name request name */
     __name : "MapModulePlugin.MapMoveByLayerContentRequest",
@@ -34,6 +36,14 @@ function(mapLayerId) {
      */
     getMapLayerId : function() {
         return this._mapLayerId;
+    },
+    /**
+     * @method getZoomToExtent
+     * @return {Boolean} zoomToExtent
+     * Oskari.mapframework.service.MapLayerService
+     */
+    getZoomToExtent : function() {
+        return this._zoomToExtent;
     }
 }, {
     /**

--- a/bundles/mapping/mapmodule/request/MapMoveByLayerContentRequestHandler.js
+++ b/bundles/mapping/mapmodule/request/MapMoveByLayerContentRequestHandler.js
@@ -3,6 +3,7 @@
  * Provides functionality to:
  * - Move the map to zoom level that is in scale with the requested maplayer.
  * - Move the map to given layers geometry if it has one.
+ * - Optionally if zoomToExtent is true, then move and zoom the map to given layer's extent
  */
 Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.MapMoveByLayerContentRequestHandler',
     /**
@@ -22,6 +23,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.MapMoveByLayer
          * @method handleRequest
          * Moves the map to zoom level that is in scale with the requested maplayer.
          * Also moves the map to given layers geometry if it has one.
+         * Optionally if zoomToExtent is true, then move and zoom the map to given layer's extent
          * @param {Oskari.mapframework.core.Core} core
          *      reference to the application core (reference sandbox core.getSandbox())
          * @param {Oskari.mapframework.bundle.mapmodule.request.MapMoveByLayerContentRequest} request
@@ -29,24 +31,35 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.MapMoveByLayer
          */
         handleRequest: function (core, request) {
             var layerId = request.getMapLayerId();
+            var zoomToExtent = request.getZoomToExtent();
             var layer = this.sandbox.findMapLayerFromSelectedMapLayers(layerId);
             if (!layer) {
                 return;
             }
 
-            // set zoom level by layer scales
-            var newZoom = this.layersPlugin.getMapModule().getClosestZoomLevel(layer.getMinScale(), layer.getMaxScale());
-            // suppress mapmove-event here and send it after we have possibly also moved the map
-            this.layersPlugin.getMapModule().setZoomLevel(newZoom, true);
-
-            // move map to geometries if available
-            // this needs to be done after the zoom since it's comparing to viewport which changes in zoom
-            if (layer.getGeometry().length > 0) {
-                var containsGeometry = this.layersPlugin.isInGeometry(layer);
-                // only move if not currently in geometry
-                if (!containsGeometry) {
-                    var center = layer.getGeometry()[0].getCentroid();
-                    this.layersPlugin.getMapModule().moveMapToLonLat({ lon: center.x, lat : center.y});
+            if (zoomToExtent){
+                // move and zoom map to layer extent
+                if (layer.getGeometry().length > 0){
+                    var bounds = this.layersPlugin.getGeometryBounds(layer.getGeometry()[0]);
+                    // suppress mapmove-event
+                    this.layersPlugin.getMapModule().zoomToExtent(bounds, true, true);
+                    var center = this.layersPlugin.getGeometryCenter(layer.getGeometry()[0]);
+                    this.layersPlugin.getMapModule().moveMapToLonLat(center);
+                }
+            } else{
+                // set zoom level by layer scales
+                var newZoom = this.layersPlugin.getMapModule().getClosestZoomLevel(layer.getMinScale(), layer.getMaxScale());
+                // suppress mapmove-event here and send it after we have possibly also moved the map
+                this.layersPlugin.getMapModule().setZoomLevel(newZoom, true);
+                // move map to geometries if available
+                // this needs to be done after the zoom since it's comparing to viewport which changes in zoom
+                if (layer.getGeometry().length > 0) {
+                    var containsGeometry = this.layersPlugin.isInGeometry(layer);
+                    // only move if not currently in geometry
+                    if (!containsGeometry) {
+                        var center = this.layersPlugin.getGeometryCenter(layer.getGeometry()[0]);
+                        this.layersPlugin.getMapModule().moveMapToLonLat(center);
+                    }
                 }
             }
             // notify components that the map has moved

--- a/bundles/mapping/mapmodule/request/MapMoveByLayerContentRequestHandler.js
+++ b/bundles/mapping/mapmodule/request/MapMoveByLayerContentRequestHandler.js
@@ -33,6 +33,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.MapMoveByLayer
             var layerId = request.getMapLayerId();
             var zoomToExtent = request.getZoomToExtent();
             var layer = this.sandbox.findMapLayerFromSelectedMapLayers(layerId);
+            var newZoom;
             if (!layer) {
                 return;
             }
@@ -45,10 +46,17 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.MapMoveByLayer
                     this.layersPlugin.getMapModule().zoomToExtent(bounds, true, true);
                     var center = this.layersPlugin.getGeometryCenter(layer.getGeometry()[0]);
                     this.layersPlugin.getMapModule().moveMapToLonLat(center);
+
+                    if (!layer.isInScale()){
+                        // set zoom level by layer scales
+                        newZoom = this.layersPlugin.getMapModule().getClosestZoomLevel(layer.getMinScale(), layer.getMaxScale());
+                        // suppress mapmove-event here and send it after we have possibly also moved the map
+                        this.layersPlugin.getMapModule().setZoomLevel(newZoom, true);
+                    }
                 }
             } else{
                 // set zoom level by layer scales
-                var newZoom = this.layersPlugin.getMapModule().getClosestZoomLevel(layer.getMinScale(), layer.getMaxScale());
+                newZoom = this.layersPlugin.getMapModule().getClosestZoomLevel(layer.getMinScale(), layer.getMaxScale());
                 // suppress mapmove-event here and send it after we have possibly also moved the map
                 this.layersPlugin.getMapModule().setZoomLevel(newZoom, true);
                 // move map to geometries if available


### PR DESCRIPTION
Added zoomToExtent (optional, default false) parameter to MapMoveByLayerContentRequest. Handler moves and zooms the map to layer extent if zoomToExtent is true and layer has geometry. 

Moved openlayers dependent getCentroid to layerplugin ol2/3 getGeometryCenter. Also added getGeometryBounds method which is used by zoomToExtnent functionality.

Fixed LayersPlugin.ol3 _parseGeometryForLayer to set geometry to array of geometries.