### PR TITLE
Featuredata drawing event fix

### DIFF
--- a/bundles/framework/featuredata2/instance.js
+++ b/bundles/framework/featuredata2/instance.js
@@ -416,7 +416,8 @@ Oskari.clazz.define("Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
                 if (!me.selectionPlugin) {
                     me.selectionPlugin = me.sandbox.findRegisteredModuleInstance('MainMapModuleMapSelectionPlugin');
                 }
-                if (me.selectionPlugin.DRAW_REQUEST_ID !== evt.getId()) {
+                // published maps won't have selection plugin always
+                if (!me.selectionPlugin || me.selectionPlugin.DRAW_REQUEST_ID !== evt.getId()) {
                     // event is from some other functionality
                     return;
                 }


### PR DESCRIPTION
Published maps won't have map selection plugin at least always so drawing event sent by measuretool  caused error.

Added check that if map selection plugin doesn't exist, featuredata doesn't handle drawing events.