### PR TITLE
Newest layers filter fix

### DIFF
--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -223,6 +223,9 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
             // also update layer groups
             this.updateLayersInGroups(layerId, null, true);
 
+            // flush cache for newest filter when layer is removed
+            this._newestLayers = null;
+
             if (layer && suppressEvent !== true) {
                 var notify = this.getSandbox().notifyAll;
                 var mapLayerEvent = Oskari.eventBuilder('MapLayerEvent');

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -126,6 +126,9 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
             // everything ok, lets add the layer
             this._loadedLayersList.push(layerModel);
 
+            // flush cache for newest filter when layer is added
+            this._newestLayers = null;
+
             if (suppressEvent !== true) {
                 // notify components of added layer if not suppressed
                 var event = Oskari.eventBuilder('MapLayerEvent')(layerModel.getId(), 'add');

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -761,7 +761,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                 }
             });
 
-            var list = layersWithCreatedDate.slice(count);
+            var list = layersWithCreatedDate.slice(0, count);
             if (list.length < count) {
                 // add layers without create date to fill in latest array
                 list = list.concat(layersWithoutCreatedDate.slice(count - list.length));


### PR DESCRIPTION
MapLayerService.getNewestLayers(count) function was refactored somewhere in the 1.46.1 PRs and was broken to return everything BUT the newest layers. This PR fixes the issue. It also fixes an issue with caching the result of the function and the cached response is now flushed when a layer is added or removed from the instance.