### PR TITLE
Userlayer move map by layer content

### DIFF
--- a/bundles/framework/myplaces3/resources/locale/en.js
+++ b/bundles/framework/myplaces3/resources/locale/en.js
@@ -85,7 +85,7 @@ Oskari.registerLocalization(
             "area": {
                 "title": "Add Area to Own Places",
                 "tooltip": "Draw an area and add it to your own places.",
-                "add": "Draw an area to the map. Click breaking points. Finally double-click an ending point and click \"Save My Place\". You can draw a hole to an area by keeping \"Alt\"-key down.",
+                "add": "Draw an area to the map. Click breaking points. Finally double-click an ending point and click \"Save My Place\".",
                 "next": "You can draw several areas in one feature.",
                 "edit": "You can move breaking points to another location by clicking them with a mouse.",
                 "save": "Save My Place",

--- a/bundles/framework/myplaces3/resources/locale/fi.js
+++ b/bundles/framework/myplaces3/resources/locale/fi.js
@@ -85,7 +85,7 @@ Oskari.registerLocalization(
             "area": {
                 "title": "Lisää alue omiin kohteisiin",
                 "tooltip": "Piirrä alue ja lisää se omiin kohteisiin.",
-                "add": "Piirrä alue kartalle. Klikkaa alueen reunapisteitä. Lopuksi kaksoisklikkaa viimeistä pistettä tai paina \"Tallenna kohde\". Voit piirtää alueeseen reiän pitämällä ALT-näppäintä pohjassa reiän piirtämisen ajan.",
+                "add": "Piirrä alue kartalle. Klikkaa alueen reunapisteitä. Lopuksi kaksoisklikkaa viimeistä pistettä tai paina \"Tallenna kohde\".",
                 "next": "Voit piirtää samaan kohteeseen useita alueita.",
                 "edit": "Voit siirtää taitepisteitä raahaamalla niitä hiirellä.",
                 "save": "Tallenna kohde",

--- a/bundles/framework/myplacesimport/UserLayersTab.js
+++ b/bundles/framework/myplacesimport/UserLayersTab.js
@@ -43,7 +43,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.UserLayersTab',
             var me = this,
                 sandbox = me.instance.getSandbox(),
                 grid = Oskari.clazz.create('Oskari.userinterface.component.Grid'),
-                addMLrequestBuilder = sandbox.getRequestBuilder('AddMapLayerRequest');
+                addMLrequestBuilder = Oskari.requestBuilder('AddMapLayerRequest'),
+                mapMoveByContentReqBuilder = Oskari.requestBuilder('MapModulePlugin.MapMoveByLayerContentRequest');
 
             grid.setVisibleFields(this.visibleFields);
             // set up the link from name field
@@ -53,6 +54,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.UserLayersTab',
                 link.append(name).bind('click', function () {
                     // add myplacesimport layer to map on name click
                     var request = addMLrequestBuilder(data.id);
+                    sandbox.request(me.instance, request);
+                    request = mapMoveByContentReqBuilder(data.id, true);
                     sandbox.request(me.instance, request);
                     return false;
                 });

--- a/bundles/framework/myplacesimport/instance.js
+++ b/bundles/framework/myplacesimport/instance.js
@@ -122,15 +122,23 @@ function () {
 
         var me = this,
             sandbox = this.getSandbox(),
-            reqBuilder, request;
+            reqBuilder,
+            request,
+            mapMoveByContentReqBuilder;
 
         this.getService().addLayerToService(layerJson, false, function(mapLayer) {
             // refresh the tab
             me.getTab().refresh();
             // Request the layer to be added to the map.
-            requestBuilder = sandbox.getRequestBuilder('AddMapLayerRequest');
-            if (requestBuilder) {
-                request = requestBuilder(mapLayer.getId());
+            reqBuilder = Oskari.requestBuilder('AddMapLayerRequest');
+            if (reqBuilder) {
+                request = reqBuilder(mapLayer.getId());
+                sandbox.request(me, request);
+            }
+            // Request to move and zoom map to layer's content
+            mapMoveByContentReqBuilder = Oskari.requestBuilder('MapModulePlugin.MapMoveByLayerContentRequest');
+            if (mapMoveByContentReqBuilder) {
+                request = mapMoveByContentReqBuilder(mapLayer.getId(), true);
                 sandbox.request(me, request);
             }
         });

--- a/bundles/framework/myplacesimport/service/MyPlacesImportService.js
+++ b/bundles/framework/myplacesimport/service/MyPlacesImportService.js
@@ -13,7 +13,7 @@ function(instance) {
 
     var ajaxUrl = this.sandbox.getAjaxUrl() + 'action_route=';
     var srsName = this.sandbox.getMap().getSrsName();
-    this.urls.create = ajaxUrl + 'CreateUserLayer&srs=' + srsName;
+    this.urls.create = ajaxUrl + 'CreateUserLayer&srs=' + srsName + '&sourceEpsg=' + srsName;
     this.urls.get = ajaxUrl + 'GetUserLayers&srs=' + srsName;
     this.urls.edit = (ajaxUrl + 'EditUserLayer');
     this.urls.getStyle = (ajaxUrl + 'GetUserLayerStyle');

--- a/bundles/mapping/mapuserlayers/plugin/UserLayersLayerPlugin.ol2.js
+++ b/bundles/mapping/mapuserlayers/plugin/UserLayersLayerPlugin.ol2.js
@@ -86,8 +86,6 @@ Oskari.clazz.define(
                 '#!#! CREATED OPENLAYER.LAYER.WMS for UserLayer ' +
                 layer.getId()
             );
-            //move and zoom map to layer extent
-            sandbox.postRequestByName('MapModulePlugin.MapMoveByLayerContentRequest',[layer.getId(), true]);
         },
         /**
          * Adds event listeners to ol-layers

--- a/bundles/mapping/mapuserlayers/plugin/UserLayersLayerPlugin.ol3.js
+++ b/bundles/mapping/mapuserlayers/plugin/UserLayersLayerPlugin.ol3.js
@@ -93,8 +93,6 @@ Oskari.clazz.define(
                 '#!#! CREATED OPENLAYER.LAYER.WMS for UserLayer ' +
                 layer.getId()
             );
-            //move and zoom map to layer extent
-            sandbox.postRequestByName('MapModulePlugin.MapMoveByLayerContentRequest',[layer.getId(), true]);
         },
         /**
          * Adds event listeners to ol-layers


### PR DESCRIPTION
Map move by layer content request was triggered on userlayer selection (add layer to map). When userlayers were added from state or from appsetup (published maps), it caused unwanted actions (map was moved to userlayer extent). Now request is triggered only when userlayer is added from userlayer tab or on userlayer import.

Removed ALT-key hole handler tip from myplaces draw helper.

Added map's srs as default source srs to userlayer import params. It is used if srs isn't found from source file (e.g. shapefile doesn't contain .prj file).