### PR TITLE
FileInput component refactoring

### DIFF
--- a/bundles/framework/divmanazer/component/FileInput.js
+++ b/bundles/framework/divmanazer/component/FileInput.js
@@ -36,8 +36,8 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
                 '<input type="file" class="basic__file" accept="<%= allowedFiles %>" <%= allowMultiple %> />' +
             '</div>')
     }
-    this.isAdvancedUpload = this.canUseAdvancedUpload();
-    this.createUi();
+    this.isAdvancedUpload = this._canUseAdvancedUpload();
+    this._createUi();
 }, {
         getElement: function () {
             return this.element;
@@ -52,21 +52,21 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
             this.options = options;
         },
         /**
-         * @method canUseAdvancedUpload
+         * @method _canUseAdvancedUpload
          *
          * Checks if the browser supports drag and drop events aswell as formdata & filereader
          * @return {boolean} true if supported 
          */
-        canUseAdvancedUpload: function() {
+        _canUseAdvancedUpload: function() {
             var div = document.createElement('div');
             return ( ('draggable' in div) || ('ondragstart' in div && 'ondrop' in div) )
                         && 'FormData' in window && 'FileReader' in window;
          },
         /**
-         * @method bindAdvancedUpload
+         * @method _bindAdvancedUpload
          * Checks for drag and drop events and select
          */
-        bindAdvancedUpload: function() {
+        _bindAdvancedUpload: function() {
             var me = this;
             var elem = this.getElement();
             var link = elem.find('a');
@@ -84,7 +84,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
                 elem.removeClass('is-dragover');
             })
             .on('drop', function(e) {
-                me.handleFileList(e.originalEvent.dataTransfer.files);
+                me._handleFileList(e.originalEvent.dataTransfer.files);
             });
 
             link.click(function(){
@@ -92,7 +92,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
             });
 
             input.change(function(e){
-                me.handleFileList(e.target.files);
+                me._handleFileList(e.target.files);
             });
 
             /*
@@ -114,15 +114,15 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
             this.setElement( form.parent() );
             */
         },
-        bindBasicUpload: function() {
+        _bindBasicUpload: function() {
             var me = this;
             var elem = this.getElement();
             var input = elem.find('input[type="file"]');
             input.change(function(e){
-                me.handleFileList(e.target.files);
+                me._handleFileList(e.target.files);
             });
         },
-        handleFileList: function (fileList){
+        _handleFileList: function (fileList){
             var me = this;
             var opts = this.options;
             var files = fileList;
@@ -131,7 +131,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
             if (opts.allowMultipleFiles === true){
                 Object.keys( files ).forEach( function ( key ) {
                     file = files[key];
-                    if (me.validateFile(file) === true){
+                    if (me._validateFile(file) === true){
                         me.files.push(file);
                     } else {
                         //TODO or keep valid files
@@ -141,10 +141,10 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
                 });
             } else {
                 if (files.length > 1){
-                    this.showPopup(this.loc('fileInput.error'),this.loc('fileInput.multipleNotAllowed'));
+                    this._showPopup(this.loc('fileInput.error'),this.loc('fileInput.multipleNotAllowed'));
                 } else {
                     file = files[0];
-                    if (file && this.validateFile(file) === true){
+                    if (file && this._validateFile(file) === true){
                         this.files = [file];
                     } else {
                         this.files = [];
@@ -152,10 +152,10 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
                 }
             }
             if (this.isAdvancedUpload){
-                this.updateFileList();
+                this._updateFileList();
             }
         },
-        updateFileList: function (){
+        _updateFileList: function (){
             var fileNameElem = this.getElement().find('.box__uploaded');
             var files = this.files;
 
@@ -165,18 +165,18 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
 
             fileNameElem.text(fileNames);
         },
-        validateFile: function (file){
+        _validateFile: function (file){
             var valid = true;
             var opts = this.options;
             //if allowed file type is defined and not empty list then check that file type is allowed
             if (opts.allowedFileTypes && opts.allowedFileTypes.length !==0 && !opts.allowedFileTypes.includes(file.type)){
                 valid = false;
-                this.showPopup(this.loc('fileInput.error'), this.loc('fileInput.invalidType'));
+                this._showPopup(this.loc('fileInput.error'), this.loc('fileInput.invalidType'));
             }
             //if max file size is defined check that file isn't too large
             if (opts.maxFileSize && file.size > opts.maxFileSize * 1048576){
                 valid = false;
-                this.showPopup(this.loc('fileInput.error'), this.loc('fileInput.fileSize', {size: opts.maxFileSize}));
+                this._showPopup(this.loc('fileInput.error'), this.loc('fileInput.fileSize', {size: opts.maxFileSize}));
             }
             return valid;
         },
@@ -184,7 +184,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
             var files = this.files;
             var opts = this.options;
             if (files.length === 0){
-                this.showPopup(this.loc('fileInput.error'), this.loc('fileInput.noFiles'));
+                this._showPopup(this.loc('fileInput.error'), this.loc('fileInput.noFiles'));
                 return null;
             } else if (opts.allowMultipleFiles !== true) {
                 return files[0]; //or should we use getFile() for single file (allowMultiple false)
@@ -196,7 +196,8 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
          * @method readFilesInBrowser
          * Checks for drag and drop events, on submit makes ajax request
          */
-        readFilesInBrowser: function ( files, cb ) {
+         //TODO do we need this??
+        _readFilesInBrowser: function ( files, cb ) {
             var files = files; // FileList object
 
             for (var i = 0, f; f = files[i]; i++) {
@@ -216,8 +217,8 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
          * @method create
          * Creates the element for handlign drag and drop
          */
-        createUi: function() {
-            var allowedFiles = this.getAcceptedTypesString();
+        _createUi: function() {
+            var allowedFiles = this._getAcceptedTypesString();
             var fileInput;
             var fileUpload;
             var opts = this.options;
@@ -243,7 +244,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
                     error: this.loc('fileInput.error')
                 }));
                 this.setElement(fileInput);
-                this.bindAdvancedUpload();
+                this._bindAdvancedUpload();
             } else {
                 fileInput = jQuery(this._template.basicInput({
                     classes: "oskari-fileinput basic-upload",
@@ -251,10 +252,10 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
                     allowedFiles: allowedFiles
                 }));
                 this.setElement(fileInput);
-                this.bindBasicUpload(fileInput);
+                this._bindBasicUpload(fileInput);
             }
         },
-        getAcceptedTypesString: function (){
+        _getAcceptedTypesString: function (){
             var allowedFiles = this.options.allowedFileTypes;
             var accepted = "";
             if (allowedFiles && allowedFiles.length > 0){
@@ -289,7 +290,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
                 document.body.removeChild(elem);
             }
         },*/
-        showPopup: function (title, msg){
+        _showPopup: function (title, msg){
             var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup'),
                 btn = dialog.createCloseButton(this.loc('buttons.close'));
             dialog.show(title, msg, [btn]);

--- a/bundles/framework/divmanazer/component/FileInput.js
+++ b/bundles/framework/divmanazer/component/FileInput.js
@@ -3,28 +3,53 @@
  * Simple file uploading component
  * Call create to create element and with getElement reference the element.
  */
-Oskari.clazz.define('Oskari.userinterface.component.FileInput', function () {
+Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (options) {
     this.loc = Oskari.getMsg.bind(null, 'DivManazer');
-    this.el = null;
-    this._template = {
-        fileBox: _.template('<div class="oskari-fileinput" style="display:none"> '+
-                    '<form method="post" action="" enctype="multipart/form-data" class="box">'+
-                        '<div class="box__input">'+
-                            '<input type="file" class="box__file" />'+
-                            '<label>  <%= fileupload %> <label for="file" style="cursor: pointer;"> <a> <%= link %> </a> </label> </label> '+
-                        '</div>'+
-                        '<div class="box__uploading"> <%= uploading %>&hellip;</div>'+
-                        '<div class="box__success"><%= success %></div>'+
-                        '<div class="box__error"><%= error %></div>'+
-                    '</form>' +
-                '</div>')
+    this.element = null;
+    this.files = [];
+    this.options = options || {
+        'allowMultipleFiles': false,
+        'maxFileSize': 10, //MB
+        'allowedFileTypes': [] // all types
     }
+    this.visible = true;
+
+    this._template = {
+        fileBox: _.template('<div class="<%= classes %>"> '+
+                    //'<form method="post" action="" enctype="multipart/form-data" class="box">'+
+                        '<div class="box__input">'+
+                            '<input type="file" class="box__file" accept="<%= allowedFiles %>" />'+
+                            '<label><%= fileupload %> ' +
+                                //'<label for="file" style="cursor: pointer;">' +
+                                '<a href="javascript:void(0);"><%= link %></a>' +
+                                //'</label>' +
+                            '</label> '+
+                        '</div>'+
+                        '<div class="box__uploaded"></div>'+
+                        //'<div class="box__uploading"> <%= uploading %>&hellip;</div>'+
+                        //'<div class="box__success"><%= success %></div>'+
+                        //'<div class="box__error"><%= error %></div>'+
+                    //'</form>' +
+                '</div>'),
+        basicInput: _.template(
+            '<div class="<%= classes %>">' +
+                '<input type="file" class="basic__file" accept="<%= allowedFiles %>" <%= allowMultiple %> />' +
+            '</div>')
+    }
+    this.isAdvancedUpload = this.canUseAdvancedUpload();
+    this.createUi();
 }, {
         getElement: function () {
-            return this.el;
+            return this.element;
         },
         setElement: function ( el ) {
-            this.el = jQuery(el);
+            this.element = el;
+        },
+        getOptions: function (){
+            return this.options;
+        },
+        setOptions: function (){
+            this.options = options;
         },
         /**
          * @method canUseAdvancedUpload
@@ -38,40 +63,47 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function () {
                         && 'FormData' in window && 'FileReader' in window;
          },
         /**
-         * @method handleDragAndDrop
-         * Checks for drag and drop events, on submit makes ajax request
+         * @method bindAdvancedUpload
+         * Checks for drag and drop events and select
          */
-        handleDragAndDrop: function( cb ) {
+        bindAdvancedUpload: function() {
             var me = this;
-            var form = this.getElement().find('.box');
-            var input = form.find('input[type="file"]');
-            form.addClass('has-advanced-upload');
-            var droppedFiles = false;
+            var elem = this.getElement();
+            var link = elem.find('a');
+            var input = elem.find('input[type="file"]');
+            var fileNameElem = elem.find('.box__uploaded');
 
-            form.on('drag dragstart dragend dragover dragenter dragleave drop', function(e) {
+            elem.on('drag dragstart dragend dragover dragenter dragleave drop', function(e) {
                 e.preventDefault();
                 e.stopPropagation();
             })
             .on('dragover dragenter', function() {
-                form.addClass('is-dragover');
+                elem.addClass('is-dragover');
             })
             .on('dragleave dragend drop', function() {
-                form.removeClass('is-dragover');
+                elem.removeClass('is-dragover');
             })
             .on('drop', function(e) {
-                droppedFiles = e.originalEvent.dataTransfer.files;
-                me.readFilesInBrowser( droppedFiles, cb );
+                me.handleFileList(e.originalEvent.dataTransfer.files);
             });
-            
 
-            form.on('submit', function(e) {
+            link.click(function(){
+                input.trigger('click');
+            });
+
+            input.change(function(e){
+                me.handleFileList(e.target.files);
+            });
+
+            /*
+            elem.on('submit', function(e) {
                 if (form.hasClass('is-uploading')) return false;
 
                 form.addClass('is-uploading').removeClass('is-error');
 
                 e.preventDefault();
 
-                var ajaxData = new FormData(form.get(0));
+                //var ajaxData = new FormData(form.get(0));
 
                 if ( droppedFiles ) {
                     jQuery.each( droppedFiles, function(i, file) {
@@ -80,7 +112,90 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function () {
                 }
             });
             this.setElement( form.parent() );
-            return this.getElement();
+            */
+        },
+        bindBasicUpload: function() {
+            var me = this;
+            var elem = this.getElement();
+            var input = elem.find('input[type="file"]');
+            input.change(function(e){
+                me.handleFileList(e.target.files);
+            });
+        },
+        handleFileList: function (fileList){
+            var me = this;
+            var opts = this.options;
+            var files = fileList;
+            var file;
+
+            if (opts.allowMultipleFiles === true){
+                Object.keys( files ).forEach( function ( key ) {
+                    file = files[key];
+                    if (me.validateFile(file) === true){
+                        me.files.push(file);
+                    } else {
+                        //TODO or keep valid files
+                        me.files = [];
+                        return;
+                    }
+                });
+            } else {
+                if (files.length > 1){
+                    this.showPopup(this.loc('fileInput.error'),this.loc('fileInput.multipleNotAllowed'));
+                } else {
+                    file = files[0];
+                    if (file && this.validateFile(file) === true){
+                        this.files = [file];
+                    } else {
+                        this.files = [];
+                    }
+                }
+            }
+            if (this.isAdvancedUpload){
+                this.updateFileList();
+            }
+        },
+        updateFileList: function (){
+            var fileNameElem = this.getElement().find('.box__uploaded');
+            var fileNames;
+            var files = this.files;
+            if (files.length === 0){
+                fileNameElem.text("");
+            } else {
+                fileNames = files[0].name;
+                for (var i = 1; i < files.length; i++){
+                    fileNames += ", " + files[i].name;
+                }
+                fileNameElem.text(fileNames);
+            }
+        },
+        validateFile: function (file){
+            var valid = true;
+            var opts = this.options;
+            var maxFileSi
+            //if allowed file type is defined and not empty list then check that file type is allowed
+            if (opts.allowedFileTypes && opts.allowedFileTypes.length !==0 && !opts.allowedFileTypes.includes(file.type)){
+                valid = false;
+                this.showPopup(this.loc('fileInput.error'), this.loc('fileInput.invalidType'));
+            }
+            //if max file size is defined check that file isn't too large
+            if (opts.maxFileSize && file.size > opts.maxFileSize * 1048576){
+                valid = false;
+                this.showPopup(this.loc('fileInput.error'), this.loc('fileInput.fileSize', {size: opts.maxFileSize}));
+            }
+            return valid;
+        },
+        getFiles: function (){
+            var files = this.files;
+            var opts = this.options;
+            if (files.length === 0){
+                this.showPopup(this.loc('fileInput.error'), this.loc('fileInput.noFiles'));
+                return null;
+            } else if (opts.allowMultipleFiles !== true) {
+                return files[0]; //or should we use getFile() for single file (allowMultiple false)
+            } else {
+                return files;
+            }
         },
         /**
          * @method readFilesInBrowser
@@ -99,7 +214,6 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function () {
                         cb( fileContent );
                     };
                 })(f);
-
                 reader.readAsText(f);
             }
         },
@@ -107,19 +221,67 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function () {
          * @method create
          * Creates the element for handlign drag and drop
          */
-        create: function() {
-            var fileinput = this._template.fileBox({ link: this.loc('fileInput').link,
-                                                    fileupload: this.loc('fileInput').fileupload,
-                                                    uploading: this.loc('fileInput').uploading,
-                                                    success: this.loc('fileInput').success,
-                                                    error: this.loc('fileInput').error });
-            this.setElement(fileinput);
+        createUi: function() {
+            var allowedFiles = this.getAcceptedTypesString();
+            var classes;
+            var fileInput;
+            var fileUpload;
+            var opts = this.options;
+            var allowMultiple;
 
-            // if( this.canUseAdvancedUpload ) {
-            //     this.handleDragAndDrop( fileinput );
-            // }
-            // return this.getElement();
+            if (opts.allowMultipleFiles === true ){
+                allowMultiple = "multiple";
+                fileUpload = this.loc('fileInput.fileUpload', {files: 2});
+            } else {
+                allowMultiple = "";
+                fileUpload = this.loc('fileInput.fileUpload', {files: 1});
+            }
+
+            if (this.isAdvancedUpload){
+                classes = "oskari-fileinput advanced-upload";
+                fileInput = jQuery(this._template.fileBox({
+                    link: this.loc('fileInput.link'),
+                    allowedFiles: allowedFiles,
+                    classes: classes,
+                    fileupload: fileUpload,
+                    allowMultiple: allowMultiple,
+                    uploading: this.loc('fileInput.uploading'),
+                    success: this.loc('fileInput.success'),
+                    error: this.loc('fileInput.error')
+                }));
+                this.setElement(fileInput);
+                this.bindAdvancedUpload();
+            } else {
+                classes = "oskari-fileinput basic-upload"
+                fileInput = jQuery(this._template.basicInput({
+                    classes: classes,
+                    allowMultiple: allowMultiple,
+                    allowedFiles: allowedFiles
+                }));
+                this.setElement(fileInput);
+                this.bindBasicUpload(fileInput);
+            }
         },
+        getAcceptedTypesString: function (){
+            var allowedFiles = this.options.allowedFileTypes;
+            var accepted = "";
+            if (allowedFiles && allowedFiles.length > 0){
+                accepted = allowedFiles[0];
+                for (var i = 1 ; i < allowedFiles.length; i++){
+                    accepted += "," + allowedFiles[i];
+                }
+            }
+            return accepted;
+        },
+        setVisible: function (visible) {
+            var elem = this.getElement();
+            if (visible === false){
+                elem.css("display", "none");
+            } else {
+                elem.css("display", "");
+            }
+        },
+        /* Do we need this??
         exportToFile: function ( data, filename ) {
             var me = this;
             var blob = new Blob([data], {type: 'text'});
@@ -134,7 +296,11 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function () {
                 elem.click();        
                 document.body.removeChild(elem);
             }
+        },*/
+        showPopup: function (title, msg){
+            var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup'),
+                btn = dialog.createCloseButton(this.loc('buttons.close'));
+            dialog.show(title, msg, [btn]);
         }
 }, {
-
 });

--- a/bundles/framework/divmanazer/component/FileInput.js
+++ b/bundles/framework/divmanazer/component/FileInput.js
@@ -157,22 +157,17 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
         },
         updateFileList: function (){
             var fileNameElem = this.getElement().find('.box__uploaded');
-            var fileNames;
             var files = this.files;
-            if (files.length === 0){
-                fileNameElem.text("");
-            } else {
-                fileNames = files[0].name;
-                for (var i = 1; i < files.length; i++){
-                    fileNames += ", " + files[i].name;
-                }
-                fileNameElem.text(fileNames);
-            }
+
+            var fileNames = files.map(function (file) {
+                return file.name;
+            }).join(', ');
+
+            fileNameElem.text(fileNames);
         },
         validateFile: function (file){
             var valid = true;
             var opts = this.options;
-            var maxFileSi
             //if allowed file type is defined and not empty list then check that file type is allowed
             if (opts.allowedFileTypes && opts.allowedFileTypes.length !==0 && !opts.allowedFileTypes.includes(file.type)){
                 valid = false;
@@ -223,7 +218,6 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
          */
         createUi: function() {
             var allowedFiles = this.getAcceptedTypesString();
-            var classes;
             var fileInput;
             var fileUpload;
             var opts = this.options;
@@ -238,11 +232,10 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
             }
 
             if (this.isAdvancedUpload){
-                classes = "oskari-fileinput advanced-upload";
                 fileInput = jQuery(this._template.fileBox({
                     link: this.loc('fileInput.link'),
                     allowedFiles: allowedFiles,
-                    classes: classes,
+                    classes: "oskari-fileinput advanced-upload",
                     fileupload: fileUpload,
                     allowMultiple: allowMultiple,
                     uploading: this.loc('fileInput.uploading'),
@@ -252,9 +245,8 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
                 this.setElement(fileInput);
                 this.bindAdvancedUpload();
             } else {
-                classes = "oskari-fileinput basic-upload"
                 fileInput = jQuery(this._template.basicInput({
-                    classes: classes,
+                    classes: "oskari-fileinput basic-upload",
                     allowMultiple: allowMultiple,
                     allowedFiles: allowedFiles
                 }));

--- a/bundles/framework/divmanazer/resources/css/fileinput.css
+++ b/bundles/framework/divmanazer/resources/css/fileinput.css
@@ -6,36 +6,31 @@
 	position: absolute;
 	z-index: -1;
 }
-.oskari-fileinput .box__file + label {
-    margin-top:2%;
-    margin-left:3%;
+.oskari-fileinput .box__input {
+    /*margin-top:2%;
+    margin-left:3%;*/
     font-size: 1em;
     font-weight: 700;
     display: inline-block;
 }
-.oskari-fileinput .box__input {
-    height:4em;
-}
-
-.oskari-fileinput.box__file:focus + label,
-.box__dragndrop,
 .box__uploading,
 .box__success,
 .box__error {
   display: none;
 }
-
-.box.has-advanced-upload {
+.oskari-fileinput.advanced-upload {
   background-color: white;
-   outline: 1px dashed lavender; 
-   outline-offset: -10px; 
+  outline: 1px dashed lavender;
+  outline-offset: -5px;
+  padding: 10px 15px 10px;
+  min-height: 3em;
 }
-.box.has-advanced-upload .box__dragndrop {
-  display: inline;
+.oskari-fileinput.is-dragover {
+  background-color: #fdf8d9;
 }
-.box.is-uploading .box__input {
+.oskari-fileinput.is-uploading .box__input {
   visibility: none;
 }
-.box.is-uploading .box__uploading {
+.oskari-fileinput.is-uploading .box__uploading {
   display: block;
 }

--- a/bundles/framework/divmanazer/resources/locale/en.js
+++ b/bundles/framework/divmanazer/resources/locale/en.js
@@ -334,11 +334,15 @@ Oskari.registerLocalization(
             }
         },
         "fileInput": {
-                "fileupload": "Drag a file here or",
-                "link":"select by browsing",
-                "uploading":"Loading",
-                "success":"Sucess",
-                "error":"Error!",
+            "fileUpload": "Drag {files, plural, one {a file} other {files}} here or",
+            "link":"select by browsing",
+            "uploading":"Loading",
+            "success":"Sucess",
+            "error":"Error!",
+            "invalidType": "File format is not allowed.",
+            "multipleNotAllowed": "Only single file is allowed to be uploaded.",
+            "fileSize": "The selected file is too large. It can be at most {size, number} Mb.",
+            "noFiles": "No file selected"
         }
     }
 });

--- a/bundles/framework/divmanazer/resources/locale/en.js
+++ b/bundles/framework/divmanazer/resources/locale/en.js
@@ -335,14 +335,14 @@ Oskari.registerLocalization(
         },
         "fileInput": {
             "fileUpload": "Drag {files, plural, one {a file} other {files}} here or",
-            "link":"select by browsing",
+            "link":"select by browsing.",
             "uploading":"Loading",
             "success":"Sucess",
             "error":"Error!",
             "invalidType": "File format is not allowed.",
             "multipleNotAllowed": "Only single file is allowed to be uploaded.",
             "fileSize": "The selected file is too large. It can be at most {size, number} Mb.",
-            "noFiles": "No file selected"
+            "noFiles": "No file selected."
         }
     }
 });

--- a/bundles/framework/divmanazer/resources/locale/fi.js
+++ b/bundles/framework/divmanazer/resources/locale/fi.js
@@ -335,7 +335,7 @@ Oskari.registerLocalization(
         },
         "fileInput": {
             "fileUpload": "Raahaa {files, plural, one {tiedosto} other {tiedostot}} tähän tai",
-            "link":"valitse selaamalla",
+            "link":"valitse selaamalla.",
             "uploading":"Ladataan",
             "success":"Valmis",
             "error":"Virhe!",

--- a/bundles/framework/divmanazer/resources/locale/fi.js
+++ b/bundles/framework/divmanazer/resources/locale/fi.js
@@ -334,11 +334,15 @@ Oskari.registerLocalization(
             }
         },
         "fileInput": {
-            "fileupload": "Raahaa lähtöaineiston sisältävä tiedosto tähän tai",
+            "fileUpload": "Raahaa {files, plural, one {tiedosto} other {tiedostot}} tähän tai",
             "link":"valitse selaamalla",
             "uploading":"Ladataan",
             "success":"Valmis",
             "error":"Virhe!",
+            "invalidType": "Tiedostomuoto ei ole sallittu.",
+            "multipleNotAllowed": "Anna vain yksi tiedosto.",
+            "fileSize": "Tiedoston koko on liian suuri. Suurin sallittu koko yksittäiselle tiedostolle on {size, number} Mt.",
+            "noFiles": "Ei tiedostoja."
         }
     }
 });

--- a/bundles/framework/divmanazer/resources/locale/sv.js
+++ b/bundles/framework/divmanazer/resources/locale/sv.js
@@ -320,11 +320,15 @@ Oskari.registerLocalization(
             }
         },
         "fileInput": {
-            "fileupload": "Raahaa lähtöaineiston sisältävä tiedosto tähän tai",
-            "link":"valitse selaamalla",
-            "uploading":"Ladataan",
-            "success":"Valmis",
-            "error":"Virhe!",
+            "fileUpload": "Drag {files, plural, one {a file} other {files}} here or",
+            "link":"select by browsing",
+            "uploading":"Loading",
+            "success":"Sucess",
+            "error":"Error!",
+            "invalidType": "Filformat är inte tillåtet.",
+            "multipleNotAllowed": "Only single file is allowed to be uploaded.",
+            "fileSize": "Den valda filen är för stor. Den högsta tillåtna storleken är {size, number} Mb.",
+            "noFiles": "Ingen fil vald"
         }
     }
 });

--- a/bundles/framework/divmanazer/resources/locale/sv.js
+++ b/bundles/framework/divmanazer/resources/locale/sv.js
@@ -320,15 +320,15 @@ Oskari.registerLocalization(
             }
         },
         "fileInput": {
-            "fileUpload": "Drag {files, plural, one {a file} other {files}} here or",
-            "link":"select by browsing",
-            "uploading":"Loading",
-            "success":"Sucess",
-            "error":"Error!",
-            "invalidType": "Filformat är inte tillåtet.",
-            "multipleNotAllowed": "Only single file is allowed to be uploaded.",
+            "fileUpload": "Dra {files, plural, one {fil} other {filerna}} hit, eller",
+            "link":"välj genom att bläddra.",
+            "uploading":"Laddar",
+            "success":"Lyckades",
+            "error":"Fel!",
+            "invalidType": "Filformatet är inte tillåtet.",
+            "multipleNotAllowed": "Endast en fil kan laddas upp.",
             "fileSize": "Den valda filen är för stor. Den högsta tillåtna storleken är {size, number} Mb.",
-            "noFiles": "Ingen fil vald"
+            "noFiles": "Ingen fil vald."
         }
     }
 });


### PR DESCRIPTION
Now FileInput component is more general implementation.

Component makes drag & drop file input box if user's browser supports it. If browser doesn't support then makes basic file input element. Selected or dropped file(s) can be retrieved by getFiles() which now shows error message if there is no files or returns [files] (allow multiple) or file.

Options: allowMultipleFiles (default false), maxFileSize (default 10), allowedFileTypes (default all).