### PR TITLE
Occasionally adding a new feature would not work with content editor

### DIFF
--- a/bundles/tampere/content-editor/view/SideContentEditor.js
+++ b/bundles/tampere/content-editor/view/SideContentEditor.js
@@ -696,7 +696,7 @@ Oskari.clazz.define('Oskari.tampere.bundle.content-editor.view.SideContentEditor
             if(fields.length === 0) { //layer view is empty, get fields from DescribeFeatureType
                 fields = ["__fid"];
                 $.each(me.fieldsTypes, function(key, value) {
-                   if(!value.startsWith("gml:")) { //skip geometry
+                   if(value.indexOf('gml:') !== 0) { //skip geometry
                        fields.push(key);
                    }
                 });


### PR DESCRIPTION
Fixed a bug where occasionally on at least IE clicking the add feature button in content editor would not work. In the browser console the complaint was 'Object doesn't support property or method startsWith'. Changed startsWith with indexOf.