### PR TITLE
Handle completed indicator list properly

### DIFF
--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -4,13 +4,7 @@
 (function (Oskari) {
     var _log = Oskari.log('StatsGrid.StatisticsService');
 
-    Oskari.clazz.define('Oskari.statistics.statsgrid.StatisticsService',
-
-    /**
-     * @method create called automatically on construction
-     * @static
-     */
-    function (sandbox, locale) {
+    Oskari.clazz.define('Oskari.statistics.statsgrid.StatisticsService', function (sandbox, locale) {
         this.sandbox = sandbox;
         this.locale = locale;
         this.cache = Oskari.clazz.create('Oskari.statistics.statsgrid.Cache');
@@ -284,13 +278,13 @@
                 setTimeout(function () {
                     me.cache.remove(cacheKey);
                     // try again after 10 seconds
-                    me.getIndicatorList(ds, function (err, newList) {
+                    me.getIndicatorList(ds, function (err, newResponse) {
                         if (err) {
                             // Don't call callback with err as we will be trying again.
                             _log.warn('Error updating indicator list.');
                             return;
                         }
-                        if (newList.indicators.length === previousList.length) {
+                        if (!newResponse.complete && newResponse.indicators.length === previousList.length) {
                             // same list size??? somethings propably wrong
                             _log.warn('Same indicator list as in previous try. There might be some problems with the service');
                             return;


### PR DESCRIPTION
Statistical indicators might be loaded in batches (when processing is slow). When the previous response had the same number of indicators as the new one this might indicate a problem with the datasource. This is logged as a warning for the developers.

However the value of "complete" listing was not checked on such occasion which resulted in the frontend showing a spinner for indicator loading even if all the indicators were loaded. 

This PR fixes that annoying issue.