### PR TITLE
Layer and group order fix

### DIFF
--- a/bundles/framework/hierarchical-layerlist/Flyout.js
+++ b/bundles/framework/hierarchical-layerlist/Flyout.js
@@ -61,7 +61,7 @@ Oskari.clazz.define('Oskari.framework.bundle.hierarchical-layerlist.Flyout',
                 var mode = data.mode;
 
                 if (mode === 'delete') {
-                    me.mapLayerService.removeLayer(data.id);
+                    me.mapLayerService.removeLayer(data.id, true);
                 } else if (mode === 'add') {
                     var layer = me.mapLayerService.createMapLayer(data.layerData);
                     me.mapLayerService.addLayer(layer);
@@ -166,7 +166,6 @@ Oskari.clazz.define('Oskari.framework.bundle.hierarchical-layerlist.Flyout',
         _getLayerGroups: function(groupingMethod) {
             var me = this,
                 groupList = [],
-                groupModel = null,
                 n,
                 layer,
                 groupAttr;
@@ -190,7 +189,7 @@ Oskari.clazz.define('Oskari.framework.bundle.hierarchical-layerlist.Flyout',
                         });
                         notLoadedBackend[group.id].getName()[Oskari.getLang()] = group.name;
                     }
-                    notLoadedBackend[group.id].layers.push(layer.getId());
+                    notLoadedBackend[group.id].getChildren().push({id:layer.getId(), type:'layer'});
                     notLoadedBackend[group.id].layersModels.push(layer);
                 }
             });
@@ -203,11 +202,12 @@ Oskari.clazz.define('Oskari.framework.bundle.hierarchical-layerlist.Flyout',
 
 
             allGroups.forEach(function(group) {
-                groupModel = Oskari.clazz.create(
+                var groupModel = Oskari.clazz.create(
                     'Oskari.framework.bundle.hierarchical-layerlist.model.LayerGroup',
                     group,
                     me.mapLayerService
                 );
+
                 groupList.push(groupModel);
             });
             return groupList;

--- a/bundles/framework/hierarchical-layerlist/Flyout.js
+++ b/bundles/framework/hierarchical-layerlist/Flyout.js
@@ -61,7 +61,7 @@ Oskari.clazz.define('Oskari.framework.bundle.hierarchical-layerlist.Flyout',
                 var mode = data.mode;
 
                 if (mode === 'delete') {
-                    me.mapLayerService.removeLayer(data.id, true);
+                    me.mapLayerService.removeLayer(data.id);
                 } else if (mode === 'add') {
                     var layer = me.mapLayerService.createMapLayer(data.layerData);
                     me.mapLayerService.addLayer(layer);

--- a/bundles/framework/hierarchical-layerlist/model/LayerGroup.js
+++ b/bundles/framework/hierarchical-layerlist/model/LayerGroup.js
@@ -9,15 +9,10 @@ Oskari.clazz.define('Oskari.framework.bundle.hierarchical-layerlist.model.LayerG
         this._name = Oskari.getLocalized(group.name);
         this._id = group.getId();
         this._selectable = group.hasSelectable();
-        this._layers = [];
-        this._groups = group.getGroups() || [];
+        this._children = group.getChildren();
         this._orderNumber = group.getOrderNumber();
         this._toolsVisible = group.hasToolsVisible();
         var me = this;
-        this.searchIndex = {};
-        group.getLayers().forEach(function(layer) {
-            me.addLayer(layer);
-        });
     }, {
         /**
          * @method setId
@@ -47,42 +42,14 @@ Oskari.clazz.define('Oskari.framework.bundle.hierarchical-layerlist.model.LayerG
         getId: function() {
             return this._id;
         },
-        /**
-         * @method addLayer
-         * @param {Layer} layer
-         */
-        addLayer: function(layer) {
-            if (layer && layer.getId() !== null) {
-                this._layers.push(layer);
-                this.searchIndex[layer.getId()] = this._getSearchIndex(layer);
-            }
-        },
-        /**
-         * @method getLayers
-         * @return {Layer[]}
-         */
-        getLayers: function() {
-            return this._layers;
-        },
-        _getSearchIndex: function(layer) {
-            var val = layer.getName() + ' ' +
-                layer.getInspireName() + ' ' +
-                layer.getOrganizationName();
-            // TODO: maybe filter out undefined texts
-            return val.toLowerCase();
-        },
-        matchesKeyword: function(layerId, keyword) {
-            var searchableIndex = this.searchIndex[layerId];
-            return searchableIndex.indexOf(keyword.toLowerCase()) !== -1;
-        },
         setSelectable: function(selectable) {
             this._selectable = selectable;
         },
         hasSelectable: function() {
             return this._selectable;
         },
-        getGroups: function() {
-            return this._groups;
+        getChildren: function() {
+            return this._children;
         },
         getOrderNumber: function() {
             return this._orderNumber;

--- a/bundles/framework/hierarchical-layerlist/service/LayerlistExtenderService.js
+++ b/bundles/framework/hierarchical-layerlist/service/LayerlistExtenderService.js
@@ -35,7 +35,7 @@
                     },
                     'subgroup-subgroup': {
                         icon: 'jstree-group-icon',
-                        valid_children: ['layer']
+                        valid_children: ['layer', 'group', 'subgroup']
                     },
                     layer: {
                         icon: 'jstree-layer-icon',

--- a/bundles/framework/hierarchical-layerlist/service/LayerlistExtenderService.js
+++ b/bundles/framework/hierarchical-layerlist/service/LayerlistExtenderService.js
@@ -35,7 +35,7 @@
                     },
                     'subgroup-subgroup': {
                         icon: 'jstree-group-icon',
-                        valid_children: ['layer', 'group', 'subgroup']
+                        valid_children: ['layer']
                     },
                     layer: {
                         icon: 'jstree-layer-icon',

--- a/bundles/framework/hierarchical-layerlist/view/LayerGroupTab.js
+++ b/bundles/framework/hierarchical-layerlist/view/LayerGroupTab.js
@@ -917,70 +917,65 @@ Oskari.clazz.define(
             }
             var layerTree = me.templates.layerTree.clone();
 
-            var addLayers = function(groupElId, layers, groupId, orders, tools) {
-                layers.forEach(function(l) {
-                    var layer = l;
-                    if (l.id) {
-                        layer = me.sb.findMapLayerFromAllAvailable(l.id);
-                    }
-                    if(layer) {
-                        var opts = {
-                            a_attr: {
-                                'data-group-id': groupId,
-                                'data-layer-id': layer.getId(),
-                                'data-tools-visible': tools
-                            }
-                        };
-
-                        orders.push({
-                            index: layer.getOrderNumber() || 0,
-                            conf: me._getJsTreeObject(jQuery("<span/>").append(me._createLayerContainer(layer).clone()).html(),
-                                'layer',
-                                opts)
-                        });
-                    }
-                });
-            };
-
-            var addSubgroups = function(type, groupId, subGroups, orders) {
-                subGroups.forEach(function(subgroup) {
-                    var subgroupChildren = [];
-                    var subgroupOrders = [];
+            var getLayerConf = function(layer,group) {
+                if(layer) {
                     var opts = {
                         a_attr: {
-                            class: (!subgroup.selectable) ? 'no-checkbox' : '',
-                            'data-group-id': subgroup.getId(),
-                            'data-parent-group-id': groupId
+                            'data-group-id': group.getId(),
+                            'data-layer-id': layer.getId(),
+                            'data-tools-visible': (typeof group.isToolsVisible == 'function') ? group.isToolsVisible() : true
                         }
                     };
 
-                    addLayers(type + '-' + subgroup.getId(), subgroup.getLayers(), subgroup.getId(), subgroupOrders);
-                    addSubgroups('subgroup-subgroup', subgroup.getId(), subgroup.getGroups(), subgroupOrders);
+                    return me._getJsTreeObject(jQuery("<span/>").append(me._createLayerContainer(layer).clone()).html(),
+                            'layer',
+                            opts);
+                }
+                return null;
+            };
 
-                    // sort
-                    subgroupOrders.sort(function compare(a, b) {
-                        if (a.index < b.index)
-                            return -1;
-                        if (a.index > b.index)
-                            return 1;
-                        return 0;
-                    });
+            var getSubgroupConf = function(maplayerGroup, parentGroup, groupPrefix) {
+                if(maplayerGroup) {
+                    var subgroupChildren = [];
 
-                    subgroupOrders.forEach(function(order) {
-                        subgroupChildren.push(order.conf);
-                    });
-                    orders.push({
-                        index: subgroup.orderNumber,
-                        conf: me._getJsTreeObject(me.sb.getLocalizedProperty(subgroup.name) + ' <span class="layer-count"></span>',
-                            type,
-                            opts, subgroupChildren)
-                    });
+                    var opts = {
+                        a_attr: {
+                            class: (!maplayerGroup.hasSelectable()) ? 'no-checkbox' : '',
+                            'data-group-id': maplayerGroup.getId(),
+                            'data-parent-group-id': parentGroup.getId()
+                        }
+                    };
 
-                });
+                    addChildren(maplayerGroup,subgroupChildren, groupPrefix+'subgroup-');
+
+                    return me._getJsTreeObject(me.sb.getLocalizedProperty(maplayerGroup.getName()) + ' <span class="layer-count"></span>',
+                            groupPrefix + 'subgroup',
+                            opts, subgroupChildren);
+                }
+                return null;
+
             };
 
             me.tabPanel.getContainer().append(layerTree);
             me.layerGroups = groups;
+
+            var addChildren = function(group, groupChildren, groupPrefix) {
+                var childrens = group.getChildren();
+                childrens.forEach(function(children){
+                    if(children.type==='layer') {
+                        var layerConf = getLayerConf(me.sb.findMapLayerFromAllAvailable(children.id), group);
+                        if (layerConf) {
+                            groupChildren.push(layerConf);
+                        }
+                    }
+                    else {
+                        var groupConf = getSubgroupConf(me._mapLayerService.getAllLayerGroups(children.id), group, groupPrefix);
+                        if (groupConf) {
+                            groupChildren.push(groupConf);
+                        }
+                    }
+                });
+            };
 
             groups.forEach(function(group) {
                 var groupOrders = [];
@@ -996,26 +991,7 @@ Oskari.clazz.define(
                     extraOpts.a_attr.class = 'no-checkbox';
                 }
 
-                //Loop through group layers
-                addLayers('group-' + group.getId(), group.getLayers(), group.getId(), groupOrders, group.isToolsVisible());
-
-
-                if (group.getGroups().length > 0) {
-                    addSubgroups('subgroup', group.getId(), group.getGroups(), groupOrders);
-                }
-
-                // sort
-                groupOrders.sort(function compare(a, b) {
-                    if (a.index < b.index)
-                        return -1;
-                    if (a.index > b.index)
-                        return 1;
-                    return 0;
-                });
-
-                groupOrders.forEach(function(order) {
-                    groupChildren.push(order.conf);
-                });
+                addChildren(group, groupChildren, '');
 
                 var groupObject = me._getJsTreeObject(group.getTitle() + ' <span class="layer-count"></span>',
                     'group', extraOpts, groupChildren, group.isToolsVisible());

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -705,7 +705,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                     layerGroups = group;
                 }
             }
-            return (id) ? layerGroups : layerGroups || this._layerGroups;
+            return (id) ? layerGroups : this._layerGroups;
         },
 
         /**

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -229,6 +229,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
             if (layer && suppressEvent !== true) {
                 var notify = this.getSandbox().notifyAll;
                 var mapLayerEvent = Oskari.eventBuilder('MapLayerEvent');
+
                 // notify components of layer removal
                 if (parentLayer) {
                     // notify a collection layer has been updated
@@ -253,6 +254,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
          *            json conf for the layer. NOTE! Only updates name for now
          */
         updateLayer: function (layerId, newLayerConf) {
+            var me = this;
             var layer = this.findMapLayer(layerId);
             if (!layer) {
                 // couldn't find layer to update
@@ -329,7 +331,15 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
             }
 
             if (newLayerConf.groups) {
-                layer.setGroups(newLayerConf.groups);
+                var groups = [];
+                newLayerConf.groups.forEach(function(groupId){
+                    var group = me.getAllLayerGroups(groupId);
+                    groups.push({
+                        id: group.getId(),
+                        name: Oskari.getLocalized(group.getName())
+                    });
+                });
+                layer.setGroups(groups);
             }
 
             if (newLayerConf.orderNumber) {
@@ -415,6 +425,12 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                         selectable: data.selectable
                     })
                 );
+
+                me.getAllLayerGroups(data.parentId).children.push({
+                    type: 'group',
+                    id: data.id,
+                    order: 100000000
+                });
             }
         },
 
@@ -437,14 +453,12 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
             // recurses the group structure
             var recurseLayerUpdate = function (group) {
                 // Check if layer is in group
-                var layerIndex = group.layers.findIndex(function (layer) {
-                    return layer.id === layerId;
+                var layerIndex = group.getChildren().findIndex(function (children) {
+                    return children.id === layerId && children.type === 'layer';
                 });
                 if (layerIndex !== -1) {
                     if (deleteLayer) {
-                        group.layers.splice(layerIndex, 1);
-                    } else {
-                        group.layers[layerIndex] = newLayerConf;
+                        group.children.splice(layerIndex, 1);
                     }
                 }
                 // recurse to next level of groups
@@ -464,15 +478,19 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                 // for each group on the layer
                 newLayerConf.groups.forEach(function (group) {
                     // find the group details
-                    var groupConf = me.getAllLayerGroups(group.id);
-                    var groupLayers = groupConf.layers || [];
+                    var groupConf = me.getAllLayerGroups(group);
+                    var groupChildren = groupConf.getChildren() || [];
                     // check if the layer is referenced in the group details
-                    var layer = groupLayers.find(function (layer) {
-                        return layer.id === newLayerConf.id;
+                    var layer = groupChildren.find(function (children) {
+                        return children.id === newLayerConf.id && children.type === 'layer';
                     });
                     // if layer is not part of the groups layers -> add it
                     if (!layer) {
-                        me.getAllLayerGroups(group.id).layers.push(newLayerConf);
+                        me.getAllLayerGroups(group).addChildren({
+                            type:'layer',
+                            id: newLayerConf.id,
+                            order:1000000
+                        });
                     }
                 });
             }
@@ -569,7 +587,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                     flatLayerGroups.push(group);
                     gatherFlatGroups(group.getGroups());
                 });
-            }
+            };
             gatherFlatGroups(me._layerGroups);
 
             this._loadLayersRecursive(pResp.layers, function () {
@@ -583,7 +601,6 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                         }) !== -1;
                     });
 
-                    group.setLayers(layersInGroup);
                     // layers are expected to have reference to groups they are in -> injecting groups to layer
                     layersInGroup.forEach(function (layer) {
                         layer.getGroups().push({
@@ -688,7 +705,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                     layerGroups = group;
                 }
             }
-            return layerGroups || this._layerGroups;
+            return (id) ? layerGroups : layerGroups || this._layerGroups;
         },
 
         /**


### PR DESCRIPTION
This PR also needs https://github.com/oskariorg/oskari-server/pull/202

# MaplayerGroup domain
- now uses children instead of layers. children array includes type, id ann order number objects

# MapLayerService
- updateLayer: Fixed save layer handling  (layer conf now includes layr groups id array) update also layer groups correct
- fixed to use also MaplayerGroup getChildren method

# Hierarchical layerlist
- now uses MaplayerGroup getChildren method to getted sorted lists (removed sortings from bundle)
