### PR TITLE
Myplaces3 bug fixes

### DIFF
--- a/bundles/framework/myplaces3/ButtonHandler.js
+++ b/bundles/framework/myplaces3/ButtonHandler.js
@@ -158,20 +158,18 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.ButtonHandler",
             // clear drawing before start
             this.instance.sandbox.postRequestByName('DrawTools.StopDrawingRequest', [this.instance.getName(), true]);  
             this.instance.getSandbox().postRequestByName('DrawTools.StartDrawingRequest', [this.instance.getName(), conf.shape, conf.drawOptions]);
-            if (!conf.geojson) {
-                // show only when drawing new place
-                this._showDrawHelper(config.drawMode);
-            }
+            this.instance.setIsEditPlace(false);
+            this._showDrawHelper(config.drawMode);
         },
         /**
          * @method sendStopDrawRequest
          * Sends a StopDrawingingRequest.
          * @param {Boolean} isCancel boolean param for StopDrawingRequest, true == canceled -> clear current drawing
+         * @param {Boolean} supressEvent boolean param for StopDrawingRequest, true to not send drawing event
          */
-        sendStopDrawRequest: function (isCancel) {
+        sendStopDrawRequest: function (isCancel, supressEvent) {
             if (isCancel) {
-                this.instance.sandbox.postRequestByName('DrawTools.StopDrawingRequest', [this.instance.getName(), true]);
-                this.instance.sandbox.postRequestByName('DrawTools.StopDrawingRequest', [this.instance.getEditPlaceName(), true]);
+                this.instance.sandbox.postRequestByName('DrawTools.StopDrawingRequest', [this.instance.getName(), true, supressEvent]);
                 this.instance.setIsFinishedDrawing(false);
             } else {
                 this.instance.setIsFinishedDrawing(true);
@@ -297,7 +295,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.ButtonHandler",
                 if (this.drawMode !== event.getToolId() && !this.ignoreEvents) {
                     // changed tool -> cancel any drawing
                     // do not trigger when placeform is shown 
-                    this.sendStopDrawRequest(true);
+                    this.sendStopDrawRequest(true, true);
                     this.instance.enableGfi(true);
                     if(this.dialog){
                         this.dialog.close();
@@ -311,7 +309,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.ButtonHandler",
              * @param {Oskari.mapping.drawtools.event.DrawingEvent} event
              */
             'DrawingEvent': function (event) {
-                if (event.getId() !== this.instance.getName()){
+                if (event.getId() !== this.instance.getName() || this.instance.isEditPlace()){
                     return;
                 }
                 if (event.getIsFinished()){
@@ -344,7 +342,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.ButtonHandler",
                     keyBoardRequest;
                 if (event.getId() == popupId){
                     this.instance.enableGfi(true);
-                    this.sendStopDrawRequest(true);
+                    this.sendStopDrawRequest(true, true);
                     if (sandbox.hasHandler('EnableMapKeyboardMovementRequest')) {
                         keyBoardRequest = Oskari.requestBuilder('EnableMapKeyboardMovementRequest')();
                         sandbox.request(this, keyBoardRequest);

--- a/bundles/framework/myplaces3/instance.js
+++ b/bundles/framework/myplaces3/instance.js
@@ -18,7 +18,7 @@ Oskari.clazz.define(
         this.myPlacesService = undefined;
         this.idPrefix = 'myplaces';
         this.finishedDrawing = false;
-        this.editPlaceName = 'EditMyPlaces3';
+        this.editPlace = false;
     }, {
         __name: 'MyPlaces3',
 
@@ -126,6 +126,13 @@ Oskari.clazz.define(
         setIsFinishedDrawing: function(bln){
             this.finishedDrawing = !!bln;
         },
+        isEditPlace: function(){
+            return this.editPlace;
+        },
+        setIsEditPlace: function(bln){
+            this.editPlace = !!bln;
+        },
+
         /**
          * @method myPlaceSelected
          * Place was selected
@@ -136,6 +143,7 @@ Oskari.clazz.define(
             // ask toolbar to select default tool
             var toolbarRequest = Oskari.requestBuilder('Toolbar.SelectToolButtonRequest')();
             this.sandbox.request(this, toolbarRequest);
+            this.editPlace = false;
             this.getMainView().cleanupDrawingVariables();
         },
 

--- a/bundles/framework/myplaces3/request/EditRequestHandler.js
+++ b/bundles/framework/myplaces3/request/EditRequestHandler.js
@@ -52,7 +52,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.request.EditRequestHan
                 center = mainMapModule.getCentroidFromGeoJSON(geometry);
                 shape =  geometry.type.replace('Multi','');
                 this.instance.myPlaceSelected();
-                this.sandbox.postRequestByName('DrawTools.StartDrawingRequest', [this.instance.getEditPlaceName(), shape, {allowMultipleDrawing: 'multiGeom', geojson: JSON.stringify(geometry), drawControl: false, showMeasureOnMap: true, style: this.instance.getDrawStyle()}]);
+                this.instance.setIsEditPlace(true);
+                this.sandbox.postRequestByName('DrawTools.StartDrawingRequest', [this.instance.getName(), shape, {allowMultipleDrawing: 'multiGeom', geojson: JSON.stringify(geometry), drawControl: false, showMeasureOnMap: true, style: this.instance.getDrawStyle()}]);
                 this.instance.getMainView().showPlaceForm(center, place);
             } else {
                 // should not happen

--- a/bundles/framework/myplaces3/resources/css/myplaces.css
+++ b/bundles/framework/myplaces3/resources/css/myplaces.css
@@ -71,3 +71,7 @@ div.imagePreview img {
 
 div.drawHelper div.measurementResult {
   margin-top: 5px; }
+
+div#newLayerForm .infoboxActionLinks {
+    padding-right: 0px;
+}

--- a/bundles/framework/myplaces3/scss/myplaces.scss
+++ b/bundles/framework/myplaces3/scss/myplaces.scss
@@ -102,3 +102,7 @@ div.imagePreview img {
 div.drawHelper div.measurementResult {
     margin-top: 5px;
 }
+
+div#newLayerForm .infoboxActionLinks {
+    padding-right: 0px;
+}

--- a/bundles/framework/myplaces3/service/MyPlacesService.js
+++ b/bundles/framework/myplaces3/service/MyPlacesService.js
@@ -750,8 +750,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
          * @param {Function} callback function to call when done, receives boolean as
          *      first argument(true == successful), myplaceModel as second parameter and boolean as third parameter (true if the category was new)
          */
-        saveMyPlace: function (myplaceModel, callback) {
-            this.commitMyPlaces([myplaceModel], callback);
+        saveMyPlace: function (myplaceModel, callback, isMovePlace) {
+            this.commitMyPlaces([myplaceModel], callback, isMovePlace);
         },
 
         /**
@@ -862,6 +862,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
                 place.setUpdateDate(feature.properties.updated);
                 place.setGeometry(feature.geometry);
                 if(isNew || isMovePlaces){
+                    this._removeMyPlace(place.getId());
                     this._addMyPlace(place);
                 }
             }

--- a/bundles/framework/myplaces3/view/MainView.js
+++ b/bundles/framework/myplaces3/view/MainView.js
@@ -114,15 +114,16 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.MainView",
 
             'DrawingEvent': function (event) {
                 if (event.getId() === this.instance.getName()) {
-                    if (this.instance.isFinishedDrawing()){
+                    if (this.instance.isEditPlace()){
+                        if (event.getIsFinished()){
+                            this.drawing = event.getGeoJson();
+                            this.drawingData = event.getData();
+                        } else {
+                            //update measurement result
+                            this._setMeasurementResult(event.getData());
+                        }
+                    }else if(this.instance.isFinishedDrawing()){
                         this._handleFinishedDrawingEvent (event);
-                    }
-                } else if (event.getId() === this.instance.getEditPlaceName()){
-                    //update measurement result
-                    this.drawingData = event.getData();
-                    this._setMeasurementResult(event.getData());
-                    if (event.getIsFinished()){
-                        this.drawing = event.getGeoJson();
                     }
                 }
             }
@@ -140,12 +141,12 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.MainView",
             this.drawingData = event.getData();
             this.showPlaceForm(location);
         },
-        _setMeasurementResult: function (){
-            if (this.form && this.drawingData){
-                if (this.drawingData.shape === "LineString"){
-                    this.form.setMeasurementResult(this.drawingData.length, "line");
-                } else if (this.drawingData.shape === "Polygon"){
-                    this.form.setMeasurementResult(this.drawingData.area, "area");
+        _setMeasurementResult: function (drawingData){
+            if (this.form && drawingData){
+                if (drawingData.shape === "LineString"){
+                    this.form.setMeasurementResult(drawingData.length, "line");
+                } else if (drawingData.shape === "Polygon"){
+                    this.form.setMeasurementResult(drawingData.area, "area");
                 }
             }
         },
@@ -188,9 +189,10 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.MainView",
                 this.form.setMeasurementResult(measurement, drawMode);
                 this.tempGeom = place.getGeometry(); //store if geometry is not edited
                 layerId = me.instance.getCategoryHandler()._getMapLayerId(place.getCategoryId());
+                this.isEditPlace = true;
             //set measurement result from drawing
             } else {
-                this._setMeasurementResult();
+                this._setMeasurementResult(this.drawingData);
             }            
 
             var formEl = me.form.getForm(categories),

--- a/bundles/framework/myplaces3/view/MainView.js
+++ b/bundles/framework/myplaces3/view/MainView.js
@@ -389,7 +389,8 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.MainView",
          */
         __savePlace: function (values) {
             var me = this,
-                drawing = this.drawing;
+                drawing = this.drawing,
+                isMovePlace = false;
             // form not open, nothing to do
             if (!values) {
                 // should not happen
@@ -413,6 +414,9 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.MainView",
                 place.setDrawToolsMultiGeometry(drawing); 
             } else if (this.tempGeom) {
                 place.setGeometry(this.tempGeom); // if not edited
+            }
+            if (values.category !== oldCategory){
+                isMovePlace = true;
             }
 
             var sandbox = this.instance.sandbox;
@@ -451,7 +455,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.MainView",
                     me.instance.showMessage(me.loc('notification.error.title'), me.loc('notification.error.savePlace'));
                 }
             };
-            this.instance.getService().saveMyPlace(place, serviceCallback);
+            this.instance.getService().saveMyPlace(place, serviceCallback, isMovePlace);
         },
         cleanupDrawingVariables: function () {
             this.drawing = null;

--- a/bundles/framework/myplaces3/view/MainView.js
+++ b/bundles/framework/myplaces3/view/MainView.js
@@ -205,6 +205,14 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.MainView",
 
             var actions = [
                 {
+                    name: me.loc('placeform.category.newLayer'),
+                    type: "link",
+                    group: 0,
+                    selector: '#newLayerForm > label',
+                    action: function () {
+                        me.form.createCategoryForm();
+                    }
+                }, {
                     name: me.loc('buttons.cancel'),
                     type: "button",
                     group: 1,

--- a/bundles/framework/myplaces3/view/PlaceForm.js
+++ b/bundles/framework/myplaces3/view/PlaceForm.js
@@ -139,7 +139,9 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.PlaceForm",
                 }
                 var imageLink = onScreenForm.find('input[data-name=imagelink]').val(),
                     categorySelection = onScreenForm.find('select[data-name=category]').val();
-
+                if(typeof categorySelection === "string"){
+                    categorySelection = parseInt(categorySelection);
+                }
                 values.place = {
                     name: placeName,
                     desc: placeDesc,

--- a/bundles/framework/myplaces3/view/PlaceForm.js
+++ b/bundles/framework/myplaces3/view/PlaceForm.js
@@ -43,7 +43,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.PlaceForm",
             '  </div>' +
             '  <div class="field" id="newLayerForm">' +
             '    <label for="category">' +
-            '      <a href="#" class="newLayerLink functional">' + this.loc('placeform.category.newLayer') + '</a>' + " " + this.loc('placeform.category.choose') +
+            '      <span>' + this.loc('placeform.category.choose') + '</span>' +
             '    </label>' +
             '    <br clear="all" />' +
             '    <select data-name="category"></select>' +
@@ -88,9 +88,6 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.PlaceForm",
             if (isPublished) {
                 // remove the layer selections if in a publised map
                 ui.find('div#newLayerForm').remove();
-            } else {
-                // otherwise bind an event when selecting to create a new layer
-                this._bindCreateNewLayer();
             }
 
             // Hide the image preview at first
@@ -142,6 +139,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.PlaceForm",
                 }
                 var imageLink = onScreenForm.find('input[data-name=imagelink]').val(),
                     categorySelection = onScreenForm.find('select[data-name=category]').val();
+
                 values.place = {
                     name: placeName,
                     desc: placeDesc,
@@ -247,25 +245,12 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.PlaceForm",
             }
         },
 
-        /**
-         * Binds the link for creating a new category.
-         *
-         * @method _bindCreateNewLayer
-         * @private
-         */
-        _bindCreateNewLayer: function () {
-            var me = this,
-                onScreenForm = me._getOnScreenForm();
-            onScreenForm.find('a.newLayerLink').live('click', function (evt) {
-                var form = me._getOnScreenForm();
-                evt.preventDefault();
-                me.categoryForm = Oskari.clazz.create('Oskari.mapframework.bundle.myplaces3.view.CategoryForm', me.instance);
-                form.find('div#newLayerForm').html(me.categoryForm.getForm());
-                //add listeners etc.
-                me.categoryForm.start();
-            });
+        createCategoryForm: function (){
+            var onScreenForm = this._getOnScreenForm();
+            this.categoryForm = Oskari.clazz.create('Oskari.mapframework.bundle.myplaces3.view.CategoryForm', this.instance);
+            onScreenForm.find('div#newLayerForm').html(this.categoryForm.getForm());
+            this.categoryForm.start();
         },
-
         /**
          * @method destroy
          * Removes eventlisteners

--- a/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol3.js
+++ b/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol3.js
@@ -408,7 +408,8 @@ Oskari.clazz.define(
                     link,
                     currentGroup,
                     group = -1,
-                    sanitizedHtml;
+                    sanitizedHtml,
+                    targetElem;
 
                 if (typeof datum.html === "string") {
                     sanitizedHtml = Oskari.util.sanitize(datum.html);
@@ -417,6 +418,7 @@ Oskari.clazz.define(
                 }
 
                 contentWrapper.append(sanitizedHtml);
+
 
 	            contentWrapper.attr('id', 'oskari_' + id + '_contentWrapper');
 
@@ -437,10 +439,15 @@ Oskari.clazz.define(
                                 value: sanitizedActionName
                             });
                         }
-
                         currentGroup = action.group;
-
-                        if (currentGroup && currentGroup === group) {
+                        if (action.selector){
+                            targetElem = contentWrapper.find(action.selector);
+                        } else {
+                            targetElem = null;
+                        }
+                        if (targetElem instanceof jQuery) {
+                            targetElem.prepend(actionTemplate);
+                        }else if (currentGroup && currentGroup === group) {
                             actionTemplateWrapper.append(actionTemplate);
                         } else {
                             actionTemplateWrapper = me._actionTemplateWrapper.clone();


### PR DESCRIPTION
ol.Overlay element stops event propagation, so createNewLayer link click didn't work because jQuery captures events on bubbling phase. Changed to use actionLink and new createCategoryForm function.

DrawTools events weren't handled properly when myplace changed while editing (click edit and then click another edit). Now DrawTools supress drawing events if is cancel (tool changed, close infobox,..) and edit myplace uses same id than new drawing. isEditPlace is used to tell the difference.

Internal data structure wasn't updated if myplace's category was changed.