### PR TITLE
Layerselection2/revert

### DIFF
--- a/bundles/framework/layerselection2/Flyout.js
+++ b/bundles/framework/layerselection2/Flyout.js
@@ -172,12 +172,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselection2.Flyout',
                 me._appendLayerFooter(layerContainer, layer, layer.isInScale(scale), true);
             }
             listContainer.sortable({
-                containment: "parent",
-                start: function (event, ui) {
-                    jQuery( ui.item ).css({ border: "1px solid #2c2c2c" })
-                },
                 stop: function (event, ui) {
-                    jQuery( ui.item ).css({ border: "" })
                     me._layerOrderChanged(ui.item);
                 }
             });


### PR DESCRIPTION
Revert the sortable layers being restricted to the flyout, not a userfriendly experience.