### PR TITLE
Minifier fix for "use strict" instruction 

### DIFF
--- a/bundles/framework/admin-layerrights/Flyout.js
+++ b/bundles/framework/admin-layerrights/Flyout.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.framework.bundle.admin-layerrights.Flyout
  *

--- a/bundles/framework/admin-layerrights/Tile.js
+++ b/bundles/framework/admin-layerrights/Tile.js
@@ -1,4 +1,3 @@
-'use strict';
 /*
  * @class Oskari.framework.bundle.admin-layerrights.Tile
  *

--- a/bundles/framework/admin-layerrights/instance.js
+++ b/bundles/framework/admin-layerrights/instance.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.framework.bundle.admin-layerrights.AdminLayerRightsBundleInstance
  *

--- a/bundles/framework/admin-users/AdminRoles.js
+++ b/bundles/framework/admin-users/AdminRoles.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.mapframework.bundle.admin-users.AdminRoles
  *

--- a/bundles/framework/divmanazer/component/Button.js
+++ b/bundles/framework/divmanazer/component/Button.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.Button
  *

--- a/bundles/framework/divmanazer/component/CheckboxInput.js
+++ b/bundles/framework/divmanazer/component/CheckboxInput.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.CheckboxInput
  *

--- a/bundles/framework/divmanazer/component/Component.js
+++ b/bundles/framework/divmanazer/component/Component.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.Component
  * Component

--- a/bundles/framework/divmanazer/component/Container.js
+++ b/bundles/framework/divmanazer/component/Container.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.Container
  * Container

--- a/bundles/framework/divmanazer/component/EmailInput.js
+++ b/bundles/framework/divmanazer/component/EmailInput.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.EmailInput
  *

--- a/bundles/framework/divmanazer/component/Fieldset.js
+++ b/bundles/framework/divmanazer/component/Fieldset.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.Fieldset
  * Generic form component

--- a/bundles/framework/divmanazer/component/Form.js
+++ b/bundles/framework/divmanazer/component/Form.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.Form
  * Generic form component

--- a/bundles/framework/divmanazer/component/FormComponent.js
+++ b/bundles/framework/divmanazer/component/FormComponent.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.FormComponent
  *

--- a/bundles/framework/divmanazer/component/FormInput.js
+++ b/bundles/framework/divmanazer/component/FormInput.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.FormInput
  * Form field to be used with Oskari.userinterface.component.Form

--- a/bundles/framework/divmanazer/component/LanguageSelect.js
+++ b/bundles/framework/divmanazer/component/LanguageSelect.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.LanguageSelect
  *

--- a/bundles/framework/divmanazer/component/MultiLevelSelect.js
+++ b/bundles/framework/divmanazer/component/MultiLevelSelect.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.MultiLevelSelect
  *

--- a/bundles/framework/divmanazer/component/NumberInput.js
+++ b/bundles/framework/divmanazer/component/NumberInput.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.NumberInput
  *

--- a/bundles/framework/divmanazer/component/PasswordInput.js
+++ b/bundles/framework/divmanazer/component/PasswordInput.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.PasswordInput
  *

--- a/bundles/framework/divmanazer/component/RadioButtonGroup.js
+++ b/bundles/framework/divmanazer/component/RadioButtonGroup.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.RadioButtonGroup
  *

--- a/bundles/framework/divmanazer/component/SearchInput.js
+++ b/bundles/framework/divmanazer/component/SearchInput.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.SearchInput
  *

--- a/bundles/framework/divmanazer/component/Select.js
+++ b/bundles/framework/divmanazer/component/Select.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.Select
  *

--- a/bundles/framework/divmanazer/component/TextAreaInput.js
+++ b/bundles/framework/divmanazer/component/TextAreaInput.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.TextAreaInput
  *

--- a/bundles/framework/divmanazer/component/TextInput.js
+++ b/bundles/framework/divmanazer/component/TextInput.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.TextInput
  *

--- a/bundles/framework/divmanazer/component/UrlInput.js
+++ b/bundles/framework/divmanazer/component/UrlInput.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.userinterface.component.UrlInput
  *

--- a/bundles/framework/geometryeditor/plugin/DrawFilterPlugin.js
+++ b/bundles/framework/geometryeditor/plugin/DrawFilterPlugin.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.mapframework.ui.module.common.GeometryEditor.DrawFilterPlugin
  */

--- a/bundles/framework/rpc/instance.js
+++ b/bundles/framework/rpc/instance.js
@@ -1,4 +1,3 @@
-'use strict';
 /**
  * @class Oskari.mapframework.bundle.rpc.RemoteProcedureCallInstance
  *


### PR DESCRIPTION
When the code is used in "development mode" (=files loaded separately) the "use strict" instruction works as expected. However when the code is minified the "use strict" instruction is hoisted to affect the whole minified file which causes problems like:
- "Uncaught ReferenceError: Proj4js is not defined (proj4js-compressed.js)"
- "Uncaught TypeError: Cannot use 'in' operator to search for 'Math' in undefined (ol-v4.4.2-oskari.js)

As it's not easy to wrap the contents of the files in the current build script to workaround this and we are moving towards a Webpack powered building tool it makes more sense to just not use the "use strict" instruction currently.