### PR TITLE
Maplegend is no longer "stateful"

### DIFF
--- a/bundles/framework/maplegend/Flyout.js
+++ b/bundles/framework/maplegend/Flyout.js
@@ -92,15 +92,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.Flyout',
         setState: function (state) {
             this.state = state;
         },
-        setContentState: function () {
-
-        },
-        getContentState: function () {
-
-            return {
-
-            };
-        },
         createUi: function () {
             this.refresh();
         },


### PR DESCRIPTION
Maplegend registered itself as stateful, but didn't do anything with the state and always returned an empty state. This means it didn't have a "state" to begin with. The state handling didn't work on embedded maps resulting in a JavaScript error any time something called for set/getState() on an embedded map WITH maplegend functionality (like resetState() over RPC). This fixes such issues.