### PR TITLE
Analyse fixes

### DIFF
--- a/bundles/analysis/analyse/view/ContentPanel.ol3.js
+++ b/bundles/analysis/analyse/view/ContentPanel.ol3.js
@@ -701,7 +701,11 @@ Oskari.clazz.define(
                     return (featureLayer.opacity * 100);
                 },
                 getFeature: function () {
-                    return formatter.writeFeature(featureSource.getFeatureById(id));
+                    var formattedFeature = formatter.writeFeatureObject(featureSource.getFeatureById(id));
+                    if (formattedFeature.properties === null) {
+                        formattedFeature.properties = {};
+                    }
+                    return formattedFeature;
                 }
             };
         },

--- a/bundles/analysis/analyse/view/ContentPanel.ol3.js
+++ b/bundles/analysis/analyse/view/ContentPanel.ol3.js
@@ -285,11 +285,17 @@ Oskari.clazz.define(
                 this.mapModule.bringToTop(this.featureLayer);
             },
             'AfterMapLayerAddEvent': function(event) {
+                if (!me.instance.analyse.isEnabled) {
+                    return;
+                }
                 this.toggleSelectionTools();
                 this.drawControls.toggleEmptySelectionBtn((this.WFSLayerService.getWFSSelections() && this.WFSLayerService.getWFSSelections().length > 0));
                 this.mapModule.bringToTop(this.featureLayer);
             },
             'AfterMapLayerRemoveEvent': function(event) {
+                if (!me.instance.analyse.isEnabled) {
+                    return;
+                }
                 this.toggleSelectionTools();
                 this.drawControls.toggleEmptySelectionBtn((this.WFSLayerService.getWFSSelections() && this.WFSLayerService.getWFSSelections().length > 0));
             }


### PR DESCRIPTION
Drawn features can now be used in analysis since features properties were modified not be NULL.

Analyse now doesn't listen AfterMapLayerAddEvent and AfterMapLayerRemoveEvent if not in analyse mode.