### PR TITLE
Reset map toolstyle to what it was instead of default when exiting publisher

### DIFF
--- a/bundles/framework/publisher2/Flyout.js
+++ b/bundles/framework/publisher2/Flyout.js
@@ -41,8 +41,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.Flyout',
          * Selects the view to show based on user (guest/loggedin)
          */
         lazyRender: function () {
-            var me = this,
-                flyout = jQuery(this.container);
+            var flyout = jQuery(this.container);
             flyout.empty();
 
             // check if the user is logged in
@@ -73,5 +72,5 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.Flyout',
          * @property {String[]} protocol
          * @static
          */
-        "extend": ["Oskari.userinterface.extension.DefaultFlyout"]
+        'extend': ['Oskari.userinterface.extension.DefaultFlyout']
     });

--- a/bundles/framework/publisher2/instance.js
+++ b/bundles/framework/publisher2/instance.js
@@ -175,7 +175,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
             if (this.getCustomTileRef()) {
                 blnEnabled ? jQuery(this.getCustomTileRef()).addClass('activePublish') : jQuery(this.getCustomTileRef()).removeClass('activePublish');
             }
-            var mapModule = me.sandbox.findRegisteredModuleInstance('MainMapModule');
             if (blnEnabled) {
                 var stateRB = Oskari.requestBuilder('StateHandler.SetStateRequest');
                 this.getSandbox().request(this, stateRB(data.configuration));
@@ -185,7 +184,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
 
                 me.getService().setNonPublisherLayers(deniedLayers || this.getLayersWithoutPublishRights());
                 me.getService().removeLayers();
-                me.getService().setMapToolStyle(mapModule.getToolStyle());
                 me.oskariLang = Oskari.getLang();
 
                 map.addClass('mapPublishMode');
@@ -208,9 +206,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
                 me.publisher.render(map);
             } else {
                 Oskari.setLang(me.oskariLang);
-
-                // change the mapmodule toolstyle back to normal
-                mapModule.changeToolStyle(me.getService().getMapToolStyle());
 
                 if (me.publisher) {
                     // show flyout?

--- a/bundles/framework/publisher2/instance.js
+++ b/bundles/framework/publisher2/instance.js
@@ -175,6 +175,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
             if (this.getCustomTileRef()) {
                 blnEnabled ? jQuery(this.getCustomTileRef()).addClass('activePublish') : jQuery(this.getCustomTileRef()).removeClass('activePublish');
             }
+            var mapModule = me.sandbox.findRegisteredModuleInstance('MainMapModule');
             if (blnEnabled) {
                 var stateRB = Oskari.requestBuilder('StateHandler.SetStateRequest');
                 this.getSandbox().request(this, stateRB(data.configuration));
@@ -184,6 +185,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
 
                 me.getService().setNonPublisherLayers(deniedLayers || this.getLayersWithoutPublishRights());
                 me.getService().removeLayers();
+                me.getService().setMapToolStyle(mapModule.getToolStyle());
                 me.oskariLang = Oskari.getLang();
 
                 map.addClass('mapPublishMode');
@@ -208,9 +210,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
                 Oskari.setLang(me.oskariLang);
 
                 // change the mapmodule toolstyle back to normal
-                var mapModule = me.sandbox.findRegisteredModuleInstance('MainMapModule');
-                // TODO: reset to what it was when publisher was started instead of removing it (mapmodule.getToolStyle())
-                mapModule.changeToolStyle(null);
+                mapModule.changeToolStyle(me.getService().getMapToolStyle());
 
                 if (me.publisher) {
                     // show flyout?

--- a/bundles/framework/publisher2/service/PublisherService.js
+++ b/bundles/framework/publisher2/service/PublisherService.js
@@ -11,14 +11,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherService',
      */
     function (sandbox) {
         this.__sandbox = sandbox;
-        this.mapToolStyle = null;
     }, {
-        setMapToolStyle: function (style) {
-            this.mapToolStyle = style;
-        },
-        getMapToolStyle: function () {
-            return this.mapToolStyle;
-        },
         /**
          * @method getLayersWithoutPublishRights
          * Checks currently selected layers and returns a subset of the list

--- a/bundles/framework/publisher2/service/PublisherService.js
+++ b/bundles/framework/publisher2/service/PublisherService.js
@@ -11,8 +11,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherService',
      */
     function (sandbox) {
         this.__sandbox = sandbox;
+        this.mapToolStyle = null;
     }, {
-
+        setMapToolStyle: function (style) {
+            this.mapToolStyle = style;
+        },
+        getMapToolStyle: function () {
+            return this.mapToolStyle;
+        },
         /**
          * @method getLayersWithoutPublishRights
          * Checks currently selected layers and returns a subset of the list

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -324,7 +324,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
         * @method gatherSelections
         * @private
         */
-        gatherSelections: function(){
+        gatherSelections: function () {
             var me = this,
                 sandbox = this.instance.getSandbox(),
                 selections = {
@@ -360,13 +360,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
          *
          */
         _editToolLayoutOff: function () {
-            var me = this,
-                sandbox = Oskari.getSandbox('sandbox');
+            var me = this;
+            var sandbox = Oskari.getSandbox();
 
-            me.panels.forEach(function(panel) {
-               if(typeof panel.stop === 'function') {
+            me.panels.forEach(function (panel) {
+                if (typeof panel.stop === 'function') {
                     panel.stop();
-               }
+                }
             });
 
             jQuery('#editModeBtn').val(me.loc.toollayout.usereditmode);
@@ -384,7 +384,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
          * @method cancel
          * Closes publisher without saving
          */
-        cancel: function() {
+        cancel: function () {
             this._editToolLayoutOff();
             this.instance.setPublishMode(false);
         },
@@ -557,23 +557,21 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
          *
          */
         _disablePreview: function () {
-            var me = this,
-                mapElement,
-                mapModule = me.instance.sandbox.findRegisteredModuleInstance('MainMapModule'),
-                plugin,
-                i;
+            var me = this;
+            var mapModule = me.instance.sandbox.findRegisteredModuleInstance('MainMapModule');
+            var plugin;
 
             // resume normal plugins
-            for (i = 0; i < me.normalMapPlugins.length; i += 1) {
+            for (var i = 0; i < me.normalMapPlugins.length; i += 1) {
                 plugin = me.normalMapPlugins[i];
                 mapModule.registerPlugin(plugin);
                 plugin.startPlugin(me.instance.sandbox);
-                if(plugin.refresh) {
+                if (plugin.refresh) {
                     plugin.refresh();
                 }
             }
 
-            //restart the stopped bundles that are not map plugins
+            // restart the stopped bundles that are not map plugins
             for (var j = 0; j < me.stoppedBundles.length; j++) {
                 if (me.stoppedBundles[j].start && typeof me.stoppedBundles[j].start === 'function') {
                     me.stoppedBundles[j].start();


### PR DESCRIPTION
Now stores the map style when entering publisher and restores it on exit rather than just resetting the default style.