### PR TITLE
Empty WFS layer selections only if there are those.

### DIFF
--- a/bundles/mapping/mapwfs2/service/Mediator.js
+++ b/bundles/mapping/mapwfs2/service/Mediator.js
@@ -395,7 +395,11 @@ Oskari.clazz.category('Oskari.mapframework.bundle.mapwfs2.service.Mediator', 'ge
         } else {
             // FIXME: pass coordinates from server in response, but not like this
             data.data.lonlat = this.lonlat;
-            me.WFSLayerService.emptyWFSFeatureSelections(layer);
+
+            if (me.WFSLayerService.getWFSSelections().length > 0) {
+                me.WFSLayerService.emptyWFSFeatureSelections(layer);
+            }
+
             if (typeof layer.getFeatureProperties === "function" && layer.hasOrder() && data.data.features !== 'empty'){
                 // this is a "userlayer" type layer - props are sorted to match the original order
                 features = data.data.features;

--- a/bundles/mapping/mapwfs2/service/Mediator.js
+++ b/bundles/mapping/mapwfs2/service/Mediator.js
@@ -396,9 +396,7 @@ Oskari.clazz.category('Oskari.mapframework.bundle.mapwfs2.service.Mediator', 'ge
             // FIXME: pass coordinates from server in response, but not like this
             data.data.lonlat = this.lonlat;
 
-            if (me.WFSLayerService.getWFSSelections().length > 0) {
-                me.WFSLayerService.emptyWFSFeatureSelections(layer);
-            }
+            me.WFSLayerService.emptyWFSFeatureSelections(layer);
 
             if (typeof layer.getFeatureProperties === "function" && layer.hasOrder() && data.data.features !== 'empty'){
                 // this is a "userlayer" type layer - props are sorted to match the original order

--- a/bundles/mapping/mapwfs2/service/WFSLayerService.js
+++ b/bundles/mapping/mapwfs2/service/WFSLayerService.js
@@ -206,9 +206,12 @@ Oskari.clazz.define(
          */
         emptyWFSFeatureSelections: function (layer) {
             var me = this;
-            _.remove(me.WFSFeatureSelections, {'layerId': layer._id});
-            var event = me.sandbox.getEventBuilder('WFSFeaturesSelectedEvent')([], layer, false);
-            me.sandbox.notifyAll(event);
+
+            if (me.getSelectedFeatureIds(layer._id)) {
+                _.remove(me.WFSFeatureSelections, {'layerId': layer._id});
+                var event = me.sandbox.getEventBuilder('WFSFeaturesSelectedEvent')([], layer, false);
+                me.sandbox.notifyAll(event);
+            }
         },
         /*
          * @method emptyWFSFeatureSelections


### PR DESCRIPTION
When map is clicked and there is WFS layer on map, WFS selections were emptied even if there were no selections. This caused some problems because of the event that was sent.

Now WFS selections are emptied only if there are those.