### PR TITLE
Toolselected fix

### DIFF
--- a/bundles/framework/mapmodule-plugin/plugin/controls/ControlsPlugin.js
+++ b/bundles/framework/mapmodule-plugin/plugin/controls/ControlsPlugin.js
@@ -30,6 +30,7 @@ Oskari.clazz.define(
      */
     function () {
         var me = this;
+        this.activeTool = null;
         me._clazz =
             'Oskari.mapframework.mapmodule.ControlsPlugin';
         me._name = 'ControlsPlugin';
@@ -141,18 +142,30 @@ Oskari.clazz.define(
                  */
                 'Toolbar.ToolSelectedEvent': function (event) {
                     // changed tool -> cancel any current tool
-                    if (this.getConfig().zoomBox !== false) {
-                        this._zoomBoxTool.deactivate();
-                    }
-                    if (this.getConfig().measureControls !== false) {
-                        this.getMapModule().orderLayersByZIndex();
-                        this._measureControls.line.deactivate();
-                        this._measureControls.area.deactivate();
+                    if (event.getToolId() === this.activeTool){
+                        this._deactivateControls(this.activeTool);
+                    } else {
+                        //deactivate all
+                        this._deactivateControls();
+                        this.activeTool = null;
                     }
                 }
             };
         },
-
+        _deactivateControls: function (skipTool){
+            if (this.getConfig().zoomBox !== false && skipTool !== 'zoombox') {
+                this._zoomBoxTool.deactivate();
+            }
+            if (this.getConfig().measureControls !== false) {
+                this.getMapModule().orderLayersByZIndex();
+                if(skipTool !== 'measureline') {
+                    this._measureControls.line.deactivate();
+                }
+                if (skipTool !== 'measurearea'){
+                    this._measureControls.area.deactivate();
+                }
+            }
+        },
         _createRequestHandlers: function () {
             var me = this,
                 mapMovementHandler = Oskari.clazz.create(

--- a/bundles/framework/mapmodule-plugin/plugin/controls/ToolSelectionHandler.js
+++ b/bundles/framework/mapmodule-plugin/plugin/controls/ToolSelectionHandler.js
@@ -57,10 +57,13 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.ToolSelectionHandler',
                 }
             } else if (toolName === 'map_control_zoom_tool' && this.controlsPlugin._zoomBoxTool) {
                 this.controlsPlugin._zoomBoxTool.activate();
+                this.controlsPlugin.activeTool = 'zoombox';
             } else if (toolName === 'map_control_measure_tool' && this.controlsPlugin._measureControls) {
                 this.controlsPlugin._measureControls.line.activate();
+                this.controlsPlugin.activeTool = 'measureline';
             } else if (toolName === 'map_control_measure_area_tool' && this.controlsPlugin._measureControls) {
                 this.controlsPlugin._measureControls.area.activate();
+                this.controlsPlugin.activeTool = 'measurearea';
             }
         }
     }, {

--- a/bundles/framework/myplaces2/ButtonHandler.js
+++ b/bundles/framework/myplaces2/ButtonHandler.js
@@ -16,6 +16,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces2.ButtonHandler",
         this.measureButtonGroup = 'basictools';
         this.ignoreEvents = false;
         this.dialog = null;
+        this.drawMode = null;
         this.loc = Oskari.getMsg.bind(null, 'MyPlaces2');
         var me = this;
         this.buttons = {
@@ -202,6 +203,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces2.ButtonHandler",
             } else if (conf.drawMode === 'measurearea') {
                 conf.drawMode = 'area';
             }
+            this.drawMode = conf.drawMode;
             var startRequest = this.instance.sandbox.getRequestBuilder('DrawPlugin.StartDrawingRequest')(conf);
             this.instance.sandbox.request(this, startRequest);
 
@@ -304,12 +306,16 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces2.ButtonHandler",
             /**
              * @method Toolbar.ToolSelectedEvent
              */
-            'Toolbar.ToolSelectedEvent': function () {
-                if (!this.ignoreEvents) {
+            'Toolbar.ToolSelectedEvent': function (event) {
+                if (event.getToolId() !== this.drawMode && !this.ignoreEvents) {
                     // changed tool -> cancel any drawing
                     // do not trigger when we return drawing tool to
                     this.sendStopDrawRequest(true);
                     this.instance.enableGfi(true);
+                    this.drawMode = null;
+                    if (this.dialog){
+                        this.dialog.close();
+                    }
                 }
             },
             /**


### PR DESCRIPTION
Myplaces2:
ToolSelected event clears and stops drawing when tool is selected. Added checking that ToolSelected event doesn't cancel drawing if selected tool matches with current drawmode.

Map controls:
Also added checking to measureControls (line, area) and zoombox tool that ignore deactivate on activeTool.