### PR TITLE
Login and register links for guest users in analyse & personaldata

### DIFF
--- a/bundles/analysis/analyse/view/NotLoggedIn.js
+++ b/bundles/analysis/analyse/view/NotLoggedIn.js
@@ -27,33 +27,27 @@ Oskari.clazz.define('Oskari.analysis.bundle.analyse.view.NotLoggedIn',
          * @param {jQuery} container reference to DOM element this component will be rendered to
          */
         render: function (container) {
-            var me = this,
-                conf = me.instance.conf,
-                sandbox = me.instance.getSandbox(),
-                content = me.template.clone(),
-                login = me.loginTemplate.clone(),
-                loginUrl = null,
-                register = me.registerTemplate.clone(),
-                registerUrl = null,
-                loginTmp = login.find('a'),
-                registerTmp = register.find('a');
+            var conf = this.instance.conf || {};
+            var content = this.template.clone();
+            var login = this.loginTemplate.clone();
+            var register = this.registerTemplate.clone();
 
-            if (conf) {
-                loginUrl = Oskari.getLocalized(conf.loginUrl);
-                registerUrl = Oskari.getLocalized(conf.registerUrl);
-            }
-            content.append(me.loc.text);
+            content.append(this.loc.text);
             container.append(content);
 
+            var loginUrl = Oskari.getLocalized(conf.loginUrl) || Oskari.urls.getLocation('login');
             if (loginUrl) {
-                loginTmp.attr('href', loginUrl);
-                loginTmp.append(me.loc.signup);
+                var loginLink = login.find('a');
+                loginLink.attr('href', loginUrl);
+                loginLink.append(this.loc.signup);
                 container.append(login);
             }
 
+            var registerUrl = Oskari.getLocalized(conf.registerUrl) || Oskari.urls.getLocation('register');
             if (registerUrl) {
-                registerTmp.attr('href', registerUrl);
-                registerTmp.append(me.loc.register);
+                var registerLink = register.find('a');
+                registerLink.attr('href', registerUrl);
+                registerLink.append(this.loc.register);
                 container.append(register);
             }
         }

--- a/bundles/framework/personaldata/Flyout.js
+++ b/bundles/framework/personaldata/Flyout.js
@@ -19,7 +19,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.Flyout',
         this.templateTabHeader = null;
         this.templateTabContent = null;
         this.tabsData = [];
-
     }, {
         /**
          * @method getName
@@ -54,10 +53,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.Flyout',
             var me = this;
             // TODO: move these to correct bundle and use AddTabRequest to add itself to PersonalData
             this.tabsData = {
-                "myviews": Oskari.clazz.create('Oskari.mapframework.bundle.personaldata.MyViewsTab', me.instance),
-                "publishedmaps": Oskari.clazz.create('Oskari.mapframework.bundle.personaldata.PublishedMapsTab', me.instance),
+                'myviews': Oskari.clazz.create('Oskari.mapframework.bundle.personaldata.MyViewsTab', me.instance),
+                'publishedmaps': Oskari.clazz.create('Oskari.mapframework.bundle.personaldata.PublishedMapsTab', me.instance),
                 // TODO should we pass conf to accounttab here?
-                "account": Oskari.clazz.create('Oskari.mapframework.bundle.personaldata.AccountTab', me.instance)
+                'account': Oskari.clazz.create('Oskari.mapframework.bundle.personaldata.AccountTab', me.instance)
             };
         },
         /**
@@ -104,30 +103,28 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.Flyout',
          * Creates the UI for a fresh start
          */
         createUi: function () {
-            var me = this,
-                sandbox = me.instance.getSandbox(),
-                flyout = jQuery(this.container), // clear container
-                tabId,
-                tab,
-                panel,
-                notLoggedIn = this.instance.getLocalization('notLoggedIn'),
-                notLoggedInText = '',
-                notLoggedInFullText = notLoggedIn,
-                conf = this.instance.conf,
-                lang = Oskari.getLang();
+            var me = this;
+            // clear container
+            var flyout = jQuery(this.container);
 
+            var notLoggedInFullText = this.instance.getLocalization('notLoggedIn');
+            var conf = this.instance.conf || {};
 
-            if(conf.logInUrl) {
-                //loginUrl = Oskari.getLocalized(conf.loginUrl); !!!!
-                notLoggedInText = '<a href="' + Oskari.getLocalized(conf.logInUrl) + '">' + this.instance.getLocalization('notLoggedInText') + '</a>';
+            // in analyse/publisher it's conf.loginUrl - in here it's conf.logInUrl !!
+            var loginUrl = Oskari.getLocalized(conf.logInUrl) || Oskari.urls.getLocation('login');
+            if (loginUrl) {
+                notLoggedInFullText += '<br/><br/>' +
+                    '<a href="' + loginUrl + '">' + this.instance.getLocalization('notLoggedInText') + '</a>';
             }
-
-            notLoggedInFullText += '<br/><br/>' + notLoggedInText;
+            var registerUrl = Oskari.urls.getLocation('register');
+            if (registerUrl) {
+                notLoggedInFullText += '<br/><br/>' +
+                    '<a href="' + registerUrl + '">' + this.instance.getLocalization('register') + '</a>';
+            }
 
             flyout.empty();
 
-            this.tabsContainer = Oskari.clazz.create('Oskari.userinterface.component.TabContainer',
-                notLoggedInFullText);
+            this.tabsContainer = Oskari.clazz.create('Oskari.userinterface.component.TabContainer', notLoggedInFullText);
 
             this.tabsContainer.insertTo(flyout);
 
@@ -136,21 +133,19 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.Flyout',
             }
 
             // now we can presume user is logged in
-            for (tabId in this.tabsData) {
-                if (this.tabsData.hasOwnProperty(tabId)) {
-                    tab = this.tabsData[tabId];
-                    panel = Oskari.clazz.create('Oskari.userinterface.component.TabPanel');
-                    panel.setTitle(tab.getTitle());
-                    panel.setId(tabId);
-                    tab.addTabContent(panel.getContainer());
+            Object.keys(this.tabsData).forEach(function (tabId) {
+                var tab = me.tabsData[tabId];
+                var panel = Oskari.clazz.create('Oskari.userinterface.component.TabPanel');
+                panel.setTitle(tab.getTitle());
+                panel.setId(tabId);
+                tab.addTabContent(panel.getContainer());
 
-                    // binds tab to events
-                    if (tab.bindEvents) {
-                        tab.bindEvents();
-                    }
-                    this.tabsContainer.addPanel(panel);
+                // binds tab to events
+                if (tab.bindEvents) {
+                    tab.bindEvents();
                 }
-            }
+                me.tabsContainer.addPanel(panel);
+            });
         },
 
         /**
@@ -158,12 +153,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.Flyout',
          *
          */
         addTab: function (item) {
-            var sandbox = this.instance.getSandbox(),
-                panel;
             if (!Oskari.user().isLoggedIn()) {
                 return;
             }
-            panel = Oskari.clazz.create('Oskari.userinterface.component.TabPanel');
+            var panel = Oskari.clazz.create('Oskari.userinterface.component.TabPanel');
             panel.setTitle(item.title);
             panel.setContent(item.content);
             panel.setId(item.id);

--- a/bundles/framework/personaldata/resources/locale/en.js
+++ b/bundles/framework/personaldata/resources/locale/en.js
@@ -7,6 +7,7 @@ Oskari.registerLocalization(
         "desc": "My Data",
         "notLoggedIn": "As a logged-in user you can see here your account information and all your saved places, map views, embedded maps, indicators, analysis and datasets.",
         "notLoggedInText": "Log in",
+        "register": "Register",
         "projectionError": {
             "title" : "Projections are incompatible",
             "msg": "Projection will be changed, so that the published map can be edited",

--- a/bundles/framework/personaldata/resources/locale/et.js
+++ b/bundles/framework/personaldata/resources/locale/et.js
@@ -7,6 +7,7 @@ Oskari.registerLocalization(
         "desc": "Minu andmed",
         "notLoggedIn": "Süsteemi loginud kasutaja saab näha oma konto andmeid, salvestatud kohti, kaardivaateid, lõimkaarte, analüüse ja andmestikke.",
         "notLoggedInText": "Logi sisse",
+        "register": "Registreeri kasutajaks",
         "tabs": {
             "myviews": {
                 "title": "Minu kaardivaated",

--- a/bundles/framework/personaldata/resources/locale/fi.js
+++ b/bundles/framework/personaldata/resources/locale/fi.js
@@ -7,6 +7,7 @@ Oskari.registerLocalization(
         "desc": "Omat tiedot",
         "notLoggedIn": "Kirjautuneena käyttäjävä voit tarkistaa täällä käyttäjätietosi sekä omat kohteesi, karttanäkymäsi, upotetut karttasi, indikaattorisi, analyysisi ja aineistosi.",
         "notLoggedInText": "Kirjaudu sisään",
+        "register": "Rekisteröidy",
         "projectionError": {
             "title" : "Projektiot eivät ole yhteensopivia",
             "msg": "Vaihdetaan projektiota karttajulkaisun muokkauksen mahdollistamiseksi.",

--- a/bundles/framework/personaldata/resources/locale/is.js
+++ b/bundles/framework/personaldata/resources/locale/is.js
@@ -7,6 +7,7 @@ Oskari.registerLocalization(
         "desc": "Gögnin mín",
         "notLoggedIn": "Gögnin mín inniheldur notandasnið og allar fitjur sem þú hefur vistað, kortasýn, ívafin kort, vísbendingar, greiningar og gagnasett. <a href='/web/is/innskra'>Skráðu þig inn til að til að skoða gögnin þín</a>.",
         "notLoggedInText": "Skrá inn",
+        "register": "Skrá",
         "tabs": {
             "myviews": {
                 "title": "Kortasýnir mínar",

--- a/bundles/framework/personaldata/resources/locale/nb.js
+++ b/bundles/framework/personaldata/resources/locale/nb.js
@@ -7,6 +7,7 @@ Oskari.registerLocalization(
         "desc": "Mine data",
         "notLoggedIn": "Mine data inneholder din brukerprofil og dine lagrede forekomster, kart, 'embeddede' kart, indikatorer, analyser og datasett. <a href='/web/nb/login'>Logg inn for å sjekke dine data</a>.",
         "notLoggedInText": "Logg inn for å kontrollere dine data",
+        "register": "Register",
         "tabs": {
             "myviews": {
                 "title": "Mine kart",

--- a/bundles/framework/personaldata/resources/locale/nn.js
+++ b/bundles/framework/personaldata/resources/locale/nn.js
@@ -7,6 +7,7 @@ Oskari.registerLocalization(
         "desc": "Mine data",
         "notLoggedIn": "Mine data innehelde brukarprofilen din og dine lagra førekomstar, kart, 'embeddede' kart, indikatorar, analyser og datasett. <a href='/web/nb/login'>Logg inn for å sjekke dine data</a>.",
         "notLoggedInText": "Logg inn",
+        "register": "Register",
         "tabs": {
             "myviews": {
                 "title": "Mine kart",

--- a/bundles/framework/personaldata/resources/locale/sk.js
+++ b/bundles/framework/personaldata/resources/locale/sk.js
@@ -7,6 +7,7 @@ Oskari.registerLocalization(
         "desc": "Moje údaje",
         "notLoggedIn": "Ako prihlásený používateľ tu môžete vidieť informácie o vašom účte, vaše uložené miesta, mapové zobrazenia, uložené mapy, indikátory, anylýzy a datasety.",
         "notLoggedInText": "Prihlásiť sa",
+        "register": "Register",
         "tabs": {
             "myviews": {
                 "title": "Moje mapové zobrazenia",

--- a/bundles/framework/personaldata/resources/locale/sv.js
+++ b/bundles/framework/personaldata/resources/locale/sv.js
@@ -7,6 +7,7 @@ Oskari.registerLocalization(
         "desc": "Mina uppgifter",
         "notLoggedIn": "Mina uppgifter innehåller din användarprofil och alla dina sparade funktioner, kartvyer, inbäddade kartor, indikatorer, analys och dataset.  <a href='/web/sv/login'>Logga in</a>.",
         "notLoggedInText": "Logga in.",
+        "register": "Registrera dig",
         "projectionError": {
             "title" : "Projektionerna är inkompatibla",
             "msg": "Utbytas projektionen för att redigera kartpubliceringen",


### PR DESCRIPTION
Personaldata and analyse bundles now support login and registration links configuration using Oskari.urls.getLocation() with 'login' and 'register' keys. Also added registration link for personaldata as similar views in publisher and analyse have it.