### PR TITLE
Statsgrid - Classification reverse colors fix

### DIFF
--- a/bundles/framework/divmanazer/component/ColorSelect.js
+++ b/bundles/framework/divmanazer/component/ColorSelect.js
@@ -41,6 +41,11 @@ Oskari.clazz.define('Oskari.userinterface.component.ColorSelect',
         this._selectedValue = null;
         this._selected = null;
         this._selection = null;
+        
+        var me = this;
+        jQuery(document).on('click', function () {
+            me.close();
+        });
     }, {
         /**
          * @method @private _destroyImpl

--- a/bundles/framework/divmanazer/component/ColorSelect.js
+++ b/bundles/framework/divmanazer/component/ColorSelect.js
@@ -306,8 +306,8 @@ Oskari.clazz.define('Oskari.userinterface.component.ColorSelect',
             me._element.append(me._selection);
 
             me._setHandlers();
-
-            jQuery(document).bind('click', function(){
+            jQuery(document).off('click');
+            jQuery(document).on('click', function(){
                 me.close();
             });
 

--- a/bundles/framework/divmanazer/component/ColorSelect.js
+++ b/bundles/framework/divmanazer/component/ColorSelect.js
@@ -193,7 +193,7 @@ Oskari.clazz.define('Oskari.userinterface.component.ColorSelect',
         /**
          * @public close close selection
          */
-        close: function(){
+        close: function() {
             var me = this;
             me._selected.attr('data-state', 'closed');
             me._selection.hide();
@@ -306,10 +306,6 @@ Oskari.clazz.define('Oskari.userinterface.component.ColorSelect',
             me._element.append(me._selection);
 
             me._setHandlers();
-            jQuery(document).off('click');
-            jQuery(document).on('click', function(){
-                me.close();
-            });
 
             me.close();
         },

--- a/bundles/statistics/statsgrid2016/components/EditClassification.js
+++ b/bundles/statistics/statsgrid2016/components/EditClassification.js
@@ -302,8 +302,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function (
         if (!service.hasMapMode('vector')) {
             me._element.find('.visible-on-vector').remove();
         }
-
-        me._colorSelect = Oskari.clazz.create('Oskari.userinterface.component.ColorSelect');
+        if (!me._colorSelect) {
+            me._colorSelect = Oskari.clazz.create('Oskari.userinterface.component.ColorSelect');
+        }
         me._element.find('.classification-colors.value').append(me._colorSelect.getElement());
 
         var stateService = me.service.getStateService();

--- a/bundles/statistics/statsgrid2016/components/EditClassification.js
+++ b/bundles/statistics/statsgrid2016/components/EditClassification.js
@@ -263,7 +263,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function (
             mode: me._element.find('select.classify-mode').val(),
             type: me._element.find('select.color-set').val(),
             name: me._colorSelect.getValue(),
-            reverseColors: me._element.find('#legend-flip-colors').attr('checked'),
+            reverseColors: me._element.find('#legend-flip-colors').is(':checked'),
             mapStyle: me._element.find('select.map-style').val(),
             // only used for points vector
             min: range[0],

--- a/bundles/statistics/statsgrid2016/components/EditClassification.js
+++ b/bundles/statistics/statsgrid2016/components/EditClassification.js
@@ -352,9 +352,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function (
         this.setEnabled(this.__enabled);
 
         me._colorSelect.setHandler(updateClassification);
-        me._element.find('select').bind('change', updateClassification);
+        me._element.find('select').on('change', updateClassification);
 
-        me._element.find('#legend-flip-colors').change(function () {
+        me._element.find('#legend-flip-colors').on('change', function () {
             updateClassification();
         });
         return me._element;


### PR DESCRIPTION
- Fix an issue with the reverse colors checkbox not working.
- Also fixes an minor issue with incrementally adding on click listeners to the checkbox on every setColorValue call