### PR TITLE
Printout selector helpers

### DIFF
--- a/bundles/framework/divmanazer/component/AccordionPanel.js
+++ b/bundles/framework/divmanazer/component/AccordionPanel.js
@@ -7,7 +7,6 @@ Oskari.clazz.define('Oskari.userinterface.component.AccordionPanel',
 
     /**
      * @method create called automatically on construction
-     * TODO: close/open methods?
      * @static
      */
     function () {
@@ -25,8 +24,8 @@ Oskari.clazz.define('Oskari.userinterface.component.AccordionPanel',
         this.content = null;
         this.html = this.template.clone();
 
-        var me = this,
-            header = me.html.find('div.header');
+        var me = this;
+        var header = me.html.find('div.header');
 
         header.click(function () {
             if (me.isOpen()) {
@@ -121,6 +120,14 @@ Oskari.clazz.define('Oskari.userinterface.component.AccordionPanel',
             header.attr('id', id);
         },
         /**
+         * @method addClass
+         * adds a class for the whole components container that enables easier styling/selector for UI tests
+         * @param {String} id id for the panel
+         */
+        addClass: function (cssClass) {
+            this.html.addClass(cssClass);
+        },
+        /**
          * @method setContent
          * Sets the panel content.
          * This can be also done with #getContainer()
@@ -136,8 +143,8 @@ Oskari.clazz.define('Oskari.userinterface.component.AccordionPanel',
          * Destroys the panel/removes it from document
          */
         destroy: function () {
-            if( !this.html){
-              return;
+            if (!this.html) {
+                return;
             }
             this.html.remove();
         },


### PR DESCRIPTION
Most of the changes are formatting, replacing deprecated functions to current ones, removing unused functions etc. 

The actual change is that AccordionPanel now has addClass() method that adds a css class given as param for the whole panel container. This can be used to add selectors for custom styling the panels and making easier selections with UI-based testing.

This also adds such classes for the printout sidebar panels: printsize, printsettings and printpreview for making them easier to find on Selenium-based testing.