### PR TITLE
DrawTools edit multigeom functionality

### DIFF
--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -217,7 +217,6 @@ Oskari.clazz.define(
         },
         // used only for editing multigeometries (allowMultipleDrawing === 'multiGeom')
         createFeatures: function(geometries, checkIntersection){
-            debugger;
             var me = this,
                 feat,
                 feats = [];


### PR DESCRIPTION
If allowMultipleDrawing is multiGeom and geojson is given (edit myplace), parse features with multigeometries to features with single geometry. Added checkintersection for parsed polygons to get correct measurement result and style.

Current drawing/feature is sent in the DrawingEvent. While modifying drawn feature send only current drawing (edited) not orginal feature.