### PR TITLE
Hierarchical layerlist search fix

### DIFF
--- a/bundles/framework/hierarchical-layerlist/resources/css/style.css
+++ b/bundles/framework/hierarchical-layerlist/resources/css/style.css
@@ -1,6 +1,8 @@
 .hierarchical-layerlist-flyout .oskari-flyoutcontentcontainer {
   max-height: none; }
 
+div.hierarchical-layerlist div.hierarchical-layerlist-search-noresults {
+  padding: 10px; }
 div.hierarchical-layerlist div.layer-filter {
   margin: 10px;
   color: #949494; }

--- a/bundles/framework/hierarchical-layerlist/scss/style.scss
+++ b/bundles/framework/hierarchical-layerlist/scss/style.scss
@@ -12,6 +12,10 @@ $selectedLayersTabLabelWidth: 50px;
 }
 
 div.hierarchical-layerlist {
+    div.hierarchical-layerlist-search-noresults {
+        padding: 10px;
+    }
+
     div.layer-filter {
         margin: 10px;
         color: #949494;

--- a/bundles/framework/hierarchical-layerlist/service/LayerlistExtenderService.js
+++ b/bundles/framework/hierarchical-layerlist/service/LayerlistExtenderService.js
@@ -44,6 +44,8 @@
                 },
                 search: {
                     show_only_matches: true,
+                    show_only_matches_children: true,
+                    close_opened_onclear: true,
                     search_callback: function(text, node) {
                         if (node.type == 'layer') {
                             var searchText = text.toLowerCase();

--- a/bundles/framework/hierarchical-layerlist/view/LayerGroupTab.js
+++ b/bundles/framework/hierarchical-layerlist/view/LayerGroupTab.js
@@ -986,7 +986,7 @@ Oskari.clazz.define(
 
             me.tabPanel.getContainer().append(layerTree);
 
-            if(jQuery('.hierarchical-layerlist-search-noresults').length === 0) {
+            if(me.tabPanel.getContainer().find('.hierarchical-layerlist-search-noresults').length === 0) {
                 var noSearchResults = me.templates.noSearchResults.clone();
                 noSearchResults.html(me.instance.getLocalization('errors.noResults')).hide();
                 me.tabPanel.getContainer().append(noSearchResults);
@@ -1084,7 +1084,8 @@ Oskari.clazz.define(
          * @param  {Boolean}                  visible has message visible
          */
         setNoResultMessageVisible: function(visible) {
-            var noResultsElement = jQuery('.hierarchical-layerlist-search-noresults');
+            var me = this;
+            var noResultsElement = me.tabPanel.getContainer().find('.hierarchical-layerlist-search-noresults');
             if(!visible) {
                 noResultsElement.hide();
                 return;


### PR DESCRIPTION
Some fixes of hierarchical layerlist search:
- no result text showed now if no layers founded
- only shows founded layers groups (not empty groups)
- moved ugly timeout different place (tryied remove but tools not rendered correctly so keep it there a while)