### PR TITLE
Indicator server calls

### DIFF
--- a/bundles/statistics/statsgrid2016/components/IndicatorParametersList.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorParametersList.js
@@ -96,6 +96,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParametersList', funct
         form.append(input);
         var formContainer = this.resetIndicatorSelectors(false);
         formContainer.append(form);
+        // focus on the year input
+        input.focus();
+
+        // create regionset selection
         var regionsetContainer = jQuery('<div></div>');
         regionsetContainer.append(this.locale('panels.newSearch.selectRegionsetPlaceholder'));
         var select = Oskari.clazz.create('Oskari.userinterface.component.SelectList');
@@ -108,6 +112,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParametersList', funct
         select.adjustChosen();
 
         formContainer.append(regionsetContainer);
+
+        // create buttons
         var btnContainer = jQuery('<div style="display:flex"></div>');
         formContainer.append(btnContainer);
 

--- a/bundles/statistics/statsgrid2016/components/IndicatorParametersList.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorParametersList.js
@@ -94,8 +94,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParametersList', funct
             label: this.locale('parameters.year')
         }));
         form.append(input);
-        // focus on the year input
-        input.focus();
         var formContainer = this.resetIndicatorSelectors(false);
         formContainer.append(form);
         // focus on the year input

--- a/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
@@ -219,10 +219,12 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
             } else {
                 // if datasource is of type "user" the user can add new indicators to it
                 btnEditIndicator.setVisible(me.service.getDatasource(Number(dsSelect.getValue())).type === 'user');
+
+                btnEditIndicator.setEnabled(indId.length === 1);
                 btnEditIndicator.setHandler(function (event) {
                     event.stopPropagation();
                     var formFlyout = me.instance.getFlyoutManager().getFlyout('indicatorForm');
-                    formFlyout.showForm(dsSelect.getValue(), indId);
+                    formFlyout.showForm(dsSelect.getValue(), indId[0]);
                 });
             }
             // this will show the params or clean them depending if values exist

--- a/bundles/statistics/statsgrid2016/resources/locale/en.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/en.js
@@ -215,8 +215,7 @@ Oskari.registerLocalization({
                 'title': '',
                 'placeholder': ''
             },
-            'notLoggedInWarning': 'The indicator data is only available for this session. The data will be lost once the page is reloaded.',
-            'notLoggedInWarningAfterServerImpl': 'Without logging in the data cannot be saved and it will only be available until page reload. Log in before adding the indicator to preserve the data.'
+            'notLoggedInWarning': 'Without logging in the data cannot be saved and it will only be available until page reload. Log in before adding the indicator to preserve the data.'
         }
     }
 });

--- a/bundles/statistics/statsgrid2016/resources/locale/fi.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/fi.js
@@ -217,8 +217,7 @@ Oskari.registerLocalization({
                 'Esimerkki 1: Helsinki;1234 \n' +
                 'Esimerkki 2: 011;5678'
             },
-            'notLoggedInWarning': 'Oman indikaattorin tiedot ovat käytettävissä vain tämän session ajan. Tiedot menetetään jos sivu ladataan uudestaan.',
-            'notLoggedInWarningAfterServerImpl': 'Kirjautumattomana oman indikaattorin tiedot ovat käytettävissä vain tämän session ajan. Kirjaudu sisään tallentaaksesi indikaattori.'
+            'notLoggedInWarning': 'Kirjautumattomana oman indikaattorin tiedot ovat käytettävissä vain tämän session ajan. Kirjaudu sisään tallentaaksesi indikaattori.'
         }
     }
 });

--- a/bundles/statistics/statsgrid2016/resources/locale/sv.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/sv.js
@@ -213,7 +213,6 @@ Oskari.registerLocalization({
                 'placeholder': ''
             }
         },
-        'notLoggedInWarning': '',
-        'notLoggedInWarningAfterServerImpl': ''
+        'notLoggedInWarning': ''
     }
 });

--- a/bundles/statistics/statsgrid2016/service/Cache.js
+++ b/bundles/statistics/statsgrid2016/service/Cache.js
@@ -19,6 +19,17 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Cache',
         get: function (key) {
             return this.cache[key];
         },
+        getKeysStartingWith: function (prefix) {
+            return Object.keys(this.cache).filter(function (key) {
+                return key.indexOf(prefix) === 0;
+            });
+        },
+        flushKeysStartingWith: function (prefix) {
+            var me = this;
+            this.getKeysStartingWith(prefix).forEach(function (key) {
+                me.remove(key);
+            });
+        },
         /**
          * Adds a callback to a response queue.
          * When multiple calls are made to same resource we only want to send one request,

--- a/bundles/statistics/statsgrid2016/service/CacheHelper.js
+++ b/bundles/statistics/statsgrid2016/service/CacheHelper.js
@@ -1,8 +1,9 @@
 /**
  * @class Oskari.statistics.statsgrid.CacheHelper
  */
-Oskari.clazz.define('Oskari.statistics.statsgrid.CacheHelper', function (cache) {
+Oskari.clazz.define('Oskari.statistics.statsgrid.CacheHelper', function (cache, service) {
     this.cache = cache;
+    this.service = service;
 }, {
     getRegionsKey: function (regionset) {
         return 'GetRegions_' + regionset;
@@ -24,5 +25,35 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.CacheHelper', function (cache) 
     },
     getIndicatorDataKeyPrefix: function (datasrc, indicatorId) {
         return 'GetIndicatorData_' + datasrc + '_' + indicatorId + '_';
+    },
+    updateIndicatorCache: function (datasrc, indicatorId, data) {
+
+    },
+    updateIndicatorDataCache: function () {
+
+    },
+    clearCacheOnDelete: function (datasrc, indicatorId, selectors, regionset) {
+        if (!selectors && !regionset) {
+            // removed the whole indicator: flush indicator from cache
+
+            this.cache.flushKeysStartingWith(this.getIndicatorDataKeyPrefix(datasrc, indicatorId));
+            var indicatorListCacheKey = this.getIndicatorListKey(datasrc);
+            var cachedListResponse = this.cache.get(indicatorListCacheKey) || {
+                complete: true,
+                indicators: []
+            };
+            // only inject when guest user, otherwise flush from cache
+            var listIndex = cachedListResponse.indicators.findIndex(function (ind) {
+                return ind.id === indicatorId;
+            });
+            if (listIndex !== -1) {
+                cachedListResponse.indicators.splice(listIndex, 1);
+            }
+            this.cache.put(indicatorListCacheKey, cachedListResponse);
+            var metadataCacheKey = this.getIndicatorMetadataKey(datasrc, indicatorId);
+            this.cache.remove(metadataCacheKey);
+        } else {
+            // TODO: MODIFY indicator in caches
+        }
     }
 });

--- a/bundles/statistics/statsgrid2016/service/CacheHelper.js
+++ b/bundles/statistics/statsgrid2016/service/CacheHelper.js
@@ -26,8 +26,68 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.CacheHelper', function (cache, 
     getIndicatorDataKeyPrefix: function (datasrc, indicatorId) {
         return 'GetIndicatorData_' + datasrc + '_' + indicatorId + '_';
     },
-    updateIndicatorCache: function (datasrc, indicatorId, data) {
+    /**
+     * @method updateIndicatorInCache
+     * @param {Number} datasrc id for datasource
+     * @param {String} indicatorId id for indicator. Note! For new indicators on guest users it's generated
+     */
+    updateIndicatorInCache: function (datasrc, indicatorId, data, callback) {
+        var me = this;
+        var updateMetadataCache = function () {
+            // only inject when guest user, otherwise flush from cache
+            var metadataCacheKey = me.getIndicatorMetadataKey(datasrc, indicatorId);
+            // flush/update indicator metadata from cache
+            var metadata = me.cache.get(metadataCacheKey) || {
+                'public': true,
+                'id': indicatorId,
+                'name': {},
+                'description': {},
+                'source': {},
+                'regionsets': [],
+                'selectors': []
+            };
+            metadata.name[Oskari.getLang()] = data.name;
+            metadata.description[Oskari.getLang()] = data.description;
+            metadata.source[Oskari.getLang()] = data.datasource;
+            me.cache.put(metadataCacheKey, metadata);
+            callback();
+        };
 
+        if (data.id) {
+            // existing indicator -> update it
+            this.service.getIndicatorList(datasrc, function (err, response) {
+                if (err) {
+                    callback(err);
+                    return;
+                }
+                var existingIndicator = response.indicators.find(function (ind) {
+                    return '' + ind.id === '' + data.id;
+                });
+                if (!existingIndicator) {
+                    callback('Tried saving an indicator with id, but id didn\'t match existing indicator');
+                    return;
+                }
+                // this probably updates the cache as well as mutable objects are being passed around
+                existingIndicator.name = data.name;
+                // possibly update "regionsets": [1851,1855] in listing cache
+                updateMetadataCache();
+            });
+        } else {
+            // new indicator
+            var indicatorListCacheKey = me.getIndicatorListKey(datasrc);
+            var cachedListResponse = me.cache.get(indicatorListCacheKey) || {
+                complete: true,
+                indicators: []
+            };
+            // only inject when guest user, otherwise flush from cache
+            cachedListResponse.indicators.push({
+                id: indicatorId,
+                name: data.name,
+                regionsets: []
+            });
+            me.cache.put(indicatorListCacheKey, cachedListResponse);
+            updateMetadataCache();
+        }
     },
     updateIndicatorDataCache: function () {
 

--- a/bundles/statistics/statsgrid2016/service/CacheHelper.js
+++ b/bundles/statistics/statsgrid2016/service/CacheHelper.js
@@ -1,0 +1,28 @@
+/**
+ * @class Oskari.statistics.statsgrid.CacheHelper
+ */
+Oskari.clazz.define('Oskari.statistics.statsgrid.CacheHelper', function (cache) {
+    this.cache = cache;
+}, {
+    getRegionsKey: function (regionset) {
+        return 'GetRegions_' + regionset;
+    },
+    getIndicatorListKey: function (datasrc) {
+        return 'GetIndicatorList_' + datasrc;
+    },
+    getIndicatorMetadataKey: function (datasrc, indicatorId) {
+        return 'GetIndicatorMetadata_' + datasrc + '_' + indicatorId;
+    },
+    getIndicatorDataKey: function (datasrc, indicatorId, selectors, regionset) {
+        var serialized = '';
+        if (typeof selectors === 'object') {
+            serialized = '_' + Object.keys(selectors).sort().map(function (key) {
+                return key + '=' + JSON.stringify(selectors[key]);
+            }).join(':');
+        }
+        return this.getIndicatorDataKeyPrefix(datasrc, indicatorId) + regionset + serialized;
+    },
+    getIndicatorDataKeyPrefix: function (datasrc, indicatorId) {
+        return 'GetIndicatorData_' + datasrc + '_' + indicatorId + '_';
+    }
+});

--- a/bundles/statistics/statsgrid2016/service/CacheHelper.js
+++ b/bundles/statistics/statsgrid2016/service/CacheHelper.js
@@ -115,6 +115,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.CacheHelper', function (cache, 
                     return item.id === selectorId;
                 });
                 if (!existingSelector) {
+                    // new selector -> add it with the only allowed value (the one we are inserting)
                     metadata.selectors.push({
                         id: selectorId,
                         name: selectorId,
@@ -124,10 +125,16 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.CacheHelper', function (cache, 
                         }]
                     });
                 } else {
+                    // there's an existing one, check if the value we are adding is new or not
                     var existingValue = existingSelector.allowedValues.find(function (item) {
-                        return '' + item.id === '' + selectorId;
+                        if (typeof item !== 'object') {
+                            // allowed value might be a simple value instead of an object
+                            return '' + item === '' + selectorValue;
+                        }
+                        return '' + item.id === '' + selectorValue;
                     });
                     if (!existingValue) {
+                        // only need to modify the values if it's a new value for the selector
                         existingSelector.allowedValues.push({
                             'name': selectorValue,
                             'id': selectorValue

--- a/bundles/statistics/statsgrid2016/service/CacheHelper.js
+++ b/bundles/statistics/statsgrid2016/service/CacheHelper.js
@@ -162,9 +162,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.CacheHelper', function (cache, 
         };
     },
     clearCacheOnDelete: function (datasrc, indicatorId, selectors, regionset) {
+        var metadataCacheKey = this.getIndicatorMetadataKey(datasrc, indicatorId);
         if (!selectors && !regionset) {
             // removed the whole indicator: flush indicator from cache
-
             this.cache.flushKeysStartingWith(this.getIndicatorDataKeyPrefix(datasrc, indicatorId));
             var indicatorListCacheKey = this.getIndicatorListKey(datasrc);
             var cachedListResponse = this.cache.get(indicatorListCacheKey) || {
@@ -179,10 +179,12 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.CacheHelper', function (cache, 
                 cachedListResponse.indicators.splice(listIndex, 1);
             }
             this.cache.put(indicatorListCacheKey, cachedListResponse);
-            var metadataCacheKey = this.getIndicatorMetadataKey(datasrc, indicatorId);
             this.cache.remove(metadataCacheKey);
-        } else {
-            // TODO: MODIFY indicator in caches
+        } else if (Oskari.user().isLoggedIn()) {
+            // flush the cache for logged in user so it gets reloaded from the server
+            // for guests this will show some erronous info, but it's a beast to track which
+            //  year/regionsets actually have data and can be removed
+            this.cache.remove(metadataCacheKey)
         }
     }
 });

--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -667,22 +667,24 @@
                 callback();
                 return;
             }
-
+            var me = this;
             jQuery.ajax({
                 type: 'POST',
                 dataType: 'json',
                 data: {
-                    // currently server only expects id, year and regionset, but for future proofing let's send all the data
-                    // TODO: change server to use datasource, id, selectors and regionset (remove year from params)
                     datasource: datasrc,
                     id: indicatorId,
                     selectors: JSON.stringify(selectors),
-                    year: selectors.year,
                     regionset: regionset
                 },
                 url: Oskari.urls.getRoute('DeleteIndicator'),
                 success: function (pResp) {
                     _log.info('DeleteIndicator', pResp);
+                    if (!selectors) {
+                        // if selectors/regionset is missing -> trigger a DatasourceEvent as the indicator listing changes
+                        var eventBuilder = Oskari.eventBuilder('StatsGrid.DatasourceEvent');
+                        me.sandbox.notifyAll(eventBuilder(datasrc));
+                    }
                     _cacheHelper.clearCacheOnDelete(datasrc, indicatorId, selectors, regionset);
                     callback();
                 },

--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -781,10 +781,39 @@
         /**
          * selectors and regionset are optional -> will only delete dataset from indicator if given
          */
-        deleteIndicator: function (datasrc, indicator, selectors, regionset, callback) {
-            // TODO: flush indicator from cache and call server
-            // "great success"
-            callback(null);
+        deleteIndicator: function (datasrc, indicatorId, selectors, regionset, callback) {
+            var clearCache = function () {
+                // TODO: flush indicator from cache
+            }
+            if (!Oskari.user().isLoggedIn()) {
+                // just flush cache
+                clearCache();
+                callback();
+                return;
+            }
+
+            jQuery.ajax({
+                type: 'POST',
+                dataType: 'json',
+                data: {
+                    // currently server only expects id, year and regionset, but for future proofing let's send all the data
+                    // TODO: change server to use datasource, id, selectors and regionset (remove year from params)
+                    datasource: datasrc,
+                    id: indicatorId,
+                    selectors: JSON.stringify(selectors),
+                    year: selectors.year,
+                    regionset: regionset
+                },
+                url: Oskari.urls.getRoute('DeleteIndicator'),
+                success: function (pResp) {
+                    _log.info('DeleteIndicator', pResp);
+                    clearCache();
+                    callback();
+                },
+                error: function (jqXHR, textStatus) {
+                    callback('Error on server');
+                }
+            });
         }
     }, {
         'protocol': ['Oskari.mapframework.service.Service']

--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -3,12 +3,13 @@
  */
 (function (Oskari) {
     var _log = Oskari.log('StatsGrid.StatisticsService');
-    var _cacheHelper = Oskari.clazz.create('Oskari.statistics.statsgrid.CacheHelper');
+    var _cache = Oskari.clazz.create('Oskari.statistics.statsgrid.Cache');
+    var _cacheHelper = Oskari.clazz.create('Oskari.statistics.statsgrid.CacheHelper', _cache);
 
     Oskari.clazz.define('Oskari.statistics.statsgrid.StatisticsService', function (sandbox, locale) {
         this.sandbox = sandbox;
         this.locale = locale;
-        this.cache = Oskari.clazz.create('Oskari.statistics.statsgrid.Cache');
+        this.cache = _cache;
         this.state = Oskari.clazz.create('Oskari.statistics.statsgrid.StateService', sandbox);
         this.colors = Oskari.clazz.create('Oskari.statistics.statsgrid.ColorService');
         this.classification = Oskari.clazz.create('Oskari.statistics.statsgrid.ClassificationService', this.colors);

--- a/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
@@ -82,7 +82,11 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
                 ind.regionsets.forEach(function (regionset) {
                     sel.allowedValues.forEach(function (value) {
                         var data = {};
-                        data[sel.id] = value.id;
+                        if (typeof value === 'object') {
+                            data[sel.id] = value.id;
+                        } else {
+                            data[sel.id] = value;
+                        }
                         data.regionset = regionset;
                         datasets.push(data);
                     });

--- a/packages/statistics/statsgrid/bundle.js
+++ b/packages/statistics/statsgrid/bundle.js
@@ -48,6 +48,9 @@ Oskari.clazz.define("Oskari.statistics.statsgrid.StatsGridBundle",
                 "src": "../../../bundles/statistics/statsgrid2016/service/Cache.js"
             }, {
                 "type": "text/javascript",
+                "src": "../../../bundles/statistics/statsgrid2016/service/CacheHelper.js"
+            }, {
+                "type": "text/javascript",
                 "src": "../../../bundles/statistics/statsgrid2016/components/IndicatorSelection.js"
             }, {
                 "type": "text/javascript",


### PR DESCRIPTION
- Added save, saveData and delete operations that actually call the server
- Moved lots of code dealing with StatisticsService cache out of the service and in to a new CacheHelper
- Disables indicator edit-button if there's more than one indicator selected
- Also fixes an issue where the indicator id for editing was an array
- Also fixes an issue where an allowed value for a an indicator parameter wasn't an object with id and name/UI-label, but only the value (like year)
- Some usability improvements like focusing on the fields the user is expected to fill after clicking a button

Note! This requires a matching oskari-server PR to function properly so don't merge before it's submitted (will link it next week).