### PR TITLE
Fix/drawtools stopdrawing

### DIFF
--- a/bundles/framework/myplaces3/view/MainView.js
+++ b/bundles/framework/myplaces3/view/MainView.js
@@ -123,6 +123,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.MainView",
                             this._setMeasurementResult(event.getData());
                         }
                     }else if(this.instance.isFinishedDrawing()){
+                        console.log(event);
                         this._handleFinishedDrawingEvent (event);
                     }
                 }
@@ -136,6 +137,12 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.MainView",
          */
         _handleFinishedDrawingEvent: function (event) {
             this.drawing = event.getGeoJson();
+            if (this.drawing.features && this.drawing.features.length === 0){
+                //no features, user clicks save my place without valid geometry
+                this.instance.showMessage(this.loc('notification.error.title'), this.loc('notification.error.savePlace'));
+                //should we start new drawing?? and inform user that line should have atleast 2 points and area 3 points
+                return;
+            }
             //TODO: closestPoint or centroid
             var location = this.instance.getSandbox().findRegisteredModuleInstance('MainMapModule').getClosestPointFromGeoJSON(this.drawing);
             this.drawingData = event.getData();

--- a/bundles/framework/myplaces3/view/MainView.js
+++ b/bundles/framework/myplaces3/view/MainView.js
@@ -123,7 +123,6 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.MainView",
                             this._setMeasurementResult(event.getData());
                         }
                     }else if(this.instance.isFinishedDrawing()){
-                        console.log(event);
                         this._handleFinishedDrawingEvent (event);
                     }
                 }

--- a/bundles/framework/publisher2/instance.js
+++ b/bundles/framework/publisher2/instance.js
@@ -20,12 +20,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
         var conf = this.getConfiguration();
         conf.name = 'Publisher2';
         conf.flyoutClazz = 'Oskari.mapframework.bundle.publisher2.Flyout';
-        if( !!this.configurationHasCustomElement() ) {
-            conf.tileClazz = null;
-            this.customElementClickHandler();
-        }
         this.defaultConf = conf;
         this.publisher = null;
+        this.customTileRef = null;
     }, {
         /**
          * @static
@@ -50,6 +47,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
                 return;
             }
             return handler.apply(this, [event]);
+        },
+        init: function () {
+            var tileElem = jQuery(this.getConfiguration().tileElement);
+            if(tileElem.length && tileElem.length !== 0) {
+                this.customTileRef = this.getConfiguration().tileElement;
+                this.conf.tileClazz = null;
+                this.customElementClickHandler(tileElem);
+            }
         },
 
         /**
@@ -135,14 +140,18 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
             return this.__service;
         },
         /**
-         * @return {String} reference to element-id to use instead of tile as bundle ui-element
+         * @return {String} reference to element-id to use instead of tile as bundle ui-element, returns null if isn't set in conf
          */
-        configurationHasCustomElement: function () {
-             return this.getConfiguration().tileElement;
+        getCustomTileRef: function () {
+             return this.customTileRef;
         },
-        customElementClickHandler: function () {
+         /**
+         * @method customElementClickHandler
+         * @param {jQuery} tileElement
+         */
+        customElementClickHandler: function (tileElement) {
             var me = this;
-            jQuery( this.configurationHasCustomElement() ).on("click", function () {
+            tileElement.on("click", function () {
                 me.getSandbox().postRequestByName(
                     'userinterface.UpdateExtensionRequest', [me, 'toggle']
                 );
@@ -165,8 +174,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
             // trigger an event letting other bundles know we require the whole UI
             var eventBuilder = Oskari.eventBuilder('UIChangeEvent');
             this.sandbox.notifyAll(eventBuilder(this.mediator.bundleId));
-            if ( !!this.configurationHasCustomElement() ) {
-                 blnEnabled ? jQuery( this.configurationHasCustomElement() ).addClass('activePublish') : jQuery( this.configurationHasCustomElement() ).removeClass('activePublish');
+            if ( this.getCustomTileRef() ) {
+                 blnEnabled ? jQuery( this.getCustomTileRef() ).addClass('activePublish') : jQuery( this.getCustomTileRef() ).removeClass('activePublish');
             }
             if (blnEnabled) {
                 var stateRB = Oskari.requestBuilder('StateHandler.SetStateRequest');

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -140,9 +140,7 @@ Oskari.clazz.define(
                 jQuery('div.' + me._tooltipClassForMeasure + "." + me._sketch.getId()).remove();
             }
             me._shape = shape;
-            if(me._id) {
-                Oskari.log('DrawTools').info('Previous drawing still on map and requesting new draw');
-            }
+
             // setup functionality id
             me._id = id;
             // setup options

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -346,17 +346,21 @@ Oskari.clazz.define(
             };
 
             if(!me.getLayerIdForFunctionality(id)) {
-                // layer not found for functionality id, nothing to do?
+                // layer not found for functionality id
+                // clear drawings from all drawing layers
+                me.clearDrawing();
                 return;
             }
             if(supressEvent === true) {
-                me.clearDrawing(id);
                 //another bundle sends StopDrawingRequest to clear own drawing (e.g. toolselected)
                 //skip deactivate draw and modify controls
                 //should be also with suppressEvent !== true ??
                 //TODO: remove this hack, when stopdrawing, startdrawing, cleardrawing,. methods and requests are handled more properly
                 if (me._id !== id){
+                    me.clearDrawing(); //clear all
                     return;
+                } else {
+                    me.clearDrawing(id); //clear drawing from given layer
                 }
             } else {
                 // try to finish unfinished (currently drawn) feature
@@ -431,23 +435,22 @@ Oskari.clazz.define(
          /**
          * @method clearDrawing
          * -  remove features from the draw layers
-         * @param {String} functionality id. If not given, will remove features from the current draw layer
+         * @param {String} functionality id. If not given, will remove features from all drawLayers
          */
         clearDrawing : function(id){
             var me = this;
+
             if(id) {
                 var layer = me.getLayer(me.getLayerIdForFunctionality(id));
                 if(layer) {
                     layer.getSource().getFeaturesCollection().clear();
                 }
             } else {
-                if(me.getLayer(me.getCurrentLayerId())) {
-                    me.getLayer(me.getCurrentLayerId()).getSource().getFeaturesCollection().clear();
-                }
-                // TODO: why is buffered layer only cleared here, but not when id is given?
-                // Should this be moved outside of the if/else?
-                me.getBufferedFeatureLayer().getSource().getFeaturesCollection().clear();
+                Object.keys(me._drawLayers).forEach(function(key){
+                    me._drawLayers[key].getSource().getFeaturesCollection().clear();
+                });
             }
+            me.getBufferedFeatureLayer().getSource().getFeaturesCollection().clear();
             // remove overlays (measurement tooltips)
             me.getMap().getOverlays().forEach(function (o) {
               if(!id || o.id === id) {


### PR DESCRIPTION
Now DrawTools tries to finish currently drawn geometry (sketch) on stopdrawing request. Fixes the bug where unfinished (not dblclicked) feature were added to drawing event and not to draw layer. Now stopdrawing request adds unfinished feature to draw layer before sending event if  2 points were drawn for lines or 3 points for area. Also updates measurements on map.

Now clearDrawing removes features from all drawlayers if id isn't given. Fixes the bug where another tool/bundle haven't cleared drawings before new tool/bundle starts to draw. StopDrawing request must be send before StartDrawing request to be sure that the drawing layers are cleared.

Publisher custom tile element configuration is now checked in init method instead of constructor.