### PR TITLE
Projection change support for "Map layers" and "Selected layers" UIs

### DIFF
--- a/bundles/framework/layerselection2/Flyout.js
+++ b/bundles/framework/layerselection2/Flyout.js
@@ -85,6 +85,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselection2.Flyout',
 
             this.templateLayerFooterOutOfContentArea = jQuery('<p class="layer-msg">' + loc['out-of-content-area'] + ' <a href="JavaScript:void(0);">' + loc['move-to-content-area'] + '</a></p>');
 
+            this.templateUnsupported = jQuery('<div class="layer-footer-unsupported">' + loc['unsupported-projection'] + '<br><a href="#">'+ loc['change-projection'] +'</a></div>');
+
             //set id to flyouttool-close
             elParent = this.container.parentElement.parentElement;
             elId = jQuery(elParent).find('.oskari-flyouttoolbar').find('.oskari-flyouttools').find('.oskari-flyouttool-close');
@@ -215,31 +217,43 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselection2.Flyout',
         _appendLayerFooter: function (layerDiv, layer, isInScale, isGeometryMatch) {
             var toolsDiv = layerDiv.find('div.layer-tools');
 
-            /* fix: we need this at anytime for slider to work */
-            var footer = this._createLayerFooter(layer, layerDiv);
-
-            if (!layer.isVisible()) {
-                toolsDiv.addClass('hidden-layer');
-                footer.css('display', 'none');
-                toolsDiv.append(this._createLayerFooterHidden(layer));
-            } else if (!isInScale) {
-                var oosFtr = this._createLayerFooterOutOfScale(layer);
-                toolsDiv.addClass('out-of-scale');
-                footer.css('display', 'none');
-                toolsDiv.append(oosFtr);
-            } else if (!isGeometryMatch) {
-                var oocaFtr = this._createLayerFooterOutOfContentArea(layer);
-                toolsDiv.addClass('out-of-content');
-                footer.css('display', 'none');
-                toolsDiv.append(oocaFtr);
+            var footer;
+            if(!layer.isSupported(this.instance.getSandbox().getMap().getSrsName())) {
+                footer = this._createUnsupportedFooter();
             } else {
-                footer.css('display', '');
+                /* fix: we need this at anytime for slider to work */
+                footer = this._createLayerFooter(layer, layerDiv);
+
+                if (!layer.isVisible()) {
+                    toolsDiv.addClass('hidden-layer');
+                    footer.css('display', 'none');
+                    toolsDiv.append(this._createLayerFooterHidden(layer));
+                } else if (!isInScale) {
+                    var oosFtr = this._createLayerFooterOutOfScale(layer);
+                    toolsDiv.addClass('out-of-scale');
+                    footer.css('display', 'none');
+                    toolsDiv.append(oosFtr);
+                } else if (!isGeometryMatch) {
+                    var oocaFtr = this._createLayerFooterOutOfContentArea(layer);
+                    toolsDiv.addClass('out-of-content');
+                    footer.css('display', 'none');
+                    toolsDiv.append(oocaFtr);
+                } else {
+                    footer.css('display', '');
+                }
             }
 
             toolsDiv.append(footer);
 
             var opa = layerDiv.find('div.layer-opacity div.opacity-slider input'),
                 slider = this._addSlider(layer, layerDiv, opa);
+        },
+        /**
+         * @private
+         * @method _createUnsupportedFooter create jQuery element for unsupported SRS footer
+         */
+        _createUnsupportedFooter: function () {
+            return this.templateUnsupported.clone();
         },
         /**
          * @private @method _switchRefreshIcon

--- a/bundles/framework/layerselection2/resources/locale/en.js
+++ b/bundles/framework/layerselection2/resources/locale/en.js
@@ -10,6 +10,8 @@ Oskari.registerLocalization(
             "show": "Show",
             "hide": "Hide",
             "hidden": "The map layer is temporarily hidden.",
+            "unsupported-projection": "Map layer cannot be shown in selected map projection.",
+            "change-projection": "Change map projection",
             "out-of-scale": "The map layer cannot be shown at this scale level.",
             "move-to-scale": "Please move to a suitable map level.",
             "out-of-content-area": "The map layer has no features at the map view area.",

--- a/bundles/framework/layerselection2/resources/locale/fi.js
+++ b/bundles/framework/layerselection2/resources/locale/fi.js
@@ -10,6 +10,8 @@ Oskari.registerLocalization(
             "show": "Näytä",
             "hide": "Piilota",
             "hidden": "Karttataso on tilapäisesti piilotettu.",
+            "unsupported-projection": "Karttatsoa ei voida näyttää tässä karttaprojektiossa.",
+            "change-projection": "Vaihda karttaprojektiota",
             "out-of-scale": "Karttatasoa ei voida näyttää valitulla mittakaavatasolla.",
             "move-to-scale": "Siirry sopivalle mittakaavatasolle.",
             "out-of-content-area": "Karttatasolla ei ole kohteita karttanäkymän alueella.",

--- a/bundles/framework/layerselection2/resources/locale/sv.js
+++ b/bundles/framework/layerselection2/resources/locale/sv.js
@@ -10,6 +10,8 @@ Oskari.registerLocalization(
             "show": "Visa",
             "hide": "Göm",
             "hidden": "Kartlagret är tillfälligt dolt.",
+            "unsupported-projection": "Denna kartlager kan inte visas med den valda kartprojektionen.",
+            "change-projection": "Ändra kartprojektion",
             "out-of-scale": "Data som ingår i detta kartlager kan inte visas på den valda skalnivån.",
             "move-to-scale": "Gå till en lämplig skalnivå.",
             "out-of-content-area": "Detta kartlager saknar innehåll vid dessa koordinater.",

--- a/bundles/framework/layerselector2/resources/css/style.css
+++ b/bundles/framework/layerselector2/resources/css/style.css
@@ -1,207 +1,153 @@
 div.layerselector2 div.layer-filter {
-    margin: 10px;
-    color: #949494;
-}
+  margin: 10px;
+  color: #949494; }
+
+div.layerselector2 div.header .badge-wrapper {
+  right: 8%;
+  max-width: 50px; }
 
 div.layerselector2 div.filter {
-    border: 1px solid #a4a4a4;
-    padding: 10px;
-    float: left;
-    cursor: pointer;
-    margin-bottom: 5px;
-    margin-left: -1px;
-}
+  border: 1px solid #a4a4a4;
+  padding: 10px;
+  float: left;
+  cursor: pointer;
+  margin-bottom: 5px;
+  margin-left: -1px; }
 
 div.layerselector2 div.accordion div.accordion_panel div.content {
-    padding: 0;
-}
+  padding: 0; }
 
 div.layerselector2 div.layer {
-    padding: 6px 10px 6px 40px;
-    background-color: #ffffff;
-    clear: both;
-
-    /* Default line height is too high, make it so the text just fits */
-    min-height: 14px;
-    line-height: 14px;
-}
-
-div.layerselector2 div.layer:nth-child(even) {
-    background-color: #f3f3f3;
-}
-
-div.layerselector2 div.layer input {
+  padding: 6px 10px 6px 40px;
+  background-color: #ffffff;
+  clear: both;
+  /* Default line height is too high, make it so the text just fits */
+  min-height: 14px;
+  line-height: 14px; }
+  div.layerselector2 div.layer:nth-child(even) {
+    background-color: #f3f3f3; }
+  div.layerselector2 div.layer input {
     float: left;
-    margin-right: 5px;
-}
-
-div.layerselector2 div.layer input[type=checkbox] {
-    margin-top: -2px;
-}
-
-div.layerselector2 div.layer label.layer-title {
+    margin-right: 5px; }
+    div.layerselector2 div.layer input[type=checkbox] {
+      margin-top: -2px; }
+  div.layerselector2 div.layer label.layer-title {
     /* Let's just imagine this is tabular data... */
-    font-size: 12px;
-}
-
-div.layerselector2 div.layer div.layer-tools {
-    float: right;
-}
-
-div.layerselector2 div.layer div.layer-icon {
+    font-size: 12px; }
+  div.layerselector2 div.layer .layer-title.not-supported {
+    opacity: 0.5; }
+  div.layerselector2 div.layer div.layer-tools {
+    float: right; }
+  div.layerselector2 div.layer div.layer-icon {
     float: left;
     width: 16px;
     height: 16px;
-    background-repeat: no-repeat;
-}
-
-div.layerselector2 div.layer div.layer-info {
+    background-repeat: no-repeat; }
+  div.layerselector2 div.layer div.layer-info {
     width: 16px;
     height: 16px;
     margin-left: 5px;
-    float: right;
-}
-
-div.layerselector2 div.layer div.layer-backendstatus-icon {
+    float: right; }
+  div.layerselector2 div.layer div.layer-backendstatus-icon {
     float: left;
     width: 20px;
     height: 16px;
     margin-right: 4px;
+    background-repeat: no-repeat; }
+  div.layerselector2 div.layer div.layer-not-supported {
+    float: left;
+    width: 20px;
+    height: 20px;
+    margin-right: 4px;
     background-repeat: no-repeat;
-}
-
-div.layerselector2 div.layer div.backendstatus-down {
+    margin-top: -2px; }
+  div.layerselector2 div.layer div.backendstatus-down {
     height: 20px !important;
     margin-bottom: 2px;
     margin-top: -2px;
-    cursor: pointer;
-}
-
-div.layerselector2 div.layer div.backendstatus-maintenance {
+    cursor: pointer; }
+  div.layerselector2 div.layer div.backendstatus-maintenance {
     height: 20px !important;
     margin-bottom: 2px;
     margin-top: -2px;
-    cursor: pointer;
-}
-
-div.layerselector2 div.layer div.backendstatus-ok {
+    cursor: pointer; }
+  div.layerselector2 div.layer div.backendstatus-ok {
     height: 20px !important;
     margin-bottom: 2px;
     margin-top: -2px;
-    cursor: pointer;
-}
-
-div.layerselector2 div.layer div.backendstatus-unknown {
+    cursor: pointer; }
+  div.layerselector2 div.layer div.backendstatus-unknown {
     height: 20px !important;
     margin-bottom: 2px;
-    margin-top: -2px;
-}
-
-div.layerselector2 div.layer div.backendstatus-unstable {
+    margin-top: -2px; }
+  div.layerselector2 div.layer div.backendstatus-unstable {
     height: 20px !important;
     margin-bottom: 2px;
-    margin-top: -2px;
-}
+    margin-top: -2px; }
 
 div.layerselector2 div.layerGroup {
-    background-color: #f3f3f3;
-    border: 1px solid #c0d0d0;
-    margin: 0;
-    padding: 0;
-}
-
-div.layerselector2 div.layerGroup.open {
-    background-color: #FFFFFF;
-}
-
-div.layerselector2 div.layerGroup div.groupIcon {
+  background-color: #f3f3f3;
+  border: 1px solid #c0d0d0;
+  margin: 0;
+  padding: 0; }
+  div.layerselector2 div.layerGroup.open {
+    background-color: #FFFFFF; }
+  div.layerselector2 div.layerGroup div.groupIcon {
     display: inline-block;
     margin-left: 12px;
-    vertical-align: middle;
-}
-
-div.layerselector2 div.layerGroup div.groupHeader {
+    vertical-align: middle; }
+  div.layerselector2 div.layerGroup div.groupHeader {
     display: inline-block;
-    padding: 8px 10px 8px 12px;
-}
+    padding: 8px 10px 8px 12px; }
 
 div.layerselector2 div.tab-content {
-    padding: 0;
-}
-
-div.layerselector2 div.tab-content div.oskarifield {
+  padding: 0; }
+  div.layerselector2 div.tab-content div.oskarifield {
     margin: 10px;
-    position: relative;
-}
-
-div.layerselector2 div.tab-content div.oskarifield input[type=text] {
-    width: 90%;
-}
-
-div.layerselector2 div.tab-content div.oskarifield .icon-close {
-    margin-right: -20px;
-}
-
-div.layerselector2 div.tab-content div.oskarifield .field-description {
-    padding: 3px 0;
-    color: #666;
-}
-
-div.layerselector2 div.tab-content div.oskarifield .field-description .icon-info {
-    display: inline-block;
-}
-
-div.layerselector2 div.tab-content div.oskarifield .related-keywords {
-    display: none;
-    overflow: hidden;
-    height: 30px;
-    line-height: 30px;
-}
-
-div.layerselector2 div.tab-content div.oskarifield .related-keywords .keywords-title {
-    box-sizing: border-box;
-    height: 30px;
-    line-height: 30px;
-    color: #000;
-    font-weight: bold;
-    float: left;
-}
-
-div.layerselector2 div.tab-content div.oskarifield .related-keywords .keyword-cont {
-    display: block;
-    box-sizing: border-box;
-    height: 30px;
-    line-height: 30px;
-    padding: 0 10px;
-    color: #0085D1;
-    float: left;
-}
-
-div.layerselector2 div.tab-content div.oskarifield .related-keywords .keyword-cont .keyword {
-    float: left;
-    min-width: 91px;
-}
-
-div.layerselector2 div.tab-content div.oskarifield .related-keywords .keyword-cont .type {
-    background-color: #333438;
-    border: solid 2px #FFDE00;
-    color: #FFDE00;
-    width: 34px;
-    line-height: 16px;
-    padding: 3px;
-    margin: 2px;
-    float: right;
-    display: inline-block;
-    text-align: center;
-}
-
-div.layerselector2 div.tab-content div.oskarifield .related-keywords .focus {
-    background-color: #333438;
-    color: white;
-}
-div.layerselector2 div.header .badge-wrapper {
-    right: 8%;
-    max-width: 50px;
-}
-
-/*# sourceMappingURL=style.css.map */
+    position: relative; }
+    div.layerselector2 div.tab-content div.oskarifield input[type=text] {
+      width: 90%; }
+    div.layerselector2 div.tab-content div.oskarifield .icon-close {
+      margin-right: -20px; }
+    div.layerselector2 div.tab-content div.oskarifield .field-description {
+      padding: 3px 0;
+      color: #666; }
+      div.layerselector2 div.tab-content div.oskarifield .field-description .icon-info {
+        display: inline-block; }
+    div.layerselector2 div.tab-content div.oskarifield .related-keywords {
+      display: none;
+      overflow: hidden;
+      height: 30px;
+      line-height: 30px; }
+      div.layerselector2 div.tab-content div.oskarifield .related-keywords .keywords-title {
+        box-sizing: border-box;
+        height: 30px;
+        line-height: 30px;
+        color: #000;
+        font-weight: bold;
+        float: left; }
+      div.layerselector2 div.tab-content div.oskarifield .related-keywords .keyword-cont {
+        display: block;
+        box-sizing: border-box;
+        height: 30px;
+        line-height: 30px;
+        padding: 0 10px;
+        color: #0085D1;
+        float: left; }
+        div.layerselector2 div.tab-content div.oskarifield .related-keywords .keyword-cont .keyword {
+          float: left;
+          min-width: 91px; }
+        div.layerselector2 div.tab-content div.oskarifield .related-keywords .keyword-cont .type {
+          background-color: #333438;
+          border: solid 2px #FFDE00;
+          color: #FFDE00;
+          width: 34px;
+          line-height: 16px;
+          padding: 3px;
+          margin: 2px;
+          float: right;
+          display: inline-block;
+          text-align: center; }
+      div.layerselector2 div.tab-content div.oskarifield .related-keywords .focus {
+        background-color: #333438;
+        color: white; }

--- a/bundles/framework/layerselector2/resources/locale/en.js
+++ b/bundles/framework/layerselector2/resources/locale/en.js
@@ -32,7 +32,8 @@ Oskari.registerLocalization(
             "type-base": "Background map",
             "type-wms": "Map layer (WMS, WMTS)",
             "type-wfs": "Data product (WFS)",
-            "type-wfs-manual": "Refresh feature data by clicking 'Feature Data' or 'Refresh' button in the map window."
+            "type-wfs-manual": "Refresh feature data by clicking 'Feature Data' or 'Refresh' button in the map window.",
+            "unsupported-srs": "Unsupported map projection"
         },
         "backendStatus": {
             "OK": {

--- a/bundles/framework/layerselector2/resources/locale/fi.js
+++ b/bundles/framework/layerselector2/resources/locale/fi.js
@@ -32,7 +32,8 @@ Oskari.registerLocalization(
             "type-base": "Taustakartta",
             "type-wms": "Karttataso",
             "type-wfs": "Tietotuote",
-            "type-wfs-manual": "Päivitä kohdetiedot kartalla klikkaamalla Kohdetiedot- tai Päivitä-painiketta karttanäkymässä."
+            "type-wfs-manual": "Päivitä kohdetiedot kartalla klikkaamalla Kohdetiedot- tai Päivitä-painiketta karttanäkymässä.",
+            "unsupported-srs": "Väärä karttaprojektio"
         },
         "backendStatus": {
             "OK": {

--- a/bundles/framework/layerselector2/resources/locale/sv.js
+++ b/bundles/framework/layerselector2/resources/locale/sv.js
@@ -32,7 +32,8 @@ Oskari.registerLocalization(
             "type-base": "Bakgrundskarta",
             "type-wms": "Kartlager (WMS, WMTS)",
             "type-wfs": "Dataprodukt (WFS)",
-            "type-wfs-manual": "Data product (WFS) - Layer is drawn on a map via Feature Data or via Refresh button action"
+            "type-wfs-manual": "Data product (WFS) - Layer is drawn on a map via Feature Data or via Refresh button action",
+            "unsupported-srs": "Ostödd kartprojektion"
         },
         "backendStatus": {
             "OK": {

--- a/bundles/framework/layerselector2/scss/style.scss
+++ b/bundles/framework/layerselector2/scss/style.scss
@@ -56,6 +56,10 @@ div.layerselector2 {
             font-size: 12px;
         }
 
+        .layer-title.not-supported {
+            opacity: 0.5;
+        }
+
         div.layer-tools {
             float: right;
         }
@@ -80,6 +84,15 @@ div.layerselector2 {
             height: 16px;
             margin-right: 4px;
             background-repeat: no-repeat;
+        }
+
+        div.layer-not-supported {
+            float: left;
+            width: 20px;
+            height: 20px;
+            margin-right: 4px;
+            background-repeat: no-repeat;
+            margin-top: -2px;
         }
 
         div.backendstatus-down {

--- a/bundles/framework/layerselector2/view/Layer.js
+++ b/bundles/framework/layerselector2/view/Layer.js
@@ -20,6 +20,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.Layer",
     }, {
         __template: '<div class="layer"><input type="checkbox" /> ' +
                     '<div class="layer-tools">'+
+                    '   <div class="layer-not-supported backendstatus-maintenance-pending" title="" ></div>' +
                     '   <div class="layer-backendstatus-icon backendstatus-unknown" title=""></div>' +
                     '   <div class="layer-icon"></div>'+
                     '   <div class="layer-info"></div>'+
@@ -202,10 +203,12 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.Layer",
             // setup id
             layerDiv.attr('layer_id', layer.getId());
             layerDiv.find('input').attr('id', 'oskari_layerselector2_layerlist_checkbox_layerid_' + layer.getId());
-            layerDiv.find('.layer-title').append(layer.getName());
-            layerDiv.find('.layer-title').click(function(){
-                layerDiv.find('input').prop('checked', !layerDiv.find('input').prop('checked')).trigger('change');
-            });
+            layerDiv.find('.layer-title')
+                .append(layer.getName())
+                .click(function(){
+                    layerDiv.find('input').prop('checked', !layerDiv.find('input').prop('checked')).trigger('change');
+                })
+                .toggleClass('not-supported', !layer.isSupported(sandbox.getMap().getSrsName()));
 
             layerDiv.find('input').change(function () {
                 checkbox = jQuery(this);
@@ -242,6 +245,13 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.Layer",
                     mapLayerId
                 ]);
             });
+
+            /**
+             * Supported projection
+             */
+            tools.find('.layer-not-supported')
+                .css('display', !layer.isSupported(sandbox.getMap().getSrsName()) ? null : 'none')
+                .attr('title', this.localization.tooltip['unsupported-srs']);
 
             return layerDiv;
         }

--- a/bundles/mapping/maparcgis/plugin/ArcGisLayerPlugin.ol3.js
+++ b/bundles/mapping/maparcgis/plugin/ArcGisLayerPlugin.ol3.js
@@ -26,7 +26,7 @@ Oskari.clazz.define('Oskari.arcgis.bundle.maparcgis.plugin.ArcGisLayerPlugin',
          * @return {Boolean}       true if this plugin handles the type of layers
          */
         isLayerSupported : function(layer) {
-            if(!layer) {
+            if(!layer || !this.isLayerSrsSupported(layer)) {
                 return false;
             }
             return layer.isLayerOfType(this.layerType) || layer.isLayerOfType(this._layerType2);

--- a/bundles/mapping/mapmodule/AbstractMapLayerPlugin.js
+++ b/bundles/mapping/mapmodule/AbstractMapLayerPlugin.js
@@ -228,10 +228,18 @@ Oskari.clazz.define(
          * @return {Boolean}       true if this plugin handles the type of layers
          */
         isLayerSupported : function(layer) {
-            if(!layer) {
+            if(!layer || !this.isLayerSrsSupported(layer)) {
                 return false;
             }
             return layer.isLayerOfType(this.getLayerTypeSelector());
+        },
+        /**
+         * @method isLayerSrsSupported Checks if layer's SRS is supported by current map view
+         * @param {Oskari.mapframework.domain.AbstractLayer}  layer
+         * @return {Boolean}
+         */
+        isLayerSrsSupported: function(layer) {
+            return layer.isSupported(this.getSandbox().getMap().getSrsName());
         },
 
         getLayerTypeIdentifier: function () {

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -78,6 +78,8 @@ Oskari.clazz.define(
 
         me._sandbox = null;
 
+        me._mapLayerService = null;
+
         // reference to map-engine controls
         me._controls = {};
         // reference to plugins
@@ -165,13 +167,6 @@ Oskari.clazz.define(
 
             me._sandbox = sandbox;
 
-            var mapLayerService = sandbox.getService('Oskari.mapframework.service.MapLayerService');
-            if(!mapLayerService) {
-                // create maplayer service to sandbox if it doesn't exist yet
-                mapLayerService = Oskari.clazz.create('Oskari.mapframework.service.MapLayerService', sandbox);
-                sandbox.registerService(mapLayerService);
-            }
-
             var stateService = Oskari.clazz.create('Oskari.mapframework.domain.Map', sandbox);
             sandbox.registerService(stateService);
             this.handleMapLinkParams(stateService);
@@ -234,7 +229,13 @@ Oskari.clazz.define(
                     sandbox.registerForEventByName(this, p);
                 }
             }
-            var layerService = sandbox.getService('Oskari.mapframework.service.MapLayerService');
+
+            this._mapLayerService = sandbox.getService('Oskari.mapframework.service.MapLayerService');
+            if(!this._mapLayerService) {
+                // create maplayer service to sandbox if it doesn't exist yet
+                this._mapLayerService = Oskari.clazz.create('Oskari.mapframework.service.MapLayerService', sandbox);
+                sandbox.registerService(this._mapLayerService);
+            }
 
             //register request handlers
             this.requestHandlers = {
@@ -243,7 +244,7 @@ Oskari.clazz.define(
                 showSpinnerRequestHandler: Oskari.clazz.create('Oskari.mapframework.bundle.mapmodule.request.ShowProgressSpinnerRequestHandler', sandbox, this),
                 userLocationRequestHandler: Oskari.clazz.create('Oskari.mapframework.bundle.mapmodule.request.GetUserLocationRequestHandler', sandbox, this),
                 registerStyleRequestHandler: Oskari.clazz.create('Oskari.mapframework.bundle.mapmodule.request.RegisterStyleRequestHandler', sandbox, this),
-                mapLayerHandler: Oskari.clazz.create('map.layer.handler', sandbox.getMap(), layerService)
+                mapLayerHandler: Oskari.clazz.create('map.layer.handler', sandbox.getMap(), this._mapLayerService)
             };
 
             sandbox.requestHandler('MapModulePlugin.MapLayerUpdateRequest', this.requestHandlers.mapLayerUpdateHandler);
@@ -2272,7 +2273,12 @@ Oskari.clazz.define(
                 keepLayersOrder = true,
                 isBaseMap = false,
                 layerPlugins = this.getLayerPlugins(),
-                layerFunctions = [];
+                layerFunctions = [],
+                sandbox = this.getSandbox();
+            
+            if(!layer.isSupported(sandbox.getMap().getSrsName())) {
+                this._mapLayerService.showUnsupportedPopup();
+            }
 
             _.each(layerPlugins, function (plugin) {
                 // true if either plugin doesn't have the function or says the layer is supported.

--- a/bundles/mapping/mapmodule/domain/AbstractLayer.js
+++ b/bundles/mapping/mapmodule/domain/AbstractLayer.js
@@ -128,6 +128,8 @@ Oskari.clazz.define(
         // Spatial reference system
         me._srs_name = null;
 
+        me._srsList = null;
+
         // Admin params, applicable only for admin users
         me._admin = null;
 
@@ -1269,6 +1271,31 @@ Oskari.clazz.define(
          */
         getSrs_name: function () {
             return this._srs_name;
+        },
+        /**
+         * @method isSupported does the layer support given projection?
+         * @param {String} projection
+         * @return {Boolean}
+         */
+        isSupported: function(projection) {
+            if(!this._srsList) {
+                return false;
+            }
+            return this._srsList.includes(projection);
+        },
+        /**
+         * @method setSrsList
+         * @param {String[]} list of projections
+         */
+        setSrsList: function(list) {
+            this._srsList = list;
+        },
+        /**
+         * @method setSrsList
+         * @return {String[]} list of projections
+         */
+        getSrsList: function() {
+            return this._srsList;
         },
         /**
          * @method setGfiContent

--- a/bundles/mapping/mapmodule/resources/locale/en.js
+++ b/bundles/mapping/mapmodule/resources/locale/en.js
@@ -19,6 +19,8 @@ Oskari.registerLocalization(
             "zoomLvl-11": "",
             "zoomLvl-12": ""
         },
+        "unsupportedProjHeader": "Notice",
+        "unsupportedProj": "Some layers added to this map view cannot be shown,\nbecause the current map projection is unsupported.",
         "plugin": {
             "LogoPlugin": {
                 "terms": "Terms of Use",

--- a/bundles/mapping/mapmodule/resources/locale/fi.js
+++ b/bundles/mapping/mapmodule/resources/locale/fi.js
@@ -19,6 +19,8 @@ Oskari.registerLocalization(
             "zoomLvl-11": "",
             "zoomLvl-12": ""
         },
+        "unsupportedProjHeader": "Huom.",
+        "unsupportedProj": "Jotkin tähän karttanäkymään lisätyt tasot\neivät tue nykyistä karttaprojektiota,\nminkä vuoksi niitä ei voida näyttää.",
         "plugin": {
             "LogoPlugin": {
                 "terms": "Käyttöehdot",

--- a/bundles/mapping/mapmodule/resources/locale/sv.js
+++ b/bundles/mapping/mapmodule/resources/locale/sv.js
@@ -19,6 +19,8 @@ Oskari.registerLocalization(
             "zoomLvl-11": "",
             "zoomLvl-12": ""
         },
+        "unsupportedProjHeader": "Obs.",
+        "unsupportedProj": "Vissa kartlager kan inte visas\nmed den valda kartprojektionen.",
         "plugin": {
             "LogoPlugin": {
                 "terms": "Användarvillkor",

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -28,6 +28,8 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
         // used to store sticky layer ids - key = layer id, value = true if sticky (=layer cant be removed)
         this._stickyLayerIds = {};
 
+        this.loc = Oskari.getMsg.bind(null, 'MapModule');
+
         /**
          * @property typeMapping
          * Mapping from map-layer json "type" parameter to a class in Oskari
@@ -48,6 +50,9 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
 
         // used for cache newest layers
         this._newestLayers = null;
+
+        this._popupService = sandbox.getService('Oskari.userinterface.component.PopupService');
+        this.popupCoolOff = false;
 
         /*
         * Layer filters
@@ -299,6 +304,9 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
             if (newLayerConf.srs_name) {
                 layer.setSrs_name(newLayerConf.srs_name);
             }
+            if (newLayerConf.srs) {
+                layer.setSrsList(newLayerConf.srs);
+            }
 
             if (newLayerConf.admin) {
                 layer.setAdmin(newLayerConf.admin);
@@ -345,6 +353,20 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                 this._sandbox.notifyAll(evt);
             }
             // TODO: notify if layer not found?
+        },
+        showUnsupportedPopup(){
+            if(this.popupCoolOff) {
+                return;
+            }
+            var popup = this._popupService.createPopup();
+
+            var buttons = [popup.createCloseButton('OK')];
+            popup.show(this.loc('unsupportedProjHeader'), this.loc('unsupportedProj').replace(/[\n]/g, '<br>'), buttons);
+
+            this.popupCoolOff = true;
+            setTimeout(function() {
+                this.popupCoolOff = false;
+            }.bind(this), 500);
         },
         /**
          * @method loadAllLayersAjax
@@ -863,6 +885,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
 
             layer.setVersion(mapLayerJson.version);
             layer.setSrs_name(mapLayerJson.srs_name);
+            layer.setSrsList(mapLayerJson.srs);
 
             // metadata
             layer.setDataUrl(mapLayerJson.dataUrl);

--- a/packages/framework/bundle/ui-components/bundle.js
+++ b/packages/framework/bundle/ui-components/bundle.js
@@ -79,6 +79,9 @@ Oskari.clazz.define("Oskari.userinterface.bundle.ui.ComponentsBundle", function(
             "type" : "text/javascript",
             "src" : "../../../../bundles/framework/divmanazer/component/Button.js"
         }, {
+            "type": "text/javascript",
+            "src": "../../../../bundles/framework/divmanazer/component/buttons/CloseButton.js"
+        }, {
             "type" : "text/javascript",
             "src" : "../../../../bundles/framework/divmanazer/component/Form.js"
         }, {


### PR DESCRIPTION
Both "Map layers" and "Selected layers" lists will now show if some layers do not support the current projection.

Unsuported layers can be added to the view normally, but the user will be shown a popup warning that the layer will not be visible. The same popup will be shown on map initial load if the view has unsupported layers.

Link that opens projection change UI has not been wired with a handler yet.