### PR TITLE
Drawtools polygon adheres to GeoJSON spec

### DIFF
--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -561,6 +561,13 @@ Oskari.clazz.define(
             var optionsForDrawingEvent = {
                 isFinished: false
             };
+            function makeClosedPolygonCoords(coords) {
+                return coords.map(function(ring) {
+                    ring = ring.slice();
+                    ring.push(ring[0].slice());
+                    return ring;
+                });
+            }
             if (shape === 'LineString') {
                  geometryFunction = function (coordinates, geometry) {
                     if (!geometry) {
@@ -621,7 +628,7 @@ Oskari.clazz.define(
                     if (!geometry) {
                         geometry = new ol.geom.Polygon(null);
                     }
-                    geometry.setCoordinates(coordinates);
+                    geometry.setCoordinates(makeClosedPolygonCoords(coordinates));
                     if(options.selfIntersection !== false) {
                         me.checkIntersection(geometry);
                     }


### PR DESCRIPTION
Add closing point to polygons, so that it consists of "linear rings":
https://tools.ietf.org/html/rfc7946#section-3.1.6