### PR TITLE
Statsgrid - grid css changes

### DIFF
--- a/bundles/statistics/statsgrid2016/resources/css/style.css
+++ b/bundles/statistics/statsgrid2016/resources/css/style.css
@@ -62,7 +62,8 @@
   padding: 5px 5px 0px 5px;
   font-weight: normal; }
   .statsgrid-grid-table-header-content .header {
-    width: 90%;
+    word-wrap: break-word;
+    width: 85%;
     position: absolute;
     top: 5px; }
     .statsgrid-grid-table-header-content .header .title {

--- a/bundles/statistics/statsgrid2016/resources/css/style.css
+++ b/bundles/statistics/statsgrid2016/resources/css/style.css
@@ -217,7 +217,7 @@ div.oskari-flyout {
       animation-duration: 0.5s;
       animation-iteration-count: 3; }
     div.oskari-flyout.statsgrid-data-flyout table.oskari-grid td {
-      text-align: left; }
+      text-align: right; }
     div.oskari-flyout.statsgrid-data-flyout label span {
       /* Indicator selection form */
       width: 200px;

--- a/bundles/statistics/statsgrid2016/resources/css/style.css
+++ b/bundles/statistics/statsgrid2016/resources/css/style.css
@@ -62,7 +62,6 @@
   padding: 5px 5px 0px 5px;
   font-weight: normal; }
   .statsgrid-grid-table-header-content .header {
-    word-wrap: break-word;
     width: 85%;
     position: absolute;
     top: 5px; }

--- a/bundles/statistics/statsgrid2016/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/scss/style.scss
@@ -103,7 +103,6 @@ $flyoutPadding: 16px;
     font-weight: normal;
 
     .header {
-        word-wrap: break-word;
         width: 85%;
         position: absolute;
         top: 5px;

--- a/bundles/statistics/statsgrid2016/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/scss/style.scss
@@ -349,7 +349,7 @@ div.oskari-flyout {
             }
 
             td {
-                text-align: left;
+                text-align: right;
             }
         }
 

--- a/bundles/statistics/statsgrid2016/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/scss/style.scss
@@ -103,7 +103,8 @@ $flyoutPadding: 16px;
     font-weight: normal;
 
     .header {
-        width: 90%;
+        word-wrap: break-word;
+        width: 85%;
         position: absolute;
         top: 5px;
         .title {


### PR DESCRIPTION
- Reduce the width of grid header so text doesn't flow under the close button.
- Align grid values to right instead of left