### PR TITLE
Stopdrawing should handle also suppressEvent

### DIFF
--- a/bundles/mapping/drawtools/instance.js
+++ b/bundles/mapping/drawtools/instance.js
@@ -123,7 +123,7 @@ function() {
             this.drawPlugin.draw(request.getId(), shapeType, request.getOptions());
         }
         else if (request.getName() === 'DrawTools.StopDrawingRequest') {
-            this.drawPlugin.stopDrawing(request.getId(), request.isClearCurrent());
+            this.drawPlugin.stopDrawing(request.getId(), request.isClearCurrent(), request.supressEvent());
         }
     },
 


### PR DESCRIPTION
For stopDrawingRequest it is possible to give parameter suppressEvent, which wasn't handled. Now it is handled so that drawingEvent is not sent if suppressEvent is 'true'.