### PR TITLE
Small fixes/optimization

### DIFF
--- a/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
@@ -380,7 +380,6 @@ Oskari.clazz.define(
             }
 
             if (fragments.length) {
-                contentData.actions = {};
                 contentData.html = this._renderFragments(fragments);
                 contentData.layerId = fragments[0].layerId;
                 content.push(contentData);

--- a/bundles/mapping/mapwfs2/service/Mediator.js
+++ b/bundles/mapping/mapwfs2/service/Mediator.js
@@ -246,6 +246,10 @@ Oskari.clazz.define(
          * featureProperties comes from user_layer table fields column
          */
         setOrderForFeatureProperties: function(layer, fields){
+            if(layer.getFeaturePropertyIndexes().length > 0) {
+                // already set
+                return;
+            }
             var orderedFieldsIndexes = [],
                 orderedFields = layer.getFeatureProperties(),
                 unOrderedFields = fields;


### PR DESCRIPTION

Infobox actions should be array if sent, but its not needed here so removed it.
Userlayer field indexes are calculated everytime it receives data, but it doesn't change so exit the method if indexes are already set.