### PR TITLE
Guided tour - popup

### DIFF
--- a/bundles/framework/guidedtour/instance.js
+++ b/bundles/framework/guidedtour/instance.js
@@ -222,7 +222,7 @@ Oskari.clazz.define(
                 checkbox.bind(
                     'change',
                     function () {
-                        if (jQuery(this).attr('checked')) {
+                        if ( jQuery(this).is(':checked') ) {
                             // Set cookie not to show guided tour again
                             jQuery.cookie(
                                 'pti_tour_seen', '1', {
@@ -249,7 +249,7 @@ Oskari.clazz.define(
                 dialog.resetPosition();
             }
         },
-        _moveGuideStep: function(delta, dialog){
+        _moveGuideStep: function(delta, dialog) {
             var currentStep = this._guideSteps[this.guideStep];
             if(currentStep.hide) {
                 currentStep.hide();


### PR DESCRIPTION
- attr("checked") has been removed in jquery 1.9 -> use the .is(":checked") instead