### PR TITLE
Featuredata2 fix ui behaviour on tab-change / layer removal

### DIFF
--- a/bundles/framework/featuredata2/Flyout.js
+++ b/bundles/framework/featuredata2/Flyout.js
@@ -205,34 +205,6 @@ Oskari.clazz.define(
             var containerEl = me.tabsContainer.getElement();
             containerEl.parents('.oskari-flyoutcontentcontainer').css('overflow', 'hidden');
         },
-
-        /**
-         * @method layerAdded
-         * @param {Oskari.mapframework.domain.WfsLayer} layer
-         *           WFS layer that was added
-         * Adds a tab for the layer
-         */
-        layerAdded: function (layer) {
-            var me = this,
-                panel = Oskari.clazz.create(
-                    'Oskari.userinterface.component.TabPanel'
-                );
-
-            panel.setTitle(layer.getName());
-            panel.setTooltip(layer.getName());
-            panel.getContainer().append(
-                this.instance.getLocalization('loading')
-            );
-            panel.layer = layer;
-            this.layers['' + layer.getId()] = panel;
-            this.tabsContainer.addPanel(panel);
-            if (!layer.isLayerOfType('userlayer')) { //Filter functionality is not implemented for userlayers
-                panel.setTitleIcon('icon-funnel', function (event) {
-                me.addFilterFunctionality(event, layer);
-                });
-            }
-        },
-
         turnOnClickOff: function () {
             var me = this;
             me.filterDialog.popup.dialog.off('click', '.add-link');
@@ -292,7 +264,32 @@ Oskari.clazz.define(
             }
             return true;
         },
+        /**
+         * @method layerAdded
+         * @param {Oskari.mapframework.domain.WfsLayer} layer
+         *           WFS layer that was added
+         * Adds a tab for the layer
+         */
+        layerAdded: function (layer) {
+            var me = this,
+                panel = Oskari.clazz.create(
+                    'Oskari.userinterface.component.TabPanel'
+                );
 
+            panel.setTitle(layer.getName());
+            panel.setTooltip(layer.getName());
+            panel.getContainer().append(
+                this.instance.getLocalization('loading')
+            );
+            panel.layer = layer;
+            this.layers['' + layer.getId()] = panel;
+            this.tabsContainer.addPanel(panel);
+            if (!layer.isLayerOfType('userlayer')) { //Filter functionality is not implemented for userlayers
+                panel.setTitleIcon('icon-funnel', function (event) {
+                me.addFilterFunctionality(event, layer);
+                });
+            }
+        },
         /**
          * @method layerRemoved
          * @param {Oskari.mapframework.domain.WfsLayer} layer
@@ -302,7 +299,6 @@ Oskari.clazz.define(
         layerRemoved: function (layer) {
             var layerId = '' + layer.getId(),
                 panel = this.layers[layerId];
-
             this.tabsContainer.removePanel(panel);
             // clean up
             if (panel) {
@@ -313,6 +309,7 @@ Oskari.clazz.define(
                 this.layers[layerId] = null;
                 delete this.layers[layerId];
             }
+            this.updateGrid();
         },
         /**
          * @method  @public selectGridValues select grid values
@@ -358,7 +355,7 @@ Oskari.clazz.define(
                 container.append(this.instance.getLocalization('errorNoFields'));
                 return;
             }
-            if(layer.getActiveFeatures().length === 0) {
+            if(layer.getActiveFeatures().length === 0 ) {
                 container.parent().children('.tab-tools').remove();
                 container.removeAttr('style');
                 container.append(this.instance.getLocalization('layer')['out-of-content-area']);
@@ -366,7 +363,7 @@ Oskari.clazz.define(
             }
             container.append(this.instance.getLocalization('loading'));
 
-            if (this.instance.__loadingStatus[layer.getId()] === 'loading' || this.instance.__loadingStatus[layer.getId()] === 'error') {
+            if (this.instance.__loadingStatus[layer.getId()] === 'error') {
                 return;
             }
 
@@ -634,7 +631,6 @@ Oskari.clazz.define(
 
                     panel.grid.setColumnSelector(true);
                     panel.grid.setResizableColumns(true);
-
                     if (conf && !conf.disableExport) {
                         panel.grid.setExcelExporter(
                             layer.getPermission('download') === 'download_permission_ok'

--- a/bundles/framework/featuredata2/Flyout.js
+++ b/bundles/framework/featuredata2/Flyout.js
@@ -181,7 +181,10 @@ Oskari.clazz.define(
                     }
                     me.selectedTab = selectedPanel;
                     if (selectedPanel) {
-                        selectedPanel.getContainer().show();
+
+                        if( selectedPanel.getContainer().css('display') == 'none') {
+                            selectedPanel.getContainer().show();
+                        }
                         // sendout highlight request for selected tab
                         if (me.active) {
                             var selection = [];
@@ -361,6 +364,11 @@ Oskari.clazz.define(
                 container.parent().children('.tab-tools').remove();
                 container.removeAttr('style');
                 container.append(this.instance.getLocalization('layer')['out-of-content-area']);
+
+                if (!panel.grid) {
+                   container.parent().find('.grid-tools').remove();
+                }
+                
                 return;
             }
             container.append(this.instance.getLocalization('loading'));

--- a/bundles/framework/featuredata2/Flyout.js
+++ b/bundles/framework/featuredata2/Flyout.js
@@ -314,7 +314,6 @@ Oskari.clazz.define(
                 delete this.layers[layerId];
                 panel.getContainer().remove();
             }
-            this.updateGrid();
         },
         /**
          * @method  @public selectGridValues select grid values

--- a/bundles/framework/featuredata2/Flyout.js
+++ b/bundles/framework/featuredata2/Flyout.js
@@ -177,11 +177,11 @@ Oskari.clazz.define(
                     if (previousPanel) {
                         request = reqBuilder(previousPanel.layer.getId(), false);
                         sandbox.request(me.instance.getName(), request);
+                        previousPanel.getContainer().hide();
                     }
                     me.selectedTab = selectedPanel;
                     if (selectedPanel) {
-                        me.updateData(selectedPanel.layer);
-
+                        selectedPanel.getContainer().show();
                         // sendout highlight request for selected tab
                         if (me.active) {
                             var selection = [];
@@ -196,6 +196,7 @@ Oskari.clazz.define(
                             request = reqBuilder(selectedPanel.layer.getId(), true);
                             sandbox.request(me.instance.getName(), request);
                         }
+                        me.updateData(selectedPanel.layer);
                     }
                 }
             );
@@ -308,6 +309,7 @@ Oskari.clazz.define(
                 delete panel.layer;
                 this.layers[layerId] = null;
                 delete this.layers[layerId];
+                panel.getContainer().remove();
             }
             this.updateGrid();
         },


### PR DESCRIPTION
if we switch to a layer with no active features, a grid for that tab is not created, and the previous tab is still visible causing bugs (showing wrong data-fields, exporting the previous layer)
- fix 1: always hide the previous panel when switching between tabs in the flyout.
- fix 2: when we update data, if there is no active features, hide the grid tools for the previous layer so we can't view wrong data.
