### PR TITLE
Grid opacity fix

### DIFF
--- a/bundles/framework/featuredata2/instance.js
+++ b/bundles/framework/featuredata2/instance.js
@@ -271,11 +271,10 @@ Oskari.clazz.define("Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
                     this.plugins['Oskari.userinterface.Flyout'].showLoadingIndicator(event.getLayerId(), false);
                     this.plugins['Oskari.userinterface.Flyout'].showErrorIndicator(event.getLayerId(), false);
 
-
                     if (layer && layer.isManualRefresh()) {
                         if (event.getNop()) {
                             this.plugins['Oskari.userinterface.Flyout'].setGridOpacity(layer, 0.5);
-                        } else if (event.getRequestType() === event.type.image || layer._activeFeatures.length === 0) {
+                        } else if (event.getRequestType() === event.type.image && layer._activeFeatures.length === 0) {
                             this.plugins['Oskari.userinterface.Flyout'].setGridOpacity(layer, 0.5);
                         }
                     }


### PR DESCRIPTION
Looks like this broke down on commit [d9c26fa6a](https://github.com/oskariorg/oskari-frontend/blob/d9c26fa6aee38bca5a6cf4f20dac368a28e49f6e/bundles/framework/featuredata2/instance.js)