### PR TITLE
jQuery live and die replacements

### DIFF
--- a/bundles/framework/myplaces2/ButtonHandler.js
+++ b/bundles/framework/myplaces2/ButtonHandler.js
@@ -280,8 +280,8 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces2.ButtonHandler",
          */
         stop: function () {
             // Toolbar.RemoveToolButtonRequest
-            // remove live bindings
-            jQuery('div.myplaces2 div.button').die();
+            // remove on bindings
+            jQuery('div.myplaces2 div.button').off();
         },
         /**
          * @method onEvent

--- a/bundles/framework/myplaces2/view/MainView.js
+++ b/bundles/framework/myplaces2/view/MainView.js
@@ -234,6 +234,9 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces2.view.MainView",
             sandbox.request(me.getName(), request);
             // A tad ugly, but for some reason this won't work if we find the input from formEl
             jQuery('input[name=placename]').focus();
+
+            // Here need add bindings
+            me.form.bindEvents();
         },
         /**
          * Destroys the opened form popup(s) from the screen.

--- a/bundles/framework/myplaces2/view/PlaceForm.js
+++ b/bundles/framework/myplaces2/view/PlaceForm.js
@@ -83,20 +83,15 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces2.view.PlaceForm",
                     }
                     selection.append(option);
                 }
-                this._bindCategoryChange();
             }
 
             if (isPublished) {
                 // remove the layer selections if in a publised map
                 ui.find('div#newLayerForm').remove();
-            } else {
-                // otherwise bind an event when selecting to create a new layer
-                this._bindCreateNewLayer();
             }
 
             // Hide the image preview at first
             this._updateImageUrl('', ui);
-            this._bindImageUrlChange();
 
             if (this.initialValues) {
                 ui.find('input[data-name=placename]').attr('value', this.initialValues.place.name);
@@ -196,6 +191,16 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces2.view.PlaceForm",
             find('div.measurementResult').
             html(this.measurementResult);
         },
+        bindEvents: function(){
+            var me = this;
+            var isPublished = (this.options ? this.options.published : false);
+            if(!isPublished) {
+                me._bindCategoryChange();
+                me._bindCreateNewLayer();
+            }
+
+            me._bindImageUrlChange();
+        },
         /**
          * @method _bindCategoryChange
          * Binds change listener for category selection.
@@ -207,7 +212,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces2.view.PlaceForm",
         _bindCategoryChange: function () {
             var me = this,
                 onScreenForm = this._getOnScreenForm();
-            onScreenForm.find('select[data-name=category]').live('change', function () {
+            onScreenForm.find('select[data-name=category]').on('change', function () {
                 // remove category form is initialized
                 if (me.categoryForm) {
                     me.categoryForm.destroy();
@@ -226,7 +231,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces2.view.PlaceForm",
         _bindImageUrlChange: function () {
             var me = this,
                 onScreenForm = me._getOnScreenForm();
-            onScreenForm.find('input[data-name=imagelink]').live('change keyup', function () {
+            onScreenForm.find('input[data-name=imagelink]').on('change keyup', function () {
                 me._updateImageUrl(jQuery(this).val(), me._getOnScreenForm());
             });
         },
@@ -258,7 +263,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces2.view.PlaceForm",
         _bindCreateNewLayer: function () {
             var me = this,
                 onScreenForm = me._getOnScreenForm();
-            onScreenForm.find('a.newLayerLink').live('click', function (evt) {
+            onScreenForm.find('a.newLayerLink').on('click', function (evt) {
                 var form = me._getOnScreenForm();
                 evt.preventDefault();
                 me.categoryForm = Oskari.clazz.create('Oskari.mapframework.bundle.myplaces2.view.CategoryForm', me.instance);
@@ -273,11 +278,11 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces2.view.PlaceForm",
          * Removes eventlisteners
          */
         destroy: function () {
-            // unbind live bindings
+            // unbind on bindings
             var onScreenForm = this._getOnScreenForm();
-            onScreenForm.find('select[data-name=category]').die();
-            onScreenForm.find('input[data-name=imagelink]').die();
-            onScreenForm.find('a.newLayerLink').die();
+            onScreenForm.find('select[data-name=category]').off();
+            onScreenForm.find('input[data-name=imagelink]').off();
+            onScreenForm.find('a.newLayerLink').off();
             if (this.categoryForm) {
                 this.categoryForm.destroy();
                 this.categoryForm = undefined;

--- a/bundles/framework/myplaces3/ButtonHandler.js
+++ b/bundles/framework/myplaces3/ButtonHandler.js
@@ -238,7 +238,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.ButtonHandler",
             if (this.drawMode === 'line'){
                 measurement = data.length;
             } else if (this.drawMode === 'area'){
-                measurement = data.area;         
+                measurement = data.area;
             } else {
                 return;
             }
@@ -267,8 +267,8 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.ButtonHandler",
 
         stop: function () {
             // Toolbar.RemoveToolButtonRequest
-            // remove live bindings
-            jQuery('div.myplaces3 div.button').die();
+            // remove on bindings
+            jQuery('div.myplaces3 div.button').off();
         },
         /**
          * @method onEvent

--- a/bundles/framework/myplaces3/view/MainView.js
+++ b/bundles/framework/myplaces3/view/MainView.js
@@ -199,7 +199,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.MainView",
             //set measurement result from drawing
             } else {
                 this._setMeasurementResult(this.drawingData);
-            }            
+            }
 
             var formEl = me.form.getForm(categories),
                 content = [{
@@ -247,6 +247,9 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.MainView",
             sandbox.request(me.getName(), request);
             // A tad ugly, but for some reason this won't work if we find the input from formEl
             jQuery('input[data-name=placename]').focus();
+
+            // Here need add bindings
+            me.form.bindEvents();
         },
         /**
          * @method _getDrawModeFromGeometry
@@ -417,7 +420,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.MainView",
             place.setAttentionText(Oskari.util.sanitize(values.attention_text));
             place.setCategoryId(values.category);
             if (drawing){
-                place.setDrawToolsMultiGeometry(drawing); 
+                place.setDrawToolsMultiGeometry(drawing);
             } else if (this.tempGeom) {
                 place.setGeometry(this.tempGeom); // if not edited
             }

--- a/bundles/framework/myplaces3/view/PlaceForm.js
+++ b/bundles/framework/myplaces3/view/PlaceForm.js
@@ -83,7 +83,6 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.PlaceForm",
                     }
                     selection.append(option);
                 }
-                this._bindCategoryChange();
             }
             if (isPublished) {
                 // remove the layer selections if in a publised map
@@ -92,7 +91,6 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.PlaceForm",
 
             // Hide the image preview at first
             this._updateImageUrl('', ui);
-            this._bindImageUrlChange();
 
             if (this.initialValues) {
                 ui.find('input[data-name=placename]').attr('value', this.initialValues.place.name);
@@ -194,6 +192,15 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.PlaceForm",
             this.measurementResult = this.loc('placeform.measurement.' + drawMode) + ' ' + measurementWithUnit;
             this._getOnScreenForm().find('div.measurementResult').html(this.measurementResult);
         },
+        bindEvents: function(){
+            var me = this;
+            var isPublished = (this.options ? this.options.published : false);
+            if(!isPublished) {
+                me._bindCategoryChange();
+            }
+
+            me._bindImageUrlChange();
+        },
         /**
          * @method _bindCategoryChange
          * Binds change listener for category selection.
@@ -205,7 +212,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.PlaceForm",
         _bindCategoryChange: function () {
             var me = this,
                 onScreenForm = this._getOnScreenForm();
-            onScreenForm.find('select[data-name=category]').live('change', function () {
+            onScreenForm.find('select[data-name=category]').on('change', function () {
                 // remove category form is initialized
                 if (me.categoryForm) {
                     me.categoryForm.destroy();
@@ -224,7 +231,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.PlaceForm",
         _bindImageUrlChange: function () {
             var me = this,
                 onScreenForm = me._getOnScreenForm();
-            onScreenForm.find('input[data-name=imagelink]').live('change keyup', function () {
+            onScreenForm.find('input[data-name=imagelink]').on('change keyup', function () {
                 me._updateImageUrl(jQuery(this).val(), me._getOnScreenForm());
             });
         },
@@ -258,11 +265,11 @@ Oskari.clazz.define("Oskari.mapframework.bundle.myplaces3.view.PlaceForm",
          * Removes eventlisteners
          */
         destroy: function () {
-            // unbind live bindings
+            // unbind on bindings
             var onScreenForm = this._getOnScreenForm();
-            onScreenForm.find('select[data-name=category]').die();
-            onScreenForm.find('input[data-name=imagelink]').die();
-            onScreenForm.find('a.newLayerLink').die();
+            onScreenForm.find('select[data-name=category]').off();
+            onScreenForm.find('input[data-name=imagelink]').off();
+            onScreenForm.find('a.newLayerLink').off();
             if (this.categoryForm) {
                 this.categoryForm.destroy();
                 this.categoryForm = undefined;


### PR DESCRIPTION
This PR replaces jQuery .live/.die methods to .on/.off.

After these changes jQuery can be updated 1.9 or newer.