### PR TITLE
Heatmap/event fix

### DIFF
--- a/bundles/mapping/heatmap/plugin/AbstractHeatmapPlugin.js
+++ b/bundles/mapping/heatmap/plugin/AbstractHeatmapPlugin.js
@@ -59,7 +59,7 @@ Oskari.clazz.define(
          * @return {undefined}
          */
         _updateLayer: function(layer) {
-            if ( layer.getId() !== this.getLayerTypeSelector() ) {
+            if ( layer.isLayerOfType( this.getLayerTypeSelector() ) ) {
                 return
             }
             var oLayers = this.getOLMapLayers(layer),

--- a/bundles/mapping/heatmap/plugin/AbstractHeatmapPlugin.js
+++ b/bundles/mapping/heatmap/plugin/AbstractHeatmapPlugin.js
@@ -66,7 +66,7 @@ Oskari.clazz.define(
                 subs = layer.getSubLayers(),
                 layerList = subs.length ? subs : [layer],
                 llen = layerList.length,
-                scale = this.getMapModule().getMap().getScale(),
+                scale = this.getSandbox().getMap().getScale(),
                 i,
                 newRes,
                 isInScale;

--- a/bundles/mapping/heatmap/plugin/AbstractHeatmapPlugin.js
+++ b/bundles/mapping/heatmap/plugin/AbstractHeatmapPlugin.js
@@ -59,6 +59,9 @@ Oskari.clazz.define(
          * @return {undefined}
          */
         _updateLayer: function(layer) {
+            if ( layer.getId() !== this.getLayerTypeSelector() ) {
+                return
+            }
             var oLayers = this.getOLMapLayers(layer),
                 subs = layer.getSubLayers(),
                 layerList = subs.length ? subs : [layer],


### PR DESCRIPTION
- Get scale from sandbox map, instead of ol
- in _updateLayer a check is made if layer id is not equal to the layer type, return