### PR TITLE
line-height problem asdi overriden css

### DIFF
--- a/applications/asdi/asdi_guest/css/overwritten.css
+++ b/applications/asdi/asdi_guest/css/overwritten.css
@@ -131,7 +131,7 @@ table {
         margin: 0;
         padding: 0;
         height: 100%;
-        font: 14px/16px "Open Sans", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif
+        font: 14px "Open Sans", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
     }
 
 	.search .resultList div h3 {


### PR DESCRIPTION
- remove the line-height specification in the asdi body overriden css.

there is a problem with the metadatacatalogue searching element `.metadataSearching`, it receives scrollbars when the line height is too narrow.