### PR TITLE
Fix for highlighted feature when layer is NOT on the map

### DIFF
--- a/bundles/mapping/mapwfs2/plugin/WfsLayerPlugin.ol3.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsLayerPlugin.ol3.js
@@ -1527,12 +1527,13 @@ Oskari.clazz.define(
                     map.setLayerIndex(wfsMapImageLayer, layerIndex);
                 }
 
-                // highlight picture on top of normal layer images
-                var layerToMove = me.getOLMapLayer(layer, me.__typeHighlight);
-                var higlightLayerIndex = mapmodule.getLayerIndex(layerToMove);
-                highlightLayer = map.getLayers().removeAt(higlightLayerIndex);
-
+                // highlight picture on top of normal layer images (if both are available)
+                // for example postprocessor bundle can highlight without the "normal layer"
                 if (normalLayer && highlightLayer) {
+                    var layerToMove = me.getOLMapLayer(layer, me.__typeHighlight);
+                    var higlightLayerIndex = mapmodule.getLayerIndex(layerToMove);
+                    highlightLayer = map.getLayers().removeAt(higlightLayerIndex);
+
                     normalLayerIndex = mapmodule.getLayerIndex(normalLayer);
                     map.getLayers().insertAt(normalLayerIndex, highlightLayer);
                 }


### PR DESCRIPTION
Fixes an issue with ol3 implementation where postprocessor bundle tries to highlight a feature from a layer that is not on the map. For example: https://kartta.paikkatietoikkuna.fi/?lang=fi&viewId=4695&nationalCadastralReferenceHighlight=111-1-13-10