### PR TITLE
Maprotator positioning fix

### DIFF
--- a/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
+++ b/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
@@ -5,7 +5,7 @@ Oskari.clazz.define( 'Oskari.mapping.maprotator.MapRotatorPlugin',
     me._clazz = 'Oskari.mapping.maprotator.MapRotatorPlugin';
     me._defaultLocation = 'top right';
     me._toolOpen = false;
-    me._index = 90;
+    me._index = 80;
     me._currentRot = null;
     me.previousDegrees = null;
     me._templates = {

--- a/bundles/mapping/maprotator/resources/css/maprotator.css
+++ b/bundles/mapping/maprotator/resources/css/maprotator.css
@@ -5,4 +5,5 @@
   background-image: url('../images/north_circle_dark.png');
   border-radius: 50%;
   margin-bottom: 8.5px !important;
+  clear: both;
 }


### PR DESCRIPTION
Maprotator had same index (90) than Feature data and maprotator didn't have css clear property so them where rendered in the same position . Changed maprotator index to 80 to render it before feature data and added clear property.