### PR TITLE
Userlayer stateful

### DIFF
--- a/bundles/framework/myplacesimport/instance.js
+++ b/bundles/framework/myplacesimport/instance.js
@@ -6,7 +6,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportBun
     this.defaultConf = {
         name: 'MyPlacesImport',
         sandbox: 'sandbox',
-        stateful: true,
+        stateful: false,
         flyoutClazz: 'Oskari.mapframework.bundle.myplacesimport.Flyout'
     };
     this.buttonGroup = 'myplaces';

--- a/bundles/framework/myplacesimport/instance.js
+++ b/bundles/framework/myplacesimport/instance.js
@@ -1,11 +1,7 @@
 /**
  * @class Oskari.mapframework.bundle.myplacesimport.MyPlacesImportBundleInstance
  */
-Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportBundleInstance',
-/**
- * @static constructor function
- */
-function () {
+Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportBundleInstance', function () {
     // these will be used for this.conf if nothing else is specified (handled by DefaultExtension)
     this.defaultConf = {
         name: 'MyPlacesImport',
@@ -30,11 +26,9 @@ function () {
      * @method start
      */
     start: function () {
-        var me = this,
-            conf = this.getConfiguration() || {},
-            sandboxName = (conf ? conf.sandbox : null) || 'sandbox',
-            sandbox = Oskari.getSandbox(sandboxName),
-            request;
+        var me = this;
+        var conf = this.getConfiguration() || {};
+        var sandbox = Oskari.getSandbox(conf.sandbox);
 
         this.sandbox = sandbox;
         sandbox.register(this);
@@ -53,12 +47,11 @@ function () {
             this.tab = this.addTab(sandbox);
             this.importService = this.createService(sandbox);
             this.importService.init();
-            this.importService.getUserLayers(function() {
+            this.importService.getUserLayers(function () {
                 me.getTab().refresh();
             });
 
-            request = sandbox.getRequestBuilder('userinterface.AddExtensionRequest')(this);
-            sandbox.request(this, request);
+            sandbox.request(this, Oskari.requestBuilder('userinterface.AddExtensionRequest')(this));
         }
 
         this.registerTool(isGuest);
@@ -68,14 +61,13 @@ function () {
      *
      * @method registerTool
      */
-    registerTool: function(isGuest) {
-        var me = this,
-            loc = this.getLocalization(),
-            sandbox = this.getSandbox(),
-            reqBuilder = sandbox.getRequestBuilder('Toolbar.AddToolButtonRequest'),
-            request;
-        this.tool.callback = function() {
-            if(!isGuest) {
+    registerTool: function (isGuest) {
+        var me = this;
+        var loc = this.getLocalization();
+        var sandbox = this.getSandbox();
+        var reqBuilder = Oskari.requestBuilder('Toolbar.AddToolButtonRequest');
+        this.tool.callback = function () {
+            if (!isGuest) {
                 // toolbar requires a callback so we need to check guest flag
                 // inside callback instead of not giving any callback
                 me.startTool();
@@ -84,8 +76,7 @@ function () {
         this.tool.tooltip = loc.tool.tooltip;
 
         if (reqBuilder) {
-            request = reqBuilder(this.toolName, this.buttonGroup, this.tool);
-            sandbox.request(this, request);
+            sandbox.request(this, reqBuilder(this.toolName, this.buttonGroup, this.tool));
         }
     },
     /**
@@ -93,22 +84,19 @@ function () {
      *
      * @method startTool
      */
-    startTool: function() {
-        var sandbox = this.getSandbox(),
-            reqBuilder = sandbox.getRequestBuilder('userinterface.UpdateExtensionRequest'),
-            toolbarReqBuilder = sandbox.getRequestBuilder('Toolbar.SelectToolButtonRequest'),
-            request, toolbarRequest;
+    startTool: function () {
+        var sandbox = this.getSandbox();
+        var reqBuilder = Oskari.requestBuilder('userinterface.UpdateExtensionRequest');
+        var toolbarReqBuilder = Oskari.requestBuilder('Toolbar.SelectToolButtonRequest');
 
         if (reqBuilder) {
             // open the flyout
-            request = reqBuilder(this, 'attach', this.getName());
-            sandbox.request(this, request);
+            sandbox.request(this, reqBuilder(this, 'attach', this.getName()));
         }
 
         if (toolbarReqBuilder) {
             // ask toolbar to select the default tool
-            toolbarRequest = toolbarReqBuilder();
-            sandbox.request(this, toolbarRequest);
+            sandbox.request(this, toolbarReqBuilder());
         }
     },
     /**
@@ -117,29 +105,26 @@ function () {
      * @method addUserLayer
      * @param {JSON} layerJson
      */
-    addUserLayer: function(layerJson) {
-        if (!layerJson) return;
+    addUserLayer: function (layerJson) {
+        if (!layerJson) {
+            return;
+        }
 
-        var me = this,
-            sandbox = this.getSandbox(),
-            reqBuilder,
-            request,
-            mapMoveByContentReqBuilder;
+        var me = this;
+        var sandbox = this.getSandbox();
 
-        this.getService().addLayerToService(layerJson, false, function(mapLayer) {
+        this.getService().addLayerToService(layerJson, false, function (mapLayer) {
             // refresh the tab
             me.getTab().refresh();
             // Request the layer to be added to the map.
-            reqBuilder = Oskari.requestBuilder('AddMapLayerRequest');
+            var reqBuilder = Oskari.requestBuilder('AddMapLayerRequest');
             if (reqBuilder) {
-                request = reqBuilder(mapLayer.getId());
-                sandbox.request(me, request);
+                sandbox.request(me, reqBuilder(mapLayer.getId()));
             }
             // Request to move and zoom map to layer's content
-            mapMoveByContentReqBuilder = Oskari.requestBuilder('MapModulePlugin.MapMoveByLayerContentRequest');
+            var mapMoveByContentReqBuilder = Oskari.requestBuilder('MapModulePlugin.MapMoveByLayerContentRequest');
             if (mapMoveByContentReqBuilder) {
-                request = mapMoveByContentReqBuilder(mapLayer.getId(), true);
-                sandbox.request(me, request);
+                sandbox.request(me, mapMoveByContentReqBuilder(mapLayer.getId(), true));
             }
         });
     },
@@ -150,7 +135,7 @@ function () {
      * @param  {Oskari.Sandbox} sandbox
      * @return {Oskari.mapframework.bundle.myplacesimport.MyPlacesImportService}
      */
-    createService: function(sandbox) {
+    createService: function (sandbox) {
         var importService = Oskari.clazz.create(
             'Oskari.mapframework.bundle.myplacesimport.MyPlacesImportService',
             this
@@ -164,7 +149,7 @@ function () {
      * @method getService
      * @return {Oskari.mapframework.bundle.myplacesimport.MyPlacesImportService}
      */
-    getService: function() {
+    getService: function () {
         return this.importService;
     },
     /**
@@ -174,18 +159,13 @@ function () {
      * @param {Oskari.Sandbox} sandbox
      * @return {Oskari.mapframework.bundle.myplacesimport.UserLayersTab}
      */
-    addTab: function(sandbox) {
-        var loc = this.getLocalization(),
-            userLayersTab = Oskari.clazz.create(
-                'Oskari.mapframework.bundle.myplacesimport.UserLayersTab',
-                this
-            ),
-            addTabReqBuilder = sandbox.getRequestBuilder('PersonalData.AddTabRequest'),
-            addTabReq;
+    addTab: function (sandbox) {
+        var loc = this.getLocalization();
+        var userLayersTab = Oskari.clazz.create('Oskari.mapframework.bundle.myplacesimport.UserLayersTab', this);
+        var addTabReqBuilder = Oskari.requestBuilder('PersonalData.AddTabRequest');
 
         if (addTabReqBuilder) {
-            addTabReq = addTabReqBuilder(loc.tab.title, userLayersTab.getContent(), false, 'userlayers');
-            sandbox.request(this, addTabReq);
+            sandbox.request(this, addTabReqBuilder(loc.tab.title, userLayersTab.getContent(), false, 'userlayers'));
         }
         return userLayersTab;
     },
@@ -193,9 +173,9 @@ function () {
      * @method getTab
      * @return {Oskari.mapframework.bundle.myplacesimport.UserLayersTab}
      */
-    getTab: function() {
+    getTab: function () {
         return this.tab;
     }
 }, {
-    "extend": ["Oskari.userinterface.extension.DefaultExtension"]
+    'extend': ['Oskari.userinterface.extension.DefaultExtension']
 });


### PR DESCRIPTION
Userlayer import has been configured to be stateful, but hasn't provided get/setState() methods. This has triggered warnings for developers in the console. As the bundle doesn't really have or need a state this PR fixes the default configuration to say the bundle isn't stateful.

Also formats the instance.js as per ESLint guidelines and replaces a couple of deprecated functions to current ones.