### PR TITLE
Hierarchical layerlist fixes

### DIFF
--- a/bundles/framework/hierarchical-layerlist/Flyout.js
+++ b/bundles/framework/hierarchical-layerlist/Flyout.js
@@ -296,7 +296,6 @@ Oskari.clazz.define('Oskari.framework.bundle.hierarchical-layerlist.Flyout',
          * @return {String} the name for the component
          */
         getName: function() {
-            //"use strict";
             return 'Oskari.framework.bundle.hierarchical-layerlist.Flyout';
         },
 

--- a/bundles/framework/hierarchical-layerlist/components/SelectedLayer.js
+++ b/bundles/framework/hierarchical-layerlist/components/SelectedLayer.js
@@ -1,8 +1,9 @@
-Oskari.clazz.define('Oskari.framework.bundle.hierarchical-layerlist.SelectedLayer', function(instance, layer, sandbox, locale) {
+Oskari.clazz.define('Oskari.framework.bundle.hierarchical-layerlist.SelectedLayer', function(instance, layer, sandbox, locale, tab) {
     this.instance = instance;
     this.locale = locale;
     this.sb = sandbox;
     this.service = this.sb.getService('Oskari.mapframework.service.MapLayerService');
+    this.tab = tab;
     this._template = jQuery('<li class="layer selected">' +
         '   <div class="layer-info">' +
         '       <div class="visible"><a></a></div>' +
@@ -249,7 +250,10 @@ Oskari.clazz.define('Oskari.framework.bundle.hierarchical-layerlist.SelectedLaye
         toggleIcon.attr('title', me.locale.tooltips.openLayerTools);
 
         if (!me._binded) {
-            me._el.find('.layer-info').bind('click', function() {
+            me._el.find('.layer-info').bind('mouseup', function() {
+                if(me.tab.hasDragging()) {
+                    return;
+                }
                 if (toggleIcon.hasClass('open')) {
                     toggleIcon.attr('title', me.locale.tooltips.openLayerTools);
                     toggleIcon.removeClass('open');

--- a/bundles/framework/hierarchical-layerlist/view/SelectedLayersTab.js
+++ b/bundles/framework/hierarchical-layerlist/view/SelectedLayersTab.js
@@ -31,6 +31,7 @@ Oskari.clazz.define(
         this._createUI();
         this._bindOskariEvents();
         this._bindExtenderServiceListeners();
+        this._dragging = false;
     }, {
         /*******************************************************************************************************************************
         /* PRIVATE METHODS
@@ -90,10 +91,12 @@ Oskari.clazz.define(
 
             layerContainer.sortable({
                 start: function(event, ui) {
+                    me._dragging = true;
                     var height = ui.item.height();
                     me._calculateContainerHeightDuringSort(height);
                 },
                 stop: function(event, ui) {
+                    me._dragging = false;
                     me._calculateContainerHeightDuringSort();
                     me._layerOrderChanged(ui.item);
                 }
@@ -153,7 +156,7 @@ Oskari.clazz.define(
                 return;
             }
             var list = me.tabPanel.getContainer().find('.layerlist');
-            var layerComponent = Oskari.clazz.create('Oskari.framework.bundle.hierarchical-layerlist.SelectedLayer', me.instance, layer, me.sb, me.locale);
+            var layerComponent = Oskari.clazz.create('Oskari.framework.bundle.hierarchical-layerlist.SelectedLayer', me.instance, layer, me.sb, me.locale, me);
             var previousLayers = list.find('li.layer');
             if (layer.isBaseLayer() && !keepLayersOrder && !forceAdd) {
                 previousLayers = list.find('li.layer[data-layerid^=base_]');
@@ -279,7 +282,7 @@ Oskari.clazz.define(
             });
 
             me._notifierService.on('AfterRearrangeSelectedMapLayerEvent', function(evt) {
-                if (event._creator !== this.instance.getName()) {
+                if (evt._creator !== me.instance.getName()) {
                     me._handleLayerOrderChanged(evt);
                 }
             });
@@ -338,10 +341,22 @@ Oskari.clazz.define(
         getTabPanel: function() {
             return this.tabPanel;
         },
+        /**
+         * Update selected laeyrs
+         * @method updateSelected  Layers
+         */
         updateSelectedLayers: function() {
             var me = this;
             me._setSelectedLayers();
             me._updateLayerCount();
+        },
+        /**
+         * Has dragging
+         * @method hasDragging
+         * @return {Boolean}   has dragging
+         */
+        hasDragging: function(){
+            return this._dragging;
         }
     }
 );


### PR DESCRIPTION
This PR fixes:
- hierarchical layer list filtering (now use recursive filter)
- selected layers tab drag&drop when using FF (before this, FF toggles layer tools when dragging)