### PR TITLE
PublishMapEditorRequest sets map state

### DIFF
--- a/bundles/framework/personaldata/PublishedMapsTab.js
+++ b/bundles/framework/personaldata/PublishedMapsTab.js
@@ -329,14 +329,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.PublishedMapsTab',
             };
             grid.setColumnValueRenderer('name', nameRenderer);
 
-            var mapLayerService = sandbox.getService('Oskari.mapframework.service.MapLayerService');
+            var service = instance.getViewService();
             var setMapState = function (data, forced, confirmCallback) {
                 var setStateRequestBuilder = sandbox.getRequestBuilder(
                     'StateHandler.SetStateRequest'
                 );
                 // error handling: check if the layers referenced in view are
                 // loaded
-                var resp = mapLayerService.isViewLayersLoaded(data.state);
+                var resp = service.isViewLayersLoaded(data, sandbox);
                 if (resp.status || forced === true) {
                     if (setStateRequestBuilder) {
                         var req = setStateRequestBuilder(data.state);
@@ -410,7 +410,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.PublishedMapsTab',
                 link.text(name);
                 link.bind('click', function () {
                     if (!me.popupOpen) {
-                        var resp = mapLayerService.isViewLayersLoaded(data.state);
+                        var resp = service.isViewLayersLoaded(data, sandbox);
                         if (resp.status) {
                             editRequestSender(data);
                         } else {

--- a/bundles/framework/personaldata/PublishedMapsTab.js
+++ b/bundles/framework/personaldata/PublishedMapsTab.js
@@ -329,14 +329,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.PublishedMapsTab',
             };
             grid.setColumnValueRenderer('name', nameRenderer);
 
-            var service = instance.getViewService();
+            var mapLayerService = sandbox.getService('Oskari.mapframework.service.MapLayerService');
             var setMapState = function (data, forced, confirmCallback) {
                 var setStateRequestBuilder = sandbox.getRequestBuilder(
                     'StateHandler.SetStateRequest'
                 );
                 // error handling: check if the layers referenced in view are
                 // loaded
-                var resp = service.isViewLayersLoaded(data, sandbox);
+                var resp = mapLayerService.isViewLayersLoaded(data.state);
                 if (resp.status || forced === true) {
                     if (setStateRequestBuilder) {
                         var req = setStateRequestBuilder(data.state);
@@ -410,11 +410,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.PublishedMapsTab',
                 link.text(name);
                 link.bind('click', function () {
                     if (!me.popupOpen) {
-                        if (setMapState(data, false, function () {
-                                setMapState(data, true);
-                                editRequestSender(data);
-                            })) {
+                        var resp = mapLayerService.isViewLayersLoaded(data.state);
+                        if (resp.status) {
                             editRequestSender(data);
+                        } else {
+                            me._confirmSetState(function() {
+                                editRequestSender(data);
+                            }, resp.msg === 'missing');
                         }
                         return false;
                     }

--- a/bundles/framework/personaldata/service/ViewService.js
+++ b/bundles/framework/personaldata/service/ViewService.js
@@ -178,6 +178,55 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.service.ViewService
                     callback(false);
                 }
             });
+        },
+        /**
+         * Checks if the layers in view data are available
+         *
+         * @method isViewLayersLoaded
+         * @param {Object} viewData
+         * @param {Object} sandbox reference to sandbox to get loaded layers
+         * @return {Object} Returns object with boolean property status (true if everything ok, false if not)
+         *    and String property msg with message key:
+         *  - 'error' == generic error
+         *  - 'missing' == layers loaded but referenced layer not found
+         *  - 'notloaded' == layers ajax call hasnt completed yet
+         */
+        isViewLayersLoaded: function (viewData, sandbox) {
+            var response = {
+                status: false,
+                msg: 'error'
+            };
+            //data.state.mapfull.state.selectedLayers[{id:<layerid>}]
+            if (viewData &&
+                viewData.state &&
+                viewData.state.mapfull &&
+                viewData.state.mapfull.state &&
+                viewData.state.mapfull.state.selectedLayers) {
+                var selected = viewData.state.mapfull.state.selectedLayers,
+                    mapLayerService = sandbox.getService('Oskari.mapframework.service.MapLayerService'),
+                    loaded = mapLayerService.isAllLayersLoaded(),
+                    layerMissing = !mapLayerService.mapHasLayers(selected.map(function(l){return l.id}));
+                    
+                if (loaded) {
+                    // layers loaded
+                    if (layerMissing) {
+                        // but some layers are missing
+                        response.msg = 'missing';
+                    } else {
+                        // and all layers found
+                        response.status = true;
+                        response.msg = 'ok';
+                    }
+                } else if (layerMissing) {
+                    // not loaded yet and layer missing
+                    response.msg = 'notloaded';
+                } else {
+                    // not loaded yet but all layers found
+                    response.status = true;
+                    response.msg = 'ok';
+                }
+            }
+            return response;
         }
     }, {
         /**

--- a/bundles/framework/personaldata/service/ViewService.js
+++ b/bundles/framework/personaldata/service/ViewService.js
@@ -178,64 +178,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.service.ViewService
                     callback(false);
                 }
             });
-        },
-        /**
-         * Checks if the layers in view data are available
-         *
-         * @method isViewLayersLoaded
-         * @param {Object} viewData
-         * @param {Object} sandbox reference to sandbox to get loaded layers
-         * @return {Object} Returns object with boolean property status (true if everything ok, false if not)
-         *    and String property msg with message key:
-         *  - 'error' == generic error
-         *  - 'missing' == layers loaded but referenced layer not found
-         *  - 'notloaded' == layers ajax call hasnt completed yet
-         */
-        isViewLayersLoaded: function (viewData, sandbox) {
-            var response = {
-                status: false,
-                msg: 'error'
-            };
-            //data.state.mapfull.state.selectedLayers[{id:<layerid>}]
-            if (viewData &&
-                viewData.state &&
-                viewData.state.mapfull &&
-                viewData.state.mapfull.state &&
-                viewData.state.mapfull.state.selectedLayers) {
-                var selected = viewData.state.mapfull.state.selectedLayers,
-                    mapLayerService = sandbox.getService('Oskari.mapframework.service.MapLayerService'),
-                    layers = mapLayerService.getAllLayers(),
-                    loaded = mapLayerService.isAllLayersLoaded(),
-                    layerMissing = false,
-                    i,
-                    layer;
-                for (i = 0; i < selected.length; ++i) {
-                    layer = mapLayerService.findMapLayer(selected[i].id, layers);
-                    if (!layer) {
-                        layerMissing = true;
-                        break;
-                    }
-                }
-                if (loaded) {
-                    // layers loaded
-                    if (layerMissing) {
-                        // but some layers are missing
-                        response.msg = 'missing';
-                    } else {
-                        // and all layers found
-                        response.status = true;
-                        response.msg = 'ok';
-                    }
-                } else if (layerMissing) {
-                    // not loaded yet and layer missing
-                    response.msg = 'notloaded';
-                } else {
-                    // not loaded yet but all layers found
-                    response.status = true;
-                    response.msg = 'ok';
-                }
-            }
-            return response;
         }
     }, {
         /**

--- a/bundles/framework/personaldata/service/ViewService.js
+++ b/bundles/framework/personaldata/service/ViewService.js
@@ -205,7 +205,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.service.ViewService
                 var selected = viewData.state.mapfull.state.selectedLayers,
                     mapLayerService = sandbox.getService('Oskari.mapframework.service.MapLayerService'),
                     loaded = mapLayerService.isAllLayersLoaded(),
-                    layerMissing = !mapLayerService.mapHasLayers(selected.map(function(l){return l.id}));
+                    layerMissing = !mapLayerService.hasLayers(selected.map(function(l){return l.id}));
                     
                 if (loaded) {
                     // layers loaded

--- a/bundles/framework/publisher2/instance.js
+++ b/bundles/framework/publisher2/instance.js
@@ -147,6 +147,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
             this.sandbox.notifyAll(eventBuilder(this.mediator.bundleId));
 
             if (blnEnabled) {
+                var stateRB = Oskari.requestBuilder('StateHandler.SetStateRequest');
+                var req = stateRB(data.configuration);
+                this.getSandbox().request(this, req);
+
                 me.getService().setNonPublisherLayers(deniedLayers);
                 me.getService().removeLayers();
                 me.oskariLang = Oskari.getLang();

--- a/bundles/framework/publisher2/request/PublishMapEditorRequestHandler.js
+++ b/bundles/framework/publisher2/request/PublishMapEditorRequestHandler.js
@@ -46,7 +46,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher.request.PublishMapEdit
 
             if (request._viewData) {
                 //get the uuid from the request
-                var uuid = request._viewData.uuid && request._viewData.uuid ? request._viewData.uuid : null;
+                var uuid = request._viewData.uuid ||  null;
                 // make the ajax call
                 jQuery.ajax({
                     url: url + '&action_route=AppSetup&uuid='+uuid,

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -1145,57 +1145,21 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
         /**
          * Checks if the layers in view data are available
          *
-         * @method isViewLayersLoaded
-         * @param {Object} viewConfig
-         * @return {Object} Returns object with boolean property status (true if everything ok, false if not)
-         *    and String property msg with message key:
-         *  - 'error' == generic error
-         *  - 'missing' == layers loaded but referenced layer not found
-         *  - 'notloaded' == layers ajax call hasnt completed yet
+         * @method mapHasLayers
+         * @param {Number[]} layerIds array of layer id
+         * @return {Boolean} Returns true if map has all layers in layerId's
          */
-        isViewLayersLoaded: function (viewConfig) {
-            var response = {
-                status: false,
-                msg: 'error'
-            };
-            //viewConfig.mapfull.state.selectedLayers[{id:<layerid>}]
-            if (viewConfig &&
-                viewConfig.mapfull &&
-                viewConfig.mapfull.state &&
-                viewConfig.mapfull.state.selectedLayers) {
-                var selected = viewConfig.mapfull.state.selectedLayers,
-                    layers = this.getAllLayers(),
-                    loaded = this.isAllLayersLoaded(),
-                    layerMissing = false,
-                    i,
-                    layer;
-                for (i = 0; i < selected.length; ++i) {
-                    layer = this.findMapLayer(selected[i].id, layers);
-                    if (!layer) {
-                        layerMissing = true;
-                        break;
-                    }
-                }
-                if (loaded) {
-                    // layers loaded
-                    if (layerMissing) {
-                        // but some layers are missing
-                        response.msg = 'missing';
-                    } else {
-                        // and all layers found
-                        response.status = true;
-                        response.msg = 'ok';
-                    }
-                } else if (layerMissing) {
-                    // not loaded yet and layer missing
-                    response.msg = 'notloaded';
-                } else {
-                    // not loaded yet but all layers found
-                    response.status = true;
-                    response.msg = 'ok';
+        mapHasLayers: function (layerIds) {
+            var layers = this.getAllLayers(),
+                i,
+                layer;
+            for (i = 0; i < layerIds.length; ++i) {
+                layer = this.findMapLayer(layerIds[i], layers);
+                if (!layer) {
+                    return false;
                 }
             }
-            return response;
+            return true;
         }
     }, {
         /**

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -1145,11 +1145,11 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
         /**
          * Checks if the layers in view data are available
          *
-         * @method mapHasLayers
+         * @method hasLayers
          * @param {Number[]} layerIds array of layer id
-         * @return {Boolean} Returns true if map has all layers in layerId's
+         * @return {Boolean} Returns true if service has all layers in layerId's
          */
-        mapHasLayers: function (layerIds) {
+        hasLayers: function (layerIds) {
             var layers = this.getAllLayers(),
                 i,
                 layer;

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -1141,6 +1141,61 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
             } else {
                 return null;
             }
+        },
+        /**
+         * Checks if the layers in view data are available
+         *
+         * @method isViewLayersLoaded
+         * @param {Object} viewConfig
+         * @return {Object} Returns object with boolean property status (true if everything ok, false if not)
+         *    and String property msg with message key:
+         *  - 'error' == generic error
+         *  - 'missing' == layers loaded but referenced layer not found
+         *  - 'notloaded' == layers ajax call hasnt completed yet
+         */
+        isViewLayersLoaded: function (viewConfig) {
+            var response = {
+                status: false,
+                msg: 'error'
+            };
+            //viewConfig.mapfull.state.selectedLayers[{id:<layerid>}]
+            if (viewConfig &&
+                viewConfig.mapfull &&
+                viewConfig.mapfull.state &&
+                viewConfig.mapfull.state.selectedLayers) {
+                var selected = viewConfig.mapfull.state.selectedLayers,
+                    layers = this.getAllLayers(),
+                    loaded = this.isAllLayersLoaded(),
+                    layerMissing = false,
+                    i,
+                    layer;
+                for (i = 0; i < selected.length; ++i) {
+                    layer = this.findMapLayer(selected[i].id, layers);
+                    if (!layer) {
+                        layerMissing = true;
+                        break;
+                    }
+                }
+                if (loaded) {
+                    // layers loaded
+                    if (layerMissing) {
+                        // but some layers are missing
+                        response.msg = 'missing';
+                    } else {
+                        // and all layers found
+                        response.status = true;
+                        response.msg = 'ok';
+                    }
+                } else if (layerMissing) {
+                    // not loaded yet and layer missing
+                    response.msg = 'notloaded';
+                } else {
+                    // not loaded yet but all layers found
+                    response.status = true;
+                    response.msg = 'ok';
+                }
+            }
+            return response;
         }
     }, {
         /**


### PR DESCRIPTION
Mapmodule state should be set in response to `PublishMapEditorRequest`, using the published map config.

Moved `isViewLayersLoaded` method to MapLayerService so that it can be reused.