### PR TITLE
"use strict" cleanup

### DIFF
--- a/applications/paikkatietoikkuna.fi/full-map/index.js
+++ b/applications/paikkatietoikkuna.fi/full-map/index.js
@@ -1,8 +1,8 @@
+'use strict';
 /**
  * Start when dom ready
  */
 jQuery(document).ready(function () {
-    "use strict";
     var getAppSetupParams = {},
         key,
         hostIdx,

--- a/applications/paikkatietoikkuna.fi/full-map_experimental/index.js
+++ b/applications/paikkatietoikkuna.fi/full-map_experimental/index.js
@@ -1,8 +1,8 @@
+'use strict';
 /**
  * Start when dom ready
  */
 jQuery(document).ready(function () {
-    "use strict";
     var getAppSetupParams = {},
         key,
         hostIdx,

--- a/bundles/framework/admin-layerrights/Flyout.js
+++ b/bundles/framework/admin-layerrights/Flyout.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.framework.bundle.admin-layerrights.Flyout
  *
@@ -12,7 +13,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Flyout',
      *        instance reference to component that created the tile
      */
     function(instance) {
-        "use strict";
+        
         var me = this;
         me.instance = instance;
         me.container = null;
@@ -36,7 +37,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Flyout',
          * @return {String} the name for the component
          */
         getName: function() {
-            "use strict";
+            
             return 'Oskari.framework.bundle.admin-layerrights.Flyout';
         },
 
@@ -52,7 +53,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Flyout',
          * Interface method implementation
          */
         setEl: function(el, width, height) {
-            "use strict";
+            
             this.container = el[0];
             if (!jQuery(this.container).hasClass('admin-layerrights')) {
                 jQuery(this.container).addClass('admin-layerrights');
@@ -66,7 +67,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Flyout',
          * that will be used to create the UI
          */
         startPlugin: function() {
-            "use strict";
+            
 
             this.template = jQuery(
                 '<div class="admin-layerrights">\n' +
@@ -95,7 +96,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Flyout',
          * Interface method implementation, does nothing atm
          */
         stopPlugin: function() {
-            "use strict";
+            
         },
 
         /**
@@ -103,7 +104,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Flyout',
          * @return {String} localized text for the title of the flyout
          */
         getTitle: function() {
-            "use strict";
+            
             return this.instance.getLocalization('title');
         },
 
@@ -113,7 +114,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Flyout',
          * flyout
          */
         getDescription: function() {
-            "use strict";
+            
             return this.instance.getLocalization('desc');
         },
 
@@ -122,7 +123,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Flyout',
          * Interface method implementation, does nothing atm
          */
         getOptions: function() {
-            "use strict";
+            
         },
 
         /**
@@ -130,7 +131,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Flyout',
          * @param {Object} state
          */
         setState: function(state) {
-            "use strict";
+            
             this.state = state;
         },
 
@@ -139,7 +140,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Flyout',
          * @return {Object} state
          */
         getState: function() {
-            "use strict";
+            
             if (!this.state) {
                 return {};
             }
@@ -150,7 +151,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Flyout',
          * Save layer rights
          */
         doSave: function() {
-            "use strict";
+            
             var me = this,
                 changedPermissions = me.extractSelections();
 
@@ -234,7 +235,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Flyout',
          * @param {String} content
          */
         setContent: function(content) {
-            "use strict";
+            
             // TODO add filters (provider/theme etc.)
             var me = this,
                 flyout = jQuery(this.container),
@@ -296,7 +297,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Flyout',
          * @return {String} Permissions table
          */
         createLayerRightGrid: function(layerRightsJSON) {
-            "use strict";
+            
             var me = this,
                 table = me._templates.table.clone(),
                 thead = table.find('thead'),
@@ -393,7 +394,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Flyout',
          * @return {Object} Dirty table rows
          */
         extractSelections: function() {
-            "use strict";
+            
             var me = this,
                 data = [],
                 container = jQuery(me.container),
@@ -475,7 +476,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Flyout',
          * @param {String} externalType
          */
         updatePermissionsTable: function(activeRole, externalType) {
-            "use strict";
+            
             var me = this;
             me.progressSpinner.start();
 
@@ -538,7 +539,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Flyout',
          * @param {String} selectedId
          */
         getExternalIdsAjaxRequest: function(externalType, selectedId) {
-            "use strict";
+            
             var me = this;
 
             //ajaxRequestGoing = true;
@@ -559,7 +560,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Flyout',
          * @param {String} selectedId
          */
         makeExternalIdsSelect: function(result, externalType, selectedId) {
-            "use strict";
+            
             var externalIdSelect = jQuery(this.container).find("select.admin-layerrights-role"),
                 optionEl,
                 d,

--- a/bundles/framework/admin-layerrights/Tile.js
+++ b/bundles/framework/admin-layerrights/Tile.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  * @class Oskari.framework.bundle.admin-layerrights.Tile
  *
@@ -12,7 +13,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Tile',
        *        reference to component that created the tile
        */
       function (instance) {
-        "use strict";
+        
         var me = this;
         me.instance = instance;
         me.container = null;
@@ -23,7 +24,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Tile',
          * @return {String} the name for the component
          */
         getName : function () {
-            "use strict";
+            
             return 'Oskari.framework.bundle.admin-layerrights.Tile';
         },
         /**
@@ -38,7 +39,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Tile',
          * Interface method implementation
          */
         setEl : function (el, width, height) {
-            "use strict";
+            
             this.container = jQuery(el);
         },
         /**
@@ -46,7 +47,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Tile',
          * Interface method implementation, calls #refresh()
          */
         startPlugin : function () {
-            "use strict";
+            
             this._addTileStyleClasses();
             this.refresh();
         },
@@ -67,7 +68,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Tile',
          * Interface method implementation, clears the container
          */
         stopPlugin : function () {
-            "use strict";
+            
             this.container.empty();
         },
         /**
@@ -75,7 +76,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Tile',
          * @return {String} localized text for the title of the tile
          */
         getTitle : function () {
-            "use strict";
+            
             return this.instance.getLocalization('title');
         },
         /**
@@ -83,7 +84,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Tile',
          * @return {String} localized text for the description of the tile
          */
         getDescription : function () {
-            "use strict";
+            
             return this.instance.getLocalization('desc');
         },
         /**
@@ -91,7 +92,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Tile',
          * Interface method implementation, does nothing atm
          */
         getOptions : function () {
-            "use strict";
+            
         },
         /**
          * @method setState
@@ -100,14 +101,14 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layerrights.Tile',
          * Interface method implementation, does nothing atm
          */
         setState : function (state) {
-            "use strict";
+            
         },
         /**
          * @method refresh
          * Creates the UI for a fresh start
          */
         refresh : function () {
-            "use strict";
+            
         }
     }, {
         /**

--- a/bundles/framework/admin-layerrights/instance.js
+++ b/bundles/framework/admin-layerrights/instance.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.framework.bundle.admin-layerrights.AdminLayerRightsBundleInstance
  *
@@ -14,7 +15,7 @@ Oskari.clazz.define("Oskari.framework.bundle.admin-layerrights.AdminLayerRightsB
      */
 
     function () {
-        "use strict";
+        
         this.sandbox = null;
         this.started = false;
         this.plugins = {};
@@ -33,7 +34,7 @@ Oskari.clazz.define("Oskari.framework.bundle.admin-layerrights.AdminLayerRightsB
          * @return {String} the name for the component
          */
         "getName": function () {
-            "use strict";
+            
             return this.__name;
         },
 
@@ -43,7 +44,7 @@ Oskari.clazz.define("Oskari.framework.bundle.admin-layerrights.AdminLayerRightsB
          * Sets the sandbox reference to this component
          */
         setSandbox: function (sandbox) {
-            "use strict";
+            
             this.sandbox = sandbox;
         },
 
@@ -52,7 +53,7 @@ Oskari.clazz.define("Oskari.framework.bundle.admin-layerrights.AdminLayerRightsB
          * @return {Oskari.Sandbox}
          */
         getSandbox: function () {
-            "use strict";
+            
             return this.sandbox;
         },
 
@@ -70,7 +71,7 @@ Oskari.clazz.define("Oskari.framework.bundle.admin-layerrights.AdminLayerRightsB
          *      structure and if parameter key is given
          */
         getLocalization: function (key) {
-            "use strict";
+            
             if (!this._localization) {
                 this._localization = Oskari.getLocalization(this.getName());
             }
@@ -85,7 +86,7 @@ Oskari.clazz.define("Oskari.framework.bundle.admin-layerrights.AdminLayerRightsB
          * implements BundleInstance protocol start methdod
          */
         "start": function () {
-            "use strict";
+            
             var me = this,
                 conf = me.conf,
                 sandboxName = (conf ? conf.sandbox : null) || 'sandbox',
@@ -132,7 +133,7 @@ Oskari.clazz.define("Oskari.framework.bundle.admin-layerrights.AdminLayerRightsB
          * implements Module protocol init method - does nothing atm
          */
         "init": function () {
-            "use strict";
+            
             return null;
         },
 
@@ -142,7 +143,7 @@ Oskari.clazz.define("Oskari.framework.bundle.admin-layerrights.AdminLayerRightsB
          * nothing atm
          */
         "update": function () {
-            "use strict";
+            
         },
 
         /**
@@ -175,7 +176,7 @@ Oskari.clazz.define("Oskari.framework.bundle.admin-layerrights.AdminLayerRightsB
          * implements BundleInstance protocol stop method
          */
         "stop": function () {
-            "use strict";
+            
             var me = this,
                 sandbox = me.sandbox(),
                 reqName = 'userinterface.RemoveExtensionRequest',
@@ -201,7 +202,7 @@ Oskari.clazz.define("Oskari.framework.bundle.admin-layerrights.AdminLayerRightsB
          * Oskari.mapframework.bundle.publisher.Tile
          */
         startExtension: function () {
-            "use strict";
+            
             this.plugins['Oskari.userinterface.Flyout'] =
                 Oskari.clazz.create('Oskari.framework.bundle.admin-layerrights.Flyout', this);
             this.plugins['Oskari.userinterface.Tile'] =
@@ -215,7 +216,7 @@ Oskari.clazz.define("Oskari.framework.bundle.admin-layerrights.AdminLayerRightsB
          * Clears references to flyout and tile
          */
         stopExtension: function () {
-            "use strict";
+            
             this.plugins['Oskari.userinterface.Flyout'] = null;
             this.plugins['Oskari.userinterface.Tile'] = null;
         },
@@ -227,7 +228,7 @@ Oskari.clazz.define("Oskari.framework.bundle.admin-layerrights.AdminLayerRightsB
          * @return {Object} references to flyout and tile
          */
         getPlugins: function () {
-            "use strict";
+            
             return this.plugins;
         },
 
@@ -236,7 +237,7 @@ Oskari.clazz.define("Oskari.framework.bundle.admin-layerrights.AdminLayerRightsB
          * @return {String} localized text for the title of the component
          */
         getTitle: function () {
-            "use strict";
+            
             return this.getLocalization('title');
         },
 
@@ -246,7 +247,7 @@ Oskari.clazz.define("Oskari.framework.bundle.admin-layerrights.AdminLayerRightsB
          * component
          */
         getDescription: function () {
-            "use strict";
+            
             return this.getLocalization('desc');
         },
 
@@ -255,7 +256,7 @@ Oskari.clazz.define("Oskari.framework.bundle.admin-layerrights.AdminLayerRightsB
          * (re)creates the UI for "selected layers" functionality
          */
         createUi: function () {
-            "use strict";
+            
             var me = this;
             me.plugins['Oskari.userinterface.Flyout'].setContent();
             me.plugins['Oskari.userinterface.Tile'].refresh();
@@ -266,7 +267,7 @@ Oskari.clazz.define("Oskari.framework.bundle.admin-layerrights.AdminLayerRightsB
          * @param {Object} state bundle state as JSON
          */
         setState: function (state) {
-            "use strict";
+            
             this.plugins['Oskari.userinterface.Flyout'].setState(state);
         },
 
@@ -275,7 +276,7 @@ Oskari.clazz.define("Oskari.framework.bundle.admin-layerrights.AdminLayerRightsB
          * @return {Object} bundle state as JSON
          */
         getState: function () {
-            "use strict";
+            
             return this.plugins['Oskari.userinterface.Flyout'].getState();
         }
     }, {

--- a/bundles/framework/admin-users/AdminRoles.js
+++ b/bundles/framework/admin-users/AdminRoles.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.mapframework.bundle.admin-users.AdminRoles
  *
@@ -237,7 +238,7 @@ Oskari.clazz.define(
          * @return {String} Permissions table
          */
         createLayerRightGrid: function (columnHeaders, layerRightsJSON) {
-            'use strict';
+            
             var table = '<table class="layer-rights-table">',
                 i = 0,
                 tr = 0,

--- a/bundles/framework/admin-users/Tile.js
+++ b/bundles/framework/admin-users/Tile.js
@@ -11,7 +11,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.admin-users.Tile',
      *     reference to component that created the tile
      */
     function (instance) {
-        //"use strict";
+        
         this.instance = instance;
         this.container = null;
         this.template = null;
@@ -21,7 +21,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.admin-users.Tile',
          * @return {String} the name for the component
          */
         getName: function () {
-            //"use strict";
+            
             return 'Oskari.mapframework.bundle.admin-users.Tile';
         },
         /**
@@ -36,7 +36,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.admin-users.Tile',
          * Interface method implementation
          */
         setEl: function (el, width, height) {
-            //"use strict";
+            
             this.container = jQuery(el);
         },
         /**
@@ -44,7 +44,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.admin-users.Tile',
          * Interface method implementation, calls #refresh()
          */
         startPlugin: function () {
-            //"use strict";
+            
             this.refresh();
         },
         /**
@@ -52,7 +52,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.admin-users.Tile',
          * Interface method implementation, clears the container
          */
         stopPlugin: function () {
-            //"use strict";
+            
             this.container.empty();
         },
         /**
@@ -60,7 +60,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.admin-users.Tile',
          * @return {String} localized text for the title of the tile
          */
         getTitle: function () {
-            //"use strict";
+            
             return this.instance.getLocalization('title');
         },
         /**
@@ -68,7 +68,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.admin-users.Tile',
          * @return {String} localized text for the description of the tile
          */
         getDescription: function () {
-            //"use strict";
+            
             return this.instance.getLocalization('desc');
         },
         /**
@@ -76,7 +76,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.admin-users.Tile',
          * Interface method implementation, does nothing atm
          */
         getOptions: function () {
-            //"use strict";
+            
         },
         /**
          * @method setState
@@ -85,7 +85,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.admin-users.Tile',
          * Interface method implementation, does nothing atm
          */
         setState: function (state) {
-            //"use strict";
+            
         },
         /**
          * @method refresh

--- a/bundles/framework/divmanazer/component/Button.js
+++ b/bundles/framework/divmanazer/component/Button.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.Button
  *
@@ -10,7 +11,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Button',
      * @static
      */
     function (name) {
-        'use strict';
+        
         this._element = document.createElement('input');
         this._element.className = 'oskari-formcomponent oskari-button';
         this._element.type = 'button';
@@ -19,32 +20,32 @@ Oskari.clazz.define('Oskari.userinterface.component.Button',
         }
     }, {
         blur: function () {
-            'use strict';
+            
             jQuery(this._element).blur();
         },
 
         focus: function () {
-            'use strict';
+            
             this._element.focus();
         },
 
         isFocus: function(){
-            'use strict';
+            
             return this._element === document.activeElement;
         },
 
         getName: function () {
-            'use strict';
+            
             return this._element.name;
         },
 
         setName: function (name) {
-            'use strict';
+            
             this._element.name = name;
         },
 
         getTitle: function () {
-            'use strict';
+            
             return this.getValue();
         },
 
@@ -53,27 +54,27 @@ Oskari.clazz.define('Oskari.userinterface.component.Button',
          * Sets the button title
          */
         setTitle: function (title) {
-            'use strict';
+            
             this.setValue(title);
         },
 
         getTooltip: function () {
-            'use strict';
+            
             return this._element.title;
         },
 
         setTooltip: function (tooltip) {
-            'use strict';
+            
             this._element.title = tooltip;
         },
 
         getValue: function () {
-            'use strict';
+            
             return this._element.value;
         },
 
         setValue: function (value) {
-            'use strict';
+            
             this._element.value = value;
         },
 
@@ -96,7 +97,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Button',
          * @param {Boolean} enabled true to enable, false to disable
          */
         _setEnabledImpl: function (enabled) {
-            'use strict';
+            
             this._element.disabled = !enabled;
         },
 
@@ -105,7 +106,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Button',
          * Sets click handler for button
          */
         _setHandlerImpl: function () {
-            'use strict';
+            
             this._element.onclick = this._handler;
         },
 
@@ -114,7 +115,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Button',
          * Sets primary status of the button
          */
         setPrimary: function (primary, focus) {
-            'use strict';
+            
             if (typeof primary !== 'boolean') {
                 throw new TypeError(
                     this.getClazz() +
@@ -139,7 +140,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Button',
          * Hide the button/hide  it in the document
          */
         hide: function () {
-            'use strict';
+            
             Oskari.getSandbox().printWarn('Oskari.userinterface.component.Button: hide is deprecated, please use setVisible instead.');
             this.setVisible(false);
         },
@@ -150,7 +151,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Button',
          * Show the button/show it in the document
          */
         show: function () {
-            'use strict';
+            
             Oskari.getSandbox().printWarn('Oskari.userinterface.component.Button: show is deprecated, please use setVisible instead.');
             this.setVisible(true);
         },
@@ -162,7 +163,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Button',
          * @param {Boolean} focus
          */
         setFocus: function(focus) {
-            'use strict';
+            
             Oskari.getSandbox().printWarn('Oskari.userinterface.component.Button: setFocus is deprecated, please use focus instead.');
             if (focus && focus === true) {
                 this.focus();
@@ -178,7 +179,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Button',
          * @return {jQuery} reference to DOM element
          */
         getButton: function () {
-            'use strict';
+            
             Oskari.getSandbox().printWarn('Oskari.userinterface.component.Button: getButton is deprecated, please use getElement instead.');
             return jQuery(this.getElement());
         },
@@ -187,7 +188,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Button',
          * @method _setVisibleImpl
          */
         _setVisibleImpl: function (visible) {
-            'use strict';
+            
             this._element.visible = visible;
             this._visible = visible;
             this.getElement().style.display = this.isVisible() ? '' : 'none';

--- a/bundles/framework/divmanazer/component/CheckboxInput.js
+++ b/bundles/framework/divmanazer/component/CheckboxInput.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.CheckboxInput
  *
@@ -9,7 +10,7 @@ Oskari.clazz.define('Oskari.userinterface.component.CheckboxInput',
      * @method create called automatically on construction
      */
     function () {
-        'use strict';
+        
         var me = this;
 
         me._clazz = 'Oskari.userinterface.component.CheckboxInput';
@@ -33,7 +34,7 @@ Oskari.clazz.define('Oskari.userinterface.component.CheckboxInput',
          * Focuses the component.
          */
         focus: function () {
-            'use strict';
+            
             this._input.focus();
         },
 
@@ -49,13 +50,13 @@ Oskari.clazz.define('Oskari.userinterface.component.CheckboxInput',
         },
 
         isEnabled: function () {
-            'use strict';
+            
             return !this._input.disabled;
         },
 
 
         _valueChanged: function () {
-            'use strict';
+            
             if (this.getHandler()) {
                 this.getHandler()(this.getValue());
             }
@@ -65,12 +66,12 @@ Oskari.clazz.define('Oskari.userinterface.component.CheckboxInput',
          * @method _setEnabledImpl
          */
         _setEnabledImpl: function (enabled) {
-            'use strict';
+            
             this._input.disabled = !enabled;
         },
 
         getName: function () {
-            'use strict';
+            
             return this._input.name;
         },
 
@@ -78,17 +79,17 @@ Oskari.clazz.define('Oskari.userinterface.component.CheckboxInput',
          * @method setName
          */
         setName: function (name) {
-            'use strict';
+            
             this._input.name = name || '';
         },
 
         getPlaceHolder: function () {
-            'use strict';
+            
             return this._input.placeholder;
         },
 
         setPlaceHolder: function (placeholder) {
-            'use strict';
+            
             this._input.placeholder = placeholder;
         },
 
@@ -96,12 +97,12 @@ Oskari.clazz.define('Oskari.userinterface.component.CheckboxInput',
          * @method _setRequiredImpl
          */
         _setRequiredImpl: function () {
-            'use strict';
+            
             this._input.required = this.isRequired();
         },
 
         getTitle: function () {
-            'use strict';
+            
             return this._titleEl.textContent;
         },
 
@@ -109,7 +110,7 @@ Oskari.clazz.define('Oskari.userinterface.component.CheckboxInput',
          * @method setTitle
          */
         setTitle: function (title) {
-            'use strict';
+            
             this._titleEl.textContent = '';
             if (title !== null && title !== undefined) {
                 this._titleEl.style.display = '';
@@ -120,7 +121,7 @@ Oskari.clazz.define('Oskari.userinterface.component.CheckboxInput',
         },
 
         getTooltip: function () {
-            'use strict';
+            
             return this._element.title;
         },
 
@@ -128,12 +129,12 @@ Oskari.clazz.define('Oskari.userinterface.component.CheckboxInput',
          * @method setTooltip
          */
         setTooltip: function () {
-            'use strict';
+            
             this._element.title = this.getTooltip();
         },
 
         getValue: function () {
-            'use strict';
+            
             return this._input.checked ? this._input.value : undefined;
         },
 
@@ -141,7 +142,7 @@ Oskari.clazz.define('Oskari.userinterface.component.CheckboxInput',
          * @method setValue
          */
         setValue: function (value) {
-            'use strict';
+            
             this._input.value = value;
         },
 
@@ -149,7 +150,7 @@ Oskari.clazz.define('Oskari.userinterface.component.CheckboxInput',
          * @method _setVisibleImpl
          */
         _setVisibleImpl: function () {
-            'use strict';
+            
             this.getElement().style.display = this.isVisible() ? '' : 'none';
         }
     }, {

--- a/bundles/framework/divmanazer/component/Component.js
+++ b/bundles/framework/divmanazer/component/Component.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.Component
  * Component
@@ -9,7 +10,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Component',
      * @static
      */
     function () {
-        'use strict';
+        
         this._clazz = 'Oskari.userinterface.component.Component';
         this._element = null;
         this._visible = true;
@@ -21,7 +22,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Component',
          * @param {Boolean} cleanup True if destroy is called just for cleanup
          */
         destroy: function (cleanup) {
-            'use strict';
+            
             this._destroyImpl(cleanup);
             if (!cleanup) {
                 if (this._element) {
@@ -38,7 +39,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Component',
          * @param {Boolean} cleanup True if destroy is called just for cleanup
          */
         _destroyImpl: function (cleanup) {
-            'use strict';
+            
             return undefined;
         },
 
@@ -47,7 +48,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Component',
          * @return {Array} Component classes in an array
          */
         _getClasses: function () {
-            'use strict';
+            
             if (this._element && this._element.className) {
                 return this._element.className.split(/\s+/).sort();
             }
@@ -59,7 +60,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Component',
          * @param {String} className
          */
         addClass: function (className) {
-            'use strict';
+            
             if(!this._element) {
                 return;
             }
@@ -75,7 +76,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Component',
          * @param {String} className
          */
         removeClass: function (className) {
-            'use strict';
+            
             if(!this._element) {
                 return;
             }
@@ -93,7 +94,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Component',
          * @param {Boolean} toggle
          */
         toggleClass: function (className, toggle) {
-            'use strict';
+            
             if (toggle) {
                 this.addClass(className);
             } else {
@@ -106,7 +107,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Component',
          * @return {String} clazz
          */
         getClazz: function () {
-            'use strict';
+            
             return this._clazz;
         },
 
@@ -115,7 +116,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Component',
          * @return {HTMLElement} element
          */
         getElement: function () {
-            'use strict';
+            
             return this._element;
         },
 
@@ -124,7 +125,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Component',
          * @return {String} name
          */
         getName: function () {
-            'use strict';
+            
             return undefined;
         },
 
@@ -133,7 +134,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Component',
          * @param {String} name
          */
         setName: function (name) {
-            'use strict';
+            
             return undefined;
         },
 
@@ -142,7 +143,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Component',
          * @return {String} title
          */
         getTitle: function () {
-            'use strict';
+            
             return undefined;
         },
 
@@ -151,7 +152,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Component',
          * @param {String} title
          */
         setTitle: function (title) {
-            'use strict';
+            
             return undefined;
         },
 
@@ -160,7 +161,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Component',
          * @return {Boolean}
          */
         isVisible: function () {
-            'use strict';
+            
             return this._visible;
         },
 
@@ -169,7 +170,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Component',
          * @param {Boolean} visible
          */
         setVisible: function (visible) {
-            'use strict';
+            
             if (typeof visible !== 'boolean') {
                 throw new TypeError(
                     this.getClazz() +
@@ -184,7 +185,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Component',
          * @param {Boolean} visible
          */
         _setVisibleImpl: function (visible) {
-            'use strict';
+            
             return undefined;
         },
 
@@ -193,7 +194,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Component',
          * @param {HTMLElement} container
          */
         insertTo: function (container) {
-            'use strict';
+            
             var cont;
             if (!container) {
                 throw new TypeError(

--- a/bundles/framework/divmanazer/component/Container.js
+++ b/bundles/framework/divmanazer/component/Container.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.Container
  * Container
@@ -9,7 +10,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Container',
      * @static
      */
     function () {
-        'use strict';
+        
         this._clazz = 'Oskari.userinterface.component.Container';
         this._components = [];
     }, {
@@ -19,7 +20,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Container',
          * @param {HTMLElement} component
          */
         addComponent: function (component) {
-            'use strict';
+            
             if(!this._element) {
                 Oskari.getSandbox().printWarn(
                     this.getClazz() + '.addComponent: container not initialized'
@@ -61,7 +62,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Container',
          * @param {HTMLElement} component
          */
         removeComponent: function (component) {
-            'use strict';
+            
             if (component === null || component === undefined) {
                 throw new TypeError(
                     this.getClazz() + '.removeComponent: ' +
@@ -86,7 +87,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Container',
          * @param {Array} components
          */
         getComponents: function () {
-            'use strict';
+            
             return this._components.slice(0);
         },
 
@@ -97,7 +98,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Container',
          * @return {Object}                   Values object
          */
         getValues: function (values, eventElement) {
-            'use strict';
+            
             var i,
                 me = this,
                 component,
@@ -146,7 +147,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Container',
          * @param {HTMLElement} component
          */
         _getComponentIndex: function (component) {
-            'use strict';
+            
             var i,
                 c,
                 ret = -1;

--- a/bundles/framework/divmanazer/component/EmailInput.js
+++ b/bundles/framework/divmanazer/component/EmailInput.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.EmailInput
  *
@@ -9,7 +10,7 @@ Oskari.clazz.define('Oskari.userinterface.component.EmailInput',
      * @method create called automatically on construction
      */
     function () {
-        'use strict';
+        
         this._element.className = 'oskari-formcomponent oskari-emailinput';
         this._input.type = 'email';
     }, {},

--- a/bundles/framework/divmanazer/component/Fieldset.js
+++ b/bundles/framework/divmanazer/component/Fieldset.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.Fieldset
  * Generic form component
@@ -9,7 +10,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Fieldset',
      * @static
      */
     function () {
-        'use strict';
+        
         var me = this;
         me._clazz = 'Oskari.userinterface.component.Fieldset';
         me._element = document.createElement('fieldset');
@@ -19,7 +20,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Fieldset',
         me._element.appendChild(me._titleEl);
     }, {
         _destroyImpl: function (cleanup) {
-            'use strict';
+            
             var i,
                 components = this.getComponents();
 
@@ -33,7 +34,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Fieldset',
          * @return {Boolean} enabled
          */
         isEnabled: function () {
-            'use strict';
+            
             return !this._element.disabled;
         },
 
@@ -42,7 +43,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Fieldset',
          * @param {Boolean} enabled
          */
         setEnabled: function (enabled) {
-            'use strict';
+            
             if (typeof enabled !== 'boolean') {
                 throw new TypeError(
                     this.getClazz() +
@@ -53,7 +54,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Fieldset',
         },
 
         getTitle: function () {
-            'use strict';
+            
             return this._titleEl.textContent;
         },
 
@@ -61,7 +62,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Fieldset',
          * @method setTitle
          */
         setTitle: function (title) {
-            'use strict';
+            
             this._titleEl.textContent = '';
             if (title !== null && title !== undefined) {
                 this._titleEl.style.display = '';

--- a/bundles/framework/divmanazer/component/Form.js
+++ b/bundles/framework/divmanazer/component/Form.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.Form
  * Generic form component
@@ -9,7 +10,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Form',
      * @static
      */
     function () {
-        'use strict';
+        
         var me = this;
         me._element = document.createElement('form');
         me._element.className = 'oskariform oskari-formcomponent oskari-form';
@@ -25,7 +26,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Form',
          *
          */
         _destroyImpl: function (cleanup) {
-            'use strict';
+            
             var i,
                 components = this.getComponents();
 
@@ -42,7 +43,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Form',
          * @return {String} Form's action
          */
         getAction: function () {
-            'use strict';
+            
             return this._element.action;
         },
 
@@ -54,7 +55,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Form',
          *
          */
         setAction: function (action) {
-            'use strict';
+            
             if (typeof action !== 'string') {
                 throw new TypeError(
                     this.getClazz() + '.setAction: action is not a string'
@@ -70,7 +71,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Form',
          * @return {Boolean} enabled
          */
         isEnabled: function () {
-            'use strict';
+            
             return !this._element.disabled;
         },
 
@@ -81,7 +82,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Form',
          *
          */
         setEnabled: function (enabled) {
-            'use strict';
+            
             if (typeof enabled !== 'boolean') {
                 throw new TypeError(
                     this.getClazz() +
@@ -99,7 +100,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Form',
          * @return {String} Form method
          */
         getMethod: function () {
-            'use strict';
+            
             return this._element.method;
         },
 
@@ -111,7 +112,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Form',
          *
          */
         setMethod: function (method) {
-            'use strict';
+            
             var mtd;
             if (typeof method !== 'string') {
                 throw new TypeError(
@@ -134,7 +135,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Form',
          *
          */
         addField: function (field) {
-            'use strict';
+            
             Oskari.getSandbox().printWarn(this.getClazz() +
                 '.addField is deprecated, please use addComponent instead.');
             this.addComponent(field);
@@ -148,7 +149,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Form',
          * @return {jQuery} form element
          */
         getForm: function (elementSelector) {
-            'use strict';
+            
             Oskari.getSandbox().printWarn(this.getClazz() +
                 '.getForm is deprecated, please use getElement instead.');
             return jQuery(this.getElement());
@@ -161,7 +162,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Form',
          * @return {Function} handler
          */
         getHandler: function () {
-            'use strict';
+            
             return this._handler;
         },
 
@@ -172,7 +173,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Form',
          *
          */
         setHandler: function (handler) {
-            'use strict';
+            
             this._handler = handler;
         },
 
@@ -199,7 +200,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Form',
          *
          */
         showErrors: function () {
-            'use strict';
+            
             Oskari.getSandbox().printWarn(
                 this.getClazz() + '.showErrors is deprecated.');
             var errors;
@@ -220,7 +221,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Form',
          *
          */
         clearErrors: function () {
-            'use strict';
+            
             Oskari.getSandbox().printWarn(
                 this.getClazz() + '.clearErrors is deprecated.'
             );
@@ -250,7 +251,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Form',
          * @return {Boolean} True
          */
         _onSubmit: function (event) {
-            'use strict';
+            
             if (this.getHandler()) {
                 this.getHandler()(this, event);
             }

--- a/bundles/framework/divmanazer/component/FormComponent.js
+++ b/bundles/framework/divmanazer/component/FormComponent.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.FormComponent
  *
@@ -9,7 +10,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
      * @method create called automatically on construction
      */
     function () {
-        'use strict';
+        
         this._clazz = 'Oskari.userinterface.component.FormComponent';
         this._enabled = true;
         this._handler = null;
@@ -26,7 +27,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * @param {Boolean} cleanup True if destroy is called just for cleanup
          */
         destroy: function (cleanup) {
-            'use strict';
+            
             this._destroyImpl(cleanup);
             if (!cleanup) {
                 if (this.getHandler()) {
@@ -43,13 +44,13 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * Focuses the component. Implement if component can be focused.
          */
         focus: function () {
-            'use strict';
+            
             return undefined;
         },
 
         // TODO
         validate: function () {
-            'use strict';
+            
             return true;
         },
 
@@ -59,7 +60,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * @return {Boolean} enabled
          */
         isEnabled: function () {
-            'use strict';
+            
             return true;
         },
 
@@ -68,7 +69,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * @param {Boolean} enabled
          */
         setEnabled: function (enabled) {
-            'use strict';
+            
             if (typeof enabled !== 'boolean') {
                 throw new TypeError(
                     this.getClazz() +
@@ -84,7 +85,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          *     Implement if the component can actually be disabled.
          */
         _setEnabledImpl: function (enabled) {
-            'use strict';
+            
             return undefined;
         },
 
@@ -93,7 +94,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * @return {Function} handler
          */
         getHandler: function () {
-            'use strict';
+            
             return this._handler;
         },
 
@@ -102,7 +103,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * @param {Function} handler
          */
         setHandler: function (handler) {
-            'use strict';
+            
             if (handler && typeof handler !== 'function') {
                 throw new TypeError(
                     this.getClazz() +
@@ -118,7 +119,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * @method _setHandlerImpl
          */
         _setHandlerImpl: function () {
-            'use strict';
+            
             return undefined;
         },
 
@@ -127,7 +128,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * @return {String} name
          */
         getName: function () {
-            'use strict';
+            
             throw new Error(
                 this.getClazz() + '.getName is unimplemented subclass'
             );
@@ -138,7 +139,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * @param {String} name
          */
         setName: function (name) {
-            'use strict';
+            
             throw new Error(
                 this.getClazz() + '.setName is unimplemented subclass'
             );
@@ -149,7 +150,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * @return {Boolean} required
          */
         isRequired: function () {
-            'use strict';
+            
             return false;
         },
 
@@ -158,7 +159,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * @param {Boolean} required
          */
         setRequired: function (required) {
-            'use strict';
+            
             if (typeof required !== 'boolean') {
                 throw new TypeError(
                     this.getClazz() +
@@ -172,7 +173,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * @method _setRequiredImpl
          */
         _setRequiredImpl: function () {
-            'use strict';
+            
             return undefined;
         },
 
@@ -181,7 +182,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * @return {String} title
          */
         getTitle: function () {
-            'use strict';
+            
             throw new Error(
                 this.getClazz() + '.getTitle is unimplemented subclass'
             );
@@ -192,7 +193,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * @param {String} title
          */
         setTitle: function (title) {
-            'use strict';
+            
             throw new Error(
                 this.getClazz() + '.setTitle is unimplemented subclass'
             );
@@ -203,7 +204,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * @return {String}
          */
         getTooltip: function () {
-            'use strict';
+            
             throw new Error(
                 this.getClazz() + '.getTooltip is unimplemented subclass'
             );
@@ -214,7 +215,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * @param {String} tooltip
          */
         setTooltip: function (tooltip) {
-            'use strict';
+            
             throw new Error(
                 this.getClazz() + '.setTooltip is unimplemented in subclass'
             );
@@ -225,7 +226,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * @return {}
          */
         getValue: function () {
-            'use strict';
+            
             throw new Error(
                 this.getClazz() + '.getValue is unimplemented subclass'
             );
@@ -237,7 +238,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormComponent',
          * @param {} value
          */
         setValue: function (value) {
-            'use strict';
+            
             throw new Error(
                 this.getClazz() + '.setValue is unimplemented subclass'
             );

--- a/bundles/framework/divmanazer/component/FormInput.js
+++ b/bundles/framework/divmanazer/component/FormInput.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.FormInput
  * Form field to be used with Oskari.userinterface.component.Form
@@ -409,7 +410,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormInput',
          * @param {Function} callback method that is called if up is pressed on the input
          */
         bindUpKey: function (callback) {
-            'use strict';
+            
             var me = this,
                 input = this._field.find('input');
 
@@ -424,7 +425,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormInput',
          * @param {Function} callback method that is called if down is pressed on the input
          */
         bindDownKey: function (callback) {
-            'use strict';
+            
             var me = this,
                 input = this._field.find('input');
 
@@ -442,7 +443,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FormInput',
          * @param {Function} callback method that is called if blur has happened for the input
          */
         bindOnBlur: function (callback) {
-            'use strict';
+            
             // all set, ready to bind requests
             var input = this._field.find('input');
             input.blur(function () {

--- a/bundles/framework/divmanazer/component/LanguageSelect.js
+++ b/bundles/framework/divmanazer/component/LanguageSelect.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.LanguageSelect
  *
@@ -11,7 +12,7 @@ Oskari.clazz.define(
      * @method create called automatically on construction
      */
     function () {
-        'use strict';
+        
         var me = this,
             i,
             languages,

--- a/bundles/framework/divmanazer/component/MultiLevelSelect.js
+++ b/bundles/framework/divmanazer/component/MultiLevelSelect.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.MultiLevelSelect
  *
@@ -9,7 +10,7 @@ Oskari.clazz.define('Oskari.userinterface.component.MultiLevelSelect',
      * @method create called automatically on construction
      */
     function () {
-        'use strict';
+        
         var me = this;
         me._clazz = 'Oskari.userinterface.component.MultiLevelSelect';
         me._element = document.createElement('fieldset');
@@ -36,14 +37,14 @@ Oskari.clazz.define('Oskari.userinterface.component.MultiLevelSelect',
          * Focuses the component
          */
         focus: function () {
-            'use strict';
+            
             if (this._selects) {
                 this._selects[0].focus();
             }
         },
 
         isEnabled: function () {
-            'use strict';
+            
             return !this.getElement().disabled;
         },
 
@@ -74,7 +75,7 @@ Oskari.clazz.define('Oskari.userinterface.component.MultiLevelSelect',
          *     Top level title is optional, it's used as a label for the select.
          */
         setOptions: function (optionsArray) {
-            'use strict';
+            
             if (!Array.isArray(optionsArray)) {
                 throw new TypeError(
                     this.getClazz() +
@@ -143,7 +144,7 @@ Oskari.clazz.define('Oskari.userinterface.component.MultiLevelSelect',
          * @return {Element}            Select element
          */
         _createSelect: function (options, value) {
-            'use strict';
+            
             if (!Array.isArray(options.options)) {
                 throw new TypeError(
                     this.getClazz() +
@@ -170,7 +171,7 @@ Oskari.clazz.define('Oskari.userinterface.component.MultiLevelSelect',
          * @param {String}     value
          */
         _setSelectOptions: function (select, options, value) {
-            'use strict';
+            
             if (options.title) {
                 select.setTitle(options.title);
             }
@@ -189,7 +190,7 @@ Oskari.clazz.define('Oskari.userinterface.component.MultiLevelSelect',
          * Called when selection is changed in any of the selects
          */
         _valueChanged: function () {
-            'use strict';
+            
             // Call user set handler if available
             if (!this._handlerInvactive && this.getHandler()) {
                 this.getHandler()(this.getValue());
@@ -201,7 +202,7 @@ Oskari.clazz.define('Oskari.userinterface.component.MultiLevelSelect',
          * @private
          */
         _setEnabledImpl: function (enabled) {
-            'use strict';
+            
             /* We can just disable the fieldset as disable is inherited from
                parent form element.... */
             this.getElement().disabled = !enabled;
@@ -219,7 +220,7 @@ Oskari.clazz.define('Oskari.userinterface.component.MultiLevelSelect',
          * @param {String} name
          */
         setName: function (name) {
-            'use strict';
+            
             var me = this,
                 i;
 
@@ -233,7 +234,7 @@ Oskari.clazz.define('Oskari.userinterface.component.MultiLevelSelect',
          * @method getTitle
          */
         getTitle: function () {
-            'use strict';
+            
             return this._titleEl.textContent;
         },
 
@@ -241,7 +242,7 @@ Oskari.clazz.define('Oskari.userinterface.component.MultiLevelSelect',
          * @method setTitle
          */
         setTitle: function (title) {
-            'use strict';
+            
             this._titleEl.textContent = '';
             if (title !== null && title !== undefined) {
                 this._titleEl.style.display = '';
@@ -255,7 +256,7 @@ Oskari.clazz.define('Oskari.userinterface.component.MultiLevelSelect',
          * @method getTooltip
          */
         getTooltip: function () {
-            'use strict';
+            
             return this.getElement().title;
         },
 
@@ -263,7 +264,7 @@ Oskari.clazz.define('Oskari.userinterface.component.MultiLevelSelect',
          * @method setTooltip
          */
         setTooltip: function (tooltip) {
-            'use strict';
+            
             this.getElement().title = tooltip;
         },
 
@@ -271,7 +272,7 @@ Oskari.clazz.define('Oskari.userinterface.component.MultiLevelSelect',
          * @method getValue
          */
         getValue: function () {
-            'use strict';
+            
             return this._selects.map(function (select) {
                 return select.getValue();
             });
@@ -281,7 +282,7 @@ Oskari.clazz.define('Oskari.userinterface.component.MultiLevelSelect',
          * @method setValue
          */
         setValue: function (value) {
-            'use strict';
+            
             var i,
                 select,
                 me = this,
@@ -321,7 +322,7 @@ Oskari.clazz.define('Oskari.userinterface.component.MultiLevelSelect',
          * @param {Boolean} visible
          */
         _setVisibleImpl: function (visible) {
-            'use strict';
+            
             this._element.style.display = this._visible ? '' : 'none';
         }
     }, {

--- a/bundles/framework/divmanazer/component/NumberInput.js
+++ b/bundles/framework/divmanazer/component/NumberInput.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.NumberInput
  *
@@ -9,7 +10,7 @@ Oskari.clazz.define('Oskari.userinterface.component.NumberInput',
      * @method create called automatically on construction
      */
     function () {
-        'use strict';
+        
         this._element.className = 'oskari-formcomponent oskari-numberinput';
         this._input.type = 'number';
     }, {
@@ -19,7 +20,7 @@ Oskari.clazz.define('Oskari.userinterface.component.NumberInput',
          * @return {String} max
          */
         getMax: function () {
-            'use strict';
+            
             return this._input.max;
         },
 
@@ -28,7 +29,7 @@ Oskari.clazz.define('Oskari.userinterface.component.NumberInput',
          * @param {String} max
          */
         setMax: function (max) {
-            'use strict';
+            
             if (!this._isNumberOrEmpty(max)) {
                 throw new TypeError(
                     this.getClazz() + '.setMax: ' + max + ' is Not a Number'
@@ -42,7 +43,7 @@ Oskari.clazz.define('Oskari.userinterface.component.NumberInput',
          * @return {String} min
          */
         getMin: function () {
-            'use strict';
+            
             return this._input.min;
         },
 
@@ -51,7 +52,7 @@ Oskari.clazz.define('Oskari.userinterface.component.NumberInput',
          * @param {String} min
          */
         setMin: function (min) {
-            'use strict';
+            
             if (!this._isNumberOrEmpty(min)) {
                 throw new TypeError(
                     this.getClazz() + '.setMin: ' + min + ' s Not a Number'
@@ -65,7 +66,7 @@ Oskari.clazz.define('Oskari.userinterface.component.NumberInput',
          * @return {String} step
          */
         getStep: function () {
-            'use strict';
+            
             return this._input.step;
         },
 
@@ -74,7 +75,7 @@ Oskari.clazz.define('Oskari.userinterface.component.NumberInput',
          * @param {String} step
          */
         setStep: function (step) {
-            'use strict';
+            
             if (!this._isNumberOrEmpty(step)) {
                 throw new TypeError(
                     this.getClazz() + '.setStep: ' + step + ' is Not a Number'
@@ -88,7 +89,7 @@ Oskari.clazz.define('Oskari.userinterface.component.NumberInput',
          * @param {String} value
          */
         setValue: function (value) {
-            'use strict';
+            
             if (!this._isNumberOrEmpty(value)) {
                 throw new TypeError(
                     this.getClazz() + '.setValue: ' + value + ' is Not a Number'

--- a/bundles/framework/divmanazer/component/PasswordInput.js
+++ b/bundles/framework/divmanazer/component/PasswordInput.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.PasswordInput
  *
@@ -9,7 +10,7 @@ Oskari.clazz.define('Oskari.userinterface.component.PasswordInput',
      * @method create called automatically on construction
      */
     function () {
-        'use strict';
+        
         this._element.className = 'oskari-formcomponent oskari-passwordinput';
         this._input.type = 'password';
     }, {},

--- a/bundles/framework/divmanazer/component/RadioButtonGroup.js
+++ b/bundles/framework/divmanazer/component/RadioButtonGroup.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.RadioButtonGroup
  *
@@ -9,7 +10,7 @@ Oskari.clazz.define('Oskari.userinterface.component.RadioButtonGroup',
      * @method create called automatically on construction
      */
     function () {
-        'use strict';
+        
         var me = this;
         me._clazz = 'Oskari.userinterface.component.RadioButtonGroup';
         me._element = document.createElement('fieldset');
@@ -23,7 +24,7 @@ Oskari.clazz.define('Oskari.userinterface.component.RadioButtonGroup',
          * Focuses the component.
          */
         focus: function () {
-            'use strict';
+            
             var radioButton = this._element.querySelector('input');
             if (radioButton) {
                 radioButton.focus();
@@ -31,7 +32,7 @@ Oskari.clazz.define('Oskari.userinterface.component.RadioButtonGroup',
         },
 
         isEnabled: function () {
-            'use strict';
+            
             return !this.getElement().disabled;
         },
 
@@ -40,7 +41,7 @@ Oskari.clazz.define('Oskari.userinterface.component.RadioButtonGroup',
          * @param {Array} options
          */
         setOptions: function (options) {
-            'use strict';
+            
             if (!Array.isArray(options)) {
                 throw new TypeError(
                     this.getClazz() +
@@ -86,7 +87,7 @@ Oskari.clazz.define('Oskari.userinterface.component.RadioButtonGroup',
         },
 
         _valueChanged: function () {
-            'use strict';
+            
             var value = this.getValue();
 
             if (this.getHandler()) {
@@ -98,12 +99,12 @@ Oskari.clazz.define('Oskari.userinterface.component.RadioButtonGroup',
          * @method _setEnabledImpl
          */
         _setEnabledImpl: function (enabled) {
-            'use strict';
+            
             this._element.disabled = !enabled;
         },
 
         getName: function () {
-            'use strict';
+            
             return this._name || '';
         },
 
@@ -111,7 +112,7 @@ Oskari.clazz.define('Oskari.userinterface.component.RadioButtonGroup',
          * @method setName
          */
         setName: function (name) {
-            'use strict';
+            
             var i,
                 inputs = this._element.querySelectorAll('input');
 
@@ -126,7 +127,7 @@ Oskari.clazz.define('Oskari.userinterface.component.RadioButtonGroup',
          * @method _setRequiredImpl
          */
         _setRequiredImpl: function () {
-            'use strict';
+            
             var i,
                 inputs = this._element.querySelectorAll('input');
             // TODO check if this actually does something...
@@ -136,7 +137,7 @@ Oskari.clazz.define('Oskari.userinterface.component.RadioButtonGroup',
         },
 
         getTitle: function () {
-            'use strict';
+            
             return this._titleEl.textContent;
         },
 
@@ -144,7 +145,7 @@ Oskari.clazz.define('Oskari.userinterface.component.RadioButtonGroup',
          * @method setTitle
          */
         setTitle: function (title) {
-            'use strict';
+            
             this._titleEl.textContent = '';
             if (title !== null && title !== undefined) {
                 this._titleEl.style.display = '';
@@ -155,7 +156,7 @@ Oskari.clazz.define('Oskari.userinterface.component.RadioButtonGroup',
         },
 
         getTooltip: function () {
-            'use strict';
+            
             return this._element.title;
         },
 
@@ -163,12 +164,12 @@ Oskari.clazz.define('Oskari.userinterface.component.RadioButtonGroup',
          * @method setTooltip
          */
         setTooltip: function (tooltip) {
-            'use strict';
+            
             this._element.title = tooltip;
         },
 
         getValue: function () {
-            'use strict';
+            
             var input = this._element.querySelector('input:checked');
             return input ? input.value : undefined;
         },
@@ -177,7 +178,7 @@ Oskari.clazz.define('Oskari.userinterface.component.RadioButtonGroup',
          * @method setValue
          */
         setValue: function (value) {
-            'use strict';
+            
             var i,
                 input,
                 inputs = this._element.querySelectorAll('input'),
@@ -201,7 +202,7 @@ Oskari.clazz.define('Oskari.userinterface.component.RadioButtonGroup',
          * @method _setVisibleImpl
          */
         _setVisibleImpl: function () {
-            'use strict';
+            
             this.getElement().style.display = this.isVisible() ? '' : 'none';
         }
     }, {

--- a/bundles/framework/divmanazer/component/SearchInput.js
+++ b/bundles/framework/divmanazer/component/SearchInput.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.SearchInput
  *
@@ -9,7 +10,7 @@ Oskari.clazz.define('Oskari.userinterface.component.SearchInput',
      * @method create called automatically on construction
      */
     function () {
-        'use strict';
+        
         this._element.className = 'oskari-formcomponent oskari-searchinput';
         this._input.type = 'search';
     },

--- a/bundles/framework/divmanazer/component/Select.js
+++ b/bundles/framework/divmanazer/component/Select.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.Select
  *
@@ -9,7 +10,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
      * @method create called automatically on construction
      */
     function () {
-        'use strict';
+        
         var me = this;
         me._clazz = 'Oskari.userinterface.component.Select';
         me._element = document.createElement('label');
@@ -31,12 +32,12 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
          * Focuses the component.
          */
         focus: function () {
-            'use strict';
+            
             this._select.focus();
         },
 
         isEnabled: function () {
-            'use strict';
+            
             return !this._element.disabled;
         },
 
@@ -45,7 +46,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
          * Does the component allow multiple selections
          */
         isMultiple: function () {
-            'use strict';
+            
             return this._select.multiple;
         },
 
@@ -54,7 +55,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
          * @param multiple
          */
         setMultiple: function (multiple) {
-            'use strict';
+            
             if (typeof multiple !== 'boolean') {
                 throw new TypeError(
                     this.getClazz() +
@@ -69,7 +70,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
          * @param {Array} options
          */
         setOptions: function (options) {
-            'use strict';
+            
             if (!Array.isArray(options)) {
                 throw new TypeError(
                     this.getClazz() +
@@ -105,7 +106,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
         },
 
         _getValueArray: function (value) {
-            'use strict';
+            
             var selectedValues = [];
 
             // Fill selected values for easy contains check
@@ -139,7 +140,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
         },
 
         _valueChanged: function () {
-            'use strict';
+            
             if (this.getHandler()) {
                 this.getHandler()(this.getValue());
             }
@@ -149,7 +150,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
          * @method _setEnabledImpl
          */
         _setEnabledImpl: function (enabled) {
-            'use strict';
+            
             this._select.disabled = !enabled;
         },
 
@@ -158,7 +159,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
          * @return {String} name
          */
         getName: function () {
-            'use strict';
+            
             return this.select.name;
         },
 
@@ -167,12 +168,12 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
          * @param {String} name
          */
         setName: function (name) {
-            'use strict';
+            
             this._select.name = name || '';
         },
 
         isRequired: function () {
-            'use strict';
+            
             return this._select.required;
         },
 
@@ -180,7 +181,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
          * @method _setRequiredImpl
          */
         _setRequiredImpl: function () {
-            'use strict';
+            
             this._select.required = this.isRequired();
         },
 
@@ -189,7 +190,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
          * @method getTitle
          */
         getTitle: function () {
-            'use strict';
+            
             return this._titleEl.textContent;
         },
 
@@ -198,7 +199,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
          * @param {String} title
          */
         setTitle: function (title) {
-            'use strict';
+            
             this._titleEl.textContent = '';
             if (title !== null && title !== undefined) {
                 this._titleEl.style.display = '';
@@ -209,7 +210,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
         },
 
         getTooltip: function () {
-            'use strict';
+            
             return this._element.title;
         },
 
@@ -217,7 +218,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
          * @method setTooltip
          */
         setTooltip: function (tooltip) {
-            'use strict';
+            
             this._element.title = tooltip;
         },
 
@@ -228,7 +229,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
         },
 
         getValue: function () {
-            'use strict';
+            
             var i,
                 me = this,
                 opts = me._select.querySelectorAll('option:checked'),
@@ -249,7 +250,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
          * @method setValue
          */
         setValue: function (value) {
-            'use strict';
+            
             var i,
                 oldValues = this._getValueArray(this.getValue()),
                 selectedValues = this._getValueArray(value),
@@ -283,7 +284,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Select',
          * @method _setVisibleImpl
          */
         _setVisibleImpl: function () {
-            'use strict';
+            
             this.getElement().style.display = this.isVisible() ? '' : 'none';
         }
     }, {

--- a/bundles/framework/divmanazer/component/TextAreaInput.js
+++ b/bundles/framework/divmanazer/component/TextAreaInput.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.TextAreaInput
  *
@@ -9,7 +10,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextAreaInput',
      * @method create called automatically on construction
      */
     function (name) {
-        'use strict';
+        
         var me = this,
             closeIcon = document.createElement('div'),
             controlsWrapper = document.createElement('div');
@@ -46,7 +47,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextAreaInput',
          * Focuses the component.
          */
         focus: function () {
-            'use strict';
+            
             this._input.focus();
         },
 
@@ -55,7 +56,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextAreaInput',
          * @return {Boolean} enabled
          */
         isEnabled: function () {
-            'use strict';
+            
             return !this.getElement().disabled;
         },
 
@@ -64,7 +65,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextAreaInput',
          * @param {Boolean} enabled
          */
         _setEnabledImpl: function (enabled) {
-            'use strict';
+            
             this._input.disabled = !enabled;
         },
 
@@ -73,7 +74,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextAreaInput',
          * @private
          */
         _valueChanged: function () {
-            'use strict';
+            
             if (this.getHandler()) {
                 this.getHandler()(this.getValue());
             }
@@ -84,7 +85,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextAreaInput',
          * @return {String} name
          */
         getName: function () {
-            'use strict';
+            
             return this._input.name;
         },
 
@@ -93,7 +94,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextAreaInput',
          * @param {String} name
          */
         setName: function (name) {
-            'use strict';
+            
             this._input.name = name || '';
         },
 
@@ -102,7 +103,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextAreaInput',
          * @return {String} placeholder
          */
         getPlaceholder: function () {
-            'use strict';
+            
             return this._input.placeholder;
         },
 
@@ -111,7 +112,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextAreaInput',
          * @param {String} placeholder
          */
         setPlaceholder: function (placeholder) {
-            'use strict';
+            
             this._input.placeholder = placeholder;
         },
 
@@ -119,7 +120,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextAreaInput',
          * @method _setRequiredImpl
          */
         _setRequiredImpl: function () {
-            'use strict';
+            
             this._input.required = this.isRequired();
         },
 
@@ -128,7 +129,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextAreaInput',
          * @return {String} title
          */
         getTitle: function () {
-            'use strict';
+            
             return this._titleEl.textContent;
         },
 
@@ -137,7 +138,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextAreaInput',
          * @param {String} title
          */
         setTitle: function (title) {
-            'use strict';
+            
             this._titleEl.textContent = '';
             if (title !== null && title !== undefined) {
                 this._titleEl.style.display = '';
@@ -152,7 +153,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextAreaInput',
          * @return {String} tooltip
          */
         getTooltip: function () {
-            'use strict';
+            
             return this._element.title;
         },
 
@@ -161,7 +162,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextAreaInput',
          * @param {String} tooltip
          */
         setTooltip: function (tooltip) {
-            'use strict';
+            
             this._element.title = tooltip;
         },
 
@@ -170,7 +171,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextAreaInput',
          * @return {String} value
          */
         getValue: function () {
-            'use strict';
+            
             return this._input.value;
         },
 
@@ -179,7 +180,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextAreaInput',
          * @param {String} value
          */
         setValue: function (value) {
-            'use strict';
+            
             this._input.value = value;
         },
 
@@ -187,7 +188,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextAreaInput',
          * @method _setVisibleImpl
          */
         _setVisibleImpl: function () {
-            'use strict';
+            
             this.getElement().style.display = this.isVisible() ? '' : 'none';
         }
     }, {

--- a/bundles/framework/divmanazer/component/TextInput.js
+++ b/bundles/framework/divmanazer/component/TextInput.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.TextInput
  *
@@ -9,7 +10,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextInput',
      * @method create called automatically on construction
      */
     function (name) {
-        'use strict';
+        
         var me = this,
             closeIcon = document.createElement('div'),
             controlsWrapper = document.createElement('div');
@@ -46,7 +47,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextInput',
          * Focuses the component.
          */
         focus: function () {
-            'use strict';
+            
             this._input.focus();
         },
 
@@ -55,7 +56,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextInput',
          * @return {Boolean} enabled
          */
         isEnabled: function () {
-            'use strict';
+            
             return !this.getElement().disabled;
         },
 
@@ -64,7 +65,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextInput',
          * @param {Boolean} enabled
          */
         _setEnabledImpl: function (enabled) {
-            'use strict';
+            
             this._input.disabled = !enabled;
         },
 
@@ -73,7 +74,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextInput',
          * @private
          */
         _valueChanged: function () {
-            'use strict';
+            
             if (this.getHandler()) {
                 this.getHandler()(this.getValue());
             }
@@ -84,7 +85,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextInput',
          * @return {String} name
          */
         getName: function () {
-            'use strict';
+            
             return this._input.name;
         },
 
@@ -93,7 +94,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextInput',
          * @param {String} name
          */
         setName: function (name) {
-            'use strict';
+            
             this._input.name = name || '';
         },
 
@@ -102,7 +103,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextInput',
          * @return {String} placeholder
          */
         getPlaceholder: function () {
-            'use strict';
+            
             return this._input.placeholder;
         },
 
@@ -111,7 +112,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextInput',
          * @param {String} placeholder
          */
         setPlaceholder: function (placeholder) {
-            'use strict';
+            
             this._input.placeholder = placeholder;
         },
 
@@ -119,7 +120,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextInput',
          * @method _setRequiredImpl
          */
         _setRequiredImpl: function () {
-            'use strict';
+            
             this._input.required = this.isRequired();
         },
 
@@ -128,7 +129,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextInput',
          * @return {String} title
          */
         getTitle: function () {
-            'use strict';
+            
             return this._titleEl.textContent;
         },
 
@@ -137,7 +138,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextInput',
          * @param {String} title
          */
         setTitle: function (title) {
-            'use strict';
+            
             this._titleEl.textContent = '';
             if (title !== null && title !== undefined) {
                 this._titleEl.style.display = '';
@@ -152,7 +153,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextInput',
          * @return {String} tooltip
          */
         getTooltip: function () {
-            'use strict';
+            
             return this._element.title;
         },
 
@@ -161,7 +162,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextInput',
          * @param {String} tooltip
          */
         setTooltip: function (tooltip) {
-            'use strict';
+            
             this._element.title = tooltip;
         },
 
@@ -170,7 +171,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextInput',
          * @return {String} value
          */
         getValue: function () {
-            'use strict';
+            
             return this._input.value;
         },
 
@@ -179,7 +180,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextInput',
          * @param {String} value
          */
         setValue: function (value) {
-            'use strict';
+            
             this._input.value = value;
         },
 
@@ -187,7 +188,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TextInput',
          * @method _setVisibleImpl
          */
         _setVisibleImpl: function () {
-            'use strict';
+            
             this.getElement().style.display = this.isVisible() ? '' : 'none';
         }
     }, {

--- a/bundles/framework/divmanazer/component/UrlInput.js
+++ b/bundles/framework/divmanazer/component/UrlInput.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.userinterface.component.UrlInput
  *
@@ -9,7 +10,7 @@ Oskari.clazz.define('Oskari.userinterface.component.UrlInput',
      * @method create called automatically on construction
      */
     function () {
-        'use strict';
+        
         this._element.className = 'oskari-formcomponent oskari-urlinput';
         this._input.type = 'url';
     }, {},

--- a/bundles/framework/geometryeditor/plugin/DrawFilterPlugin.js
+++ b/bundles/framework/geometryeditor/plugin/DrawFilterPlugin.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.mapframework.ui.module.common.GeometryEditor.DrawFilterPlugin
  */
@@ -2061,7 +2062,7 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.geometryeditor.DrawFil
         if (!Array.prototype.forEach) {
 
             Array.prototype.forEach = function forEach(callback, thisArg) {
-                'use strict';
+                
                 var T, k;
 
                 if (this === null) {

--- a/bundles/framework/layerselector2/Flyout.js
+++ b/bundles/framework/layerselector2/Flyout.js
@@ -13,7 +13,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
      */
 
     function (instance) {
-        //"use strict";
+        
         this.instance = instance;
         this.container = null;
         this.template = null;
@@ -30,7 +30,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * @return {String} the name for the component
          */
         getName: function () {
-            //"use strict";
+            
             return 'Oskari.mapframework.bundle.layerselector2.Flyout';
         },
 
@@ -46,7 +46,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * Interface method implementation
          */
         setEl: function (el, width, height) {
-            //"use strict";
+            
             this.container = el[0];
             if (!jQuery(this.container).hasClass('layerselector2')) {
                 jQuery(this.container).addClass('layerselector2');
@@ -59,7 +59,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * Interface method implementation, assigns the HTML templates that will be used to create the UI
          */
         startPlugin: function () {
-            //"use strict";
+            
             var me = this,
                 inspireTab = Oskari.clazz.create(
                     'Oskari.mapframework.bundle.layerselector2.view.LayersTab',
@@ -153,7 +153,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * Interface method implementation, does nothing atm
          */
         stopPlugin: function () {
-            //"use strict";
+            
         },
 
         /**
@@ -161,7 +161,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * @return {String} localized text for the title of the flyout
          */
         getTitle: function () {
-            //"use strict";
+            
             return this.instance.getLocalization('title');
         },
 
@@ -170,7 +170,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * @return {String} localized text for the description of the flyout
          */
         getDescription: function () {
-            //"use strict";
+            
             return this.instance.getLocalization('desc');
         },
 
@@ -179,7 +179,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * Interface method implementation, does nothing atm
          */
         getOptions: function () {
-            //"use strict";
+            
         },
 
         /**
@@ -189,7 +189,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * Interface method implementation, does nothing atm
          */
         setState: function (state) {
-            //"use strict";
+            
             this.state = state;
         },
 
@@ -199,7 +199,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * @param {Object} state a content state
          */
         setContentState: function (state) {
-            //"use strict";
+            
             var i,
                 tab;
             // prepare for complete state reset
@@ -217,7 +217,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
         },
 
         getContentState: function () {
-            //"use strict";
+            
             var state = {},
                 i,
                 tab;
@@ -236,7 +236,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * Creates the UI for a fresh start
          */
         createUi: function () {
-            //"use strict";
+            
             var me = this,
                 // clear container
                 cel = jQuery(this.container),
@@ -295,7 +295,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * @method  @public populateLayers
          */
         populateLayers: function () {
-            //"use strict";
+            
             var me = this;
             var sandbox = this.instance.getSandbox(),
                 // populate layer list
@@ -327,7 +327,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * @private
          */
         _getLayerGroups: function (layers, groupingMethod) {
-            //"use strict";
+            
             var me = this,
                 groupList = [],
                 group = null,
@@ -374,7 +374,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * @param {String} groupingMethod method name to sort by
          */
         _layerListComparator: function (a, b, groupingMethod) {
-            //"use strict";
+            
             var nameA = a[groupingMethod]().toLowerCase(),
                 nameB = b[groupingMethod]().toLowerCase();
             if (nameA === nameB && (a.getName() && b.getName())) {
@@ -399,7 +399,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * let's refresh ui to match current layer selection
          */
         handleLayerSelectionChanged: function (layer, isSelected) {
-            //"use strict";
+            
             var i,
                 tab;
             for (i = 0; i < this.layerTabs.length; i += 1) {
@@ -415,7 +415,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * let's refresh ui to match current layers
          */
         handleLayerModified: function (layer) {
-            //"use strict";
+            
             var me = this,
                 i,
                 tab;
@@ -432,7 +432,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * let's refresh ui to match current layers
          */
         handleLayerSticky: function (layer) {
-            //"use strict";
+            
             var me = this,
                 i,
                 tab;
@@ -449,7 +449,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * let's refresh ui to match current layers
          */
         handleLayerAdded: function (layer) {
-            //"use strict";
+            
             var me = this;
             me.populateLayers();
             // we could just add the layer to correct group and update the layer count for the group
@@ -463,7 +463,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * let's refresh ui to match current layers
          */
         handleLayerRemoved: function (layerId) {
-            //"use strict";
+            
             var me = this;
             me.populateLayers();
             // we could  just remove the layer and update the layer count for the group

--- a/bundles/framework/layerselector2/Tile.js
+++ b/bundles/framework/layerselector2/Tile.js
@@ -12,7 +12,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Tile',
      */
 
     function (instance) {
-        //"use strict";
+        
         this.instance = instance;
         this.container = null;
         this.template = null;
@@ -22,7 +22,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Tile',
          * @return {String} the name for the component
          */
         getName: function () {
-            //"use strict";
+            
             return 'Oskari.mapframework.bundle.layerselector2.Tile';
         },
         /**
@@ -37,7 +37,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Tile',
          * Interface method implementation
          */
         setEl: function (el, width, height) {
-            //"use strict";
+            
             this.container = jQuery(el);
         },
         /**
@@ -66,7 +66,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Tile',
          * Interface method implementation, clears the container
          */
         stopPlugin: function () {
-            //"use strict";
+            
             this.container.empty();
         },
         /**
@@ -74,7 +74,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Tile',
          * @return {String} localized text for the title of the tile
          */
         getTitle: function () {
-            //"use strict";
+            
             return this.instance.getLocalization('title');
         },
         /**
@@ -82,7 +82,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Tile',
          * @return {String} localized text for the description of the tile
          */
         getDescription: function () {
-            //"use strict";
+            
             return this.instance.getLocalization('desc');
         },
         /**
@@ -90,7 +90,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Tile',
          * Interface method implementation, does nothing atm
          */
         getOptions: function () {
-            //"use strict";
+            
         },
         /**
          * @method setState
@@ -99,7 +99,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Tile',
          * Interface method implementation, does nothing atm
          */
         setState: function (state) {
-            //"use strict";
+            
         },
         /**
          * @method refresh

--- a/bundles/framework/layerselector2/instance.js
+++ b/bundles/framework/layerselector2/instance.js
@@ -16,7 +16,7 @@ Oskari.clazz.define(
      */
 
     function () {
-        //"use strict";
+        
         this.sandbox = null;
         this.started = false;
         this.plugins = {};
@@ -33,7 +33,7 @@ Oskari.clazz.define(
          * @return {String} the name for the component
          */
         getName: function () {
-            //"use strict";
+            
             return this.__name;
         },
         /**
@@ -42,7 +42,7 @@ Oskari.clazz.define(
          * Sets the sandbox reference to this component
          */
         setSandbox: function (sandbox) {
-            //"use strict";
+            
             this.sandbox = sandbox;
         },
         /**
@@ -50,7 +50,7 @@ Oskari.clazz.define(
          * @return {Oskari.Sandbox}
          */
         getSandbox: function () {
-            //"use strict";
+            
             return this.sandbox;
         },
 
@@ -65,7 +65,7 @@ Oskari.clazz.define(
          *     structure and if parameter key is given
          */
         getLocalization: function (key) {
-            //"use strict";
+            
             if (!this._localization) {
                 this._localization = Oskari.getLocalization(this.getName());
             }
@@ -80,7 +80,7 @@ Oskari.clazz.define(
          * implements BundleInstance protocol start method
          */
         start: function () {
-            //"use strict";
+            
             var me = this,
                 conf = me.conf,
                 sandboxName = conf ? conf.sandbox : 'sandbox',
@@ -143,7 +143,7 @@ Oskari.clazz.define(
          * implements Module protocol init method - does nothing atm
          */
         init: function () {
-            //"use strict";
+            
             return null;
         },
         /**
@@ -151,7 +151,7 @@ Oskari.clazz.define(
          * implements BundleInstance protocol update method - does nothing atm
          */
         update: function () {
-            //"use strict";
+            
         },
         /**
          * @method onEvent
@@ -159,7 +159,7 @@ Oskari.clazz.define(
          * Event is handled forwarded to correct #eventHandlers if found or discarded if not.
          */
         onEvent: function (event) {
-            //"use strict";
+            
             var handler = this.eventHandlers[event.getName()];
             if (!handler) {
                 return;
@@ -180,7 +180,7 @@ Oskari.clazz.define(
              * Calls flyouts handleLayerSelectionChanged() method
              */
             AfterMapLayerRemoveEvent: function (event) {
-                //"use strict";
+                
                 this.plugins['Oskari.userinterface.Flyout'].handleLayerSelectionChanged(event.getMapLayer(), false);
             },
 
@@ -191,7 +191,7 @@ Oskari.clazz.define(
              * Calls flyouts handleLayerSelectionChanged() method
              */
             AfterMapLayerAddEvent: function (event) {
-                //"use strict";
+                
                 this.plugins['Oskari.userinterface.Flyout'].handleLayerSelectionChanged(event.getMapLayer(), true);
             },
 
@@ -200,7 +200,7 @@ Oskari.clazz.define(
              * @param {Oskari.mapframework.event.common.MapLayerEvent} event
              */
             MapLayerEvent: function (event) {
-                //"use strict";
+                
                 var me = this,
                     flyout = me.plugins['Oskari.userinterface.Flyout'],
                     tile = me.plugins['Oskari.userinterface.Tile'],
@@ -278,7 +278,7 @@ Oskari.clazz.define(
          * implements BundleInstance protocol stop method
          */
         stop: function () {
-            //"use strict";
+            
             var me = this,
                 sandbox = me.sandbox(),
                 request,
@@ -306,7 +306,7 @@ Oskari.clazz.define(
          * Oskari.mapframework.bundle.layerselector2.Tile
          */
         startExtension: function () {
-            //"use strict";
+            
             this.plugins['Oskari.userinterface.Flyout'] = Oskari.clazz.create(
                 'Oskari.mapframework.bundle.layerselector2.Flyout',
                 this
@@ -322,7 +322,7 @@ Oskari.clazz.define(
          * Clears references to flyout and tile
          */
         stopExtension: function () {
-            //"use strict";
+            
             this.plugins['Oskari.userinterface.Flyout'] = null;
             this.plugins['Oskari.userinterface.Tile'] = null;
         },
@@ -332,7 +332,7 @@ Oskari.clazz.define(
          * @return {Object} references to flyout and tile
          */
         getPlugins: function () {
-            //"use strict";
+            
             return this.plugins;
         },
         /**
@@ -340,7 +340,7 @@ Oskari.clazz.define(
          * @return {String} localized text for the title of the component
          */
         getTitle: function () {
-            //"use strict";
+            
             return this.getLocalization('title');
         },
         /**
@@ -348,7 +348,7 @@ Oskari.clazz.define(
          * @return {String} localized text for the description of the component
          */
         getDescription: function () {
-            //"use strict";
+            
             return this.getLocalization('desc');
         },
         /**
@@ -356,7 +356,7 @@ Oskari.clazz.define(
          * (re)creates the UI for "all layers" functionality
          */
         createUi: function () {
-            //"use strict";
+            
             var me = this;
             me.plugins['Oskari.userinterface.Flyout'].createUi();
             me.plugins['Oskari.userinterface.Tile'].refresh();
@@ -367,7 +367,7 @@ Oskari.clazz.define(
          * @param {Object} state bundle state as JSON
          */
         setState: function (state) {
-            //"use strict";
+            
             this.plugins['Oskari.userinterface.Flyout'].setContentState(state);
         },
 
@@ -376,7 +376,7 @@ Oskari.clazz.define(
          * @return {Object} bundle state as JSON
          */
         getState: function () {
-            //"use strict";
+            
             return this.plugins['Oskari.userinterface.Flyout'].getContentState();
         },
 

--- a/bundles/framework/layerselector2/model/LayerGroup.js
+++ b/bundles/framework/layerselector2/model/LayerGroup.js
@@ -6,7 +6,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.model.LayerGroup'
      */
 
     function (title) {
-        //"use strict";
+        
         this.name = title;
         this.layers = [];
         this.searchIndex = {};
@@ -16,7 +16,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.model.LayerGroup'
          * @param {String} value
          */
         setTitle: function (value) {
-            //"use strict";
+            
             this.name = value;
         },
         /**
@@ -24,7 +24,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.model.LayerGroup'
          * @return {String}
          */
         getTitle: function () {
-            //"use strict";
+            
             return this.name;
         },
         /**
@@ -32,7 +32,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.model.LayerGroup'
          * @param {Layer} layer
          */
         addLayer: function (layer) {
-            //"use strict";
+            
             this.layers.push(layer);
             this.searchIndex[layer.getId()] = this._getSearchIndex(layer);
         },
@@ -41,11 +41,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.model.LayerGroup'
          * @return {Layer[]}
          */
         getLayers: function () {
-            //"use strict";
+            
             return this.layers;
         },
         _getSearchIndex: function (layer) {
-            //"use strict";
+            
             var val = layer.getName() + ' ' +
                 layer.getInspireName() + ' ' +
                 layer.getOrganizationName();
@@ -53,7 +53,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.model.LayerGroup'
             return val.toLowerCase();
         },
         matchesKeyword: function (layerId, keyword) {
-            //"use strict";
+            
             var searchableIndex = this.searchIndex[layerId];
             return searchableIndex.indexOf(keyword.toLowerCase()) !== -1;
         }

--- a/bundles/framework/layerselector2/view/Layer.js
+++ b/bundles/framework/layerselector2/view/Layer.js
@@ -11,7 +11,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.Layer",
      */
 
     function (layer, sandbox, localization) {
-        //"use strict";
+        
         this.sandbox = sandbox;
         this.localization = localization;
         this.layer = layer;
@@ -32,11 +32,11 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.Layer",
          * @return {String} layer id
          */
         getId: function () {
-            //"use strict";
+            
             return this.layer.getId();
         },
         setVisible: function (bln) {
-            //"use strict";
+            
             // TODO assúme boolean and clean up everyhting that passes somehting else
             // checking since we dont assume param is boolean
             if (bln) {
@@ -46,7 +46,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.Layer",
             }
         },
         setSelected: function (isSelected) {
-            //"use strict";
+            
             // TODO assúme boolean and clean up everyhting that passes somehting else
             // checking since we dont assume param is boolean
             this.ui.find('input').attr('checked', !!isSelected);
@@ -56,7 +56,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.Layer",
          * @method updateLayerContent
          */
         updateLayerContent: function (layer) {
-            //"use strict";
+            
             /* set title */
             var newName = layer.getName(),
                 /* set/clear alert if required */
@@ -100,7 +100,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.Layer",
 
         },
         getContainer: function () {
-            //"use strict";
+            
             return this.ui;
         },
         /**
@@ -110,7 +110,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.Layer",
          * @param {Oskari.mapframework.domain.WmsLayer/Oskari.mapframework.domain.WfsLayer/Oskari.mapframework.domain.VectorLayer/Object} layer to render
          */
         _createLayerContainer: function (layer) {
-            //"use strict";
+            
             var me = this,
                 sandbox = me.sandbox,
                 // create from layer template

--- a/bundles/framework/layerselector2/view/LayersTab.js
+++ b/bundles/framework/layerselector2/view/LayersTab.js
@@ -39,17 +39,17 @@ Oskari.clazz.define(
     }, {
 
         getTitle: function () {
-            //"use strict";
+            
             return this.title;
         },
 
         getTabPanel: function () {
-            //"use strict";
+            
             return this.tabPanel;
         },
 
         getState: function () {
-            //"use strict";
+            
             var state = {
                 tab: this.getTitle(),
                 filter: this.filterField.getValue(),
@@ -59,7 +59,7 @@ Oskari.clazz.define(
         },
 
         setState: function (state) {
-            //"use strict";
+            
             if (!state) {
                 return;
             }
@@ -88,7 +88,7 @@ Oskari.clazz.define(
          * Creates info icon for given oskarifield
          */
         _createInfoIcon: function (oskarifield) {
-            //"use strict";
+            
             var me = this,
                 infoIcon = jQuery('<div class="icon-info"></div>'),
                 indicatorCont = oskarifield.find('.field-description');
@@ -123,7 +123,7 @@ Oskari.clazz.define(
          * @param  {String} oskarifieldId oskari field id
          */
         _createUI: function (oskarifieldId) {
-            //"use strict";
+            
             var me = this,
                 oskarifield,
                 layerFilter;
@@ -179,7 +179,7 @@ Oskari.clazz.define(
          * @return {Oskari.userinterface.component.FormInput} field
          */
         getFilterField: function () {
-            //"use strict";
+            
             var me = this,
                 field,
                 timer = 0;
@@ -219,7 +219,7 @@ Oskari.clazz.define(
          * Calls all needed functions to do the layer filtering.
          */
         _fireFiltering: function (keyword, event, me) {
-            //"use strict";
+            
             // Filter by name
             me.filterLayers(keyword);
 
@@ -240,7 +240,7 @@ Oskari.clazz.define(
          * @param  {Array} groups
          */
         showLayerGroups: function (groups) {
-            //"use strict";
+            
             var me = this,
                 i,
                 groupsLength = groups.length,
@@ -316,7 +316,7 @@ Oskari.clazz.define(
          * Also checks if all layers in a group is hidden and hides the group as well.
          */
         filterLayers: function (keyword, ids) {
-            //"use strict";
+            
             var me = this,
                 visibleGroupCount = 0,
                 visibleLayerCount,
@@ -391,7 +391,7 @@ Oskari.clazz.define(
          * Clears related keywords popup
          */
         clearRelatedKeywordsPopup: function (keyword, oskarifield) {
-            //"use strict";
+            
             // clear only if sent keyword has changed or it is not null
             if (this.sentKeyword && this.sentKeyword !== keyword) {
                 oskarifield.find('.related-keywords').html('').hide();
@@ -411,7 +411,7 @@ Oskari.clazz.define(
          * Also checks if all layers in a group is hidden and hides the group as well.
          */
         _relatedKeywordsPopup: function (keyword, event, me) {
-            //"use strict";
+            
             //event.preventDefault();
             var oskarifield = jQuery(event.currentTarget).parents(
                     '.oskarifield'
@@ -492,7 +492,7 @@ Oskari.clazz.define(
          * Concatenates (in place) those values from arr2 to arr1 that are not present in arr1
          */
         _concatNew: function (arr1, arr2) {
-            //"use strict";
+            
             var me = this,
                 i;
 
@@ -510,7 +510,7 @@ Oskari.clazz.define(
          * Determines if the given value... has a value.
          */
         _isDefined: function (value) {
-            //"use strict";
+            
             return typeof value !== 'undefined' && value !== null && value !== '';
         },
 
@@ -522,7 +522,7 @@ Oskari.clazz.define(
          * Returns true if keyword contains match (ignoring case)
          */
         _containsIgnoreCase: function (keyword, match) {
-            //"use strict";
+            
             var me = this;
             return me._isDefined(keyword) && me._isDefined(match) && keyword.toLowerCase().indexOf(match.toLowerCase()) > -1;
         },
@@ -536,7 +536,7 @@ Oskari.clazz.define(
          * Also returns false if one or both types are not defined
          */
         _matchesIgnoreCase: function (type1, type2) {
-            //"use strict";
+            
             var me = this;
             return me._isDefined(type1) && me._isDefined(type2) && type1.toLowerCase() === type2.toLowerCase();
         },
@@ -550,7 +550,7 @@ Oskari.clazz.define(
          * Also checks if all layers in a group is hidden and hides the group as well.
          */
         _showRelatedKeywords: function (userInput, keywords, oskarifield) {
-            //"use strict";
+            
             var me = this,
                 relatedKeywordsCont = me.getFilterField().getField().find(
                     '.related-keywords'
@@ -640,7 +640,7 @@ Oskari.clazz.define(
         },
 
         _showAllLayers: function () {
-            //"use strict";
+            
             var i,
                 group,
                 layers,
@@ -670,7 +670,7 @@ Oskari.clazz.define(
         },
 
         setLayerSelected: function (layerId, isSelected) {
-            //"use strict";
+            
             var layerCont = this.layerContainers[layerId];
             if (layerCont) {
                 layerCont.setSelected(isSelected);
@@ -678,7 +678,7 @@ Oskari.clazz.define(
         },
 
         updateLayerContent: function (layerId, layer) {
-            //"use strict";
+            
             var layerCont = this.layerContainers[layerId];
             if (layerCont) {
                 layerCont.updateLayerContent(layer);

--- a/bundles/framework/layerselector2/view/PublishedLayersTab.js
+++ b/bundles/framework/layerselector2/view/PublishedLayersTab.js
@@ -10,7 +10,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.PublishedLay
      */
 
     function (instance, title) {
-        //"use strict";
+        
         this.instance = instance;
         this.title = title;
         this.layerGroups = [];
@@ -19,17 +19,17 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.PublishedLay
     }, {
 
         getTitle: function () {
-            //"use strict";
+            
             return this.title;
         },
 
         getTabPanel: function () {
-            //"use strict";
+            
             return this.tabPanel;
         },
 
         getState: function () {
-            //"use strict";
+            
             var state = {
                 tab: this.getTitle(),
                 filter: this.filterField.getValue(),
@@ -46,7 +46,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.PublishedLay
         },
 
         setState: function (state) {
-            //"use strict";
+            
             if (!state) {
                 return;
             }
@@ -63,7 +63,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.PublishedLay
         },
 
         _createUI: function () {
-            //"use strict";
+            
             var me = this;
             me.tabPanel = Oskari.clazz.create('Oskari.userinterface.component.TabPanel');
             me.tabPanel.setTitle(this.title);
@@ -82,7 +82,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.PublishedLay
         },
 
         getFilterField: function () {
-            //"use strict";
+            
             if (this.filterField) {
                 return this.filterField;
             }
@@ -101,7 +101,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.PublishedLay
         },
 
         _searchTrigger: function (keyword) {
-            //"use strict";
+            
             var me = this;
             // clear any previous search if search field changes
             if (me.searchTimer) {
@@ -120,7 +120,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.PublishedLay
         },
 
         _relatedSearchTrigger: function (keyword) {
-            //"use strict";
+            
             var me = this;
             // clear any previous search if search field changes
             if (me.searchTimer) {
@@ -134,7 +134,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.PublishedLay
         },
 
         tabSelected: function () {
-            //"use strict";
+            
             // update data if now done so yet
             if (this.layerGroups.length === 0) {
                 this.accordion.showMessage(this.instance.getLocalization('loading'));
@@ -162,7 +162,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.PublishedLay
         },
 
         tabUnselected: function () {
-            //"use strict";
+            
         },
 
         /**
@@ -170,7 +170,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.PublishedLay
          * @private
          */
         _populateLayerGroups: function (jsonResponse) {
-            //"use strict";
+            
             var me = this,
                 sandbox = me.instance.getSandbox(),
                 mapLayerService = sandbox.getService('Oskari.mapframework.service.MapLayerService'),
@@ -205,7 +205,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.PublishedLay
          * @return maplayer json for the category
          */
         _getPublishedLayer: function (jsonResponse, mapLayerService, usersOwnLayer) {
-            //"use strict";
+            
             var baseJson = this._getMapLayerJsonBase(),
                 layer;
             baseJson.wmsUrl = "/karttatiili/myplaces?myCat=" + jsonResponse.id + "&"; // this.instance.conf.wmsUrl
@@ -244,7 +244,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.PublishedLay
          * @return {Object}
          */
         _getMapLayerJsonBase: function () {
-            //"use strict";
+            
             var catLoc = this.instance.getLocalization('published'),
                 json = {
                     wmsName: 'ows:my_places_categories',
@@ -259,7 +259,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.PublishedLay
         },
 
         showLayerGroups: function (groups) {
-            //"use strict";
+            
             var me = this,
                 i,
                 group,
@@ -320,7 +320,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.PublishedLay
          */
 
         _search: function (keyword) {
-            //"use strict";
+            
             var me = this;
 
             if (!keyword || keyword.length === 0) {
@@ -359,7 +359,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.PublishedLay
         },
 
         setLayerSelected: function (layerId, isSelected) {
-            //"use strict";
+            
             var layerCont = this.layerContainers[layerId];
             if (layerCont) {
                 layerCont.setSelected(isSelected);
@@ -367,7 +367,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselector2.view.PublishedLay
         },
 
         updateLayerContent: function (layerId, layer) {
-            //"use strict";
+            
             // empty the listing to trigger refresh when this tab is selected again
             this.accordion.removeMessage();
             this.showLayerGroups([]);

--- a/bundles/framework/rpc/instance.js
+++ b/bundles/framework/rpc/instance.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @class Oskari.mapframework.bundle.rpc.RemoteProcedureCallInstance
  *
@@ -38,7 +39,7 @@ Oskari.clazz.define(
          * BundleInstance protocol method
          */
         start: function () {
-            'use strict';
+            
             var me = this,
                 channel,
                 conf = this.conf || {},
@@ -402,7 +403,7 @@ Oskari.clazz.define(
          *
          */
         _bindFunctions: function (channel) {
-            'use strict';
+            
             var me = this,
                 funcs = this._allowedFunctions;
             var bindFunction = function(name) {
@@ -443,7 +444,7 @@ Oskari.clazz.define(
          * @return {Boolean} Does origin match config domain
          */
         _domainMatch: function (origin) {
-            'use strict';
+            
             var sb = this.sandbox;
             if(!origin) {
                 this.log.warn('No origin in RPC message');
@@ -476,7 +477,7 @@ Oskari.clazz.define(
          *
          */
         _registerEventHandler: function (eventName) {
-            'use strict';
+            
             var me = this;
             if (me.eventHandlers[eventName]) {
                 // Event handler already in place
@@ -500,7 +501,7 @@ Oskari.clazz.define(
          *
          */
         stop: function () {
-            'use strict';
+            
             var me = this,
                 sandbox = this.sandbox,
                 p;
@@ -528,7 +529,7 @@ Oskari.clazz.define(
          *
          */
         onEvent: function (event) {
-            'use strict';
+            
             var me = this,
                 handler = me.eventHandlers[event.getName()];
             if (!handler) {
@@ -548,7 +549,7 @@ Oskari.clazz.define(
          * @return {Object}       Event params
          */
         _getParams: function (event) {
-            'use strict';
+            
             var ret = {},
                 key,
                 allowedTypes = ['string', 'number', 'boolean'];
@@ -597,7 +598,7 @@ Oskari.clazz.define(
          *
          */
         update: function () {
-            'use strict';
+            
             return undefined;
         },
 
@@ -608,7 +609,7 @@ Oskari.clazz.define(
          *
          */
         _unregisterEventHandler: function (eventName) {
-            'use strict';
+            
             delete this.eventHandlers[eventName];
             this.sandbox.unregisterFromEventByName(this, eventName);
         }

--- a/bundles/liikennevirasto/lakapa-layerselector2/model/LayerGroup.js
+++ b/bundles/liikennevirasto/lakapa-layerselector2/model/LayerGroup.js
@@ -6,7 +6,7 @@ Oskari.clazz.define('Oskari.liikennevirasto.bundle.lakapa.layerselector2.model.L
 	     */
 
 	    function (title) {
-	        //"use strict";
+	        
 	        this.name = title;
 	        this.layers = [];
 	        this.searchIndex = {};
@@ -16,7 +16,7 @@ Oskari.clazz.define('Oskari.liikennevirasto.bundle.lakapa.layerselector2.model.L
 	         * @param {String} value
 	         */
 	        setTitle: function (value) {
-	            //"use strict";
+	            
 	            this.name = value;
 	        },
 	        /**
@@ -24,7 +24,7 @@ Oskari.clazz.define('Oskari.liikennevirasto.bundle.lakapa.layerselector2.model.L
 	         * @return {String}
 	         */
 	        getTitle: function () {
-	            //"use strict";
+	            
 	            return this.name;
 	        },
 	        /**
@@ -32,7 +32,7 @@ Oskari.clazz.define('Oskari.liikennevirasto.bundle.lakapa.layerselector2.model.L
 	         * @param {Layer} layer
 	         */
 	        addLayer: function (layer) {
-	            //"use strict";
+	            
 	            this.layers.push(layer);
 	            this.searchIndex[layer.getId()] = this._getSearchIndex(layer);
 	        },
@@ -41,11 +41,11 @@ Oskari.clazz.define('Oskari.liikennevirasto.bundle.lakapa.layerselector2.model.L
 	         * @return {Layer[]}
 	         */
 	        getLayers: function () {
-	            //"use strict";
+	            
 	            return this.layers;
 	        },
 	        _getSearchIndex: function (layer) {
-	            //"use strict";
+	            
 	            var val = layer.getName() + ' ' +
 	                layer.getInspireName() + ' ' +
 	                layer.getOrganizationName();
@@ -53,7 +53,7 @@ Oskari.clazz.define('Oskari.liikennevirasto.bundle.lakapa.layerselector2.model.L
 	            return val.toLowerCase();
 	        },
 	        matchesKeyword: function (layerId, keyword) {
-	            //"use strict";
+	            
 	            var searchableIndex = this.searchIndex[layerId];
 	            return searchableIndex.indexOf(keyword.toLowerCase()) !== -1;
 	        }


### PR DESCRIPTION
Moved "use strict" to file level from function level to cleanup codebase.

All files that had "use strict" in any function, have it now on first line. All code that was in strict mode before still is after the change. Some code that wasn't strict mode has been changed to strict mode. It's possible adding strict mode to this code breaks it, but it's unlikely.