### PR TITLE
Statsgrid - Classification minified css fix

### DIFF
--- a/bundles/statistics/statsgrid2016/publisher/OpacityTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/OpacityTool.js
@@ -32,6 +32,9 @@ function() {},
         if(!stats) {
             return;
         }
+        if(!stats.classificationPlugin) {
+            stats.createClassificationView(enabled);
+        }
         if(enabled) {
             stats.classificationPlugin.makeTransparent(true);
         } else {

--- a/bundles/statistics/statsgrid2016/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/scss/style.scss
@@ -601,9 +601,6 @@ div.oskari-flyout {
         text-shadow: none;
         color: #000;
     }
-.legend-transparent {
-   background-color: transparent;
-}
 .active-header {
     display: flex;
     justify-content: space-between;
@@ -764,7 +761,9 @@ div.oskari-flyout {
         clear: both;
     }
 }
-
+.legend-transparent {
+   background-color: transparent;
+}
 /* Mobile popup tuning */
 .divmanazerpopup.statsgrid-mobile-legend {
     .popup-body {

--- a/bundles/statistics/statsgrid2016/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/scss/style.scss
@@ -587,10 +587,10 @@ div.oskari-flyout {
     .statsgrid-legend-plugin-transparent .geostats-legend-counter {
       color: #ffffff;
     }
-    .statsgrid-legend-plugin-transparent .accordion_panel {
+    .statsgrid-legend-plugin-transparent .accordion .accordion_panel {
       background-color: transparent;
     }
-    .statsgrid-legend-plugin-transparent .accordion_panel .open {
+    .statsgrid-legend-plugin-transparent .accordion .accordion_panel.open {
       background-color: transparent;
     }
     .statsgrid-legend-plugin-transparent .dropdown {


### PR DESCRIPTION
- Scss file was missing some specific selectors
- Added check to OpacityTool if classificationplugin is available