### PR TITLE
Adding allow="geolocation" for iframe snippet

### DIFF
--- a/bundles/framework/publisher2/instance.js
+++ b/bundles/framework/publisher2/instance.js
@@ -50,7 +50,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
         },
         init: function () {
             var tileElem = jQuery(this.getConfiguration().tileElement);
-            if(tileElem.length && tileElem.length !== 0) {
+            if (tileElem.length && tileElem.length !== 0) {
                 this.customTileRef = this.getConfiguration().tileElement;
                 this.conf.tileClazz = null;
                 this.customElementClickHandler(tileElem);
@@ -67,21 +67,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
              * @param {Oskari.mapframework.bundle.publisher.event.MapPublishedEvent} event
              */
             'Publisher.MapPublishedEvent': function (event) {
-                var loc = this.getLocalization(),
-                    dialog = Oskari.clazz.create(
-                        'Oskari.userinterface.component.Popup'
-                    ),
-                    okBtn = dialog.createCloseButton(loc.BasicView.buttons.ok),
-                    url,
-                    iframeCode,
-                    textarea,
-                    content,
-                    width = event.getWidth(),
-                    height = event.getHeight();
+                var loc = this.getLocalization();
+                var url = event.getUrl();
+                var iframeCode = '<div class="codesnippet"><code>&lt;iframe src="' + url + '" allow="geolocation" style="border: none;';
+                var width = event.getWidth();
+                var height = event.getHeight();
 
-                okBtn.addClass('primary');
-                url = event.getUrl();
-                iframeCode = '<div class="codesnippet"><code>&lt;iframe src="' + url + '" style="border: none;';
                 if (width !== null && width !== undefined) {
                     iframeCode += ' width: ' + width + ';';
                 }
@@ -92,8 +83,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
 
                 iframeCode += '"&gt;&lt;/iframe&gt;</code></div>';
 
-                content = loc.published.desc + '<br/><br/>' + iframeCode;
+                var content = loc.published.desc + '<br/><br/>' + iframeCode;
 
+                var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+                var okBtn = dialog.createCloseButton(loc.BasicView.buttons.ok);
+                okBtn.addClass('primary');
                 dialog.show(loc.published.title, content, [okBtn]);
                 this.setPublishMode(false);
             }
@@ -110,28 +104,29 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
             // create and register request handler
             var reqHandler = Oskari.clazz.create(
                 'Oskari.mapframework.bundle.publisher.request.PublishMapEditorRequestHandler',
-                function(data) {
+                function (data) {
                     me.setPublishMode(true, data);
                 });
             sandbox.requestHandler('Publisher.PublishMapEditorRequest', reqHandler);
 
             // Let's add publishable filter to layerlist if user is logged in
-            if(Oskari.user().isLoggedIn()) {
+            if (Oskari.user().isLoggedIn()) {
                 var mapLayerService = Oskari.getSandbox().getService('Oskari.mapframework.service.MapLayerService');
-                mapLayerService.registerLayerFilter('publishable', function(layer){
+                mapLayerService.registerLayerFilter('publishable', function (layer) {
                     return (layer.getPermission('publish') === 'publication_permission_ok');
                 });
 
                 // Add layerlist filter button
                 var layerlistService = Oskari.getSandbox().getService('Oskari.mapframework.service.LayerlistService');
-                if(layerlistService) {
-                    layerlistService.registerLayerlistFilterButton(loc.layerFilter.buttons.publishable,
-                    loc.layerFilter.tooltips.publishable,
-                    {
-                        active: 'layer-publishable',
-                        deactive: 'layer-publishable-disabled'
-                    },
-                    'publishable');
+                if (layerlistService) {
+                    layerlistService.registerLayerlistFilterButton(
+                        loc.layerFilter.buttons.publishable,
+                        loc.layerFilter.tooltips.publishable,
+                        {
+                            active: 'layer-publishable',
+                            deactive: 'layer-publishable-disabled'
+                        },
+                        'publishable');
                 }
             }
             this._registerForGuidedTour();
@@ -139,22 +134,22 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
         /**
          * @return {Oskari.mapframework.bundle.publisher2.PublisherService} service for state holding
          */
-        getService : function() {
+        getService: function () {
             return this.__service;
         },
         /**
          * @return {String} reference to element-id to use instead of tile as bundle ui-element, returns null if isn't set in conf
          */
         getCustomTileRef: function () {
-             return this.customTileRef;
+            return this.customTileRef;
         },
-         /**
+        /**
          * @method customElementClickHandler
          * @param {jQuery} tileElement
          */
         customElementClickHandler: function (tileElement) {
             var me = this;
-            tileElement.on("click", function () {
+            tileElement.on('click', function () {
                 me.getSandbox().postRequestByName(
                     'userinterface.UpdateExtensionRequest', [me, 'toggle']
                 );
@@ -177,13 +172,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
             // trigger an event letting other bundles know we require the whole UI
             var eventBuilder = Oskari.eventBuilder('UIChangeEvent');
             this.sandbox.notifyAll(eventBuilder(this.mediator.bundleId));
-            if ( this.getCustomTileRef() ) {
-                 blnEnabled ? jQuery( this.getCustomTileRef() ).addClass('activePublish') : jQuery( this.getCustomTileRef() ).removeClass('activePublish');
+            if (this.getCustomTileRef()) {
+                blnEnabled ? jQuery(this.getCustomTileRef()).addClass('activePublish') : jQuery(this.getCustomTileRef()).removeClass('activePublish');
             }
             if (blnEnabled) {
                 var stateRB = Oskari.requestBuilder('StateHandler.SetStateRequest');
                 this.getSandbox().request(this, stateRB(data.configuration));
-                if(data.uuid) {
+                if (data.uuid) {
                     this._showEditNotification();
                 }
 
@@ -206,14 +201,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
                     me.getLocalization('BasicView'),
                     data
                 );
-                //call set enabled before rendering the panels (avoid duplicate "normal map plugins")
+                // call set enabled before rendering the panels (avoid duplicate "normal map plugins")
                 me.publisher.setEnabled(true);
                 me.publisher.render(map);
             } else {
                 Oskari.setLang(me.oskariLang);
 
-                //change the mapmodule toolstyle back to normal
-                var mapModule = me.sandbox.findRegisteredModuleInstance("MainMapModule");
+                // change the mapmodule toolstyle back to normal
+                var mapModule = me.sandbox.findRegisteredModuleInstance('MainMapModule');
                 // TODO: reset to what it was when publisher was started instead of removing it (mapmodule.getToolStyle())
                 mapModule.changeToolStyle(null);
 
@@ -244,7 +239,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
          * Initial data for publisher to preselect certain tools by default and assume current map state as starting point
          * @return {Object}
          */
-        getDefaultData: function() {
+        getDefaultData: function () {
             var config = {
                 mapfull: {
                     conf: {
@@ -255,7 +250,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
                         ]
                     }
                 },
-                "featuredata2": {
+                'featuredata2': {
                     conf: {}
                 }
             };
@@ -270,8 +265,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
          * @private
          */
         _showEditNotification: function () {
-            var loc = this.getLocalization('edit'),
-                dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+            var loc = this.getLocalization('edit');
+            var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
             dialog.show(loc.popup.title, loc.popup.msg);
             dialog.fadeout();
         },
@@ -300,16 +295,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
          * list of layers that can't be published.
          */
         getLayersWithoutPublishRights: function () {
-            var deniedLayers = [],
-                selectedLayers = this.sandbox.findAllSelectedMapLayers(),
-                i,
-                layer;
-            for (i = 0; i < selectedLayers.length; i += 1) {
-                layer = selectedLayers[i];
-                if (!this.hasPublishRight(layer)) {
-                    deniedLayers.push(layer);
-                }
-            }
+            var me = this;
+            var selectedLayers = this.sandbox.getMap().getLayers();
+            var deniedLayers = selectedLayers.filter(function (layer) {
+                return !me.hasPublishRight(layer);
+            });
             return deniedLayers;
         },
         /**
@@ -320,10 +310,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
          */
         __guidedTourDelegateTemplate: {
             priority: 40,
-            show: function(){
+            show: function () {
                 this.sandbox.postRequestByName('userinterface.UpdateExtensionRequest', [null, 'attach', 'Publisher2']);
             },
-            hide: function(){
+            hide: function () {
                 this.sandbox.postRequestByName('userinterface.UpdateExtensionRequest', [null, 'close', 'Publisher2']);
             },
             getTitle: function () {
@@ -334,7 +324,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
                 content.append(this.getLocalization().guidedTour.message);
                 return content;
             },
-            getLinks: function() {
+            getLinks: function () {
                 var me = this;
                 var loc = this.getLocalization().guidedTour;
                 var linkTemplate = jQuery('<a href="#"></a>');
@@ -364,16 +354,16 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
          * @method _registerForGuidedTour
          * Registers bundle for guided tour help functionality. Waits for guided tour load if not found
          */
-        _registerForGuidedTour: function() {
+        _registerForGuidedTour: function () {
             var me = this;
-            function sendRegister() {
+            function sendRegister () {
                 var requestBuilder = Oskari.requestBuilder('Guidedtour.AddToGuidedTourRequest');
-                if(requestBuilder){
+                if (requestBuilder) {
                     var delegate = {
                         bundleName: me.getName()
                     };
-                    for(var prop in me.__guidedTourDelegateTemplate){
-                        if(typeof me.__guidedTourDelegateTemplate[prop] === 'function') {
+                    for (var prop in me.__guidedTourDelegateTemplate) {
+                        if (typeof me.__guidedTourDelegateTemplate[prop] === 'function') {
                             delegate[prop] = me.__guidedTourDelegateTemplate[prop].bind(me); // bind methods to bundle instance
                         } else {
                             delegate[prop] = me.__guidedTourDelegateTemplate[prop]; // assign values
@@ -383,20 +373,20 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
                 }
             }
 
-            function handler(msg){
-                if(msg.id === 'guidedtour') {
+            function handler (msg) {
+                if (msg.id === 'guidedtour') {
                     sendRegister();
                 }
             }
 
             var tourInstance = me.sandbox.findRegisteredModuleInstance('GuidedTour');
-            if(tourInstance) {
+            if (tourInstance) {
                 sendRegister();
             } else {
                 Oskari.on('bundle.start', handler);
             }
         }
     }, {
-        "extend" : ["Oskari.userinterface.extension.DefaultExtension"]
+        'extend': ['Oskari.userinterface.extension.DefaultExtension']
     }
 );

--- a/bundles/framework/publisher2/view/FlyoutNotLoggedIn.js
+++ b/bundles/framework/publisher2/view/FlyoutNotLoggedIn.js
@@ -27,33 +27,27 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.FlyoutNotLoggedI
          * @param {jQuery} container reference to DOM element this component will be rendered to
          */
         render: function (container) {
-            var me = this,
-                conf = me.instance.conf,
-                sandbox = me.instance.getSandbox(),
-                content = me.template.clone(),
-                login = me.loginTemplate.clone(),
-                loginUrl = null,
-                register = me.registerTemplate.clone(),
-                registerUrl = null,
-                loginTmp = login.find('a'),
-                registerTmp = register.find('a');
+            var conf = this.instance.conf || {};
+            var content = this.template.clone();
+            var login = this.loginTemplate.clone();
+            var register = this.registerTemplate.clone();
 
-            if (conf) {
-                loginUrl = Oskari.getLocalized(conf.loginUrl);
-                registerUrl = Oskari.getLocalized(conf.registerUrl);
-            }
-            content.append(me.loc.text);
+            content.append(this.loc.text);
             container.append(content);
 
+            var loginUrl = Oskari.getLocalized(conf.loginUrl) || Oskari.urls.getLocation('login');
             if (loginUrl) {
-                loginTmp.attr('href', loginUrl);
-                loginTmp.append(me.loc.signup);
+                var loginLink = login.find('a');
+                loginLink.attr('href', loginUrl);
+                loginLink.append(this.loc.signup);
                 container.append(login);
             }
 
+            var registerUrl = Oskari.getLocalized(conf.registerUrl) || Oskari.urls.getLocation('register');
             if (registerUrl) {
-                registerTmp.attr('href', registerUrl);
-                registerTmp.append(me.loc.register);
+                var registerLink = register.find('a');
+                registerLink.attr('href', registerUrl);
+                registerLink.append(this.loc.register);
                 container.append(register);
             }
         }

--- a/bundles/framework/publisher2/view/FlyoutStartView.js
+++ b/bundles/framework/publisher2/view/FlyoutStartView.js
@@ -40,8 +40,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.FlyoutStartView'
          * component will be rendered to
          */
         render: function (container) {
-            var me = this,
-                content = me.template.clone();
+            var me = this;
+            var content = me.template.clone();
             me.content = content;
 
             content.find('div.content').before(me.loc.text);
@@ -51,7 +51,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.FlyoutStartView'
             touContentLink.append(me.loc.touLink);
             var conf = me.instance.conf || {};
             var url = me.instance.sandbox.getLocalizedProperty(conf.termsOfUseUrl) || '';
-            if(url.indexOf('http') === 0) {
+            if (url.indexOf('http') === 0) {
                 // starts with http - use as a link
                 touContentLink.attr('target', '_blank');
                 touContentLink.attr('href', url);
@@ -77,7 +77,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.FlyoutStartView'
                     var req = publishMapEditorRequestBuilder();
                     me.instance.sandbox.request(me.instance, req);
                 }
-
             });
             me.buttons['continue'] = continueButton;
             me._updateContinueButton();
@@ -106,16 +105,17 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.FlyoutStartView'
          */
         _renderLayerLists: function () {
             // empty any current lists
-            var me = this,
-                container = me.content.find('div.content'),
-                layers = [],
-                deniedLayers = [],
-                selectedLayers = me.instance.sandbox.findAllSelectedMapLayers(),
-                i,
-                layer,
-                layersList,
-                heading,
-                txt;
+            var me = this;
+            var container = me.content.find('div.content');
+            var layers = [];
+            var deniedLayers = [];
+            var selectedLayers = me.instance.sandbox.findAllSelectedMapLayers();
+            var i;
+            var layer;
+            var layersList;
+            var heading;
+            var txt;
+
             container.find('div.error').remove();
             container.find('div.layerlist').remove();
             for (i = 0; i < selectedLayers.length; ++i) {
@@ -153,8 +153,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.FlyoutStartView'
                     container.append(deniedLayersList);
                 }
             } else {
-                var errorsList = me.templateError.clone(),
-                    error = me.templateListItem.clone();
+                var errorsList = me.templateError.clone();
+                var error = me.templateListItem.clone();
                 error.append(me.loc.layerlist_empty);
                 errorsList.find('ul').append(error);
                 container.append(errorsList);
@@ -177,11 +177,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.FlyoutStartView'
          * @return {jQuery} DOM element with layer listing
          */
         _getRenderedLayerList: function (list) {
-            var layerList = this.templateLayerList.clone(),
-                listElement = layerList.find('ul'),
-                i,
-                layer,
-                item;
+            var layerList = this.templateLayerList.clone();
+            var listElement = layerList.find('ul');
+            var i;
+            var layer;
+            var item;
             for (i = 0; i < list.length; ++i) {
                 layer = list[i];
                 item = this.templateListItem.clone();
@@ -232,8 +232,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.FlyoutStartView'
                 return;
             }
 
-            var dlg = Oskari.clazz.create('Oskari.userinterface.component.Popup'),
-                closeBtn = dlg.createCloseButton(me.loc.buttons.close);
+            var dlg = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+            var closeBtn = dlg.createCloseButton(me.loc.buttons.close);
 
             closeBtn.setHandler(function () {
                 dlg.close(true);


### PR DESCRIPTION
Mostly formatting changes and hack removal noticed while debugging myplaces <> publisher interaction. Relies on #349 for handling login/register urls properly when urls are not configured.

Adds allow="geolocation" for iframe snippet in publisher because of https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-permissions-in-cross-origin-iframes