### PR TITLE
DrawTools now enable multigeometries

### DIFF
--- a/api/mapping/drawtools/request/startdrawingrequest.md
+++ b/api/mapping/drawtools/request/startdrawingrequest.md
@@ -71,7 +71,7 @@ Parameters for options-object:
     </td>
 </tr>
 <tr>
-  <td> allowMultipleDrawing </td><td> Boolean/String </td><td> true - multiple selection is allowed.<br> false - after drawing is finished (by doubleclick), will stop drawing tool, but keeps selection on the map.<br> 'single' - selection will be removed before drawing a new selection.</td><td> true</td>
+  <td> allowMultipleDrawing </td><td> Boolean/String </td><td> true - multiple selection is allowed.<br> false - after drawing is finished (by doubleclick), will stop drawing tool, but keeps selection on the map.<br> 'single' - selection will be removed before drawing a new selection.<br> 'multiGeom' - gathers drawn shapes into a single feature with multigeometry instead of sending multiple features in DrawingEvent. </td><td> true</td>
 </tr>
 <tr>
   <td> drawControl </td><td> Boolean </td><td> true - activates draw control.<br> false - drawing will not activated.</td><td> true</td>

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -104,7 +104,11 @@ Oskari.clazz.define(
          * @param {Object} options include:
          *                  {Number} buffer: buffer for drawing buffered line and dot. If not given or 0, will disable dragging.
          *                  {Object} style: styles for draw, modify and intersect mode. If options don't include custom style, sets default styles
-         *                  {Boolean} allowMiltipleDrawing: true - multiple selection is allowed, false - selection will be removed before drawing a new selection. Default is false.
+         *                  {Boolean/String} allowMultipleDrawing: true - multiple selection is allowed, 
+         *                                                         false - after drawing is finished (by doubleclick), will stop drawing tool, but keeps selection on the map. 
+         *                                                        'single' - selection will be removed before drawing a new selection.
+         *                                                        'multiGeom' - form multigeometry from drawn features. 
+         *                                                         Default is false.
          *                  {Boolean} showMeasureOnMap: true - if measure result should be displayed on map near drawing feature. Default is false.
          *                  {Boolean} drawControl: true - will activate draw control, false - will not activate. Default is true.
          *                  {Boolean} modifyControl: true - will activate modify control, false, will not activate. Default is true.
@@ -288,6 +292,7 @@ Oskari.clazz.define(
                 clearCurrent: clearCurrent,
                 isFinished: true
             };
+
             if(!me.getLayerIdForFunctionality(id)) {
                 // layer not found for functionality id, nothing to do?
                 return;
@@ -354,6 +359,7 @@ Oskari.clazz.define(
          * @param {object} options include:
          *                  {Boolean} clearCurrent: true - all selection will be removed from the map after stopping plugin, false - will keep selection on the map. Default is false.
          *                  {Boolean} isFinished: true - if drawing is completed. Default is false.
+         *                  {Boolean} multiGeom: true - make multigeometry. Default is false
          */
         sendDrawingEvent: function(id, options) {
             var me = this,
@@ -362,6 +368,7 @@ Oskari.clazz.define(
                 layerId = me.getLayerIdForFunctionality(id),
                 isFinished = false;
             var requestedBuffer = me.getOpts('buffer') || 0;
+
             features = me.getFeatures(layerId);
 
             if(!features) {
@@ -387,6 +394,7 @@ Oskari.clazz.define(
                     }
                     break;
             }
+
             var geojson = me.getFeaturesAsGeoJSON(features);
             geojson.crs = me._getSRS();
             var bufferedGeoJson = me.getFeaturesAsGeoJSON(bufferedFeatures);
@@ -449,39 +457,113 @@ Oskari.clazz.define(
          * @return {String} geojson
          */
         getFeaturesAsGeoJSON : function(features) {
-            var me = this;
-            var geoJSONformatter = new ol.format.GeoJSON();
-            var geoJsonObject =  {
+            var me = this,
+                geoJsonObject =  {
                     type: 'FeatureCollection',
                     features: []
-                };
-            if(!features) {
+                },
+                measures,
+                jsonObject,
+                buffer,
+                i;
+
+            if(!features || features.length === 0) {
                 return geoJsonObject;
             }
-            features.forEach(function (f) {
-                var buffer, length, area;
-                if(f.buffer) {
-                    buffer = f.buffer;
+
+            // form multigeometry from features
+            if (me.drawMultiGeom) {
+                measures = me.sumMeasurements(features);
+                var geometries = [];
+
+                for (i=0; i < features.length; i++) {
+                    var feature = features[i];
+                    if (!buffer && feature.buffer) {
+                        buffer = feature.buffer;
+                    }
+                    var geometry = feature.getGeometry();
+                    geometries.push(geometry);
                 }
-                var measures = me.sumMeasurements([f]);
-                var jsonObject = geoJSONformatter.writeFeatureObject(f);
-                jsonObject.properties = {};
-                if(buffer) {
-                    jsonObject.properties.buffer = buffer;
-                }
-                if(measures.length) {
-                    jsonObject.properties.length = measures.length;
-                }
-                if(!me._featuresValidity[f.getId()]) {
-                    jsonObject.properties.area = me._loc.intersectionNotAllowed;
-                } else if(measures.area) {
-                    jsonObject.properties.area = measures.area;
-                }
+
+                var multiGeometry = me.createMultiGeometry(geometries);
+
+                var feature = new ol.Feature({geometry: multiGeometry});
+                feature.setId(me.generateNewFeatureId());
+
+                jsonObject = me.formJsonObject(feature, measures, buffer);
                 geoJsonObject.features.push(jsonObject);
-            });
+            } else {
+                features.forEach(function (feature) {
+                    if(feature.buffer) {
+                        buffer = feature.buffer;
+                    }
+                    measures = me.sumMeasurements([feature]);
+
+                    if(!me._featuresValidity[feature.getId()]) {
+                        measures.area = me._loc.intersectionNotAllowed;
+                    } 
+                    jsonObject = me.formJsonObject(feature, measures, buffer);
+                    geoJsonObject.features.push(jsonObject);
+                });
+            }
 
             return geoJsonObject;
         },
+
+        createMultiGeometry: function(geometries) {
+            var featureGeom = null;
+
+            var appendGeometry = function(geometry){
+                switch (geometry.getType()) {
+                    case 'Point':
+                        if(!featureGeom) {
+                             featureGeom = new ol.geom.MultiPoint();
+                        }
+                        featureGeom.appendPoint(geometry);
+                        break;
+                    case 'LineString':
+                        if(!featureGeom) {
+                             featureGeom = new ol.geom.MultiLineString();
+                        }
+                        featureGeom.appendLineString(geometry);
+                        break;
+                    case 'Polygon':
+                        if(!featureGeom) {
+                             featureGeom = new ol.geom.MultiPolygon();
+                        }
+                        featureGeom.appendPolygon(geometry);
+                        break;
+                }
+            };
+
+            geometries.forEach(function(geometry){
+                appendGeometry(geometry);
+            });
+
+            return featureGeom;
+        },
+
+        formJsonObject: function (feature, measures, buffer) {
+            var me = this,
+                geoJSONformatter = new ol.format.GeoJSON(),
+                jsonObject = geoJSONformatter.writeFeatureObject(feature);
+
+            jsonObject.properties = {};
+            
+            if(measures.length) {
+                jsonObject.properties.length = measures.length;
+            }
+            if(!me._featuresValidity[feature.getId()]) {
+                jsonObject.properties.area = me._loc.intersectionNotAllowed;
+            } else if(measures.area) {
+                jsonObject.properties.area = measures.area;
+            }
+            if(buffer) {
+                jsonObject.properties.buffer = buffer;
+            }
+            return jsonObject;
+        },
+
         /**
          * Calculates line length and polygon area as measurements
          * @param  {Array} features features with geometries
@@ -584,6 +666,11 @@ Oskari.clazz.define(
             var optionsForDrawingEvent = {
                 isFinished: false
             };
+
+            if (options.allowMultipleDrawing === 'multiGeom') {
+                me.drawMultiGeom = true;
+            }
+
             function makeClosedPolygonCoords(coords) {
                 return coords.map(function(ring) {
                     ring = ring.slice();

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -359,7 +359,6 @@ Oskari.clazz.define(
          * @param {object} options include:
          *                  {Boolean} clearCurrent: true - all selection will be removed from the map after stopping plugin, false - will keep selection on the map. Default is false.
          *                  {Boolean} isFinished: true - if drawing is completed. Default is false.
-         *                  {Boolean} multiGeom: true - make multigeometry. Default is false
          */
         sendDrawingEvent: function(id, options) {
             var me = this,

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -803,9 +803,15 @@ Oskari.clazz.define(
                 me._showIntersectionWarning = true;
                 me.pointerMoveHandler();
                 me._mode = '';
-                if(options.allowMultipleDrawing === false) {
+
+                //stop drawing without modifying
+                if(options.allowMultipleDrawing === false && options.modifyControl === false) {
                     me.stopDrawing(me._id, false);
+                } else if (options.allowMultipleDrawing === false) {
+                    //stop drawing and start modifying
+                    me.removeInteractions(me._draw, me._id);
                 }
+
                 evt.feature.setStyle(me._styles.modify);
                 // activate modify interaction after new drawing is finished
                 if(options.modifyControl !== false) {


### PR DESCRIPTION
It is now possible to give value 'multiGeom' to parameter allowMultipleDrawing in StartDrawingRequest. By giving that value DrawPlugin gathers drawn shapes into a single feature with multigeometry instead of sending multiple features in DrawingEvent.

Bug related to parameter allowMultipleDrawing = false is also fixed.