### PR TITLE
Set parameter 'drawMultiGeom' to false by default

### DIFF
--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -125,6 +125,7 @@ Oskari.clazz.define(
             // TODO : start draw control
             // use default style if options don't include custom style
             var me = this;
+            me.drawMultiGeom = false;
             //disable gfi
             me.getMapModule().setDrawingMode(true);
             // TODO: why not just call the stopDrawing()/_cleanupInternalState() method here?

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -125,7 +125,8 @@ Oskari.clazz.define(
             // TODO : start draw control
             // use default style if options don't include custom style
             var me = this;
-            me.drawMultiGeom = false;
+
+            me.drawMultiGeom = options.allowMultipleDrawing === 'multiGeom';
             //disable gfi
             me.getMapModule().setDrawingMode(true);
             // TODO: why not just call the stopDrawing()/_cleanupInternalState() method here?
@@ -666,10 +667,6 @@ Oskari.clazz.define(
             var optionsForDrawingEvent = {
                 isFinished: false
             };
-
-            if (options.allowMultipleDrawing === 'multiGeom') {
-                me.drawMultiGeom = true;
-            }
 
             function makeClosedPolygonCoords(coords) {
                 return coords.map(function(ring) {


### PR DESCRIPTION
Parameter 'drawMultiGeom' is now set to false by default when drawing is started. It is set to true if it is defined so in request options.