### PR TITLE
Fix initial state for publisher

### DIFF
--- a/bundles/framework/publisher2/instance.js
+++ b/bundles/framework/publisher2/instance.js
@@ -148,8 +148,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
 
             if (blnEnabled) {
                 var stateRB = Oskari.requestBuilder('StateHandler.SetStateRequest');
-                var req = stateRB(data.configuration);
-                this.getSandbox().request(this, req);
+                this.getSandbox().request(this, stateRB(data.configuration));
 
                 me.getService().setNonPublisherLayers(deniedLayers);
                 me.getService().removeLayers();

--- a/bundles/framework/publisher2/instance.js
+++ b/bundles/framework/publisher2/instance.js
@@ -72,7 +72,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
 
                 okBtn.addClass('primary');
                 url = event.getUrl();
-                //url = this.sandbox.getLocalizedProperty(this.conf.publishedMapUrl) + event.getId();
                 iframeCode = '<div class="codesnippet"><code>&lt;iframe src="' + url + '" style="border: none;';
                 if (width !== null && width !== undefined) {
                     iframeCode += ' width: ' + width + ';';
@@ -94,14 +93,17 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
          * @method afterStart
          */
         afterStart: function () {
+            var me = this;
             var sandbox = this.getSandbox();
             var loc = this.getLocalization();
 
             this.__service = Oskari.clazz.create('Oskari.mapframework.bundle.publisher2.PublisherService', sandbox);
             // create and register request handler
             var reqHandler = Oskari.clazz.create(
-                    'Oskari.mapframework.bundle.publisher.request.PublishMapEditorRequestHandler',
-                    this);
+                'Oskari.mapframework.bundle.publisher.request.PublishMapEditorRequestHandler',
+                function(data) {
+                    me.setPublishMode(true, data);
+                });
             sandbox.requestHandler('Publisher.PublishMapEditorRequest', reqHandler);
 
             // Let's add publishable filter to layerlist if user is logged in
@@ -136,12 +138,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
          * returns them when exiting the publish mode.
          *
          * @param {Boolean} blnEnabled true to enable, false to disable/return to normal mode
-         * @param {Layer[]} deniedLayers layers that the user can't publish
          * @param {Object} data View data that is used to prepopulate publisher (optional)
+         * @param {Layer[]} deniedLayers layers that the user can't publish (optional)
          */
-        setPublishMode: function (blnEnabled, deniedLayers, data) {
-            var me = this,
-                map = jQuery('#contentMap');
+        setPublishMode: function (blnEnabled, data, deniedLayers) {
+            var me = this;
+            var map = jQuery('#contentMap');
+            data = data || this.getDefaultData();
             // trigger an event letting other bundles know we require the whole UI
             var eventBuilder = Oskari.eventBuilder('UIChangeEvent');
             this.sandbox.notifyAll(eventBuilder(this.mediator.bundleId));
@@ -149,8 +152,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
             if (blnEnabled) {
                 var stateRB = Oskari.requestBuilder('StateHandler.SetStateRequest');
                 this.getSandbox().request(this, stateRB(data.configuration));
+                if(data.uuid) {
+                    this._showEditNotification();
+                }
 
-                me.getService().setNonPublisherLayers(deniedLayers);
+                me.getService().setNonPublisherLayers(deniedLayers || this.getLayersWithoutPublishRights());
                 me.getService().removeLayers();
                 me.oskariLang = Oskari.getLang();
 
@@ -202,6 +208,41 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
                 me.getService().addLayers();
                 me.getFlyout().close();
             }
+        },
+        /**
+         * Initial data for publisher to preselect certain tools by default and assume current map state as starting point
+         * @return {Object}
+         */
+        getDefaultData: function() {
+            var config = {
+                mapfull: {
+                    conf: {
+                        plugins: [
+                            {id: 'Oskari.mapframework.bundle.mapmodule.plugin.ScaleBarPlugin'},
+                            {id: 'Oskari.mapframework.mapmodule.ControlsPlugin'},
+                            {id: 'Oskari.mapframework.mapmodule.GetInfoPlugin'}
+                        ]
+                    }
+                },
+                "featuredata2": {
+                    conf: {}
+                }
+            };
+            // setup current mapstate so layers are not removed
+            var state = this.getSandbox().getCurrentState();
+            // merge state to initial config
+            return { configuration: jQuery.extend(true, config, state) };
+        },
+        /**
+         * @method _showEditNotification
+         * Shows notification that the user starts editing an existing published map
+         * @private
+         */
+        _showEditNotification: function () {
+            var loc = this.getLocalization('edit'),
+                dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+            dialog.show(loc.popup.title, loc.popup.msg);
+            dialog.fadeout();
         },
         /**
          * @method hasPublishRight

--- a/bundles/framework/publisher2/request/PublishMapEditorRequestHandler.js
+++ b/bundles/framework/publisher2/request/PublishMapEditorRequestHandler.js
@@ -12,9 +12,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher.request.PublishMapEdit
     function (instance) {
         this.instance = instance;
     }, {
-
-        __defaultToolsConfig: {
-            configuration: {
+        getDefaultData: function() {
+            var config = {
                 mapfull: {
                     conf: {
                         plugins: [
@@ -28,7 +27,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher.request.PublishMapEdit
                     conf: {
                     }
                 }
-            }
+            };
+            // setup current mapstate so layers are not removed
+            var sb = this.instance.getSandbox();
+            var state = sb.getCurrentState();
+            // only merge mapfull state so tools like statsgrid are not switched on "since they have state"
+            config.mapfull.state = state.mapfull.state;
+
+            return { configuration: config };
         },
         /**
          * @method handleRequest
@@ -41,28 +47,24 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher.request.PublishMapEdit
          */
         handleRequest: function (core, request) {
             var me = this,
-                sandbox = me.instance.getSandbox(),
-                url = sandbox.getAjaxUrl();
+                url = Oskari.urls.getRoute('AppSetup');
 
-            if (request._viewData) {
+            if (request.getEditMap()) {
                 //get the uuid from the request
-                var uuid = request._viewData.uuid ||  null;
+                var uuid = request.getEditMap().uuid ||  null;
                 // make the ajax call
                 jQuery.ajax({
-                    url: url + '&action_route=AppSetup&uuid='+uuid,
+                    url: url + '&uuid='+uuid,
                     type: 'GET',
                     dataType: 'json',
                     success: function (data) {
                         data.uuid = uuid;
                         me.instance.setPublishMode(true, me.instance.getLayersWithoutPublishRights(), data);
                         me._showEditNotification();
-                    },
-                    error: function(response) {
                     }
                 });
             } else {
-                var defaultToolsConfig = me.__defaultToolsConfig;
-                me.instance.setPublishMode(true, me.instance.getLayersWithoutPublishRights(), defaultToolsConfig);
+                me.instance.setPublishMode(true, me.instance.getLayersWithoutPublishRights(), this.getDefaultData());
             }
 
         },

--- a/bundles/framework/publisher2/request/PublishMapEditorRequestHandler.js
+++ b/bundles/framework/publisher2/request/PublishMapEditorRequestHandler.js
@@ -6,36 +6,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher.request.PublishMapEdit
     /**
      * @method create called automatically on construction
      * @static
-     * @param {Oskari.mapframework.bundle.publisher.PublisherBundleInstance} instance
-     *          reference to publisher instance
+     * @param {Function} openEditor
+     *          function to call to open the publish editor. Optional initial data can be passed as parameter.
      */
-    function (instance) {
-        this.instance = instance;
+    function (openEditor) {
+        this.openEditor = openEditor;
     }, {
-        getDefaultData: function() {
-            var config = {
-                mapfull: {
-                    conf: {
-                        plugins: [
-                            {id: 'Oskari.mapframework.bundle.mapmodule.plugin.ScaleBarPlugin'},
-                            {id: 'Oskari.mapframework.mapmodule.ControlsPlugin'},
-                            {id: 'Oskari.mapframework.mapmodule.GetInfoPlugin'}
-                        ]
-                    }
-                },
-                "featuredata2": {
-                    conf: {
-                    }
-                }
-            };
-            // setup current mapstate so layers are not removed
-            var sb = this.instance.getSandbox();
-            var state = sb.getCurrentState();
-            // only merge mapfull state so tools like statsgrid are not switched on "since they have state"
-            config.mapfull.state = state.mapfull.state;
-
-            return { configuration: config };
-        },
         /**
          * @method handleRequest
          * Shows/hides the maplayer specified in the request in OpenLayers implementation.
@@ -46,38 +22,27 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher.request.PublishMapEdit
          *      request to handle
          */
         handleRequest: function (core, request) {
-            var me = this,
-                url = Oskari.urls.getRoute('AppSetup');
+            var me = this;
 
-            if (request.getEditMap()) {
-                //get the uuid from the request
-                var uuid = request.getEditMap().uuid ||  null;
-                // make the ajax call
-                jQuery.ajax({
-                    url: url + '&uuid='+uuid,
-                    type: 'GET',
-                    dataType: 'json',
-                    success: function (data) {
-                        data.uuid = uuid;
-                        me.instance.setPublishMode(true, me.instance.getLayersWithoutPublishRights(), data);
-                        me._showEditNotification();
-                    }
-                });
-            } else {
-                me.instance.setPublishMode(true, me.instance.getLayersWithoutPublishRights(), this.getDefaultData());
+            if (!request.getEditMap()) {
+                me.openEditor();
+                return;
             }
-
-        },
-        /**
-         * @method _showEditNotification
-         * Shows notification that the user starts editing an existing published map
-         * @private
-         */
-        _showEditNotification: function () {
-            var loc = this.instance.getLocalization('edit'),
-                dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
-            dialog.show(loc.popup.title, loc.popup.msg);
-            dialog.fadeout();
+            //get the uuid from the request
+            var uuid = request.getEditMap().uuid || null;
+            // make the ajax call
+            jQuery.ajax({
+                url: Oskari.urls.getRoute('AppSetup'),
+                data: {
+                    uuid : uuid
+                },
+                type: 'GET',
+                dataType: 'json',
+                success: function (data) {
+                    data.uuid = uuid;
+                    me.openEditor(data);
+                }
+            });
         }
     }, {
         /**


### PR DESCRIPTION
Fix for PR #194 since the publisher now ALWAYS uses StateRequest to setup the app for preview. The "default data" only had configuration to setup the initial publisher tools and this change constructs the missing parts of initial publisher data using current app state.