### PR TITLE
Statsgrid UI fixes

### DIFF
--- a/api/ui/divmanazer/grid.md
+++ b/api/ui/divmanazer/grid.md
@@ -80,7 +80,11 @@ me.grid.setGroupingHeader([
 grid.renderTo(someElement);
 
 // select row and scroll table to selected
-grid.select(wantedRowValue, false, scrollableElement);
+var scrollableObject = {
+  element: jQuery('.scrallobleElement'),
+  fixTopPosition: 16 // if need fix calculated top position then use this number. Number means at how many pixels are decreased in calculated element row top location.
+  }:
+grid.select(wantedRowValue, false, scrollableObject);
 
 // moves selected rows as first rows of the table
 grid.moveSelectedRowsTop(true);

--- a/bundles/framework/divmanazer/component/GridSelection.js
+++ b/bundles/framework/divmanazer/component/GridSelection.js
@@ -47,9 +47,9 @@ Oskari.clazz.category(
          * @param {String} value id for the data to be selected
          * @param {Boolean} keepPrevious
          * True to keep previous selection, false to clear before selecting
-         * @param {Object} scrollableElement If element defined then scroll grid to selected row. If scrollableELment is null then not scroll.
+         * @param {Object} scrollable If defined then scroll grid to selected row. If scrollable.eLement is null then not scroll.
          */
-        select: function (value, keepPrevious, scrollableElement) {
+        select: function (value, keepPrevious, scrollable) {
             var me = this;
             if(!me.model) {
                 return;
@@ -79,11 +79,12 @@ Oskari.clazz.category(
                 me.sortBy(me.lastSort.attr, me.lastSort.descending);
             }
 
-            if(scrollableElement) {
-                scrollableElement.scrollTop(0);
-                var row = scrollableElement.find('tr[data-id="'+value+'"]');
+            if(scrollable && scrollable.element) {
+                scrollable.element.scrollTop(0);
+                var row = scrollable.element.find('tr[data-id="'+value+'"]');
+                var fixTopPosition = scrollable.fixTopPosition || 0;
                 if(row.length > 0) {
-                    scrollableElement.scrollTop(row.position().top);
+                    scrollable.element.scrollTop(row.position().top - fixTopPosition);
                 }
             }
         },

--- a/bundles/statistics/statsgrid2016/components/Datatable.js
+++ b/bundles/statistics/statsgrid2016/components/Datatable.js
@@ -425,7 +425,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function(sandbox, l
             if(event.getTriggeredBy() === 'map' && parent.length>0) {
                 scrollableElement = parent;
             }
-            me.grid.select(event.getRegion(), false, scrollableElement);
+            me.grid.select(event.getRegion(), false, {element: scrollableElement, fixTopPosition: jQuery('.oskari-flyout.statsgrid-data-flyout .oskari-flyouttoolbar').height()});
         });
 
         this.service.on('StatsGrid.ActiveIndicatorChangedEvent', function(event) {

--- a/bundles/statistics/statsgrid2016/components/EditClassification.js
+++ b/bundles/statistics/statsgrid2016/components/EditClassification.js
@@ -114,7 +114,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function(s
     for(var i=100;i>=30;i-=10) {
         transparencyEl.append('<option value="'+i+'">'+ i +' %</option>');
     }
-    this.__templates.classification.find('select.transparency-value option[value=80]').attr('selected', 'selected');
+    this.__templates.classification.find('select.transparency-value option[value=100]').attr('selected', 'selected');
 
     this.log = Oskari.log('Oskari.statistics.statsgrid.EditClassification');
 

--- a/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
+++ b/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
@@ -127,7 +127,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function(inst
                         layerId: me.LAYER_ID,
                         prio: index,
                         showLayer: true,
-                        opacity: classification.opacity ||80,
+                        opacity: classification.opacity || 100,
                         layerName: locale.layer.name,
                         layerInspireName: locale.layer.inspireName,
                         layerOrganizationName: locale.layer.organizationName,

--- a/bundles/statistics/statsgrid2016/resources/css/style.css
+++ b/bundles/statistics/statsgrid2016/resources/css/style.css
@@ -115,7 +115,7 @@ div.oskari-flyout {
     max-width: 700px;
     /* Chosen fixes */ }
     div.oskari-flyout.statsgrid-search-flyout .statsgrid-search-container {
-      padding: 1.2em; }
+      padding: 16px; }
     div.oskari-flyout.statsgrid-search-flyout label span {
       /* Indicator selection form */
       width: 200px;
@@ -210,7 +210,7 @@ div.oskari-flyout {
     max-width: 700px;
     /* Chosen fixes */ }
     div.oskari-flyout.statsgrid-data-flyout .oskari-datacharts {
-      padding: 1.2em; }
+      padding: 16px; }
     div.oskari-flyout.statsgrid-data-flyout table.oskari-grid th.selected {
       background-color: #FDF8D9;
       animation-name: statsgridcolumnselection;
@@ -317,7 +317,7 @@ div.oskari-flyout {
     div.oskari-flyout.statsgrid-data-flyout .oskari-datacharts #graphic .grid path {
       stroke-width: 0; }
   div.oskari-flyout.statsgrid-diagram-flyout .oskari-datacharts {
-    padding: 1.2em; }
+    padding: 16px; }
 
 /* ********************************************
  * Statsgrid legend

--- a/bundles/statistics/statsgrid2016/resources/css/style.css
+++ b/bundles/statistics/statsgrid2016/resources/css/style.css
@@ -200,6 +200,11 @@ div.oskari-flyout {
         background-color: #000000; }
         div.oskari-flyout.statsgrid-search-flyout .statsgrid-grouping-header.sources span {
           font-weight: normal; }
+    div.oskari-flyout.statsgrid-search-flyout div.extrafeatures div.title {
+      font-weight: bold;
+      margin-top: 12px; }
+    div.oskari-flyout.statsgrid-search-flyout div.extrafeatures div.content label.oskari-formcomponent {
+      margin-bottom: 0; }
   div.oskari-flyout.statsgrid-data-flyout {
     /* TODO: limits the table from blowing up the flyout, but this needs to be handled in some other way */
     max-width: 700px;

--- a/bundles/statistics/statsgrid2016/resources/locale/en.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/en.js
@@ -57,7 +57,7 @@ Oskari.registerLocalization(
                 "noRegionset": "No area selected"
             },
             "extraFeatures": {
-                "title": "EXTRA CONDITIONS AND FEATURES",
+                "title": "Additional features",
                 "hideMapLayers": "Hide other map layers",
                 "openTableCheckbox": "Open table",
                 "openDiagramCheckbox": "Open bar chart"

--- a/bundles/statistics/statsgrid2016/resources/locale/fi.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/fi.js
@@ -57,7 +57,7 @@ Oskari.registerLocalization(
                 "noRegionset": "Ei aluevalintaa"
             },
             "extraFeatures": {
-                "title": "LISÄEHDOT JA -OMINAISUUDET",
+                "title": "Lisäominaisuudet",
                 "hideMapLayers": "Piilota muut karttatasot",
                 "openTableCheckbox": "Avaa taulukko",
                 "openDiagramCheckbox": "Avaa pylväsdiagrammiesitys"

--- a/bundles/statistics/statsgrid2016/resources/locale/sv.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/sv.js
@@ -57,7 +57,7 @@ Oskari.registerLocalization(
                 "noRegionset": "Ingen områdesindelning"
             },
             "extraFeatures": {
-                "title": "TILLLÄGSVILLKOR OCH -EGENSKAPER",
+                "title": "Ytterligare egenskaper",
                 "hideMapLayers": "Gömma andra kartlager",
                 "openTableCheckbox": "Öppna tabell",
                 "openDiagramCheckbox": "Öppna diagram"

--- a/bundles/statistics/statsgrid2016/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/scss/style.scss
@@ -315,6 +315,19 @@ div.oskari-flyout {
                 }
             }
         }
+
+        div.extrafeatures {
+            div.title {
+                font-weight:bold;
+                margin-top:12px;
+            }
+
+            div.content {
+                label.oskari-formcomponent {
+                    margin-bottom: 0;
+                }
+            }
+        }
     }
 
     /* ********************************************

--- a/bundles/statistics/statsgrid2016/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/scss/style.scss
@@ -6,7 +6,7 @@ $buttonTextColor: #ffffff;
 $inputWidth: 94%;
 $buttonWidth: 86%;
 
-$flyoutPadding: 1.2em;
+$flyoutPadding: 16px;
 
 
 /* ********************************************

--- a/bundles/statistics/statsgrid2016/view/SearchFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/SearchFlyout.js
@@ -54,43 +54,18 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
     },
     addContent : function (el, isEmbedded) {
         var me = this;
-        var accordion = Oskari.clazz.create(
-                'Oskari.userinterface.component.Accordion'
-            );
-        var panels = me.getPanels(isEmbedded);
-        var service = me.sandbox.getService('Oskari.statistics.statsgrid.StatisticsService');
-        var state = service.getStateService();
-        el.append(me.getNewSearchElement(isEmbedded));
-        _.each(panels, function(p) {
-            accordion.addPanel(p.panel);
-        });
-
-        accordion.insertTo(el);
-    },
-    closePanels: function() {
-        var panels = this.__panels || [];
-        _.each(panels, function(p) {
-            p.panel.close();
-        });
-    },
-    getPanels : function(isEmbedded) {
-        var panels = [];
-        if(isEmbedded) {
-            // no panels for embedded map
-            return panels;
-        }
-
-        panels.push(this.getExtraFeaturesPanel());
-        return panels;
-    },
-    getNewSearchElement: function(isEmbedded){
-        var me = this;
         // no search for embedded map
         if(isEmbedded) {
-            return null;
+            return;
         }
+        var service = me.sandbox.getService('Oskari.statistics.statsgrid.StatisticsService');
+        var state = service.getStateService();
+        el.append(me.getNewSearchElement());
+        el.append(me.getExtraFeaturesElement());
+    },
+    getNewSearchElement: function(){
+        var me = this;
         var container = jQuery('<div></div>');
-
         var locale = this.instance.getLocalization();
 
         var selectionComponent = Oskari.clazz.create('Oskari.statistics.statsgrid.IndicatorSelection', me.instance, me.sandbox);
@@ -130,15 +105,14 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
 
         return container;
     },
-    getExtraFeaturesPanel: function(){
-        var panel = Oskari.clazz.create('Oskari.userinterface.component.AccordionPanel');
-        var container = panel.getContainer();
+    getExtraFeaturesElement: function(){
+        var me = this;
+        var container = jQuery('<div class="extrafeatures"><div class="title"></div><div class="content"></div></div>');
         var locale = this.instance.getLocalization();
 
-        panel.setTitle(locale.panels.extraFeatures.title);
-        container.append(this._extraFeatures.getPanelContent());
-
-        return {id:'extraFeaturesPanel', panel:panel};
+        container.find('.title').html(locale.panels.extraFeatures.title);
+        container.find('.content').append(this._extraFeatures.getPanelContent());
+        return container;
     },
      getLegendFlyout : function() {
         if(this.__legendFlyout) {

--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -68,11 +68,11 @@ a:focus {
 
 /* Selection colours */
 ::selection {
-  background: #fdf8d9;
+  background: #ffd400;
 }
 
 ::-moz-selection {
-  background: #fdf8d9;
+  background: #ffd400;
 }
 
 img::selection {


### PR DESCRIPTION
### Statsgrid2016
* Extra options are now showed without accordion
![statsgrid_search_flyout](https://user-images.githubusercontent.com/570159/34381011-6c798138-eb0e-11e7-8672-e17583547a4d.png)
* Now stats areas are not transparent by default
* Now clicked map area scrolls correct datatable row 