### PR TITLE
Remove reference to removed file in printout

### DIFF
--- a/packages/framework/bundle/printout/bundle.js
+++ b/packages/framework/bundle/printout/bundle.js
@@ -35,9 +35,6 @@ Oskari.clazz.define("Oskari.mapframework.bundle.printout.PrintoutBundle", functi
             "src": "../../../../bundles/framework/printout/Tile.js"
         }, {
             "type": "text/javascript",
-            "src": "../../../../bundles/framework/printout/plugin/LegendPlugin.js"
-        }, {
-            "type": "text/javascript",
             "src": "../../../../bundles/framework/printout/service/PrintService.js"
         }, {
             "type": "text/javascript",


### PR DESCRIPTION
Removed the file in #202 the reference for loader remained in bundle.js. Removing it here.