### PR TITLE
Myplaces3 and DrawTools gfi handling

### DIFF
--- a/bundles/framework/myplaces3/ButtonHandler.js
+++ b/bundles/framework/myplaces3/ButtonHandler.js
@@ -152,11 +152,10 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.ButtonHandler",
         sendDrawRequest: function (config) {
             this.drawMode = config.drawMode;
             this.instance.setIsFinishedDrawing(false);
-            this.instance.enableGfi(false);
 
             var conf = jQuery.extend(true, {}, config);
             // clear drawing before start
-            this.instance.sandbox.postRequestByName('DrawTools.StopDrawingRequest', [this.instance.getName(), true]);  
+            this.instance.getSandbox().postRequestByName('DrawTools.StopDrawingRequest', [this.instance.getName(), true, true]);
             this.instance.getSandbox().postRequestByName('DrawTools.StartDrawingRequest', [this.instance.getName(), conf.shape, conf.drawOptions]);
             this.instance.setIsEditPlace(false);
             this._showDrawHelper(config.drawMode);
@@ -294,9 +293,8 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.ButtonHandler",
             'Toolbar.ToolSelectedEvent': function (event) {
                 if (this.drawMode !== event.getToolId() && !this.ignoreEvents) {
                     // changed tool -> cancel any drawing
-                    // do not trigger when placeform is shown 
+                    // do not trigger when placeform is shown
                     this.sendStopDrawRequest(true, true);
-                    this.instance.enableGfi(true);
                     if(this.dialog){
                         this.dialog.close();
                     }
@@ -324,8 +322,6 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.ButtonHandler",
                         this.instance.sandbox.request(this, toolbarRequest);
                         // disable ignore to act normally after ^request
                         this.ignoreEvents = false;
-                        // select tool selection will enable gfi -> disable it again
-                        this.instance.enableGfi(false);
                         if (this.dialog) {
                             this.dialog.close();
                         }
@@ -341,7 +337,6 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.ButtonHandler",
                     form = this.instance.getMainView().getForm(),
                     keyBoardRequest;
                 if (event.getId() == popupId){
-                    this.instance.enableGfi(true);
                     this.sendStopDrawRequest(true, true);
                     if (sandbox.hasHandler('EnableMapKeyboardMovementRequest')) {
                         keyBoardRequest = Oskari.requestBuilder('EnableMapKeyboardMovementRequest')();

--- a/bundles/framework/myplaces3/instance.js
+++ b/bundles/framework/myplaces3/instance.js
@@ -101,17 +101,6 @@ Oskari.clazz.define(
             this.loc('notification.error.title'), this.loc('notification.error.generic'));
         },
         /**
-         * @method enableGfi
-         * Enables/disables the gfi functionality
-         * @param {Boolean} blnEnable true to enable, false to disable
-         */
-        enableGfi: function (blnEnable) {
-            var gfiReqBuilder = Oskari.requestBuilder('MapModulePlugin.GetFeatureInfoActivationRequest');
-            if (gfiReqBuilder) {
-                this.sandbox.request(this.buttons, gfiReqBuilder(blnEnable));
-            }
-        },
-        /**
          * @method getService
          * Returns the my places main service
          * @return {Oskari.mapframework.bundle.myplaces3.service.MyPlacesService}

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -127,6 +127,9 @@ Oskari.clazz.define(
             var me = this;
 
             me.drawMultiGeom = options.allowMultipleDrawing === 'multiGeom';
+            if(me._gfiTimeout){
+                clearTimeout(me._gfiTimeout);
+            }
             //disable gfi
             me.getMapModule().setDrawingMode(true);
             // TODO: why not just call the stopDrawing()/_cleanupInternalState() method here?
@@ -348,9 +351,15 @@ Oskari.clazz.define(
                 // layer not found for functionality id, nothing to do?
                 return;
             }
-
             if(supressEvent === true) {
                 me.clearDrawing(id);
+                //another bundle sends StopDrawingRequest to clear own drawing (e.g. toolselected)
+                //skip deactivate draw and modify controls
+                //should be also with suppressEvent !== true ??
+                //TODO: remove this hack, when stopdrawing, startdrawing, cleardrawing,. methods and requests are handled more properly
+                if (me._id !== id){
+                    return;
+                }
             } else {
                 me.sendDrawingEvent(id, options);
             }
@@ -360,7 +369,7 @@ Oskari.clazz.define(
             me._cleanupInternalState();
             me.getMap().un('pointermove', me.pointerMoveHandler, me);
             //enable gfi
-            setTimeout(function () {
+            me._gfiTimeout = setTimeout(function () {
                 me.getMapModule().setDrawingMode(false);
             }, 500);
         },

--- a/bundles/mapping/mapmodule/mapmodule.ol3.js
+++ b/bundles/mapping/mapmodule/mapmodule.ol3.js
@@ -115,6 +115,11 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.MapModule',
                 var mapClickedEvent = sandbox.getEventBuilder('MapClickedEvent')(lonlat, evt.pixel[0], evt.pixel[1], CtrlPressed);
                 sandbox.notifyAll(mapClickedEvent);
             });
+            map.on('dblclick', function () {
+                if (me.getDrawingMode()) {
+                    return false;
+                }
+            });
 
             map.on('pointermove', function (evt) {
 

--- a/bundles/mapping/mapwfs2/plugin/WfsLayerPlugin.ol3.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsLayerPlugin.ol3.js
@@ -782,7 +782,9 @@ Oskari.clazz.define(
                 var OLLayer = this.getOLMapLayer(
                     event.getMapLayer()
                 );
-                //OLLayer.redraw();
+                if (typeof OLLayer.getSource().refresh ==='function'){
+                    OLLayer.getSource().refresh();
+                }
 
                 this.getIO().setMapLayerStyle(
                     event.getMapLayer().getId(),
@@ -1560,6 +1562,7 @@ Oskari.clazz.define(
          */
         deleteTileCache: function (layerId, styleName) {
             // TODO: force reload of tiles - required for custom style change
+            // now layer's source is refreshed in changeMapLayerStyleHandler
         }
     }, {
         extend: ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],


### PR DESCRIPTION
Removed gfi handling from myplaces3 because DrawTools does enabling and disabling gfi internally.

Disabled double click while drawing. Fixes the bug that finish drawing causes DoubleClickZoom with allowmultipledrawing = false. 

Now wfs layer's source is refreshed to clear cache when style is changed.