### PR TITLE
Hierarchical layerlist drag fix

### DIFF
--- a/bundles/admin/admin-hierarchical-layerlist/instance.js
+++ b/bundles/admin/admin-hierarchical-layerlist/instance.js
@@ -193,7 +193,8 @@ Oskari.clazz.define("Oskari.admin.bundle.admin.HierarchicalLayerListBundleInstan
             me.service.addLayerlistOption('plugins', ['checkbox', 'changed', 'wholerow', 'types', 'search', 'state', 'conditionalselect', 'dnd'], false);
             me.service.addLayerlistOption('dnd', {
                 use_html5: true,
-                inside_pos: 'last'
+                inside_pos: 'last',
+                drag_selection: false
             });
         },
 


### PR DESCRIPTION
Fixed admin hierarchical layerlist drag & save. Now savae only current item (previously all selected items was dragged).