### PR TITLE
Statsgrid regionset selection

### DIFF
--- a/bundles/statistics/statsgrid2016/components/EditClassification.js
+++ b/bundles/statistics/statsgrid2016/components/EditClassification.js
@@ -1,14 +1,14 @@
-Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function(sandbox, locale) {
+Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function (sandbox, locale) {
     this.sb = sandbox;
     this.LAYER_ID = 'STATS_LAYER';
     this.service = this.sb.getService('Oskari.statistics.statsgrid.StatisticsService');
     this.classificationService = this.sb.getService('Oskari.statistics.statsgrid.ClassificationService');
     this.locale = locale;
     var me = this;
-    me.service.on('StatsGrid.ClassificationChangedEvent', function(event) {
+    me.service.on('StatsGrid.ClassificationChangedEvent', function (event) {
         me.setValues(event.getCurrent());
     });
-    me.service.on('AfterChangeMapLayerOpacityEvent', function(event) {
+    me.service.on('AfterChangeMapLayerOpacityEvent', function (event) {
         me.setLayerOpacityValue(event.getMapLayer());
     });
     this.__templates = {
@@ -91,7 +91,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function(s
                     '</div>'+
                 '</div>'+
 
-
                 '<div class="classification-color-set visible-map-style-choropleth">'+
                     '<div class="label">'+ this.locale.colorset.setselection +'</div>'+
                     '<div class="color-set value">'+
@@ -103,16 +102,14 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function(s
                         '</select>'+
                     '</div>'+
                 '</div>'+
-
             '</div>'+
-
             '</div>')
 
     };
 
     var transparencyEl = this.__templates.classification.find('select.transparency-value');
-    for(var i=100;i>=30;i-=10) {
-        transparencyEl.append('<option value="'+i+'">'+ i +' %</option>');
+    for (var i = 100; i >= 30; i -= 10) {
+        transparencyEl.append('<option value="' + i + '">' + i + ' %</option>');
     }
     this.__templates.classification.find('select.transparency-value option[value=100]').attr('selected', 'selected');
 
@@ -128,22 +125,21 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function(s
         element: null
     };
     this._showNumericValueCheckButton = null;
-
 }, {
-    _toggleMapStyle: function(mapStyle) {
+    _toggleMapStyle: function (mapStyle) {
         var me = this;
         var style = mapStyle || 'choropleth';
         me._element.find('.visible-map-style-points').hide();
         me._element.find('.visible-map-style-choropleth').hide();
         me._element.find('.visible-map-style-' + style).show();
     },
-    setLayerOpacityValue: function(layer){
+    setLayerOpacityValue: function (layer) {
         var me = this;
-        if(me.hasSelectChange) {
+        if (me.hasSelectChange) {
             me.hasSelectChange = false;
             return;
         }
-        if(layer.getId() === me.LAYER_ID) {
+        if (layer.getId() === me.LAYER_ID) {
             var transparencyEl = me._element.find('select.transparency-value');
             transparencyEl.find('option#hiddenvalue').remove();
             var hiddenOption = jQuery('<option id="hiddenvalue" disabled hidden>' + layer.getOpacity() + ' %' +'</option>');
@@ -159,23 +155,23 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function(s
      * @method setValues init selections
      * @param  {Object} classification options. Defaults to current active indicator options
      */
-    setValues: function(classification){
+    setValues: function (classification) {
         var me = this;
 
-        if(!this._element) {
+        if (!this._element) {
             // not rendered yet
             return;
         }
         var service = me.service;
         var state = service.getStateService();
         var ind = state.getActiveIndicator();
-        if(!ind) {
+        if (!ind) {
             // no active indicator
             return;
         }
         classification = classification || state.getClassificationOpts(ind.hash);
 
-        me._element.find('select.map-style').bind('change', function(){
+        me._element.find('select.map-style').bind('change', function () {
             var el = jQuery(this);
             var value = el.val();
             me._toggleMapStyle(value);
@@ -193,7 +189,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function(s
         var amount = me._element.find('select.amount-class');
         amount.empty();
         var option = jQuery('<option></option>');
-        for(var i=amountRange.min;i<amountRange.max+1;i++) {
+        for (var i = amountRange.min; i < amountRange.max + 1; i++) {
             var op = option.clone();
             op.html(i);
             op.attr('value', i);
@@ -206,7 +202,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function(s
         me._element.find('#legend-flip-colors').attr('checked', classification.reverseColors);
         // update color selection values
         var colors = service.getColorService().getDefaultSimpleColors();
-        if(mapStyle === 'choropleth') {
+        if (mapStyle === 'choropleth') {
             colors = service.getColorService().getOptionsForType(classification.type, classification.count, classification.reverseColors);
         }
 
@@ -215,17 +211,17 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function(s
         me._colorSelect.refresh();
 
         // disable invalid choices
-        service.getIndicatorData(ind.datasource, ind.indicator, ind.selections, state.getRegionset(), function(err, data) {
-            if(err) {
+        service.getIndicatorData(ind.datasource, ind.indicator, ind.selections, state.getRegionset(), function (err, data) {
+            if (err) {
                 // propably nothing to tell the user at this point. There will be some invalid choices available on the form
                 return;
             }
             var validOptions = service.getClassificationService().getAvailableOptions(data);
-            if(validOptions.maxCount) {
+            if (validOptions.maxCount) {
                 var options = amount.find('option');
-                options.each(function(index, opt) {
+                options.each(function (index, opt) {
                     opt = jQuery(opt);
-                    if(opt.val() > validOptions.maxCount) {
+                    if (opt.val() > validOptions.maxCount) {
                         opt.attr('disabled', true);
                     }
                 });
@@ -236,20 +232,20 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function(s
         var max = classification.max || me._rangeSlider.defaultValues[1];
         var updateClassification = false;
 
-        if(max-min < classification.count * (me._rangeSlider.step || 1) ) {
+        if (max - min < classification.count * (me._rangeSlider.step || 1)) {
             min = me._rangeSlider.defaultValues[0];
             max = me._rangeSlider.defaultValues[1];
             updateClassification = true;
         }
-        me._rangeSlider.element.slider('values', [min,max]);
+        me._rangeSlider.element.slider('values', [min, max]);
         me._rangeSlider.element.attr('data-count', classification.count || amountRange[0]);
         me._showNumericValueCheckButton.setChecked((typeof classification.showValues === 'boolean') ? classification.showValues : false);
 
-        if(updateClassification) {
-            state.setClassification(ind.hash,  me.getSelectedValues(), true);
+        if (updateClassification) {
+            state.setClassification(ind.hash, me.getSelectedValues(), true);
         }
 
-        if(classification.transparency) {
+        if (classification.transparency) {
             me.sb.postRequestByName('ChangeMapLayerOpacityRequest', [me.LAYER_ID, classification.transparency]);
         }
     },
@@ -258,7 +254,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function(s
      * @method  @public getSelectedValues gets selected values
      * @return {Object} selected values object
      */
-    getSelectedValues: function(){
+    getSelectedValues: function () {
         var me = this;
         var range = me._rangeSlider.element.slider('values');
         var values = {
@@ -273,10 +269,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function(s
             min: range[0],
             max: range[1],
             transparency: me._element.find('select.transparency-value').val(),
-            showValues: (me._showNumericValueCheckButton.getValue() === 'on') ? true : false
+            showValues: (me._showNumericValueCheckButton.getValue() === 'on')
         };
 
-        if(values.mapStyle !== 'points') {
+        if (values.mapStyle !== 'points') {
             delete values.min;
             delete values.max;
             delete values.transparency;
@@ -291,19 +287,19 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function(s
      * @method  @public getElement  get element
      * @return {Object} jQuery element object
      */
-    getElement: function() {
+    getElement: function () {
         var me = this;
         var service = me.service;
-        if(!service) {
+        if (!service) {
             // not available yet
             return;
         }
-        if(me._element) {
+        if (me._element) {
             return me._element;
         }
         me._element = me.__templates.classification.clone();
 
-        if(!service.hasMapMode('vector')) {
+        if (!service.hasMapMode('vector')) {
             me._element.find('.visible-on-vector').remove();
         }
 
@@ -311,26 +307,26 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function(s
         me._element.find('.classification-colors.value').append(me._colorSelect.getElement());
 
         var stateService = me.service.getStateService();
-        var updateClassification = function() {
+        var updateClassification = function () {
             me.hasSelectChange = true;
             stateService.setClassification(stateService.getActiveIndicator().hash, me.getSelectedValues());
         };
 
-        if(!me._rangeSlider.element) {
+        if (!me._rangeSlider.element) {
             me._rangeSlider.element = me._element.find('.point-range');
 
             me._rangeSlider.element.slider({
                 min: me._rangeSlider.min,
                 max: me._rangeSlider.max,
-                step:me._rangeSlider.step,
+                step: me._rangeSlider.step,
                 range: true,
-                values: [me._rangeSlider.defaultValues[0],me._rangeSlider.defaultValues[1]],
+                values: [me._rangeSlider.defaultValues[0], me._rangeSlider.defaultValues[1]],
                 slide: function (event, ui) {
                     var min = ui.values[0];
                     var max = ui.values[1];
                     var el = jQuery(this);
                     var count = (!isNaN(el.attr('data-count'))) ? parseFloat(el.attr('data-count')) : 2;
-                    if(max-min >= count * (me._rangeSlider.step || 1)) {
+                    if (max - min >= count * (me._rangeSlider.step || 1)) {
                         return true;
                     }
                     return false;
@@ -341,49 +337,45 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function(s
             });
         }
 
-        if(!me._showNumericValueCheckButton) {
+        if (!me._showNumericValueCheckButton) {
             me._showNumericValueCheckButton = Oskari.clazz.create('Oskari.userinterface.component.CheckboxInput');
             me._showNumericValueCheckButton.setTitle(me.locale.classify.map.showValues);
-            me._showNumericValueCheckButton.setHandler(function(){
+            me._showNumericValueCheckButton.setHandler(function () {
                 updateClassification();
             });
             me._element.find('.numeric-value').append(me._showNumericValueCheckButton.getElement());
         }
-
 
         // setup initial values
         me.setValues();
         // might have been set before render
         this.setEnabled(this.__enabled);
 
-
         me._colorSelect.setHandler(updateClassification);
         me._element.find('select').bind('change', updateClassification);
 
-        me._element.find('#legend-flip-colors').change(function(){
+        me._element.find('#legend-flip-colors').change(function () {
             updateClassification();
         });
         return me._element;
-
     },
     /**
      * @method  @public setEnabled set enabled
      * @param {Boolean} enabled is edit enabled or not
      */
-    setEnabled: function(enabled) {
+    setEnabled: function (enabled) {
         var me = this;
-        if(typeof enabled !== 'boolean') {
+        if (typeof enabled !== 'boolean') {
             return;
         }
         this.__enabled = !!enabled;
-        if(!this._element) {
+        if (!this._element) {
             // not rendered yet
             return;
         }
         me._element.find('select').prop('disabled', !enabled).trigger('chosen:updated');
         me._element.find('button').prop('disabled', !enabled);
         me._colorSelect.setEnabled(enabled);
-        me._element.find('.point-range').slider('option','disabled',!enabled);
+        me._element.find('.point-range').slider('option','disabled', !enabled);
     }
-
 });

--- a/bundles/statistics/statsgrid2016/components/ExtraFeatures.js
+++ b/bundles/statistics/statsgrid2016/components/ExtraFeatures.js
@@ -1,17 +1,17 @@
-Oskari.clazz.define('Oskari.statistics.statsgrid.ExtraFeatures', function(sandbox, locale) {
+Oskari.clazz.define('Oskari.statistics.statsgrid.ExtraFeatures', function (sandbox, locale) {
     this.locale = locale;
     this.sb = sandbox;
     this._checkboxes = [];
 }, {
-    /****** PUBLIC METHODS ******/
+    /** **** PUBLIC METHODS ******/
     /**
      * @method  @public getPanelContent get content panel
      */
-    getPanelContent: function() {
+    getPanelContent: function () {
         var me = this;
         var content = jQuery('<div></div>');
         me._initCheckboxes();
-        me._checkboxes.forEach(function(buttonConf){
+        me._checkboxes.forEach(function (buttonConf) {
             content.append(buttonConf.button.getElement());
         });
         return content;
@@ -21,28 +21,28 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ExtraFeatures', function(sandbo
      * @method @public getValues get extra feature values
      * @return {Object} extra features values
      */
-    getValues: function(){
+    getValues: function () {
         var me = this;
         var values = {};
-        me._checkboxes.forEach(function(chkConf){
+        me._checkboxes.forEach(function (chkConf) {
             values[chkConf.id] = chkConf.button.isChecked();
         });
         return values;
     },
 
-    /****** PRIVATE METHODS ******/
-    _initCheckboxes: function(){
+    /** **** PRIVATE METHODS ******/
+    _initCheckboxes: function () {
         var me = this;
         me._checkboxes.push({
-            id:'hideOtherLayers',
+            id: 'hideOtherLayers',
             button: me._getHideOtherLayersCheckbox()
         });
         me._checkboxes.push({
-            id:'openTable',
+            id: 'openTable',
             button: me._getOpenTableCheckbox()
         });
         me._checkboxes.push({
-            id:'openDiagram',
+            id: 'openDiagram',
             button: me._getOpenDiagramCheckbox()
         });
     },
@@ -50,8 +50,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ExtraFeatures', function(sandbo
      * @method  @private _getOpenTableCheckbox  gets open table checbox element and sets this handler
      * @return {Object} checkbox element
      */
-    _getOpenDiagramCheckbox: function() {
-        var me = this;
+    _getOpenDiagramCheckbox: function () {
         var checkbox = Oskari.clazz.create('Oskari.userinterface.component.CheckboxInput');
         checkbox.setTitle(this.locale.openDiagramCheckbox);
         checkbox.setChecked(false);
@@ -61,8 +60,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ExtraFeatures', function(sandbo
      * @method  @private _getOpenTableCheckbox  gets open table checbox element and sets this handler
      * @return {Object} checkbox element
      */
-    _getOpenTableCheckbox: function() {
-        var me = this;
+    _getOpenTableCheckbox: function () {
         var checkbox = Oskari.clazz.create('Oskari.userinterface.component.CheckboxInput');
         checkbox.setTitle(this.locale.openTableCheckbox);
         checkbox.setChecked(false);
@@ -72,12 +70,12 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ExtraFeatures', function(sandbo
      * @method  @private _getHideOtherLayersCheckbox  gets hide other layers checbox element and sets this handler
      * @return {Object} checkbox element
      */
-    _getHideOtherLayersCheckbox: function() {
+    _getHideOtherLayersCheckbox: function () {
         var me = this;
         var checkbox = Oskari.clazz.create('Oskari.userinterface.component.CheckboxInput');
         checkbox.setTitle(this.locale.hideMapLayers);
         checkbox.setChecked(false);
-        checkbox.setHandler(function() {
+        checkbox.setHandler(function () {
             me._toggleSelectedLayersVisibility(checkbox.isChecked());
         });
         return checkbox;
@@ -86,14 +84,14 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ExtraFeatures', function(sandbo
      * @method  @private _toggleSelectedLayersVisibility toggle selected layers visibility
      * @param  {Boolean} checked if checked then hide all map layers
      */
-    _toggleSelectedLayersVisibility: function(checked) {
+    _toggleSelectedLayersVisibility: function (checked) {
         var sandbox = this.sb;
         if (!sandbox.hasHandler('MapModulePlugin.MapLayerVisibilityRequest')) {
             return;
         }
         var selectedLayers = sandbox.findAllSelectedMapLayers();
-        selectedLayers.forEach(function(layer){
-            if(checked && layer.getId() !== 'STATS_LAYER') {
+        selectedLayers.forEach(function (layer) {
+            if (checked && layer.getId() !== 'STATS_LAYER') {
                 sandbox.postRequestByName('MapModulePlugin.MapLayerVisibilityRequest', [layer.getId(), false]);
             } else {
                 sandbox.postRequestByName('MapModulePlugin.MapLayerVisibilityRequest', [layer.getId(), true]);

--- a/bundles/statistics/statsgrid2016/components/IndicatorParameters.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorParameters.js
@@ -1,4 +1,4 @@
-Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParameters', function(instance, sandbox) {
+Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParameters', function (instance, sandbox) {
     this.instance = instance;
     this.sb = sandbox;
     this.service = sandbox.getService('Oskari.statistics.statsgrid.StatisticsService');
@@ -7,20 +7,19 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParameters', function(
     this._selections = [];
     Oskari.makeObservable(this);
 }, {
-    __templates : {
-        main : _.template('<div class="stats-ind-params">'+
-            '</div>'),
-        select : _.template('<div class="parameter"><div class="label" id=${id}>${label}</div><div class="clear"></div></div>'),
-        option : _.template('<option value="${id}">${name}</option>')
+    __templates: {
+        main: _.template('<div class="stats-ind-params"></div>'),
+        select: _.template('<div class="parameter"><div class="label" id=${id}>${label}</div><div class="clear"></div></div>'),
+        option: _.template('<option value="${id}">${name}</option>')
     },
 
-    /****** PUBLIC METHODS ******/
+    /** **** PUBLIC METHODS ******/
 
     /**
      * @method  @public  clean clean params
      */
-    clean : function() {
-        if(!this.container) {
+    clean: function () {
+        if (!this.container) {
             return;
         }
         this.container.remove();
@@ -34,7 +33,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParameters', function(
      * @param  {String} indId    indicator id
      * @param  {Object} elements elements
      */
-    indicatorSelected : function(el, datasrc, indId, elements) {
+    indicatorSelected: function (el, datasrc, indId, elements) {
         var me = this;
         var locale = me.instance.getLocalization();
         var errorService = me.service.getErrorService();
@@ -43,8 +42,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParameters', function(
 
         this.clean();
 
-        if(!indId && indId ==='')  {
-            if(elements.dataLabelWithTooltips) {
+        if (!indId && indId === '') {
+            if (elements.dataLabelWithTooltips) {
                 elements.dataLabelWithTooltips.find('.tooltip').show();
             }
             return;
@@ -56,61 +55,61 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParameters', function(
 
         me.spinner.insertTo(cont.parent().parent());
         me.spinner.start();
-        if(!this.regionSelector) {
+        if (!this.regionSelector) {
             this.regionSelector = Oskari.clazz.create('Oskari.statistics.statsgrid.RegionsetSelector', me.sb, me.instance.getLocalization());
         }
-        this.service.getIndicatorMetadata(datasrc, indId, function(err, indicator) {
+        this.service.getIndicatorMetadata(datasrc, indId, function (err, indicator) {
             me.spinner.stop();
-            if(elements.dataLabelWithTooltips) {
+            if (elements.dataLabelWithTooltips) {
                 elements.dataLabelWithTooltips.find('.tooltip').hide();
             }
-            if(err) {
+            if (err) {
                 // notify error!!
-                errorService.show(locale.errors.title,locale.errors.indicatorMetadataError);
+                errorService.show(locale.errors.title, locale.errors.indicatorMetadataError);
                 return;
             }
 
             // selections
             me._selections = [];
-            indicator.selectors.forEach(function(selector, index) {
-                var placeholderText = (panelLoc.selectionValues[selector.id] && panelLoc.selectionValues[selector.id].placeholder) ? panelLoc.selectionValues[selector.id].placeholder :panelLoc.defaultPlaceholder;
+            indicator.selectors.forEach(function (selector, index) {
+                var placeholderText = (panelLoc.selectionValues[selector.id] && panelLoc.selectionValues[selector.id].placeholder) ? panelLoc.selectionValues[selector.id].placeholder : panelLoc.defaultPlaceholder;
                 var label = (locale.parameters[selector.id]) ? locale.parameters[selector.id] : selector.id;
-                var tempSelect = jQuery(me.__templates.select({id:selector.id,label:label}));
+                var tempSelect = jQuery(me.__templates.select({id: selector.id, label: label}));
                 var options = {
                     placeholder_text: placeholderText,
-                    allow_single_deselect : true,
+                    allow_single_deselect: true,
                     disable_search_threshold: 10,
                     width: '100%'
                 };
                 var selections = [];
                 var select = Oskari.clazz.create('Oskari.userinterface.component.SelectList', selector.id);
 
-                selector.allowedValues.forEach(function(val) {
+                selector.allowedValues.forEach(function (val) {
                     var name = val.name || val.id || val;
                     val.title = val.name;
                     var optName = (panelLoc.selectionValues[selector.id] && panelLoc.selectionValues[selector.id][name]) ? panelLoc.selectionValues[selector.id][name] : name;
 
                     var valObject = {
-                            id : val.id || val,
-                            title : optName
+                        id: val.id || val,
+                        title: optName
                     };
                     selections.push(valObject);
                 });
 
                 var dropdown = select.create(selections, options);
-                dropdown.css({width:'205px'});
+                dropdown.css({width: '205px'});
                 select.adjustChosen();
                 select.selectFirstValue();
                 tempSelect.find('.label').append(dropdown);
-                if(index > 0) {
+                if (index > 0) {
                     dropdown.parent().addClass('margintop');
                 }
                 cont.append(tempSelect);
                 me._selections.push(select);
             });
 
-            if(indicator.regionsets.length === 0) {
-                errorService.show(locale.errors.title,locale.errors.regionsetsIsEmpty);
+            if (indicator.regionsets.length === 0) {
+                errorService.show(locale.errors.title, locale.errors.regionsetsIsEmpty);
             }
             var regionSelect = me.regionSelector.create(indicator.regionsets);
             me.regionSelector.setWidth(205);
@@ -118,28 +117,32 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParameters', function(
             regionSelect.value(me.service.getStateService().getRegionset());
             cont.append(regionSelect.container);
             // Add margin if there is selections
-            if(indicator.selectors.length > 0) {
+            if (indicator.selectors.length > 0) {
                 regionSelect.container.addClass('margintop');
             } else {
-                errorService.show(locale.errors.title,locale.errors.indicatorMetadataIsEmpty);
+                errorService.show(locale.errors.title, locale.errors.indicatorMetadataIsEmpty);
             }
 
             me._values = {
-                datasource : datasrc,
-                indicator : indId,
-                regionset: regionSelect.value()
+                ds: datasrc,
+                ind: indId,
+                regionsetComponent: regionSelect
             };
 
-            me.trigger('indicator.changed', indicator.regionsets.length>0);
+            me.trigger('indicator.changed', indicator.regionsets.length > 0);
         });
     },
-    getValues: function(){
+    getValues: function () {
         var me = this;
-        var selections = {};
-        me._selections.forEach(function(select) {
-            selections[select.getId()] = select.getValue();
+        var values = {
+            datasource: me._values.ds,
+            indicator: me._values.ind,
+            regionset: me._values.regionsetComponent.value(),
+            selections: {}
+        };
+        me._selections.forEach(function (select) {
+            values.selections[select.getId()] = select.getValue();
         });
-        me._values.selections = selections;
-        return me._values;
+        return values;
     }
 });

--- a/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
@@ -1,4 +1,4 @@
-Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function(instance, sandbox) {
+Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (instance, sandbox) {
     this.instance = instance;
     this.sb = sandbox;
     this.service = sandbox.getService('Oskari.statistics.statsgrid.StatisticsService');
@@ -7,81 +7,79 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function(i
     this.element = null;
     Oskari.makeObservable(this);
 }, {
-    __templates : {
-        main : _.template('<div class="statsgrid-ds-selections"></div>'),
-        selections : _.template('<div class="statsgrid-indicator-selections"></div>'),
-        select : _.template('<div class="selection">'+
-            '<div class="title">${name}</div>'+
-            '<div class=${clazz}>'+
-            '</div>'+
+    __templates: {
+        main: _.template('<div class="statsgrid-ds-selections"></div>'),
+        selections: _.template('<div class="statsgrid-indicator-selections"></div>'),
+        select: _.template('<div class="selection">' +
+            '<div class="title">${name}</div>' +
+            '<div class=${clazz}>' +
+            '</div>' +
             '</div>'),
-        headerWithTooltip:  _.template('<div class="selection tooltip">'+
-            '<div class="title">${title}</div>'+
-            '<div class="tooltip">${tooltip1}</div>'+
-            '<div class="tooltip">${tooltip2}</div>'+
+        headerWithTooltip: _.template('<div class="selection tooltip">' +
+            '<div class="title">${title}</div>' +
+            '<div class="tooltip">${tooltip1}</div>' +
+            '<div class="tooltip">${tooltip2}</div>' +
             '</div>'),
-        option : _.template('<option value="${id}">${name}</option>')
+        option: _.template('<option value="${id}">${name}</option>')
     },
-    /****** PRIVATE METHODS ******/
+    /** **** PRIVATE METHODS ******/
 
     /**
      * @method  @private _populateIndicators populate indicators
      * @param  {Object} select  jQuery element of selection
      * @param  {Integer} datasrc datasource
      */
-    _populateIndicators : function(select, datasrc) {
+    _populateIndicators: function (select, datasrc) {
         var me = this;
         var errorService = me.service.getErrorService();
         var locale = me.instance.getLocalization();
 
-        if(!datasrc || datasrc === '') {
+        if (!datasrc || datasrc === '') {
             return;
         }
 
-        this.service.getIndicatorList(datasrc, function(err, result) {
+        this.service.getIndicatorList(datasrc, function (err, result) {
             var results = [];
 
-            if(err) {
+            if (err) {
                 // notify error!!
-                Oskari.log('Oskari.statistics.statsgrid.IndicatorSelection').warn(" Error getting indicator list");
-                errorService.show(locale.errors.title,locale.errors.indicatorListError);
+                Oskari.log('Oskari.statistics.statsgrid.IndicatorSelection').warn('Error getting indicator list');
+                errorService.show(locale.errors.title, locale.errors.indicatorListError);
                 return;
             }
 
-
-            result.indicators.forEach(function(ind) {
+            result.indicators.forEach(function (ind) {
                 var resultObj = {
                     id: ind.id,
                     title: Oskari.getLocalized(ind.name)
                 };
                 results.push(resultObj);
-
             });
             var value = select.getValue();
-            select.updateOptions( results );
+            select.updateOptions(results);
             select.setValue(value);
-            if(result.complete) {
+            if (result.complete) {
                 me.spinner.stop();
 
-                if(result.indicators.length === 0) {
-                    errorService.show(locale.errors.title,locale.errors.indicatorListIsEmpty);
+                if (result.indicators.length === 0) {
+                    errorService.show(locale.errors.title, locale.errors.indicatorListIsEmpty);
                 }
             }
         });
     },
-    setElement: function ( el ) {
+    setElement: function (el) {
         this.element = el;
     },
     getElement: function () {
         return this.element;
     },
-    /****** PUBLIC METHODS ******/
+    /** **** PUBLIC METHODS ******/
 
     /**
      * @method  @public getPanelContent get panel content
      * @return {Object} jQuery element
      */
-    getPanelContent: function() {
+    getPanelContent: function () {
         var me = this;
         var main = jQuery(this.__templates.main());
         var locale = me.instance.getLocalization();
@@ -89,89 +87,88 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function(i
 
         var datasources = this.service.getDatasource();
         var sources = [];
-        datasources.forEach(function(ds){
+        datasources.forEach(function (ds) {
             var dataObj = {
-                id : ds.id,
+                id: ds.id,
                 title: ds.name
             };
             sources.push(dataObj);
         });
         // Datasources
-        main.append(jQuery(this.__templates.select({name : locale.panels.newSearch.datasourceTitle, clazz : 'stats-ds-selector'})));
+        main.append(jQuery(this.__templates.select({name: locale.panels.newSearch.datasourceTitle, clazz: 'stats-ds-selector'})));
         // chosen works better when it has context for the element, get a new reference for chosen
         var dsSelector = main.find('.stats-ds-selector');
         var options = {
-            placeholder_text : locale.panels.newSearch.selectDatasourcePlaceholder,
-            allow_single_deselect : true,
+            placeholder_text: locale.panels.newSearch.selectDatasourcePlaceholder,
+            allow_single_deselect: true,
             disable_search_threshold: 10,
             no_results_text: locale.panels.newSearch.noResults,
             width: '100%'
         };
         var select = Oskari.clazz.create('Oskari.userinterface.component.SelectList');
         var dropdown = select.create(sources, options);
-        dropdown.css({width:'100%'});
+        dropdown.css({width: '100%'});
         dsSelector.append(dropdown);
         select.adjustChosen();
 
         // Indicator list
-        main.append(jQuery(this.__templates.select({name : locale.panels.newSearch.indicatorTitle, clazz : 'stats-ind-selector'})));
+        main.append(jQuery(this.__templates.select({name: locale.panels.newSearch.indicatorTitle, clazz: 'stats-ind-selector'})));
         // chosen works better when it has context for the element, get a new reference for chosen
         var indicatorSelector = main.find('.stats-ind-selector');
         me.spinner.insertTo(indicatorSelector);
         var indicOptions = {
             placeholder_text: locale.panels.newSearch.selectIndicatorPlaceholder,
-            allow_single_deselect : true,
+            allow_single_deselect: true,
             disable_search_threshold: 10,
             no_results_text: locale.panels.newSearch.noResults,
             width: '100%'
         };
         var indicSelect = Oskari.clazz.create('Oskari.userinterface.component.SelectList');
         var indicDropdown = indicSelect.create(undefined, indicOptions);
-        indicDropdown.css({width:'100%'});
+        indicDropdown.css({width: '100%'});
         indicatorSelector.append(indicDropdown);
         indicSelect.adjustChosen();
 
         // Refine data label and tooltips
-        var dataLabelWithTooltips = jQuery(this.__templates.headerWithTooltip({title: panelLoc.refineSearchLabel, tooltip1:panelLoc.refineSearchTooltip1 || '', tooltip2: panelLoc.refineSearchTooltip2 || ''}));
+        var dataLabelWithTooltips = jQuery(this.__templates.headerWithTooltip({title: panelLoc.refineSearchLabel, tooltip1: panelLoc.refineSearchTooltip1 || '', tooltip2: panelLoc.refineSearchTooltip2 || ''}));
         main.append(dataLabelWithTooltips);
 
         // Refine data selections
         var selectionsContainer = jQuery(this.__templates.selections());
         main.append(selectionsContainer);
 
-        dsSelector.on('change', function() {
+        dsSelector.on('change', function () {
             me._params.clean();
 
             // If removed selection then need to be also update indicator selection
-            if(select.getValue() === '') {
+            if (select.getValue() === '') {
                 indicatorSelector.val(indicatorSelector.find('option:first').val());
                 indicatorSelector.trigger('change');
                 indicatorSelector.trigger('chosen:updated');
-            }
-            // else show spinner
-            else {
+            } else {
+                // else show spinner
                 me.spinner.start();
             }
 
-            me._populateIndicators(indicSelect , select.getValue());
+            me._populateIndicators(indicSelect, select.getValue());
         });
 
-        indicatorSelector.on('change', function() {
+        indicatorSelector.on('change', function () {
             me._params.indicatorSelected(selectionsContainer,
                 select.getValue(),
                 indicSelect.getValue(),
                 {
-                    dataLabelWithTooltips:dataLabelWithTooltips
+                    dataLabelWithTooltips: dataLabelWithTooltips
                 });
         });
 
-        me._params.on('indicator.changed', function(enabled){
+        me._params.on('indicator.changed', function (enabled) {
             me.trigger('indicator.changed', enabled);
         });
 
-        this.service.on('StatsGrid.DatasourceEvent', function(evt) {
+        this.service.on('StatsGrid.DatasourceEvent', function (evt) {
             var currentDS = select.getValue();
-            if(currentDS !== evt.getDatasource()) {
+            if (currentDS !== evt.getDatasource()) {
                 return;
             }
             // update indicator list
@@ -180,8 +177,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function(i
         me.setElement(main);
         return main;
     },
-    getValues: function() {
-        if(!this._params) {
+    getValues: function () {
+        if (!this._params) {
             return {};
         }
 
@@ -192,5 +189,4 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function(i
         var indicSel = el.find('.stats-ind-selector');
         return indicSel;
     }
-
 });

--- a/bundles/statistics/statsgrid2016/view/SearchFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/SearchFlyout.js
@@ -3,29 +3,30 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
     this.element = null;
     this.sandbox = this.instance.getSandbox();
     this.service = this.sandbox.getService('Oskari.statistics.statsgrid.StatisticsService');
-    this._extraFeatures = Oskari.clazz.create('Oskari.statistics.statsgrid.ExtraFeatures', this.instance.getSandbox(), this.instance.getLocalization().panels.extraFeatures, this);
+    this._extraFeatures = Oskari.clazz.create('Oskari.statistics.statsgrid.ExtraFeatures',
+        this.instance.getSandbox(), this.instance.getLocalization().panels.extraFeatures, this);
     var me = this;
-    this.on('show', function() {
-        if(!me.getElement()) {
+    this.on('show', function () {
+        if (!me.getElement()) {
             me.createUi();
             me.addClass('statsgrid-search-flyout');
             me.setContent(me.getElement());
         }
     });
 }, {
-    setElement: function ( el ) {
+    setElement: function (el) {
         this.element = el;
     },
     getElement: function () {
         return this.element;
     },
     clearUi: function () {
-        if( this.element === null ) {
+        if (this.element === null) {
             return;
         }
         this.element.empty();
     },
-    getExtraFeatures: function(){
+    getExtraFeatures: function () {
         return this._extraFeatures;
     },
     /**
@@ -37,10 +38,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
         var locale = this.instance.getLocalization();
         // empties all
         this.clearUi();
-        this.setElement( jQuery( '<div class="statsgrid-search-container"></div>' ) );
+        this.setElement(jQuery('<div class="statsgrid-search-container"></div>'));
         var title = locale.flyout.title;
         var parent = this.getElement().parent().parent();
-        if(isEmbedded) {
+        if (isEmbedded) {
             parent.find('.oskari-flyout-title p').html(title);
             // Remove close button from published
             parent.find('.oskari-flyouttools').hide();
@@ -52,18 +53,15 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
         this.showLegend(!isEmbedded);
         this.addContent(this.getElement(), isEmbedded);
     },
-    addContent : function (el, isEmbedded) {
-        var me = this;
-        // no search for embedded map
-        if(isEmbedded) {
+    addContent: function (el, isEmbedded) {
+        if (isEmbedded) {
+            // no search for embedded map
             return;
         }
-        var service = me.sandbox.getService('Oskari.statistics.statsgrid.StatisticsService');
-        var state = service.getStateService();
-        el.append(me.getNewSearchElement());
-        el.append(me.getExtraFeaturesElement());
+        el.append(this.getNewSearchElement());
+        el.append(this.getExtraFeaturesElement());
     },
-    getNewSearchElement: function(){
+    getNewSearchElement: function () {
         var me = this;
         var container = jQuery('<div></div>');
         var locale = this.instance.getLocalization();
@@ -77,12 +75,12 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
         btn.setEnabled(false);
         btn.insertTo(container);
 
-        btn.setHandler(function(event) {
+        btn.setHandler(function (event) {
             event.stopPropagation();
             var values = selectionComponent.getValues();
 
             var added = me.service.getStateService().addIndicator(values.datasource, values.indicator, values.selections);
-            if(added === false) {
+            if (added === false) {
                 // already added, set as active instead
                 var hash = me.service.getStateService().getHash(values.datasource, values.indicator.selections);
                 me.service.getStateService().setActiveIndicator(hash);
@@ -91,22 +89,21 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
 
             var extraValues = me.getExtraFeatures().getValues();
 
-            if(extraValues.openTable) {
+            if (extraValues.openTable) {
                 me.instance.getFlyoutManager().open('table');
             }
-            if(extraValues.openDiagram) {
+            if (extraValues.openDiagram) {
                 me.instance.getFlyoutManager().open('diagram');
             }
         });
 
-        selectionComponent.on('indicator.changed', function(enabled){
+        selectionComponent.on('indicator.changed', function (enabled) {
             btn.setEnabled(enabled);
         });
 
         return container;
     },
-    getExtraFeaturesElement: function(){
-        var me = this;
+    getExtraFeaturesElement: function () {
         var container = jQuery('<div class="extrafeatures"><div class="title"></div><div class="content"></div></div>');
         var locale = this.instance.getLocalization();
 
@@ -114,8 +111,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
         container.find('.content').append(this._extraFeatures.getPanelContent());
         return container;
     },
-     getLegendFlyout : function() {
-        if(this.__legendFlyout) {
+    getLegendFlyout: function () {
+        if (this.__legendFlyout) {
             return this.__legendFlyout;
         }
         var locale = this.instance.getLocalization().legend;
@@ -124,8 +121,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
             cls: 'statsgrid-legend-flyout'
         });
         flyout.makeDraggable({
-            handle : '.oskari-flyouttoolbar, .statsgrid-legend-container > .header',
-            scroll : false
+            handle: '.oskari-flyouttoolbar, .statsgrid-legend-container > .header',
+            scroll: false
         });
         this.__legendFlyout = flyout;
         // render content
@@ -135,17 +132,17 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
         flyout.setContent(container);
         return this.__legendFlyout;
     },
-    showLegend : function(enabled) {
+    showLegend: function (enabled) {
         var me = this;
-        if(!enabled) {
+        if (!enabled) {
             me.removeSideTools();
             return;
         }
         var locale = this.instance.getLocalization();
-        me.addSideTool(locale.legend.title, function(el, bounds) {
+        me.addSideTool(locale.legend.title, function (el, bounds) {
             // lazy render
             var flyout = me.getLegendFlyout();
-            if(flyout.isVisible()) {
+            if (flyout.isVisible()) {
                 flyout.hide();
             } else {
                 // show and reset position


### PR DESCRIPTION
Breaking my own rules here about making formatting changes in a dedicated PR and proper changes in another one since this includes mostly formatting changes. The actual bug fix is for IndicatorParameters.getValues() that didn't return the selected regionset correctly. Now it does.