### PR TITLE
3D view bug fixes: Zoomlevels, map state reset, minified build.

### DIFF
--- a/bundles/framework/mapfull/instance.js
+++ b/bundles/framework/mapfull/instance.js
@@ -401,16 +401,16 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
          *
          */
         setState: function (state, ignoreLocation) {
-            var me = this,
-                mapmodule = me.getMapModule(),
-                mapModuleName = mapmodule.getName(),
-                rbAdd,
-                len,
-                i,
-                layer,
-                sandbox =  me.getSandbox(),
-                rbOpacity = Oskari.requestBuilder('ChangeMapLayerOpacityRequest'),
-                rbVisible = Oskari.requestBuilder('MapModulePlugin.MapLayerVisibilityRequest');
+            var me = this;
+            var mapmodule = me.getMapModule();
+            var mapModuleName = mapmodule.getName();
+            var rbAdd;
+            var len;
+            var i;
+            var layer;
+            var sandbox = me.getSandbox();
+            var rbOpacity = Oskari.requestBuilder('ChangeMapLayerOpacityRequest');
+            var rbVisible = Oskari.requestBuilder('MapModulePlugin.MapLayerVisibilityRequest');
 
             me._teardownState(mapmodule);
 
@@ -424,6 +424,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
                         state.zoom
                     );
                 }
+                // set 3D camera position
                 if (state.hasOwnProperty('camera')) {
                     try {
                         mapmodule.setCamera(state.camera);
@@ -445,7 +446,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
                     layer = state.selectedLayers[i];
 
                     var oskariLayer = me.getSandbox().findMapLayerFromAllAvailable(layer.id);
-                    if(oskariLayer) {
+                    if (oskariLayer) {
                         oskariLayer.setVisible(!layer.hidden);
                     }
                     sandbox.request(

--- a/bundles/framework/statehandler/state-methods.js
+++ b/bundles/framework/statehandler/state-methods.js
@@ -55,11 +55,16 @@ Oskari.clazz.category('Oskari.mapframework.bundle.statehandler.StateHandlerBundl
         if (startupState) {
             me.useState(startupState);
         } else {
+            var data = {
+                uuid: Oskari.app.getUuid(),
+                noSavedState: true
+            }
             jQuery.ajax({
-                dataType: "json",
-                type: "GET",
+                dataType: 'json',
+                data: data,
+                type: 'GET',
                 // noSavedState=true parameter tells we dont want the state saved in session
-                url: me.sandbox.getAjaxUrl() + 'action_route=GetAppSetup&noSavedState=true',
+                url: Oskari.urls.getRoute('GetAppSetup'),
                 success: function (data) {
                     if (data && data.configuration) {
                         me._setStartupState(data.configuration);

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -384,7 +384,7 @@ Oskari.clazz.define(
         _setZoomLevelImpl: Oskari.AbstractFunc('_setZoomLevelImpl'),
         /* --------- /Impl specific - PRIVATE ----------------------------> */
 
-        /* Impl specific - found in ol2 AND ol3 modules BUT parameters and/or return value differ!!
+        /* Impl specific - found in ol2, ol3 and olCesium modules BUT parameters and/or return value differ!!
 ------------------------------------------------------------------> */
         addLayer: Oskari.AbstractFunc('addLayer'),
         removeLayer: Oskari.AbstractFunc('removeLayer'),
@@ -394,6 +394,9 @@ Oskari.clazz.define(
         _addMapControlImpl: Oskari.AbstractFunc('_addMapControlImpl(ctl)'),
         _removeMapControlImpl: Oskari.AbstractFunc('_removeMapControlImpl(ctl)'),
         getStyle: Oskari.AbstractFunc('getStyle'),
+        set3dEnabled: Oskari.AbstractFunc('set3dEnabled'),
+        getCamera: Oskari.AbstractFunc('getCamera'),
+        setCamera: Oskari.AbstractFunc('setCamera'),
         /* --------- /Impl specific - PARAM DIFFERENCES  ----------------> */
 
         /* ---------------- SHARED FUNCTIONS --------------- */
@@ -785,6 +788,7 @@ Oskari.clazz.define(
             return layerResolutions;
         },
         /* --------------- /MAP ZOOM ------------------------ */
+
 
         /* --------------- MAP STATE ------------------------ */
 

--- a/packages/paikkatietoikkuna/bundle/mapmodule/bundle.js
+++ b/packages/paikkatietoikkuna/bundle/mapmodule/bundle.js
@@ -34,21 +34,6 @@ Oskari.clazz.define(
                     "src": "../../../../libraries/Proj4js/proj4js-2.2.1/proj4-src.js"
                 },
                 /*
-                 * Cesium
-                 */
-                {
-                    "type": "text/javascript",
-                    "expose" : "Cesium",
-                    "src": "../../../../libraries/ol-cesium/Cesium/Cesium.js"
-                },
-                /*
-                 * Ol-Cesium
-                 */
-                {
-                    "type": "text/javascript",
-                    "src": "../../../../libraries/ol-cesium/olcesium.js"
-                },
-                /*
                  * Abstract base
                  */
                 {


### PR DESCRIPTION
Blocks: https://github.com/nls-oskari/kartta.paikkatietoikkuna.fi/pull/33
Removes 3D libraries from Oskari-packages. 3D libraries will be loaded directly from the index page.

Fixes an issue where zoom bar stopped responding, when zoomed outside ol zoom levels in 3D view.
Fixes map state reset functionality by resetting the state to originally loaded map state using view uuid.
Small coding convention fixes.