### PR TITLE
Remove ol2 and add drawtools since ASDI is now ol4-based

### DIFF
--- a/applications/asdi/asdi_guest/minifierAppSetup.json
+++ b/applications/asdi/asdi_guest/minifierAppSetup.json
@@ -9,18 +9,6 @@
                 }
             }
         }, {
-            "bundlename": "openlayers-default-theme",
-            "metadata": {
-                "Import-Bundle": {
-                    "openlayers-default-theme": {
-                        "bundlePath": "../../../packages/openlayers/bundle/"
-                    },
-                    "openlayers-full-map": {
-                        "bundlePath": "../../../packages/openlayers/bundle/"
-                    }
-                }
-            }
-        }, {
             "bundlename": "mapfull",
             "metadata": {
                 "Import-Bundle": {
@@ -44,6 +32,15 @@
                     },
                     "mapwmts": {
                         "bundlePath": "../../../packages/mapping/ol3/"
+                    }
+                }
+            }
+        }, {
+            "bundlename" : "drawtools",
+            "metadata" : {
+                "Import-Bundle" : {
+                    "drawtools" : {
+                        "bundlePath" : "../../../packages/mapping/ol3/"
                     }
                 }
             }


### PR DESCRIPTION
Currently the minifier AppSetup includes both OpenLayers 2 AND 3 while the drawtools bundle (required for measuring and other draw ops) is not included. This fixes the issue.