### PR TITLE
Initial support for editing user indicators

### DIFF
--- a/bundles/statistics/statsgrid2016/components/IndicatorForm.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorForm.js
@@ -15,6 +15,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorForm', function (local
     },
     createForm: function () {
         if (this.getElement()) {
+            this.resetForm();
             return this.getElement();
         }
         var form = this.__templates.form({
@@ -54,5 +55,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorForm', function (local
     resetForm: function () {
         // the element is a form
         this.getElement()[0].reset();
+        this.getElement().find('textarea').text('');
     }
 });

--- a/bundles/statistics/statsgrid2016/components/IndicatorForm.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorForm.js
@@ -28,17 +28,16 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorForm', function (local
         return this.element;
     },
     setValues: function (name, desc, source) {
-        // TODO: test impl
         var elements = this.getElement().find('.stats-indicator-form-item');
         elements.each(function (index, element) {
             element = jQuery(element);
             var key = element.attr('name');
             if (key === 'name') {
-                element.val(name);
+                element.val(Oskari.getLocalized(name) || '');
             } else if (key === 'description') {
-                element.text(desc);
+                element.val(Oskari.getLocalized(desc) || '');
             } else if (key === 'datasource') {
-                element.val(source);
+                element.val(Oskari.getLocalized(source) || '');
             }
         });
     },
@@ -53,8 +52,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorForm', function (local
         return data;
     },
     resetForm: function () {
-        // the element is a form
-        this.getElement()[0].reset();
-        this.getElement().find('textarea').text('');
+        // set empty values
+        this.setValues();
     }
 });

--- a/bundles/statistics/statsgrid2016/components/IndicatorParametersList.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorParametersList.js
@@ -44,17 +44,41 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParametersList', funct
         var me = this;
         var listEl = this.getElement().find('ul');
         listEl.empty();
+        if (!datasets) {
+            return;
+        }
         datasets.forEach(function (dataset) {
+            // TODO: formatting/nice UI
             var item = me.__templates.listItem({
+                year: me.locale('parameters.year') + ' ' + dataset.year,
+                regionset: me.getRegionsetName(dataset.regionset)
+            });
+            // TODO: add edit/delete links
+            /* for edit:
+            me.trigger('insert.data', {
                 year: dataset.year,
                 regionset: dataset.regionset
             });
-            // TODO: edit/delete
+            for delete:
+            me.trigger('delete.data', {
+                year: dataset.year,
+                regionset: dataset.regionset
+            });
+            */
             listEl.append(item);
         })
     },
     setRegionsets: function (availableRegionsets) {
         this.availableRegionsets = availableRegionsets;
+    },
+    getRegionsetName: function (id) {
+        var regionset = this.availableRegionsets.find(function (regionset) {
+            return regionset.id === id;
+        });
+        if (regionset) {
+            return regionset.name;
+        }
+        return id;
     },
     resetIndicatorSelectors: function (showInsertButton) {
         var formContainer = this.getElement().find('.new-indicator-dataset-params');

--- a/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
@@ -183,6 +183,11 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
         btnAddIndicator.insertTo(main);
         btnAddIndicator.setVisible(false);
 
+        var btnEditIndicator = Oskari.clazz.create('Oskari.userinterface.component.buttons.EditButton');
+        btnEditIndicator.setPrimary(false);
+        btnEditIndicator.insertTo(main);
+        btnEditIndicator.setVisible(false);
+
         dsSelector.on('change', function () {
             me._params.clean();
             // If selection was removed -> reset indicator selection
@@ -191,6 +196,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
                 indicSelect.updateOptions([]);
                 indicSelect.reset();
                 btnAddIndicator.setVisible(false);
+                btnEditIndicator.setVisible(false);
                 return;
             }
 
@@ -210,6 +216,14 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
             // second check is for placeholder
             if (!indId || !indId.length) {
                 dataLabelWithTooltips.find('.tooltip').show();
+            } else {
+                // if datasource is of type "user" the user can add new indicators to it
+                btnEditIndicator.setVisible(me.service.getDatasource(Number(dsSelect.getValue())).type === 'user');
+                btnEditIndicator.setHandler(function (event) {
+                    event.stopPropagation();
+                    var formFlyout = me.instance.getFlyoutManager().getFlyout('indicatorForm');
+                    formFlyout.showForm(dsSelect.getValue(), indId);
+                });
             }
             // this will show the params or clean them depending if values exist
             me._params.indicatorSelected(

--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -636,6 +636,7 @@
                 },
                 url: Oskari.urls.getRoute('SaveIndicator'),
                 success: function (pResp) {
+                    _log.info('SaveIndicator', pResp);
                     callback(null, {
                         id: indicatorId
                     });
@@ -759,6 +760,7 @@
                     },
                     url: Oskari.urls.getRoute('AddIndicatorData'),
                     success: function (pResp) {
+                        _log.info('AddIndicatorData', pResp);
                         callback(null, {
                             id: indicatorId
                         });

--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -781,8 +781,10 @@
         /**
          * selectors and regionset are optional -> will only delete dataset from indicator if given
          */
-        deleteIndicator: function (datasrc, indicator, selectors, regionset) {
+        deleteIndicator: function (datasrc, indicator, selectors, regionset, callback) {
             // TODO: flush indicator from cache and call server
+            // "great success"
+            callback(null);
         }
     }, {
         'protocol': ['Oskari.mapframework.service.Service']

--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -626,7 +626,6 @@
             /*
             return;
             }
-            */
             jQuery.ajax({
                 type: 'POST',
                 dataType: 'json',
@@ -650,6 +649,7 @@
                     callback('Error saving data to server');
                 }
             });
+            */
         },
         saveIndicatorData: function (datasrc, indicatorId, selectors, data, callback) {
             var me = this;
@@ -752,6 +752,7 @@
                 _log.info('Saved data with key', dataCacheKey, data);
 
                 callback();
+                /*
                 // send to server
                 jQuery.ajax({
                     type: 'POST',
@@ -774,6 +775,7 @@
                         callback('Error saving data to server');
                     }
                 });
+                */
             });
         },
         /**

--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -770,6 +770,12 @@
                     }
                 });
             });
+        },
+        /**
+         * selectors and regionset are optional -> will only delete dataset from indicator if given
+         */
+        deleteIndicator: function (datasrc, indicator, selectors, regionset) {
+            // TODO: flush indicator from cache and call server
         }
     }, {
         'protocol': ['Oskari.mapframework.service.Service']

--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -621,14 +621,20 @@
             /*
             return;
             }
+            */
             jQuery.ajax({
                 type: 'POST',
                 dataType: 'json',
                 data: {
+                    // my indicators datasource id
                     datasource: datasrc,
-                    data: JSON.stringify(data)
+                    id: data.id,
+                    name: data.name,
+                    desc: data.description,
+                    // textual name for the source the data is from
+                    source: data.datasource
                 },
-                url: Oskari.urls.getRoute('N/A'),
+                url: Oskari.urls.getRoute('SaveIndicator'),
                 success: function (pResp) {
                     callback(null, {
                         id: indicatorId
@@ -638,7 +644,6 @@
                     callback('Error saving data to server');
                 }
             });
-            */
         },
         saveIndicatorData: function (datasrc, indicatorId, selectors, data, callback) {
             var me = this;
@@ -741,6 +746,27 @@
                 _log.info('Saved data with key', dataCacheKey, data);
 
                 callback();
+                // send to server
+                jQuery.ajax({
+                    type: 'POST',
+                    dataType: 'json',
+                    data: {
+                        datasource: datasrc,
+                        id: indicatorId,
+                        selectors: JSON.stringify(selectors),
+                        regionset: regionset,
+                        data: JSON.stringify(data)
+                    },
+                    url: Oskari.urls.getRoute('AddIndicatorData'),
+                    success: function (pResp) {
+                        callback(null, {
+                            id: indicatorId
+                        });
+                    },
+                    error: function (jqXHR, textStatus) {
+                        callback('Error saving data to server');
+                    }
+                });
             });
         }
     }, {

--- a/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
@@ -16,7 +16,15 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
         me.showDatasetForm(selectors);
     });
     this.indicatorParamsList.on('delete.data', function (selectors) {
-        me.service.deleteIndicator(me.datasourceId, me.indicatorId, { year: selectors.year }, selectors.regionset);
+        me.service.deleteIndicator(me.datasourceId, me.indicatorId, { year: selectors.year }, selectors.regionset, function (err) {
+            if (err) {
+                // TODO: handle error properly
+                Oskari.log('IndicatorFormFlyout').error('Error deleting dataset', err);
+                return;
+            }
+            // refresh the dataset listing on form
+            me.updateDatasetList();
+        });
     });
     this.indicatorDataForm.on('cancel', function () {
         me.genericInfoPanel.open();
@@ -56,9 +64,12 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
         if (!indicatorId) {
             return;
         }
+        this.updateDatasetList();
+    },
+    updateDatasetList: function () {
         // call this.indicatorForm.setValues() based on datasourceId, indicatorId passing existing datasets
         var me = this;
-        this.service.getIndicatorMetadata(datasourceId, indicatorId, function (err, ind) {
+        this.service.getIndicatorMetadata(me.datasourceId, me.indicatorId, function (err, ind) {
             if (err) {
                 // TODO: handle error properly
                 Oskari.log('IndicatorFormFlyout').error(err);
@@ -78,7 +89,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
             });
             me.indicatorParamsList.setDatasets(datasets); // [{ year : 2017, regionset: 1850}]
         });
-
     },
     getElement: function () {
         return this.element;

--- a/bundles/statistics/statsgrid2016/view/SearchFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/SearchFlyout.js
@@ -70,6 +70,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
 
         var btn = Oskari.clazz.create('Oskari.userinterface.component.Button');
         btn.addClass('margintopLarge');
+        btn.setPrimary(true);
         btn.setTitle(locale.panels.newSearch.addButtonTitle);
         btn.setEnabled(false);
         btn.insertTo(container);


### PR DESCRIPTION
- Adds an edit button for user indicators in the "search indicators" flyout.
- Clicking the edit now prefills the fields in the form based on the existing user indicator.
- When entering data to existing year/regionset combination the data form is prefilled with existing data from the indicator that's being edited.

TODO: 
- UI is still terrible
- Validation of values is pretty much non-existent.
- No saving to server yet
