### PR TITLE
Personaldata profile url

### DIFF
--- a/applications/paikkatietoikkuna.fi/full-map/index.js
+++ b/applications/paikkatietoikkuna.fi/full-map/index.js
@@ -40,17 +40,6 @@ jQuery(document).ready(function () {
                 return;
             }
             app.init(appSetup);
-
-            // setup env urls if they were not part of the appSetup
-            // TODO: remove once env has these
-            if (!Oskari.urls.getLocation('login')) {
-                Oskari.urls.set('login', '/auth');
-            }
-            if (!Oskari.urls.getLocation('register')) {
-                var lang = appSetup.env.lang || window.language;
-                Oskari.urls.set('register', 'https://omatili.maanmittauslaitos.fi/?lang=' + lang);
-            }
-
             app.startApplication(function () {
                 var sb = Oskari.getSandbox();
                 gfiParamHandler(sb);

--- a/applications/paikkatietoikkuna.fi/full-map_experimental/index.js
+++ b/applications/paikkatietoikkuna.fi/full-map_experimental/index.js
@@ -41,17 +41,6 @@ jQuery(document).ready(function () {
             }
 
             app.init(appSetup);
-
-            // setup env urls if they were not part of the appSetup
-            // TODO: remove once env has these
-            if (!Oskari.urls.getLocation('login')) {
-                Oskari.urls.set('login', '/auth');
-            }
-            if (!Oskari.urls.getLocation('register')) {
-                var lang = appSetup.env.lang || window.language;
-                Oskari.urls.set('register', 'https://omatili.maanmittauslaitos.fi/?lang=' + lang);
-            }
-
             app.startApplication(function () {
                 var sb = Oskari.getSandbox();
                 gfiParamHandler(sb);

--- a/bundles/framework/personaldata/AccountTab.js
+++ b/bundles/framework/personaldata/AccountTab.js
@@ -12,9 +12,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.AccountTab',
      */
 
     function (instance) {
-        this.conf = instance.conf;
+        this.conf = instance.conf || {};
         this.instance = instance;
         this.template = jQuery('<div class="account"><table class="info oskari-grid"></table><div class="bottomlinks"></div></div>');
+        this.fieldTemplate = jQuery('<tr class="dataField"><th class="label"></th><td class="value"></td></tr>');
+        this.linkTemplate = jQuery('<a href=""></a>&nbsp; ');
         this.loc = Oskari.getMsg.bind(null, 'PersonalData');
     }, {
         getTitle: function () {
@@ -27,63 +29,52 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.AccountTab',
         },
 
         _createAccountTab: function (container) {
-            var me = this,
-                sandbox = me.instance.getSandbox(),
-                fieldTemplate = jQuery('<tr class="dataField"><th class="label"></th><td class="value"></td></tr>'),
-                user = Oskari.user(),
-                profileLink = jQuery('#oskari-profile-link'),
-                accountData = [{
-                    label: me.loc('tabs.account.firstName'),
-                    value: user.getFirstName()
-                }, {
-                    label: me.loc('tabs.account.lastName'),
-                    value: user.getLastName()
-                }, {
-                    label: me.loc('tabs.account.nickName'),
-                    value: user.getNickName()
-                }, {
-                    label: me.loc('tabs.account.email'),
-                    value: user.getEmail()
-                }],
-                infoContainer = container.find('.info'),
-                i,
-                data,
-                fieldContainer,
-                bottomLinks,
-                bottomLinksContainer,
-                link,
-                changeInfoUrl = null;
+            var me = this;
+            var user = Oskari.user();
+            var accountData = [{
+                label: me.loc('tabs.account.firstName'),
+                value: user.getFirstName()
+            }, {
+                label: me.loc('tabs.account.lastName'),
+                value: user.getLastName()
+            }, {
+                label: me.loc('tabs.account.nickName'),
+                value: user.getNickName()
+            }, {
+                label: me.loc('tabs.account.email'),
+                value: user.getEmail()
+            }];
 
-            profileLink.on('click', function() {
-              me.instance.openProfileTab();
-              return false;
-            });
-
-            for (i = 0; i < accountData.length; i += 1) {
-                data = accountData[i];
-                fieldContainer = fieldTemplate.clone();
+            // main content
+            var infoContainer = container.find('.info');
+            accountData.forEach(function (data) {
+                var fieldContainer = me.fieldTemplate.clone();
                 fieldContainer.find('.label').html(data.label);
                 fieldContainer.find('.value').html(data.value);
                 infoContainer.append(fieldContainer);
-            }
+            });
 
-            if (me.conf) {
-                changeInfoUrl = sandbox.getLocalizedProperty(me.conf.changeInfoUrl);
+            // bottom links
+            var bottomLinksContainer = container.find('div.bottomlinks');
+            var changeInfoUrl = Oskari.getLocalized(me.conf.changeInfoUrl) || Oskari.urls.getLocation('profile');
+            var bottomLinks = [];
+            if (changeInfoUrl) {
+                bottomLinks.push({
+                    label: me.loc('tabs.account.changeInfo'),
+                    href: changeInfoUrl
+                });
             }
+            bottomLinks.forEach(function (data) {
+                var link = me.linkTemplate.clone();
+                link.attr('href', data.href);
+                link.html(data.label);
+                bottomLinksContainer.append(link);
+            });
 
-            bottomLinks = [{
-                // FIXME get URL from bundle config
-                label: me.loc('tabs.account.changeInfo'),
-                href: changeInfoUrl
-            }];
-            bottomLinksContainer = container.find('div.bottomlinks');
-            for (i = 0; i < bottomLinks.length; i += 1) {
-                data = bottomLinks[i];
-                if (data.href && data.label) {
-                    link = jQuery('<a href="' + data.href + '">' + data.label + '</a>&nbsp; ');
-                    bottomLinksContainer.append(link);
-                }
-            }
-
+            // attach handler to possible external element if found on the page
+            jQuery('#oskari-profile-link').on('click', function () {
+                me.instance.openProfileTab();
+                return false;
+            });
         }
 });


### PR DESCRIPTION
With this PR the personaldata bundle adds support for Oskari.urls.getLocation('profile'). Bundle specific configuration is preferred, but if absent the profile url is used instead since these kinds of URLs tend to be server specific instead of appsetup specific. 

Also removes some hacky configs from Paikkatietoikkuna application now that oskariorg/oskari-server#205 has been merged.