### PR TITLE
Single click handing fixes

### DIFF
--- a/bundles/framework/hierarchical-layerlist/service/LayerlistExtenderService.js
+++ b/bundles/framework/hierarchical-layerlist/service/LayerlistExtenderService.js
@@ -19,7 +19,8 @@
                     check_callback: true,
                     themes: {
                         variant: 'large'
-                    }
+                    },
+                    dblclick_toggle: false
                 },
                 checkbox: {
                     keep_selected_style: false

--- a/bundles/framework/hierarchical-layerlist/view/LayerGroupTab.js
+++ b/bundles/framework/hierarchical-layerlist/view/LayerGroupTab.js
@@ -776,6 +776,10 @@ Oskari.clazz.define(
                 }
             });
 
+            if(node.type.indexOf('group') > -1 && !jQuery(event.target).hasClass('jstree-checkbox')) {
+                return;
+            }
+
             var layerId = null;
 
             var allSelectedLayers = me.sb.findAllSelectedMapLayers();
@@ -1057,6 +1061,13 @@ Oskari.clazz.define(
                 me.sb.findAllSelectedMapLayers().forEach(function(layer) {
                     me._toggleLayerCheckboxes(layer.getId(), true);
                 });
+            });
+
+            // Add click handler for toggle groups open/close state
+            me.getJsTreeElement().on('click', function(evt) {
+                if(!jQuery(evt.target).hasClass('jstree-checkbox') && !jQuery(evt.target).hasClass('jstree-ocl')) {
+                    me.getJsTreeElement().jstree(true).toggle_node(evt.target);
+                }
             });
         },
 


### PR DESCRIPTION
Fixed group click handling so at groups click not checks groups (and their subgroups and layers). 
Click only toggle node open/close.