### PR TITLE
Don't send mapClickedEvent while drawing.

### DIFF
--- a/bundles/analysis/analyse/view/DrawControls.js
+++ b/bundles/analysis/analyse/view/DrawControls.js
@@ -319,10 +319,8 @@ Oskari.clazz.define(
             var me = this,
                 toolsPanel = me.drawToolsPanel;
 
-            if (toolsPanel.html.find('div[class*=selection-]').hasClass('active')) {
-                toolsPanel.html.find('div[class*=selection-]').removeClass('active');
-                me.selectionPlugin.stopDrawing();
-            }
+            me.selectionButtonsRenderer.removeButtonSelection();
+            me.selectionPlugin.stopDrawing();
         },
 
         /**

--- a/bundles/framework/featuredata2/PopupHandler.js
+++ b/bundles/framework/featuredata2/PopupHandler.js
@@ -266,6 +266,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.featuredata2.PopupHandler",
 
             if (isActive) {
                 jQuery(content).find(".active").removeClass("active");
+                me.WFSLayerService.setSelectionToolsActive(false);
             }
         }
     });

--- a/bundles/framework/featuredata2/instance.js
+++ b/bundles/framework/featuredata2/instance.js
@@ -439,10 +439,11 @@ Oskari.clazz.define("Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
 
                 me.selectionPlugin.setFeatures(geojson.features);
                 me.selectionPlugin.stopDrawing();
-                me.popupHandler.removeButtonSelection();
 
                 var event = me.sandbox.getEventBuilder("WFSSetFilter")(geojson);
                 me.sandbox.notifyAll(event);
+
+                me.popupHandler.removeButtonSelection();
             },
             'AfterMapMoveEvent': function() {
                 var me = this;

--- a/bundles/framework/featuredata2/plugin/MapSelectionPlugin.js
+++ b/bundles/framework/featuredata2/plugin/MapSelectionPlugin.js
@@ -59,7 +59,6 @@ Oskari.clazz.define(
          * clears the layer of any drawn features
          */
         stopDrawing: function () {
-            this.WFSLayerService.setSelectionToolsActive(false);
             this.clearDrawing();
             // disable all draw controls
             this._toggleControl();
@@ -87,17 +86,7 @@ Oskari.clazz.define(
                 }
             }
         },
-        /**
-         * @method removeActiveClass
-         * triggers the click event on the button container in PopupHandler after draw has ended to deselct the drawing tool
-         */
-        removeActiveClass: function () {
-            if( this.caller ) {
-                this.caller.btnContainer.trigger("click", true);
-            } else {
-                Oskari.log(this.getName() + " no caller provided in configuration.");
-            }
-        },
+
         /**
          * Initializes the plugin:
          * - drawControls

--- a/bundles/framework/mapmodule-plugin/plugin/controls/OskariNavigation.js
+++ b/bundles/framework/mapmodule-plugin/plugin/controls/OskariNavigation.js
@@ -50,6 +50,9 @@ OskariNavigation = OpenLayers.Class(OpenLayers.Control.Navigation, {
             'dblclick': movementHook(this.defaultDblClick),
             'dblrightclick': movementHook(this.defaultDblRightClick),
             'click': function(evt) {
+                if (me.mapmodule.getDrawingMode()) {
+                    return;
+                }
                 me.mapmodule.__sendMapClickEvent(evt);
                 return true;
             }

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -122,7 +122,7 @@ Oskari.clazz.define(
             // use default style if options don't include custom style
             var me = this;
             //disable gfi
-            me.setGFIEnabled(false);
+            me.getMapModule().setDrawingMode(true);
             // TODO: why not just call the stopDrawing()/_cleanupInternalState() method here?
             me.removeInteractions(me._draw, me._id);
             me.removeInteractions(me._modify, me._id);
@@ -304,7 +304,10 @@ Oskari.clazz.define(
             me._cleanupInternalState();
             me.getMap().un('pointermove', me.pointerMoveHandler, me);
             //enable gfi
-            me.setGFIEnabled(true);
+            setTimeout(function () {
+                me.getMapModule().setDrawingMode(false);
+            }, 500);
+            
         },
         _cleanupInternalState: function() {
             this._shape = null;

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -105,6 +105,8 @@ Oskari.clazz.define(
         this._cursorStyle = '';
         this.log = Oskari.log('AbstractMapModule');
 
+        this.isDrawing = false;
+
 
         this.templates = {
             'crosshair': jQuery(
@@ -113,6 +115,7 @@ Oskari.clazz.define(
                     '<div class="oskari-crosshair-horizontal-bar"></div>'+
                 '</div>')
         };
+
     }, {
         /**
          * Moved from core, to be removed
@@ -476,6 +479,18 @@ Oskari.clazz.define(
          */
         getProjection: function () {
             return this._projectionCode;
+        },
+
+        setDrawingMode: function (mode) {
+            if (mode) {
+                this.isDrawing = true;
+            } else {
+                this.isDrawing = false;
+            }
+        },
+
+        getDrawingMode: function () {
+            return this.isDrawing;
         },
 /* --------------- MAP LOCATION ------------------------ */
         /**

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -482,11 +482,7 @@ Oskari.clazz.define(
         },
 
         setDrawingMode: function (mode) {
-            if (mode) {
-                this.isDrawing = true;
-            } else {
-                this.isDrawing = false;
-            }
+            this.isDrawing = !!mode;
         },
 
         getDrawingMode: function () {

--- a/bundles/mapping/mapmodule/mapmodule.ol3.js
+++ b/bundles/mapping/mapmodule/mapmodule.ol3.js
@@ -104,6 +104,9 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.MapModule',
             });
 
             map.on('singleclick', function (evt) {
+                if (me.getDrawingMode()) {
+                    return;
+                }
                 var CtrlPressed = evt.originalEvent.ctrlKey;
                 var lonlat = {
                   lon : evt.coordinate[0],


### PR DESCRIPTION
Now it is possible to tell mapmodule that drawing is on or off with setDrawingMode(). Drawing mode can be asked from mapmodule with getDrawingMode(). DrawPlugin uses this to tell mapmodule about drawing state and mapmodule then uses this information when map is clicked to know whether mapClickedEvent should be sent or not. While drawing, the event is not sent.

All this was made to make GFI popup handling easier and to avoid unnecessary event handling.