### PR TITLE
Coordinate transformation file handling

### DIFF
--- a/bundles/framework/divmanazer/component/FileInput.js
+++ b/bundles/framework/divmanazer/component/FileInput.js
@@ -257,14 +257,16 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function (option
         },
         _getAcceptedTypesString: function (){
             var allowedFiles = this.options.allowedFileTypes;
-            var accepted = "";
-            if (allowedFiles && allowedFiles.length > 0){
-                accepted = allowedFiles[0];
-                for (var i = 1 ; i < allowedFiles.length; i++){
-                    accepted += "," + allowedFiles[i];
-                }
+            var acceptedTypes;
+            if (Array.isArray(allowedFiles)){
+                acceptedTypes = allowedFiles.map(function (type) {
+                    return type;
+                }).join(',');
+            } else {
+                //if not defined in option, accept all
+                acceptedTypes = "";
             }
-            return accepted;
+            return acceptedTypes;
         },
         setVisible: function (visible) {
             var elem = this.getElement();

--- a/bundles/framework/divmanazer/component/FileInput.js
+++ b/bundles/framework/divmanazer/component/FileInput.js
@@ -120,9 +120,10 @@ Oskari.clazz.define('Oskari.userinterface.component.FileInput', function () {
             // }
             // return this.getElement();
         },
-        exportToFile: function ( data, filename ) {
+        //TODO should these be in different place
+        exportToFile: function ( data, filename, type ) {
             var me = this;
-            var blob = new Blob([data], {type: 'text'});
+            var blob = new Blob([data], {type: type});
             if( window.navigator.msSaveOrOpenBlob ) {
                 window.navigator.msSaveBlob(blob, filename);
             }

--- a/bundles/framework/divmanazer/component/SelectList.js
+++ b/bundles/framework/divmanazer/component/SelectList.js
@@ -117,7 +117,6 @@ Oskari.clazz.define('Oskari.userinterface.component.SelectList', function (id) {
         if (enableFlag) {
             chosen.prop('disabled', false);
         } else {
-            this.resetToPlaceholder();
             chosen.prop('disabled', true);
         }
         chosen.trigger('chosen:updated');

--- a/bundles/mapping/mapmodule/mapmodule.ol2.js
+++ b/bundles/mapping/mapmodule/mapmodule.ol2.js
@@ -356,6 +356,11 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.MapModule',
                 return a.getZIndex()-b.getZIndex();
             });
         },
+        isPointInExtent: function (extent, x, y){
+            var extent = new OpenLayers.Bounds(extent);
+            return extent.contains(x,y);
+        },
+
 /* --------- /Impl specific --------------------------------------> */
 
 

--- a/bundles/mapping/mapmodule/mapmodule.ol3.js
+++ b/bundles/mapping/mapmodule/mapmodule.ol3.js
@@ -569,6 +569,9 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.MapModule',
             var extent = olGeom.getExtent();
             return {left: extent[0], bottom: extent[1], right: extent[2], top: extent[3]};
         },
+        isPointInExtent: function (extent, x, y){
+            return ol.extent.containsXY(extent, x, y);
+        },
         /* --------- /Impl specific --------------------------------------> */
 
         /* Impl specific - PRIVATE

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateSystemSelection.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateSystemSelection.js
@@ -1,16 +1,14 @@
 Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateSystemSelection',
-    function (view, loc, type, options) {
+    function (view, loc, type, helper) {
         this.view = view;
         this.loc = loc;
-        this.options = options;
+        this.helper = helper;
         this.type = type;
         this.element = null;
         this.select = Oskari.clazz.create('Oskari.coordinatetransformation.component.select', view );
         this.systemInfo = Oskari.clazz.create('Oskari.coordinatetransformation.view.CoordinateSystemInformation');
         this.selectInstances = {};
         this.dropdowns = {};
-        //this.enableProjectionSystem = false;
-        this.selections;
         this._template = {
             systemWrapper: jQuery('<div class="coordinateSystemWrapper"></div>'),
             coordinateSystemSelection: _.template(
@@ -81,7 +79,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateSystemS
             wrapper.append(coordinateSystemSelection);
             this.setElement(wrapper);
 
-            var json = this.options;
+            var json = this.helper.getOptionsJSON();
             Object.keys( json ).forEach( function ( key ) {
                 var selector = "." + key;
                 var container = jQuery(wrapper.find(selector)).find(".selectMountPoint");
@@ -90,9 +88,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateSystemS
             });
             // hide projection select
             this.showProjectionSelect(false);
-            //init selections
-            this.storeSelectionValues();
-            this.handleInfoLink();
+            this.handleInfoLinks();
         },
         createDropdown: function (container, json, key){
             var me = this;
@@ -106,6 +102,10 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateSystemS
                 };
             var selections = [];
             Object.keys( json ).forEach( function ( key ) {
+                //don't add default/placeholder option
+                if (key === "DEFAULT"){
+                    return;
+                }
                 var obj = json[key];
                 var valObj = {
                     id : key,
@@ -119,15 +119,15 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateSystemS
                 width:'180px'
             });
             select.adjustChosen();
-            select.selectFirstValue();
+
             dropdown.on('change', function(event) {
-                //event.stopPropagation();
                 me.handleSelectValueChange( select );
             });
             container.append(dropdown);
             this.dropdowns[key] = dropdown;
             this.selectInstances[key] = select;
         },
+
         /**
          * @method createAndHandleSelect
          * @desc creates an instance of the { Oskari.coordinatetransformation.component.select },
@@ -149,7 +149,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateSystemS
             });
         },*/
         //TODO
-        handleInfoLink: function () {
+        handleInfoLinks: function () {
             var me = this;
             this.getElement().find('.infolink').on('click', function ( event ) {
                 event.stopPropagation();
@@ -171,50 +171,19 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateSystemS
                 this.dropdowns[dropdownId].find( 'option' ).css('display', '');
             }
         },
-        updateGoeCoordDropdown: function () {
-            var clsSelector = this.makeClassSelectorFromSelections();
-            this.updateDropdownOptions( "geodetic-coordinate", clsSelector );
-            this.resetSelectToPlaceholder("geodetic-coordinate");
-        },
-        makeClassSelector: function (variable) {
-            if (variable === "DEFAULT" || variable === ""){
-                return "";
-            }
-            return "." + variable;
-        },
-        makeClassSelectorFromSelections: function (){
-            var selects = this.selections;
-            return this.makeClassSelector(selects.coordinate)+
-                this.makeClassSelector(selects.projection)+
-                this.makeClassSelector(selects.datum);
-        },
+
         /**
          * @method handleSelectValueChange
-         * @param {string} currentValue - value of the dropdown we changed
+         * @param {SelectList} select - dropdown we changed
          * @desc handle hiding and showing dropdown options based on user selection 
          */
         handleSelectValueChange: function (select) {
             var currentValue = select.getValue();
             var selectId = select.getId();
-            var me = this;
-            this.storeSelectionValue(selectId, currentValue);
-            var clsSelector;
             var disableElevSystem = false;
-            var showElevationRow = false;
-            //placeholder value is DEFAULT, removed value is ""
-            if (currentValue === ""){
-                currentValue = "DEFAULT";
-            }
-
             switch ( selectId ) {
                 case "datum":
-                    clsSelector = this.makeClassSelector(currentValue);
-                    this.resetSelectsToPlaceholder();
-                    //Update all dropdowns
-                    Object.keys( this.dropdowns ).forEach( function ( key ) {
-                        me.updateDropdownOptions( key, clsSelector );
-                    });
-                    this.showProjectionSelect(false);
+                    this.resetAndUpdateSelects();
                     break;
                 case "coordinate":
                     if (currentValue === "COORD_PROJ_2D") {
@@ -224,67 +193,66 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateSystemS
                     }
                     if (currentValue === "COORD_GEOG_3D" || currentValue === "COORD_PROJ_3D"){
                         disableElevSystem = true;
-                        showElevationRow = true;
                     }
-                    this.updateGoeCoordDropdown();
+                    this.resetAndUpdateCoordSelect();
                     break;
                 case "projection":
                     showProjSystem = true;
-                    this.updateGoeCoordDropdown();
+                    this.resetAndUpdateCoordSelect();
                     break;
                 case "elevation":
-                    if (currentValue !== "DEFAULT" ){
-                        showElevationRow = true;
-                    }
                     break;
                 case "geodetic-coordinate":
-                    if (currentValue === "EPSG:4936" || currentValue === "EPSG:4937") { //3D
+                    if (this.helper.is3DSystem(currentValue)) {
                         disableElevSystem = true;
-                        showElevationRow = true;
                     }
                     break;
                 default:
+                    Oskari.log(this.getName()).warn("Invalid select");
                     return;
             }
-            this.storeSelectionValues();
             this.disableElevationSelection(disableElevSystem);
-            this.updateSelectValues();
             this.trigger('CoordSystemChanged', this.type);
         },
         disableElevationSelection: function (disable){
             var select = this.selectInstances.elevation;
             if (disable === true){
-                select.resetToPlaceholder();
-                select.setValue('DEFAULT');
-                select.setEnabled(false);
+                //TODO
+                //select.resetSelectToPlaceholder();
+                select.setValue('');
+                select.setEnabled(false, true);
             } else {
-                select.setEnabled(true);
+                select.setEnabled(true, true);
             }
         },
-        disableInputSelections: function (disable){
+        disableAllSelections: function (disable){
             var selects = this.selectInstances;
             if (disable === true){
                 Object.keys( selects ).forEach( function ( key ) {
-                    selects[key].setEnabled(false);
+                    selects[key].setEnabled(false, true);
                 });
             }else{
                 Object.keys( selects ).forEach( function ( key ) {
-                    selects[key].setEnabled(true);
+                    selects[key].setEnabled(true, true);
                 });
             }
         },
         selectMapProjection: function (){
-            var mapSrs = Oskari.getSandbox().getMap().getSrsName();
-            var srsOptions = this.view.instance.getEpsgValues(mapSrs);
+            var srsOptions = this.helper.getMapEpsgValues();
             var selects = this.selectInstances;
             if (srsOptions){
                 selects.datum.setValue(srsOptions.datum);
                 selects.coordinate.setValue(srsOptions.coord);
-                selects["geodetic-coordinate"].setValue(mapSrs);
-                this.resetSelectToPlaceholder("elevation");
+                if (srsOptions.coord === "COORD_PROJ_2D"){
+                    this.showProjectionSelect(true);
+                    selects.projection.setValue(srsOptions.proj);
+                }
+                selects["geodetic-coordinate"].setValue(srsOptions.srs);
+                //TODO
+                //selects.elevation.resetSelectToPlaceholder();
+                selects.elevation.setValue("");
             }
-            this.storeSelectionValues();
-            this.updateSelectValues();
+            this.updateAllDropdowns();
             this.trigger('CoordSystemChanged', this.type);
         },
         showProjectionSelect: function (display){
@@ -293,55 +261,78 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateSystemS
                 jQuery(elem).css("display","");
             } else {
                 jQuery(elem).css("display", "none");
-                this.resetSelectToPlaceholder("projection");
+                //TODO
+                //this.selectInstances.projection.resetSelectToPlaceholder();
+                this.selectInstances.projection.setValue("");
             }
         },
         getSelections: function (){
-            return this.selections;
+            var selects = this.selectInstances;
+            var selections = {};
+            Object.keys( selects ).forEach( function ( key ) {
+                selections[key] = selects[key].getValue();
+            });
+            return selections;
         },
         getSrs: function () {
-            return this.selections["geodetic-coordinate"];
+            return this.selectInstances["geodetic-coordinate"].getValue();
         },
         getElevation: function () {
-            return this.selections.elevation;
+            return this.selectInstances.elevation.getValue();
         },
-        storeSelectionValue: function (key, value){
-            if (value === "DEFAULT"){
-                this.selections[key] = ""; //TODO null or ""
-            } else {
-                this.selections[key] = value
-            }
+        resetAllSelections: function (){
+            this.disableElevationSelection(false);
+            this.resetAndUpdateSelects(true);
+            this.trigger('CoordSystemChanged', this.type);
         },
-        storeSelectionValues: function () {
-            var me = this;
-            var values = {};
-            var value;
-            Object.keys( this.selectInstances ).forEach( function ( instance ) {
-                value = me.selectInstances[instance].getValue();
-                if (value === "DEFAULT"){
-                    values[instance] = ""; //TODO null or ""
-                } else {
-                    values[instance] = value
-                }
-            });
-            me.selections = values;
-        },
-        resetSelectsToPlaceholder: function (resetDatum) {
+        resetAndUpdateSelects: function (resetDatum) {
             var selects = this.selectInstances;
             Object.keys( selects ).forEach( function ( key ) {
                 if (key === "datum" && resetDatum !== true){
                     return;
                 }
-                selects[key].resetToPlaceholder();
-                selects[key].setValue('DEFAULT'); //TODO
+                //TODO
+                //selects[key].resetToPlaceholder();
+                selects[key].setValue("");
             });
+            this.showProjectionSelect(false);
+            this.updateAllDropdowns();
         },
-        resetSelectToPlaceholder: function (key){
-            var select = this.selectInstances[key];
-            if (select){
-                select.resetToPlaceholder();
-                select.setValue('DEFAULT'); //TODO
+        updateAllDropdowns: function (){
+            coordSelector = this.makeClassSelectorFromSelections();
+            datumSelector = this.makeClassSelectorFromDatum();
+            //Filter dropdowns with clsSelector if selector is "" then show all options
+            this.updateDropdownOptions( "geodetic-coordinate", coordSelector );
+            this.updateDropdownOptions( "projection", datumSelector );
+            this.updateDropdownOptions( "coordinate", datumSelector );
+            //update chosen-results manually because dropdown's selections are handled after change by css
+            this.getElement().find('select').trigger('chosen:updated');
+        },
+        resetAndUpdateCoordSelect: function (){
+            var clsSelector = this.makeClassSelectorFromSelections();
+            var select = this.selectInstances["geodetic-coordinate"];
+            //TODO
+            //select.resetToPlaceholder();
+            select.setValue('');
+            this.updateDropdownOptions( "geodetic-coordinate", clsSelector );
+            //update chosen-results manually because dropdown's selections are handled after change by css
+            this.getElement().find(".geodetic-coordinate select").trigger('chosen:updated');
+        },
+        makeClassSelector: function (variable) {
+            if (variable === ""){
+                return "";
             }
+            return "." + variable;
+        },
+        makeClassSelectorFromDatum: function (){
+            var datum = this.selectInstances.datum.getValue();
+            return this.makeClassSelector(datum);
+        },
+        makeClassSelectorFromSelections: function (){
+            var selects = this.getSelections();
+            return this.makeClassSelector(selects.coordinate)+
+                this.makeClassSelector(selects.projection)+
+                this.makeClassSelector(selects.datum);
         },
         updateSelectValues: function () {
             var selects = this.selectInstances;

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/SourceSelect.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/SourceSelect.js
@@ -6,7 +6,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.SourceSelect',
         me._template = {
             sourceWrapper: jQuery('<div class="sourceWrapper"></div>'),
             source: _.template(
-                '<div class="coordinate-datasource"> </br> ' +
+                '<div class="coordinate-datasource">' +
                     '<h4>${title}</h4>'+
                     '<form>'+
                         '<input type="radio" id="clipboard" name="load" value="keyboard">' +

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/table.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/table.js
@@ -61,7 +61,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.table', function(
             var isEmpty = true;
             var elevationCells = me.getElements().rows.find('.elevation');
             if ( dimension === 2 ) {
-                elevationCells.attr("contenteditable", false); //TODO always??
+                //elevationCells.attr("contenteditable", false); //TODO always??
                 //check if elevationcells have value, if true don't hide but grey out
                 /*elevationCells.each( function (key, val) {
                     var element = jQuery( val );
@@ -76,7 +76,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.table', function(
                     elevationCells.addClass('oskari-hidden');
                 //}
             } else {
-                elevationCells.attr("contenteditable", true); //TODO always??
+                //elevationCells.attr("contenteditable", true); //TODO always??
 
                 /*if ( elevationCells.hasClass('cell-disabled') ) {
                     elevationCells.removeClass('cell-disabled');
@@ -130,7 +130,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.table', function(
          * @method render
          * @param { Array } coords, array of coordinate arrays
          */
-        render: function ( coords ) {
+        render: function ( coords, dimension) {
             var table = this.getElements().table;
             var row,
                 rowData = {},
@@ -140,13 +140,14 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.table', function(
                 coord = coords[i];
                 rowData.col1 = coord[0];
                 rowData.col2 = coord[1];
-                if (coord[2]){
+                if (dimension === 3){
                     rowData.elev = coord[2];
                 }
                 row = this.template.row({coords:rowData});
                 table.prepend(row);
             }
             this.handleTableSize(coords.length, true);
+            this.handleDisplayingElevationRows(dimension)
             //table.trigger('RowCountChanged');
         },
         displayNumberOfDataRows: function ( number ) {

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/table.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/table.js
@@ -230,7 +230,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.table', function(
         },*/
         updateHeader: function (epsgValues, elevSystem) {
             this.getElements().header.remove();
-            if (!epsgValues){
+            if (!epsgValues.coord){
                 return;
             }
             var x = "",

--- a/bundles/paikkatietoikkuna/coordinatetransformation/instance.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/instance.js
@@ -33,7 +33,7 @@ function () {
         this.loc = Oskari.getMsg.bind(null, 'coordinatetransformation');
         this.isMapSelection = false;
         this.sandbox = Oskari.getSandbox();
-        this.coordSystemOptions = null;
+        //TODO should dimensions be handled by dataHandler
         this.dimensions = {
             input: 2,
             output: 2
@@ -50,16 +50,7 @@ function () {
         return this.transformationService;
     },
     setDimension: function (type, srs, elevation){
-        var srsValues = this.getEpsgValues(srs),
-            dimension;
-        if (srsValues && (srsValues.coord === "COORD_PROJ_3D" || srsValues.coord === "COORD_GEOG_3D")){
-            dimension = 3;
-        } else if (elevation !== ""){
-            dimension = 3;
-        } else {
-            dimension = 2;
-        }
-        this.dimensions[type] = dimension;
+        this.dimensions[type] = this.helper.getDimension(srs, elevation);
     },
     getDimension: function (type){
         return this.dimensions[type];
@@ -71,12 +62,9 @@ function () {
      * @method afterStart
      */
     afterStart: function () {
+        this.helper = Oskari.clazz.create( 'Oskari.coordinatetransformation.helper');
         this.transformationService = Oskari.clazz.create( 'Oskari.coordinatetransformation.TransformationService', this );
-        //this._mapmodule = sandbox.findRegisteredModuleInstance('MainMapModule');
-        this.helper = Oskari.clazz.create( 'Oskari.coordinatetransformation.helper', this);
         this.dataHandler = Oskari.clazz.create( 'Oskari.coordinatetransformation.CoordinateDataHandler' );
-        this.coordSystemOptions = this.helper.getOptionsJSON();
-        this.helper.createCls(this.coordSystemOptions);
         this.instantiateViews();
         this.createUi();
         this.bindListeners();
@@ -94,13 +82,6 @@ function () {
             me.views.transformation.outputTable.render(coords, dimensions.output);
         });
     },
-
-    getcoordSystemOptions: function () {
-        return this.coordSystemOptions;
-    },
-    getEpsgValues: function (srs) {
-        return this.coordSystemOptions["geodetic-coordinate"][srs];
-    },
     getPlugins: function() {
         return this.plugins;
     },
@@ -110,12 +91,9 @@ function () {
     getHelper: function () {
         return this.helper;
     },
-    hasInputCoords: function () { //TODO to handler
-        return this.dataHandler.getInputCoords().length !== 0;
-    },
     instantiateViews: function () {
         this.views = {
-            transformation: Oskari.clazz.create('Oskari.coordinatetransformation.view.transformation', this, this.getcoordSystemOptions()),
+            transformation: Oskari.clazz.create('Oskari.coordinatetransformation.view.transformation', this, this.helper, this.dataHandler),
             MapSelection: Oskari.clazz.create('Oskari.coordinatetransformation.view.CoordinateMapSelection', this),
             mapmarkers: Oskari.clazz.create('Oskari.coordinatetransformation.view.mapmarkers', this)
         }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/instance.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/instance.js
@@ -36,7 +36,7 @@ function () {
         this.coordSystemOptions = null;
         this.dimensions = {
             input: 2,
-            result: 2
+            output: 2
         };
 }, {
     __name: 'coordinatetransformation',
@@ -64,6 +64,9 @@ function () {
     getDimension: function (type){
         return this.dimensions[type];
     },
+    getDimensions: function (){
+        return this.dimensions;
+    },
     /**
      * @method afterStart
      */
@@ -80,14 +83,15 @@ function () {
     },
     bindListeners: function (){
         var me = this;
+        var dimensions = this.getDimensions();
         this.dataHandler.on('InputCoordAdded', function (coords) {
-            me.views.transformation.inputTable.render(coords);
+            me.views.transformation.inputTable.render(coords, dimensions.input);
         });
         this.dataHandler.on('InputCoordsChanged', function (coords) {
-            me.views.transformation.inputTable.render(coords);
+            me.views.transformation.inputTable.render(coords, dimensions.input);
         });
         this.dataHandler.on('ResultCoordsChanged', function (coords) {
-            me.views.transformation.outputTable.render(coords);
+            me.views.transformation.outputTable.render(coords, dimensions.output);
         });
     },
 
@@ -156,12 +160,15 @@ function () {
             if (!this.isMapSelection) {
                 return;
             }
-            var lonlat = event._lonlat;
-            var coordArray = this.dataHandler.lonLatCoordToArray(lonlat, true); //TODO check mapSrs lonFirst
-
+            var label;
+            var lonlat = {
+                lon: parseInt(event._lonlat.lon),
+                lat: parseInt(event._lonlat.lat)
+            }
             //add coords to map coords
             this.dataHandler.addMapCoord(lonlat);
-            this.helper.addMarkerForCoords(coordArray, true, true); //TODO check mapSrs lonFirst
+            label = this.helper.getLabelForMarker(lonlat);
+            this.helper.addMarkerForCoords(lonlat, label);
         },
         'userinterface.ExtensionUpdatedEvent': function (event) {
             if(event.getExtension().getName() !==this.getName()){

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/css/filesettings.css
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/css/filesettings.css
@@ -2,10 +2,26 @@
     width: 39em;
     display: inline-block;
 }
-.oskari-coordinate-form .filerow, .formatRow, .decimalSeparator, .headerLineCount {
+.oskari-coordinate-form > div {/*.filerow, .formatRow, .decimalSeparator, .headerLineCount, .decimalLineCount {*/
     float:left;
     clear: left;
     padding-top: 0.875em; 
+}
+.oskari-coordinate-form > .lbl {
+    float:left;
+    clear: left;
+    padding-top: 6px;
+    padding-left: 11em;
+}
+.oskari-coordinate-form .infolink {
+    float: left;
+}
+.oskari-coordinate-form label span {
+    float: left;
+}
+.oskari-coordinate-form input[type="number"]{
+    float: left;
+    width: 12em;
 }
 .oskari-coordinate-form .title {
     font-weight: bold;
@@ -18,16 +34,19 @@
 .oskari-coordinate-form .lbl > .chkbox {
     float: left;
 }
-.oskari-coordinate-form .lbl {
+/*.oskari-coordinate-form .lbl {
     float: right;
     padding-left: 3em;
-}
+}*/
 .oskari-coordinate-form .settingsSelect {
     float: left;
+    width: 13em;
+    margin: 2px;
 }
 .oskari-coordinate-form .settingsSelect > select {
-    float: right;
-    width: 12em;
+    float: left;
+    width: 14em;
+    font-size: 13px;
 }
 .oskari-coordinate-form .cancel {
     clear: left;

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
@@ -170,7 +170,8 @@ Oskari.registerLocalization(
                     "point": "Point",
                     "comma": "Comma",
                     "tab": "Tabulator",
-                    "space": "Space"
+                    "space": "Space",
+                    "semicolon": "Semicolon"
                 }
             },
             "export": {

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
@@ -85,24 +85,47 @@ Oskari.registerLocalization(
                 "confirmClear": "Haluatko tyhjentää taulukot?"
             },
             "transform": {
+                "warnings": {
+                    "title": "Huomio!",
+                    "3DTo2D": "Valitsemissasi lähtötiedoissa on mukana korkeusarvoja, mutta tulostiedoissa ei. Tuloskoordinaatteihin ei siis tule korkeusarvoja mukaan. Haluatko jatkaa?",
+                    "2DTo3D": "Valitsemissasi lähtötiedoissa ei ole korkeusarvoja, mutta tulostiedoissa on. Lähtöaineiston korkeusarvoiksi lisätään 0 ja korkeusjärjestelmäksi N2000. Haluatko jatkaa?"
+                },
                 "validateErrors": {
                     "title": "Virhe!",
                     "crs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna sekä lähtö- että tulostiedoissa.",
                     "sourceHeight": "Lähtötietojen korkeusjärjestelmää ei ole valittu.",
                     "targetHeight": "Tulostietojen korkeusjärjestelmää ei ole valittu.",
                     "noInputData": "Ei muunnettavia koordinaatteja.",
-                    "noInputFile": "Lähtöaineiston sisältävää tiedostoa ei ole valittu."
+                    "noInputFile": "Lähtöaineiston sisältävää tiedostoa ei ole valittu.",
+                    "noFileName": "Anna tiedostonimi.",
+                    "doubleComma": "Desimaali- ja koordinaattierotin eivät voi molemmat olla pilkkuja."
                 },
                 "responseErrors": {
                     "title": "Virhe muunnoksessa!",
-                    "errorMsg": "Koordinaattimuunnos epäonnistui..."
+                    "generic": "Koordinaattimuunnos epäonnistui...",
+                    "invalid_coord": "Koordinaatti virheellinen. Tarkasta, että muunnettavat koordinaatit on oikeassa muodossa sekä geodeettinen koordinaatti- ja kokeusjärjestelmä ovat oikein.",
+                    "invalid_number": "Koordinaatti virheellinen. Tarkasta..",
+                    "no_coordinates": "Ei koordinaatteja",
+                    "invalid_file_settings": "Invalid file settings",
+                    "no_file": "No file entry",
+                    "invalid_coord_length": "Tiedostossa virheellinen koordinaatti. Tarkasta, että otsakerivit, käytä tunnistetta sekä geoodeettinen koordinaatti- ja korkeusjärjestelmä ovat määritetty oikein."
+                },
+                "responseFile": {
+                    "title": "Attention!",
+                    "hasMoreCoordinates": "Lähtöaineistosta ei voida muuntaa taulukkoon yli {maxCoordsToArray, number} koordinaattia. Jos haluat muuntaa kaikki koordinaatit, käytä Vie tulokset tiedostoon -toimintoa."
                 }
             }
         },
         "mapMarkers":{
             "show":{
                 "title": "Näytä sijainnit kartalla",
-                "info" : "Tarkastele muunnettuja koordinaatteja kartalla."
+                "info" : "Tarkastele muunnettuja koordinaatteja kartalla.",
+                "errorTitle": "Virhe sijaintien näyttämisessä",
+                "transformError": "Muunna koordinaatit ennen sijaintien näyttämistä kartalla.",
+                "lon": "Lon",
+                "lat": "Lat",
+                "north": "N",
+                "east": "E"
             },
             "select":{
                 "title": "Näytä sijainnit kartalla",
@@ -114,24 +137,41 @@ Oskari.registerLocalization(
             "clearTable": "Tyhjennä taulukot",
             "showMarkers": "Näytä sijainnit kartalla",
             "export": "Vie tulokset tiedostoon",
-            "select": "Valitse",
+            "select": "Välj",
             "cancel": "Peruuta",
             "done": "Valmis",
             "ok": "Ok",
-            "close": "Sulje"
+            "close": "Stäng"
         },
         "fileSettings": {
             "options": {
-                "degree": "Aste",
-                "gradian": "Gooni (graadi)",
-                "radian": "Radiaani",
-                "point": "Piste",
-                "comma": "Pilkku",
-                "format": "Kulman muoto/yksikkö",
-                "decimalSeparator": "Desimaalierotin",
-                "headerCount": "Otsakerivien määrä",
-                "reverseCoords": "Koordinaatit käänteisesti",
-                "useId": "Käytä tunnistetta"
+                "decimalSeparator": "Decimal separator",
+                "coordinateSeparator": "Coordinate separator",
+                "headerCount": "Header line count",
+                "decimalCount": "Decimal precision",
+                "reverseCoords": "Coordinates reversed",
+                "useId": "Use id infront",
+                "writeHeader": "Write a header",
+                "useCardinals": "Use cardinals (N,E,W,S)",
+                "lineEnds": "Line ends to output",
+                "degreeFormat":{
+                    "label": "Angle pattern",
+                    "degree": "Degree",
+                    "gradian": "Grade",
+                    "radian": "Radian"
+                },
+                "lineSeparator": {
+                    "label": "Line separator",
+                    "win": "Windows / DOS",
+                    "unix": "Unix",
+                    "mac": "MacOS"
+                },
+                "delimeters":{
+                    "point": "Point",
+                    "comma": "Comma",
+                    "tab": "Tabulator",
+                    "space": "Space"
+                }
             },
             "export": {
                 "title": "Aineiston muodostaminen",

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
@@ -170,7 +170,8 @@ Oskari.registerLocalization(
                     "point": "Piste",
                     "comma": "Pilkku",
                     "tab": "Tabulaattori",
-                    "space" : "Välilyönti"
+                    "space": "Välilyönti",
+                    "semicolon": "Puolipiste"
                 }
             },
             "export": {

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
@@ -85,27 +85,50 @@ Oskari.registerLocalization(
                 "confirmClear": "Haluatko tyhjentää taulukot?"
             },
             "transform": {
+                "warnings": {
+                    "title": "Huomio!",
+                    "3DTo2D": "Valitsemissasi lähtötiedoissa on mukana korkeusarvoja, mutta tulostiedoissa ei. Tuloskoordinaatteihin ei siis tule korkeusarvoja mukaan. Haluatko jatkaa?",
+                    "2DTo3D": "Valitsemissasi lähtötiedoissa ei ole korkeusarvoja, mutta tulostiedoissa on. Lähtöaineiston korkeusarvoiksi lisätään 0 ja korkeusjärjestelmäksi N2000. Haluatko jatkaa?"
+                },
                 "validateErrors": {
                     "title": "Virhe!",
                     "crs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna sekä lähtö- että tulostiedoissa.",
                     "sourceHeight": "Lähtötietojen korkeusjärjestelmää ei ole valittu.",
                     "targetHeight": "Tulostietojen korkeusjärjestelmää ei ole valittu.",
                     "noInputData": "Ei muunnettavia koordinaatteja.",
-                    "noInputFile": "Lähtöaineiston sisältävää tiedostoa ei ole valittu."
+                    "noInputFile": "Lähtöaineiston sisältävää tiedostoa ei ole valittu.",
+                    "noFileName": "Anna tiedostonimi.",
+                    "doubleComma": "Desimaali- ja koordinaattierotin eivät voi molemmat olla pilkkuja."
                 },
                 "responseErrors": {
                     "title": "Virhe muunnoksessa!",
-                    "errorMsg": "Koordinaattimuunnos epäonnistui..."
+                    "generic": "Koordinaattimuunnos epäonnistui...",
+                    "invalid_coord": "Koordinaatti virheellinen. Tarkasta, että muunnettavat koordinaatit on oikeassa muodossa sekä geodeettinen koordinaatti- ja kokeusjärjestelmä ovat oikein.",
+                    "invalid_number": "Koordinaatti virheellinen. Tarkasta..",
+                    "no_coordinates": "Ei koordinaatteja",
+                    "invalid_file_settings": "Invalid file settings",
+                    "no_file": "No file entry",
+                    "invalid_coord_length": "Tiedostossa virheellinen koordinaatti. Tarkasta, että otsakerivit, käytä tunnistetta sekä geoodeettinen koordinaatti- ja korkeusjärjestelmä ovat määritetty oikein."
+                },
+                "responseFile": {
+                    "title": "Huomio!",
+                    "hasMoreCoordinates": "Lähtöaineistosta ei voida muuntaa taulukkoon yli {maxCoordsToArray, number} koordinaattia. Jos haluat muuntaa kaikki koordinaatit, käytä Vie tulokset tiedostoon -toimintoa."
                 }
             }
         },
         "mapMarkers":{
             "show":{
                 "title": "Näytä sijainnit kartalla",
-                "info" : "Tarkastele muunnettuja koordinaatteja kartalla."
+                "info": "Tarkastele muunnettuja koordinaatteja kartalla.",
+                "errorTitle": "Virhe sijaintien näyttämisessä",
+                "transformError": "Muunna koordinaatit ennen sijaintien näyttämistä kartalla.",
+                "lon": "Lon",
+                "lat": "Lat",
+                "north": "N",
+                "east": "E"
             },
             "select":{
-                "title": "Näytä sijainnit kartalla",
+                "title": "Valitse sijainnit kartalta",
                 "info": "Valitse yksi tai useampia pisteitä kartalta klikkaamalla."
             }
         },
@@ -122,16 +145,33 @@ Oskari.registerLocalization(
         },
         "fileSettings": {
             "options": {
-                "degree": "Aste",
-                "gradian": "Gooni (graadi)",
-                "radian": "Radiaani",
-                "point": "Piste",
-                "comma": "Pilkku",
-                "format": "Kulman muoto/yksikkö",
                 "decimalSeparator": "Desimaalierotin",
+                "coordinateSeparator": "Koordinaattierotin",
                 "headerCount": "Otsakerivien määrä",
+                "decimalCount": "Desimaalien tarkkuus",
                 "reverseCoords": "Koordinaatit käänteisesti",
-                "useId": "Käytä tunnistetta"
+                "useId": "Käytä tunnistetta",
+                "writeHeader": "Kirjoita otsakerivi tiedostoon",
+                "useCardinals": "Käytä kardinaaleja (N,E,W,S)",
+                "lineEnds": "Tulosteeseen rivin loput",
+                "degreeFormat":{
+                    "label": "Kulman muoto/yksikkö",
+                    "degree": "Aste",
+                    "gradian": "Gooni (graadi)",
+                    "radian": "Radiaani"
+                },
+                "lineSeparator": {
+                    "label": "Rivin erotin",
+                    "win": "Windows / DOS",
+                    "unix": "Unix",
+                    "mac": "MacOS"
+                },
+                "delimeters":{
+                    "point": "Piste",
+                    "comma": "Pilkku",
+                    "tab": "Tabulaattori",
+                    "space" : "Välilyönti"
+                }
             },
             "export": {
                 "title": "Aineiston muodostaminen",

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
@@ -124,7 +124,7 @@ Oskari.registerLocalization(
                 "transformError": "Muunna koordinaatit ennen sijaintien näyttämistä kartalla.",
                 "lon": "Lon",
                 "lat": "Lat",
-                "north": "N", //or P
+                "north": "N",
                 "east": "E"
             },
             "select":{
@@ -167,10 +167,11 @@ Oskari.registerLocalization(
                     "mac": "MacOS"
                 },
                 "delimeters":{
-                    "point": "Piste",
-                    "comma": "Pilkku",
+                    "point": "Punkt",
+                    "comma": "Kommatecken",
                     "tab": "Tabulaattori",
-                    "space" : "Välilyönti"
+                    "space": "Utslutning",
+                    "semicolon": "Semikolon"
                 }
             },
             "export": {

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
@@ -85,24 +85,47 @@ Oskari.registerLocalization(
                 "confirmClear": "Haluatko tyhjentää taulukot?"
             },
             "transform": {
+                "warnings": {
+                    "title": "Huomio!",
+                    "3DTo2D": "Valitsemissasi lähtötiedoissa on mukana korkeusarvoja, mutta tulostiedoissa ei. Tuloskoordinaatteihin ei siis tule korkeusarvoja mukaan. Haluatko jatkaa?",
+                    "2DTo3D": "Valitsemissasi lähtötiedoissa ei ole korkeusarvoja, mutta tulostiedoissa on. Lähtöaineiston korkeusarvoiksi lisätään 0 ja korkeusjärjestelmäksi N2000. Haluatko jatkaa?"
+                },
                 "validateErrors": {
                     "title": "Virhe!",
                     "crs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna sekä lähtö- että tulostiedoissa.",
                     "sourceHeight": "Lähtötietojen korkeusjärjestelmää ei ole valittu.",
                     "targetHeight": "Tulostietojen korkeusjärjestelmää ei ole valittu.",
                     "noInputData": "Ei muunnettavia koordinaatteja.",
-                    "noInputFile": "Lähtöaineiston sisältävää tiedostoa ei ole valittu."
+                    "noInputFile": "Lähtöaineiston sisältävää tiedostoa ei ole valittu.",
+                    "noFileName": "Anna tiedostonimi.",
+                    "doubleComma": "Desimaali- ja koordinaattierotin eivät voi molemmat olla pilkkuja."
                 },
                 "responseErrors": {
                     "title": "Virhe muunnoksessa!",
-                    "errorMsg": "Koordinaattimuunnos epäonnistui..."
+                    "generic": "Koordinaattimuunnos epäonnistui...",
+                    "invalid_coord": "Koordinaatti virheellinen. Tarkasta, että muunnettavat koordinaatit on oikeassa muodossa sekä geodeettinen koordinaatti- ja kokeusjärjestelmä ovat oikein.",
+                    "invalid_number": "Koordinaatti virheellinen. Tarkasta..",
+                    "no_coordinates": "Ei koordinaatteja",
+                    "invalid_file_settings": "Invalid file settings",
+                    "no_file": "No file entry",
+                    "invalid_coord_length": "Tiedostossa virheellinen koordinaatti. Tarkasta, että otsakerivit, käytä tunnistetta sekä geoodeettinen koordinaatti- ja korkeusjärjestelmä ovat määritetty oikein."
+                },
+                "responseFile": {
+                    "title": "Huomio!",
+                    "hasMoreCoordinates": "Lähtöaineistosta ei voida muuntaa taulukkoon yli {maxCoordsToArray, number} koordinaattia. Jos haluat muuntaa kaikki koordinaatit, käytä Vie tulokset tiedostoon -toimintoa."
                 }
             }
         },
         "mapMarkers":{
             "show":{
                 "title": "Näytä sijainnit kartalla",
-                "info" : "Tarkastele muunnettuja koordinaatteja kartalla."
+                "info" : "Tarkastele muunnettuja koordinaatteja kartalla.",
+                "errorTitle": "Virhe sijaintien näyttämisessä",
+                "transformError": "Muunna koordinaatit ennen sijaintien näyttämistä kartalla.",
+                "lon": "Lon",
+                "lat": "Lat",
+                "north": "N", //or P
+                "east": "E"
             },
             "select":{
                 "title": "Näytä sijainnit kartalla",
@@ -122,16 +145,33 @@ Oskari.registerLocalization(
         },
         "fileSettings": {
             "options": {
-                "degree": "Aste",
-                "gradian": "Gooni (graadi)",
-                "radian": "Radiaani",
-                "point": "Piste",
-                "comma": "Pilkku",
-                "format": "Kulman muoto/yksikkö",
                 "decimalSeparator": "Desimaalierotin",
+                "coordinateSeparator": "Koordinaattierotin",
                 "headerCount": "Otsakerivien määrä",
+                "decimalCount": "Desimaalien tarkkuus",
                 "reverseCoords": "Koordinaatit käänteisesti",
-                "useId": "Käytä tunnistetta"
+                "useId": "Käytä tunnistetta",
+                "writeHeader": "Kirjoita otsakerivi tiedostoon",
+                "useCardinals": "Käytä kardinaaleja (N,E,W,S)",
+                "lineEnds": "Tulosteeseen rivin loput",
+                "degreeFormat":{
+                    "label": "Kulman muoto/yksikkö",
+                    "degree": "Aste",
+                    "gradian": "Gooni (graadi)",
+                    "radian": "Radiaani"
+                },
+                "lineSeparator": {
+                    "label": "Rivin erotin",
+                    "win": "Windows / DOS",
+                    "unix": "Unix",
+                    "mac": "MacOS"
+                },
+                "delimeters":{
+                    "point": "Piste",
+                    "comma": "Pilkku",
+                    "tab": "Tabulaattori",
+                    "space" : "Välilyönti"
+                }
             },
             "export": {
                 "title": "Aineiston muodostaminen",

--- a/bundles/paikkatietoikkuna/coordinatetransformation/util/CoordinateDataHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/util/CoordinateDataHandler.js
@@ -22,6 +22,9 @@ Oskari.clazz.define('Oskari.coordinatetransformation.CoordinateDataHandler', fun
             this.trigger('InputCoordsChanged', coords);
         }
     },
+    hasInputCoords: function () {
+        return this.inputCoords.length !== 0;
+    },
     getResultCoords: function() {
         return this.resultCoords;
     },

--- a/bundles/paikkatietoikkuna/coordinatetransformation/util/helper.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/util/helper.js
@@ -1,12 +1,13 @@
-Oskari.clazz.define('Oskari.coordinatetransformation.helper', function(instance) {
+Oskari.clazz.define('Oskari.coordinatetransformation.helper', function() {
     var me = this;
     this.loc = Oskari.getMsg.bind(null, 'coordinatetransformation');
-    this.instance = instance;
     this.sb = Oskari.getSandbox();
     this.removeMarkersReq = Oskari.requestBuilder('MapModulePlugin.RemoveMarkersRequest');
     this.addMarkerReq = Oskari.requestBuilder('MapModulePlugin.AddMarkerRequest');
     this.mapmodule = this.sb.findRegisteredModuleInstance('MainMapModule');
     this.mapSrs = this.sb.getMap().getSrsName();
+    this.epsgValues = this.getGeodeticCoordinateOptions();
+    this.elevationSystems = this.getElevationOptions();
     this.mapEpsgValues = this.getEpsgValues(this.mapSrs);
 }, {
     getName: function() {
@@ -77,7 +78,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.helper', function(instance)
         var epsgValues = epsgValues || this.mapEpsgValues,
             lonLabel,
             latLabel;
-        if (epsgValues.coord === "COORD_GEOG_2D" || epsgValues.coord === "COORD_GEOG_3D"){ //TODO isgeog
+        if (epsgValues.coord === "COORD_GEOG_2D" || epsgValues.coord === "COORD_GEOG_3D"){
             lonLabel = this.loc('mapMarkers.show.lon');
             latLabel = this.loc('mapMarkers.show.lat');
         } else {
@@ -153,7 +154,15 @@ Oskari.clazz.define('Oskari.coordinatetransformation.helper', function(instance)
         dialog.show(title, message, [btn]);
     },
     getEpsgValues: function (srs) {
-        return this.getOptionsJSON()["geodetic-coordinate"][srs];
+        if (srs && this.epsgValues.hasOwnProperty(srs)){
+            return this.epsgValues[srs];
+        }
+        return {};
+    },
+    getMapEpsgValues: function () {
+        var epsg = this.mapEpsgValues;
+        epsg.srs = this.mapSrs;
+        return epsg;
     },
     isGeogSystem: function(srs){
         var epsgValues = this.getEpsgValues(srs);
@@ -163,7 +172,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.helper', function(instance)
             return false;
         }
     },
-    is3DSystem: function (srs){ //or is3DSelection(crsSettings) 3D or 2D + height
+    is3DSystem: function (srs){
         var epsgValues = this.getEpsgValues(srs);
         if (epsgValues.coord === "COORD_PROJ_3D" || epsgValues.coord === "COORD_GEOG_3D"){
             return true;
@@ -187,342 +196,369 @@ Oskari.clazz.define('Oskari.coordinatetransformation.helper', function(instance)
         }
         return this.mapmodule.isPointInExtent(epsgValues.bounds, x, y);
     },
-    getDimension: function(){
-        //TODO from instance
+    getDimension: function(srs, elevation){
+        var srsValues = this.getEpsgValues(srs);
+        var dimension;
+        if (srsValues && (srsValues.coord === "COORD_PROJ_3D" || srsValues.coord === "COORD_GEOG_3D")){
+            dimension = 3;
+        } else if (this.elevationSystems.hasOwnProperty(elevation)){
+            dimension = 3;
+        } else {
+            dimension = 2;
+        }
+        return dimension;
     },
     getOptionsJSON: function() {
-         return {
-            "datum": {
-                "DEFAULT": {
-                    "title": this.loc('flyout.coordinateSystem.noFilter'),
-                    "cls": "DATUM_KKJ DATUM_EUREF-FIN"
-                },
-                "DATUM_KKJ": {
-                    "title": "KKJ",
-                    "cls": "DATUM_KKJ DATUM_EUREF-FIN"
-                },
-                "DATUM_EUREF-FIN": {
-                    "title": "EUREF-FIN",
-                    "cls": "DATUM_KKJ DATUM_EUREF-FIN"
-                }
+        var geoCoords = this.getGeodeticCoordinateOptions();
+        this.createCls(geoCoords);
+        return {
+            "datum": this.getDatumOptions(),
+            "coordinate": this.getCoordinateOptions(),
+            "projection": this.getProjectionOptions(),
+            "geodetic-coordinate": geoCoords,
+            "elevation": this.getElevationOptions()
+        }
+
+    },
+    getDatumOptions: function() {
+        return {
+            "DEFAULT": {
+                "title": this.loc('flyout.coordinateSystem.noFilter'),
+                "cls": "DATUM_KKJ DATUM_EUREF-FIN"
             },
-            "coordinate": {
-                "DEFAULT": {
-                    "title": this.loc('flyout.coordinateSystem.noFilter'),
-                     "cls": "DATUM_KKJ DATUM_EUREF-FIN"
-                },
-                "COORD_PROJ_2D": {
-                    "title": this.loc('flyout.coordinateSystem.coordinateSystem.proj2D'),
-                    "cls": "DATUM_KKJ DATUM_EUREF-FIN",
-                    "dimension": 2
-                },
-                "COORD_PROJ_3D": {
-                    "title": this.loc('flyout.coordinateSystem.coordinateSystem.proj3D'),
-                    "cls": "DATUM_EUREF-FIN",
-                    "dimension": 3
-                },
-                "COORD_GEOG_2D": {
-                    "title": this.loc('flyout.coordinateSystem.coordinateSystem.geo2D'),
-                    "cls": "DATUM_EUREF-FIN DATUM_KKJ",
-                    "dimension": 2
-                },
-                "COORD_GEOG_3D": {
-                    "title": this.loc('flyout.coordinateSystem.coordinateSystem.geo3D'),
-                    "cls": "DATUM_EUREF-FIN",
-                    "dimension": 3
-                }
+            "DATUM_KKJ": {
+                "title": "KKJ",
+                "cls": "DATUM_KKJ DATUM_EUREF-FIN"
             },
-            "projection": {
-                "DEFAULT": {
-                    "title": this.loc('flyout.coordinateSystem.noFilter'),
-                    "cls": "DATUM_KKJ DATUM_EUREF-FIN"
-                },
-                "PROJECTION_KKJ": {
-                    "title": "KKJ",
-                    "cls": "DATUM_KKJ"
-                },
-                "PROJECTION_TM": {
-                    "title": "Transversal Mercator",
-                    "cls": "DATUM_EUREF-FIN"
-                },
-                "PROJECTION_GK": {
-                    "title": "Gauss-Kruger",
-                    "cls": "DATUM_EUREF-FIN"
-                },
-                "PROJECTION_LAEA":{
-                    "title": "Lambert Azimuthal Equal Area",
-                    "cls": "DATUM_EUREF-FIN"
-                },
-                "PROJECTION_LCC": {
-                    "title": "Lambert Conic Conformal",
-                    "cls": "DATUM_EUREF-FIN"
-                }
+            "DATUM_EUREF-FIN": {
+                "title": "EUREF-FIN",
+                "cls": "DATUM_KKJ DATUM_EUREF-FIN"
+            }
+        }
+    },
+    getCoordinateOptions: function() {
+        return {
+            "DEFAULT": {
+                "title": this.loc('flyout.coordinateSystem.noFilter'),
+                 "cls": "DATUM_KKJ DATUM_EUREF-FIN"
             },
-            "geodetic-coordinate": { //bounds:[minx, miny, maxx, maxy], lonFirst: true -> lonlat, EN, XY
-                "DEFAULT": {
-                    "title": this.loc('flyout.coordinateSystem.geodeticCoordinateSystem.choose'),
-                    "datum":"",
-                    "proj":"",
-                    "coord":"",
-                },
-                //newer GK EPSG-codes which have false easting 500000 prefixed with zone number -> GK19 19500000
-                "EPSG:3873":{
-                    "title": "ETRS-GK19",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_GK",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [16136220.08, 4245436.94, 19729336.74, 9392386.51],
-                    "lonFirst": false
-                },
-                "EPSG:3874": {
-                    "title": "ETRS-GK20",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_GK",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [17036139.71, 4284384.64, 20718673.04, 9388493.84],
-                    "lonFirst": false
-                },
-                "EPSG:3875": {
-                    "title": "ETRS-GK21",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_GK",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [17935765.83, 4324906.92, 21707943.90, 9384787.32],
-                    "lonFirst": false
-                },
-                "EPSG:3876":{
-                    "title": "ETRS-GK22",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_GK",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [18835101.07, 4367049.45, 22697152.55, 9381268.03],
-                    "lonFirst": false
-                },
-                "EPSG:3877":{
-                    "title": "ETRS-GK23",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_GK",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [19734149.31, 4410859.98, 23686302.23, 9377936.99],
-                    "lonFirst": false
-                },
-                "EPSG:3878":{
-                    "title": "ETRS-GK24",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_GK",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [20632915.73, 4456388.39, 24675396.21, 9374795.15],
-                    "lonFirst": false
-                },
-                "EPSG:3879":{
-                    "title": "ETRS-GK25",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_GK",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [21531406.93, 4503686.78, 25664437.76, 9371843.41],
-                    "lonFirst": false
-                },
-                "EPSG:3880":{
-                    "title": "ETRS-GK26",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_GK",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [22429630.98, 4552809.52, 26653430.17, 9369082.63],
-                    "lonFirst": false
-                },
-                "EPSG:3881":{
-                    "title": "ETRS-GK27",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_GK",
-                    "coord":"COORD_PROJ_2D",
-                    "bounds": [23327597.57, 4603813.37, 27642376.73, 9366513.60],
-                    "lonFirst": false
-                },
-                "EPSG:3882":{
-                    "title": "ETRS-GK28",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_GK",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [24225318.05, 4656757.53, 28631280.76, 9364137.06],
-                    "lonFirst": false
-                },
-                "EPSG:3883":{
-                    "title":"ETRS-GK29",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_GK",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [25122805.55, 4711703.72, 29620145.58, 9361953.68],
-                    "lonFirst": false
-                },
-                "EPSG:3884":{
-                    "title":"ETRS-GK30",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_GK",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [26020075.09, 4768716.31, 30608974.53, 9359964.10],
-                    "lonFirst": false
-                },
-                "EPSG:3885":{
-                    "title": "ETRS-GK31",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_GK",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [26917143.71, 4827862.39, 31597770.94, 9358168.88],
-                    "lonFirst": false
-                },
-                "EPSG:3035":{
-                    "title": "ETRS-LAEA",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_LAEA",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [1896628.62, 1507846.05, 4656644.57, 6827128.02],
-                    "lonFirst": false
-                },
-                "EPSG:3034":{
-                    "title": "ETRS-LCC",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_LCC",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [1584884.54,1150546.94,4435373.08,6675249.46],
-                    "lonFirst": false
-                },
-                "EPSG:3046":{
-                    "title":"ETRS-TM34",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_TM",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [-3062460.04, 4323108.17, 707860.72, 9381033.40],
-                    "lonFirst": false
-                },
-                "EPSG:3047":{
-                    "title": "ETRS-TM35",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_TM",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [-3669433.90, 4601644.86, 642319.78, 9362767.00],
-                    "lonFirst": false
-                },
-                "EPSG:3048":{
-                    "title": "ETRS-TM36",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_TM",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [-4283197.87, 4949558.27, 575249.45, 9351421.46],
-                    "lonFirst": false
-                },
-                "EPSG:3067":{
-                    "title": "ETRS-TM35FIN",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "PROJECTION_TM",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [-3669433.90, 4601644.86, 642319.78, 9362767.00],
-                    "lonFirst": true
-                },
-                "EPSG:4258":{
-                    "title": "EUREF-FIN-GRS80",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "",
-                    "coord": "COORD_GEOG_2D",
-                    "bounds": [-16.1, 32.88, 39.65, 84.17],
-                    "lonFirst": false
-                },
-                "EPSG:4937":{
-                    "title": "EUREF-FIN-GRS80h",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "",
-                    "coord": "COORD_GEOG_3D",
-                    "bounds": [-16.1, 32.88, 39.65, 84.17],
-                    "lonFirst": false
-                },
-                "EPSG:4936":{
-                    "title": "EUREF-FIN-XYZ",
-                    "datum": "DATUM_EUREF-FIN",
-                    "proj": "",
-                    "coord": "COORD_PROJ_3D",
-                    "bounds": [5151420.52, -1486881.13, 500495.11, 414781.77],
-                    "lonFirst": true
-                },
-                "EPSG:3386":{
-                    "title": this.loc('flyout.coordinateSystem.geodeticCoordinateSystem.kkj', {'zone':0}),
-                    "datum": "DATUM_KKJ",
-                    "proj": "PROJECTION_KKJ",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [569217.09, 6663791.81, 583029.96, 6693054.88],
-                    "lonFirst": false
-                },
-                "EPSG:2391":{
-                    "title": this.loc('flyout.coordinateSystem.geodeticCoordinateSystem.kkj', {'zone':1}),
-                    "datum": "DATUM_KKJ",
-                    "proj": "PROJECTION_KKJ",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [1415885.57, 6628437.53, 1559300.06, 7695112.84],
-                    "lonFirst": false
-                },
-                "EPSG:2392":{
-                    "title": this.loc('flyout.coordinateSystem.geodeticCoordinateSystem.kkj', {'zone':2}),
-                    "datum": "DATUM_KKJ",
-                    "proj": "PROJECTION_KKJ",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [2415851.96, 6627314.46, 2560464.61, 7647148.92],
-                    "lonFirst": false
-                },
-                "EPSG:2393":{
-                    "title": this.loc('flyout.coordinateSystem.geodeticCoordinateSystem.ykj'),
-                    "datum": "DATUM_KKJ",
-                    "proj": "PROJECTION_KKJ",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [3064557.21, 6651895.29, 3674549.99, 7785726.70],
-                    "lonFirst": false
-                },
-                "EPSG:2394":{
-                    "title": this.loc('flyout.coordinateSystem.geodeticCoordinateSystem.kkj', {'zone':4}),
-                    "datum": "DATUM_KKJ",
-                    "proj": "PROJECTION_KKJ",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [4418851.11, 6759862.03, 4557959.34, 7748619.72],
-                    "lonFirst": false
-                },
-                "EPSG:3387":{
-                    "title": this.loc('flyout.coordinateSystem.geodeticCoordinateSystem.kkj', {'zone':5}),
-                    "datum": "DATUM_KKJ",
-                    "proj": "PROJECTION_KKJ",
-                    "coord": "COORD_PROJ_2D",
-                    "bounds": [5423705.81, 6970442.95, 5428707.25, 6989284.23],
-                    "lonFirst": false
-                },
-                "EPSG:4123":{//KKJ_GEO
-                    "title": "KKJ-Hayford",
-                    "datum": "DATUM_KKJ",
-                    "proj": "",
-                    "coord": "COORD_GEOG_2D",
-                    "bounds": [19.24, 59.75, 31.59, 70.09],
-                    "lonFirst": false
-                }
+            "COORD_PROJ_2D": {
+                "title": this.loc('flyout.coordinateSystem.coordinateSystem.proj2D'),
+                "cls": "DATUM_KKJ DATUM_EUREF-FIN",
+                "dimension": 2
             },
-            "elevation": {
-                "DEFAULT": {
-                    "title": this.loc('flyout.coordinateSystem.heightSystem.none'),
-                    "cls":"DATUM_KKJ DATUM_EUREF-FIN DATUM_DEFAULT"
-                },
-                "EPSG:3900": {
-                    "title":"N2000",
-                    "cls":"DATUM_KKJ DATUM_EUREF-FIN DATUM_DEFAULT"
-                },
-                "EPSG:5717": {
-                    "title":"N60",
-                    "cls":"DATUM_KKJ DATUM_EUREF-FIN DATUM_DEFAULT"
-                },
-                "N43": { //no EPSG
-                    "title":"N43",
-                    "cls":"DATUM_KKJ DATUM_EUREF-FIN DATUM_DEFAULT"
-                }
+            "COORD_PROJ_3D": {
+                "title": this.loc('flyout.coordinateSystem.coordinateSystem.proj3D'),
+                "cls": "DATUM_EUREF-FIN",
+                "dimension": 3
+            },
+            "COORD_GEOG_2D": {
+                "title": this.loc('flyout.coordinateSystem.coordinateSystem.geo2D'),
+                "cls": "DATUM_EUREF-FIN DATUM_KKJ",
+                "dimension": 2
+            },
+            "COORD_GEOG_3D": {
+                "title": this.loc('flyout.coordinateSystem.coordinateSystem.geo3D'),
+                "cls": "DATUM_EUREF-FIN",
+                "dimension": 3
+            }
+        }
+    },
+    getProjectionOptions: function() {
+        return {
+            "DEFAULT": {
+                "title": this.loc('flyout.coordinateSystem.noFilter'),
+                "cls": "DATUM_KKJ DATUM_EUREF-FIN"
+            },
+            "PROJECTION_KKJ": {
+                "title": "KKJ",
+                "cls": "DATUM_KKJ"
+            },
+            "PROJECTION_TM": {
+                "title": "Transversal Mercator",
+                "cls": "DATUM_EUREF-FIN"
+            },
+            "PROJECTION_GK": {
+                "title": "Gauss-Kruger",
+                "cls": "DATUM_EUREF-FIN"
+            },
+            "PROJECTION_LAEA":{
+                "title": "Lambert Azimuthal Equal Area",
+                "cls": "DATUM_EUREF-FIN"
+            },
+            "PROJECTION_LCC": {
+                "title": "Lambert Conic Conformal",
+                "cls": "DATUM_EUREF-FIN"
+            }
+        }
+    },
+    //bounds:[minx, miny, maxx, maxy], lonFirst: true -> lonlat, EN, XY
+    getGeodeticCoordinateOptions: function() {
+        return {
+            "DEFAULT": {
+                "title": this.loc('flyout.coordinateSystem.geodeticCoordinateSystem.choose'),
+                "datum":"",
+                "proj":"",
+                "coord":"",
+            },
+            //newer GK EPSG-codes which have false easting 500000 prefixed with zone number -> GK19 19500000
+            "EPSG:3873":{
+                "title": "ETRS-GK19",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_GK",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [16136220.08, 4245436.94, 19729336.74, 9392386.51],
+                "lonFirst": false
+            },
+            "EPSG:3874": {
+                "title": "ETRS-GK20",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_GK",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [17036139.71, 4284384.64, 20718673.04, 9388493.84],
+                "lonFirst": false
+            },
+            "EPSG:3875": {
+                "title": "ETRS-GK21",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_GK",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [17935765.83, 4324906.92, 21707943.90, 9384787.32],
+                "lonFirst": false
+            },
+            "EPSG:3876":{
+                "title": "ETRS-GK22",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_GK",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [18835101.07, 4367049.45, 22697152.55, 9381268.03],
+                "lonFirst": false
+            },
+            "EPSG:3877":{
+                "title": "ETRS-GK23",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_GK",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [19734149.31, 4410859.98, 23686302.23, 9377936.99],
+                "lonFirst": false
+            },
+            "EPSG:3878":{
+                "title": "ETRS-GK24",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_GK",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [20632915.73, 4456388.39, 24675396.21, 9374795.15],
+                "lonFirst": false
+            },
+            "EPSG:3879":{
+                "title": "ETRS-GK25",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_GK",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [21531406.93, 4503686.78, 25664437.76, 9371843.41],
+                "lonFirst": false
+            },
+            "EPSG:3880":{
+                "title": "ETRS-GK26",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_GK",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [22429630.98, 4552809.52, 26653430.17, 9369082.63],
+                "lonFirst": false
+            },
+            "EPSG:3881":{
+                "title": "ETRS-GK27",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_GK",
+                "coord":"COORD_PROJ_2D",
+                "bounds": [23327597.57, 4603813.37, 27642376.73, 9366513.60],
+                "lonFirst": false
+            },
+            "EPSG:3882":{
+                "title": "ETRS-GK28",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_GK",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [24225318.05, 4656757.53, 28631280.76, 9364137.06],
+                "lonFirst": false
+            },
+            "EPSG:3883":{
+                "title":"ETRS-GK29",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_GK",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [25122805.55, 4711703.72, 29620145.58, 9361953.68],
+                "lonFirst": false
+            },
+            "EPSG:3884":{
+                "title":"ETRS-GK30",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_GK",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [26020075.09, 4768716.31, 30608974.53, 9359964.10],
+                "lonFirst": false
+            },
+            "EPSG:3885":{
+                "title": "ETRS-GK31",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_GK",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [26917143.71, 4827862.39, 31597770.94, 9358168.88],
+                "lonFirst": false
+            },
+            "EPSG:3035":{
+                "title": "ETRS-LAEA",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_LAEA",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [1896628.62, 1507846.05, 4656644.57, 6827128.02],
+                "lonFirst": false
+            },
+            "EPSG:3034":{
+                "title": "ETRS-LCC",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_LCC",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [1584884.54,1150546.94,4435373.08,6675249.46],
+                "lonFirst": false
+            },
+            "EPSG:3046":{
+                "title":"ETRS-TM34",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_TM",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [-3062460.04, 4323108.17, 707860.72, 9381033.40],
+                "lonFirst": false
+            },
+            "EPSG:3047":{
+                "title": "ETRS-TM35",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_TM",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [-3669433.90, 4601644.86, 642319.78, 9362767.00],
+                "lonFirst": false
+            },
+            "EPSG:3048":{
+                "title": "ETRS-TM36",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_TM",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [-4283197.87, 4949558.27, 575249.45, 9351421.46],
+                "lonFirst": false
+            },
+            "EPSG:3067":{
+                "title": "ETRS-TM35FIN",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "PROJECTION_TM",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [-3669433.90, 4601644.86, 642319.78, 9362767.00],
+                "lonFirst": true
+            },
+            "EPSG:4258":{
+                "title": "EUREF-FIN-GRS80",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "",
+                "coord": "COORD_GEOG_2D",
+                "bounds": [-16.1, 32.88, 39.65, 84.17],
+                "lonFirst": false
+            },
+            "EPSG:4937":{
+                "title": "EUREF-FIN-GRS80h",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "",
+                "coord": "COORD_GEOG_3D",
+                "bounds": [-16.1, 32.88, 39.65, 84.17],
+                "lonFirst": false
+            },
+            "EPSG:4936":{
+                "title": "EUREF-FIN-XYZ",
+                "datum": "DATUM_EUREF-FIN",
+                "proj": "",
+                "coord": "COORD_PROJ_3D",
+                "bounds": [5151420.52, -1486881.13, 500495.11, 414781.77],
+                "lonFirst": true
+            },
+            "EPSG:3386":{
+                "title": this.loc('flyout.coordinateSystem.geodeticCoordinateSystem.kkj', {'zone':0}),
+                "datum": "DATUM_KKJ",
+                "proj": "PROJECTION_KKJ",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [569217.09, 6663791.81, 583029.96, 6693054.88],
+                "lonFirst": false
+            },
+            "EPSG:2391":{
+                "title": this.loc('flyout.coordinateSystem.geodeticCoordinateSystem.kkj', {'zone':1}),
+                "datum": "DATUM_KKJ",
+                "proj": "PROJECTION_KKJ",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [1415885.57, 6628437.53, 1559300.06, 7695112.84],
+                "lonFirst": false
+            },
+            "EPSG:2392":{
+                "title": this.loc('flyout.coordinateSystem.geodeticCoordinateSystem.kkj', {'zone':2}),
+                "datum": "DATUM_KKJ",
+                "proj": "PROJECTION_KKJ",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [2415851.96, 6627314.46, 2560464.61, 7647148.92],
+                "lonFirst": false
+            },
+            "EPSG:2393":{
+                "title": this.loc('flyout.coordinateSystem.geodeticCoordinateSystem.ykj'),
+                "datum": "DATUM_KKJ",
+                "proj": "PROJECTION_KKJ",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [3064557.21, 6651895.29, 3674549.99, 7785726.70],
+                "lonFirst": false
+            },
+            "EPSG:2394":{
+                "title": this.loc('flyout.coordinateSystem.geodeticCoordinateSystem.kkj', {'zone':4}),
+                "datum": "DATUM_KKJ",
+                "proj": "PROJECTION_KKJ",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [4418851.11, 6759862.03, 4557959.34, 7748619.72],
+                "lonFirst": false
+            },
+            "EPSG:3387":{
+                "title": this.loc('flyout.coordinateSystem.geodeticCoordinateSystem.kkj', {'zone':5}),
+                "datum": "DATUM_KKJ",
+                "proj": "PROJECTION_KKJ",
+                "coord": "COORD_PROJ_2D",
+                "bounds": [5423705.81, 6970442.95, 5428707.25, 6989284.23],
+                "lonFirst": false
+            },
+            "EPSG:4123":{//KKJ_GEO
+                "title": "KKJ-Hayford",
+                "datum": "DATUM_KKJ",
+                "proj": "",
+                "coord": "COORD_GEOG_2D",
+                "bounds": [19.24, 59.75, 31.59, 70.09],
+                "lonFirst": false
+            }
+        }
+    },
+    getElevationOptions: function(){
+        return {
+            "DEFAULT": {
+                "title": this.loc('flyout.coordinateSystem.heightSystem.none'),
+                "cls":"DATUM_KKJ DATUM_EUREF-FIN DATUM_DEFAULT"
+            },
+            "EPSG:3900": {
+                "title":"N2000",
+                "cls":"DATUM_KKJ DATUM_EUREF-FIN DATUM_DEFAULT"
+            },
+            "EPSG:5717": {
+                "title":"N60",
+                "cls":"DATUM_KKJ DATUM_EUREF-FIN DATUM_DEFAULT"
+            },
+            "N43": { //no EPSG
+                "title":"N43",
+                "cls":"DATUM_KKJ DATUM_EUREF-FIN DATUM_DEFAULT"
             }
         }
     },
     createCls: function(json){
-        var geoCoords = json["geodetic-coordinate"];
-        Object.keys( geoCoords ).forEach( function ( key ) {
-            var geoCoord = geoCoords[key];
+        Object.keys( json ).forEach( function ( key ) {
+            var geoCoord = json[key];
             if (key === "DEFAULT"){
                 geoCoord.cls = "";
             } else {
@@ -531,43 +567,4 @@ Oskari.clazz.define('Oskari.coordinatetransformation.helper', function(instance)
         });
 
     }
-    /*
-    getMappedEPSG: function ( value ) {
-        var EPSG = {
-            'ETRS-GK19': "EPSG:3126",
-            'ETRS-GK20': "EPSG:3127",
-            'ETRS-GK21': "EPSG:3128",
-            'ETRS-GK22': "EPSG:3129",
-            'ETRS-GK23': "EPSG:3130",
-            'ETRS-GK24': "EPSG:3131",
-            'ETRS-GK25': "EPSG:3132",
-            'ETRS-GK26': "EPSG:3133",
-            'ETRS-GK27': "EPSG:3134",
-            'ETRS-GK28': "EPSG:3135",
-            'ETRS-GK29': "EPSG:3136",
-            'ETRS-GK30': "EPSG:3137",
-            'ETRS-GK31': "EPSG:3138",
-            'ETRS-LAEA': "EPSG:3035",
-            'ETRS-LCC': "EPSG:3034",
-            'ETRS-TM34': "EPSG:3046",
-            'ETRS-TM35': "EPSG:3047",
-            'ETRS-TM36': "EPSG:3048", 
-            'ETRS-TM35FIN': "EPSG:3067", 
-            'EUREF-FIN-GEO2D': "EPSG:4258", 
-            'EUREF-FIN-GEO3D': "EPSG:4937", 
-            'ETRS-EUREF-FIN_SUORAK3d': "EPSG:4936", 
-            'KKJ0': "EPSG:3386", 
-            'KKJ1': "EPSG:2391", 
-            'KKJ2': "EPSG:2392", 
-            'KKJ3': "EPSG:2393", 
-            'KKJ4': "EPSG:2394", 
-            'KKJ5': "EPSG:3387", 
-            'KKJ_GEO': "EPSG:4123", 
-            'KORKEUSJ_N2000': "EPSG:3900",
-            'KORKEUSJ_N60': "EPSG:5717",
-            'KORKEUSJ_N43': "N43"
-	    }
-
-        return EPSG[value];
-}*/
 });

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/CoordinateMapSelection.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/CoordinateMapSelection.js
@@ -23,26 +23,26 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.CoordinateMapSelection
             var me = this;
             var helper = me.instance.getHelper();
             var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup'),
-            btn = dialog.createCloseButton(this.loc('actions.done')),
-            cancelBtn = Oskari.clazz.create('Oskari.userinterface.component.Button');
+                btn = dialog.createCloseButton(this.loc('actions.done')),
+                cancelBtn = Oskari.clazz.create('Oskari.userinterface.component.Button');
             cancelBtn.setTitle(this.loc('actions.cancel'));
             btn.addClass('primary');
             me.dialog = dialog;
 
             cancelBtn.setHandler(function() {
                 helper.removeMarkers();
-                dialog.close();
                 me.instance.toggleViews("transformation");
                 me.instance.setMapSelectionMode(false);
                 me.instance.addMapCoordsToInput(false);
+                dialog.close();
             });
 
             btn.setHandler(function() {
                 me.instance.setMapSelectionMode(false);
                 helper.removeMarkers();
-                dialog.close();
                 me.instance.toggleViews("transformation");
                 me.instance.addMapCoordsToInput(true);
+                dialog.close();
             });
 
             dialog.show(this.loc('mapMarkers.select.title'), this.loc('mapMarkers.select.info'), [cancelBtn, btn]);

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/FileHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/FileHandler.js
@@ -1,20 +1,43 @@
 Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
-    function (dataHandler, loc, type) {
+    function (helper, loc, type) {
         var me = this;
         Oskari.makeObservable(this);
-        me.dataHandler = dataHandler;
+        me.helper = helper;
         me.loc = loc;
         me.element = null;
         me.type = type; // import, export
         me.settings;
+        me.showFormatRow = true;
         me._template = {
             settings: _.template('<div class="oskari-coordinate-form">' +
-                                    '<% if (typeof fileName  !== "undefined") { %> '+
+                                    '<% if (obj.export === true) { %> '+
                                         '<div class="fileRow">' +
                                             '<b class="title">${fileName}</b>' +
                                             '<input id="filename" type="text">' +
                                         '</div>'+
-                                    '<% } %>'+            
+                                        '<div class="decimalCountLine"> '+
+                                            '<b class="title">${decimalCount}</b>'+
+                                            '<input id="decimals" type="number" value="0" min="0" max = "20" required> '+
+                                            '<div class="infolink icon-info"></div>' +
+                                        '</div>'+
+                                        '<div class="lineSeparatorRow"> '+
+                                            '<b class="title">${lineSeparator}</b> '+
+                                            '<div class="settingsSelect">'+
+                                                '<select id="lineSeparator">'+
+                                                    '<option value="win">Windows / DOS</option>'+
+                                                    '<option value="unix">Unix</option>'+
+                                                    '<option value="mac">MacOS</option>'+
+                                                '</select>'+
+                                            '</div>'+
+                                            '<div class="infolink icon-info"></div>' +
+                                        '</div>'+
+                                    '<% } else { %>'+
+                                        '<div class="headerLineCount"> '+
+                                            '<b class="title">${headerCount}</b>'+
+                                            '<input id="headerrow" type="number" value="0" min="0" required> '+
+                                            '<div class="infolink icon-info"></div>' +
+                                        '</div>'+
+                                    '<% } %> ' +
                                     '<div class="formatRow"> '+
                                         '<b class="title">${format}</b> '+
                                         '<div class="settingsSelect">'+
@@ -22,41 +45,63 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
                                                 '<option value="degree">${degree}</option>'+
                                                 '<option value="gradian">${gradian}</option>'+
                                                 '<option value="radian">${radian}</option>'+
-                                                '<option value="DDD.dd">DDD.dd</option>'+
-                                                '<option value="DD MM SS.ss">DD MM SS.ss</option>'+
-                                                '<option value="DD MM.mm">DD MM.mm</option>'+
-                                                '<option value="DDMMSS.ss">DDMMSS.ss</option>'+
-                                                '<option value="DDMM.mm">DDMM.mm</option>'+
+                                                '<option value="DD">DD</option>'+
+                                                '<option value="DD MM SS">DD MM SS</option>'+
+                                                '<option value="DD MM">DD MM</option>'+
+                                                '<option value="DDMMSS">DDMMSS</option>'+
+                                                '<option value="DDMM">DDMM</option>'+
                                             '</select>'+
                                         '</div>'+
-                                        '<label class="lbl">' +
-                                            '<input id="prefixId" class="chkbox" type="checkbox">' +
-                                            '${id}' +
-                                        '</label>'+
+                                        '<div class="infolink icon-info"></div>' +
                                     '</div>'+
                                     '<div class="decimalSeparator"> '+
                                         '<b class="title">${decimalSeparator}</b> '+
                                         '<div class="settingsSelect">'+
-                                            '<select id="decimalseparator">'+
-                                                '<option value="point">${point}</option>'+
+                                            '<select id="decimalSeparator">'+
+                                                '<option value=".">${point}</option>'+
+                                                '<option value=",">${comma}</option>'+
+                                            '</select>'+
+                                        '</div>' +
+                                        '<div class="infolink icon-info"></div>' +
+                                    '</div>' +
+                                    '<div class="coordinateSeparator"> '+
+                                        '<b class="title">${coordinateSeparator}</b> '+
+                                        '<div class="settingsSelect">'+
+                                            '<select id="coordinateSeparator">'+
+                                                '<option value="tab">${tab}</option>'+
+                                                '<option value="space">${space}</option>'+
                                                 '<option value="comma">${comma}</option>'+
                                             '</select>'+
                                         '</div>' +
-                                        '<label class="lbl">' +
-                                            '<input id="reversecoordinates" class="chkbox" type="checkbox">' +
-                                            '${reverseCoords}' +
-                                        '</label> '+
+                                        '<div class="infolink icon-info"></div>' +
                                     '</div>' +
-                                    '<div class="headerLineCount"> '+
-                                        '<b class="title">${headerCount}</b>'+
-                                        '<input id="headerrow" type="number"> '+
-                                    '</div>'+
-                                    //'<input id="overlay-btn" class="cancel" type="button" value="${cancel} " />' +
-                                    //'<% if(typeof(fileExport) !== "undefined") { %>'+
-                                    //    '<input id="overlay-btn" class="done" type="button" value="${fileExport}" />'+
-                                    //'<% } else { %>'+
-                                    //    '<input id="overlay-btn" class="done" type="button" value="${done}" />' +
-                                    //'<% } %>' +
+                                    '<label class="lbl">' +
+                                        '<input id="prefixId" class="chkbox" type="checkbox">' +
+                                        '<span>${prefixId}</span>' +
+                                        '<div class="infolink icon-info"></div>' +
+                                    '</label>'+
+                                    '<label class="lbl">' +
+                                        '<input id="reversecoordinates" class="chkbox" type="checkbox">' +
+                                        '<span>${reverseCoords}</span>' +
+                                        '<div class="infolink icon-info"></div>' +
+                                    '</label> '+
+                                    '<% if (obj.export === true) { %> '+
+                                        '<label class="lbl">' +
+                                            '<input id="writeHeader" class="chkbox" type="checkbox">' +
+                                            '<span>${writeHeader}</span>' +
+                                            '<div class="infolink icon-info"></div>' +
+                                        '</label>'+
+                                        '<label class="lbl">' +
+                                            '<input id="lineEnds" class="chkbox" type="checkbox">' +
+                                            '<span>${lineEnds}</span>' +
+                                            '<div class="infolink icon-info"></div>' +
+                                        '</label>'+
+                                        '<label class="lbl">' +
+                                            '<input id="useCardinals" class="chkbox" type="checkbox">' +
+                                            '<span>${useCardinals}</span>' +
+                                            '<div class="infolink icon-info"></div>' +
+                                        '</label>'+
+                                    '<% } %>' +
                                 '</div>' +
                             '</div>'
                                 )
@@ -74,46 +119,40 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
         getSettings: function (){
             return this.settings;
         },
+        setShowFormatRow: function (visible){
+            this.showFormatRow = !!visible;
+        },
         create: function() {
-            var fileSettings;
-            if ( this.type === "export" ) {
-                fileSettings = this._template.settings({
-                    //title: this.loc('fileSettings.export.title'),
-                    fileName: this.loc('fileSettings.export.fileName'),
-                    //fileExport: this.loc('fileSettings.export.fileName'),
-                    format: this.loc('fileSettings.options.format'),
-                    decimalSeparator: this.loc('fileSettings.options.decimalSeparator'),
-                    id: this.loc('fileSettings.options.useId'),
-                    reverseCoords: this.loc('fileSettings.options.reverseCoords'),
-                    headerCount: this.loc('fileSettings.options.headerCount'),
-                    //cancel: this.loc('actions.cancel'),
-                    //done: this.loc('actions.done'),
-                    degree: this.loc('fileSettings.options.degree'),
-                    gradian: this.loc('fileSettings.options.gradian'),
-                    radian: this.loc('fileSettings.options.radian'),
-                    point: this.loc('fileSettings.options.point'),
-                    comma: this.loc('fileSettings.options.comma')
-                });
-            } else {
-                fileSettings = this._template.settings({
-                    //title: this.loc('fileSettings.import.title'),
-                    //fileExport: this.loc('fileSettings'),
-                    format: this.loc('fileSettings.options.format'),
-                    decimalSeparator: this.loc('fileSettings.options.decimalSeparator'),
-                    id: this.loc('fileSettings.options.useId'),
-                    reverseCoords: this.loc('fileSettings.options.reverseCoords'),
-                    headerCount: this.loc('fileSettings.options.headerCount'),
-                    //cancel: this.loc('actions.cancel'),
-                    //done: this.loc('actions.done'),
-                    degree: this.loc('fileSettings.options.degree'),
-                    gradian: this.loc('fileSettings.options.gradian'),
-                    radian: this.loc('fileSettings.options.radian'),
-                    point: this.loc('fileSettings.options.point'),
-                    comma: this.loc('fileSettings.options.comma')
-                });
+            var fileSettings,
+                element;
+            fileSettings = {
+                export: false,
+                fileName: this.loc('fileSettings.export.fileName'),
+                format: this.loc('fileSettings.options.degreeFormat.label'),
+                decimalSeparator: this.loc('fileSettings.options.decimalSeparator'),
+                coordinateSeparator: this.loc('fileSettings.options.coordinateSeparator'),
+                prefixId: this.loc('fileSettings.options.useId'),
+                reverseCoords: this.loc('fileSettings.options.reverseCoords'),
+                headerCount: this.loc('fileSettings.options.headerCount'),
+                decimalCount: this.loc('fileSettings.options.decimalCount'),
+                degree: this.loc('fileSettings.options.degreeFormat.degree'),
+                gradian: this.loc('fileSettings.options.degreeFormat.gradian'),
+                radian: this.loc('fileSettings.options.degreeFormat.radian'),
+                point: this.loc('fileSettings.options.delimeters.point'),
+                comma: this.loc('fileSettings.options.delimeters.comma'),
+                tab: this.loc('fileSettings.options.delimeters.tab'),
+                space: this.loc('fileSettings.options.delimeters.space'),
+                writeHeader: this.loc('fileSettings.options.writeHeader'),
+                lineEnds: this.loc('fileSettings.options.lineEnds'),
+                useCardinals: this.loc('fileSettings.options.useCardinals'),
+                lineSeparator: this.loc('fileSettings.options.lineSeparator.label')
+            };
+            if (this.type === "export"){
+                fileSettings.export = true;
             }
-
-            this.setElement( fileSettings );
+            element = this._template.settings(fileSettings);
+            this.setElement( element );
+            this.bindInfoLinks();
         },
         /*createEventHandlers: function ( dialog ) {
             var me = this;
@@ -130,19 +169,28 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
          * @method getFormSelections
          */
         getFormSelections: function () {
-            var element = jQuery('.oskari-coordinate-form');
+            //var element = jQuery('.oskari-coordinate-form');
+            var element = this.getElement();
             var settings = {
-                filename: element.find('#filename').val(),
+                fileName: element.find('#filename').val(),
                 unit: element.find('#unit option:checked').val(),
-                decimalSeparator: element.find('#decimalseparator option:checked').val(),
+                decimalSeparator: element.find('#decimalSeparator option:checked').val(),
+                coordinateSeparator: element.find('#coordinateSeparator option:checked').val(),
                 prefixId: element.find('#prefixId').is(":checked"),
                 axisFlip: element.find('#reversecoordinates').is(":checked"),
                 headerLineCount: element.find('#headerrow').val(),
+                lineSeparator: element.find("#lineSeparator").val(),
+                decimalCount: element.find('#decimals').val(),
+                writeHeader: element.find('#writeHeader').is(":checked"),
+                writeLineEndings: element.find('#lineEnds').is(":checked"),
+                writeCardinals: element.find('#useCardinals').is(":checked")
             }
             return settings;
         },
-        showFileDialogue: function(callback) {
+        showFileDialogue: function(callback, requireFileName) {
             var me = this;
+            var elem = this.getElement();
+            var formatRow = elem.find('.formatRow');
             var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
             var title = this.type === "import" ? this.loc('fileSettings.import.title') : this.loc('fileSettings.export.title');
             var btnText = this.type === "import" ? this.loc('actions.done') : this.loc('actions.export');
@@ -151,6 +199,9 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
             btn.setTitle(btnText);
             btn.setHandler(function() {
                 me.settings = me.getFormSelections();
+                if (me.helper.validateFileSelections(me.settings, requireFileName) === false){
+                    return;
+                }
                 if (typeof callback === "function"){
                     callback(me.settings);
                 }
@@ -159,10 +210,35 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
 
             dialog.createCloseIcon();
             dialog.makeDraggable();
+            if (this.showFormatRow === false){
+                formatRow.css("display","none");
+            } else {
+                formatRow.css("display","");
+            }
 
-            dialog.show(title, jQuery( this.getElement() ), [cancelBtn, btn]);
+            dialog.show(title, elem, [cancelBtn, btn]);
             //this.createEventHandlers( dialog );
         },
+        bindInfoLinks: function () {
+            var me = this;
+            this.getElement().find('.infolink').on('click', function ( event ) {
+                event.preventDefault();
+                me.showInfoPopup();
+            });
+        },
+        showInfoPopup: function(){
+            var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+            var btn = dialog.createCloseButton(this.loc('actions.ok'));
+            btn.addClass('primary');
+            btn.setHandler( function () {
+                dialog.close(true);
+            });
+            dialog.show("title", "info", [btn]);
+            dialog.moveTo(this);
+            dialog.makeDraggable();
+
+        },
+        /*
         exportFile: function ( settings ) {
             var exportArray = this.dataHandler.getOutputCoords();
             //this.dataHandler.getCoordinateObject().forEach( function ( pair ) {
@@ -173,7 +249,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
             } else {
                 Oskari.log(this.getName()).warn("No transformed coordinates to write to file!");
             }
-        }
+        }*/
     }
 );
  

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/FileHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/FileHandler.js
@@ -71,6 +71,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
                                                 '<option value="tab">${tab}</option>'+
                                                 '<option value="space">${space}</option>'+
                                                 '<option value="comma">${comma}</option>'+
+                                                '<option value="semicolon">${semicolon}</option>'+
                                             '</select>'+
                                         '</div>' +
                                         '<div class="infolink icon-info"></div>' +
@@ -140,6 +141,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
                 radian: this.loc('fileSettings.options.degreeFormat.radian'),
                 point: this.loc('fileSettings.options.delimeters.point'),
                 comma: this.loc('fileSettings.options.delimeters.comma'),
+                semicolon: this.loc('fileSettings.options.delimeters.semicolon'),
                 tab: this.loc('fileSettings.options.delimeters.tab'),
                 space: this.loc('fileSettings.options.delimeters.space'),
                 writeHeader: this.loc('fileSettings.options.writeHeader'),

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/transformation.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/transformation.js
@@ -5,10 +5,15 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
         me.loc = Oskari.getMsg.bind(null, 'coordinatetransformation');
         me.conversionContainer = null
         me.sourceSelection = null; //TODO move
+        me.helper = me.instance.getHelper();
 
-        me.fileinput = Oskari.clazz.create('Oskari.userinterface.component.FileInput', me.loc);
-        me.importFileHandler = Oskari.clazz.create('Oskari.coordinatetransformation.view.FileHandler', me.dataHandler, me.loc, "import");
-        me.exportFileHandler = Oskari.clazz.create('Oskari.coordinatetransformation.view.FileHandler', me.dataHandler, me.loc, "export");
+        me.fileInput = Oskari.clazz.create('Oskari.userinterface.component.FileInput', {
+            'allowMultipleFiles': false,
+            'maxFileSize': 50,
+            'allowedFileTypes': ["text/plain"]
+        });
+        me.importFileHandler = Oskari.clazz.create('Oskari.coordinatetransformation.view.FileHandler', me.helper, me.loc, "import");
+        me.exportFileHandler = Oskari.clazz.create('Oskari.coordinatetransformation.view.FileHandler', me.helper, me.loc, "export");
 
         me.inputTable = Oskari.clazz.create('Oskari.coordinatetransformation.component.table', this, me.loc, "input" );
         me.outputTable = Oskari.clazz.create('Oskari.coordinatetransformation.component.table', this, me.loc, "output");
@@ -20,8 +25,6 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
 
         me.importFileHandler.create();
         me.exportFileHandler.create();
-
-        me.userFiles = [];
 
         me.inputSystem.on('CoordSystemChanged', function(type){
             me.onSystemSelectionChange(type);
@@ -88,21 +91,17 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
                 system.append( element );
             }
             wrapper.append(system);
-            this.fileinput.create();
-            if ( this.fileinput.canUseAdvancedUpload() ) { //TODO
-                var fileInputElement = this.fileinput.handleDragAndDrop( this.storeFileData.bind( this ) );
-            }
-            wrapper.find( '.datasource-info' ).append( fileInputElement );
+
+            this.fileInput.setVisible(false);
+            wrapper.find( '.datasource-info' ).append( this.fileInput.getElement() );
 
             wrapper.append( inputTable );
             wrapper.append( transformButton );
             wrapper.append( targetTable );
             wrapper.append( utilRow );
 
-
             jQuery(container).append(wrapper);
 
-            //this.inputTable.handleClipboardPasteEvent();
             this.handleButtons();
             this.handleRadioButtons();
         },
@@ -125,15 +124,6 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
         getSourceSelection: function () {
             return this.sourceSelection;
         },
-        /**
-         * @method readFileData
-         * Pass this function as a callback to fileinput to get the file-data
-         */
-        storeFileData: function( fileData ) {
-            this.userFiles = fileData;
-            //var dataJson = this.instance.getDataHandler().validateData( fileData );
-            //this.updateCoordinateData( "import", dataJson );
-        },
         //TODO do we need this??
         getSelectionValue: function ( selectListInstance ) {
             return selectListInstance.getValue();
@@ -145,12 +135,15 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
         getCrsOptions: function () {
             var input = this.inputSystem;
             var target = this.outputSystem;
+            var dimensions = this.instance.getDimensions();
 
             return options = {
                 sourceCrs: input.getSrs(),
                 sourceElevationCrs: input.getElevation(),
                 targetCrs: target.getSrs(),
-                targetElevationCrs: target.getElevation()
+                targetElevationCrs: target.getElevation(),
+                sourceDimension: dimensions.input,
+                targetDimension: dimensions.output
             }
         },
         showMessage: function (title, message){
@@ -164,30 +157,37 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
                 srs,
                 table,
                 heightSystem,
-                dimension;
-
+                dimension,
+                fileHandler;
             if (type === "input"){
                 selections = this.inputSystem.getSelections();
                 table = this.inputTable;
+                fileHandler = this.importFileHandler;
             } else {
                 selections = this.outputSystem.getSelections();
                 table = this.outputTable;
+                fileHandler = this.exportFileHandler;
             }
-
             srs = selections['geodetic-coordinate'];
             heightSystem = selections.elevation;
             this.instance.setDimension(type, srs, heightSystem);
             epsgValues = this.instance.getEpsgValues(srs);
-
             if (epsgValues){
                 table.updateHeader(epsgValues, heightSystem);
+                if (epsgValues.coord === "COORD_GEOG_2D" || epsgValues.coord === "COORD_GEOG_3D"){ //TODO helper isGeogSystem(srs)
+                    fileHandler.setShowFormatRow(true);
+                } else {
+                    fileHandler.setShowFormatRow(false);
+                }
             } else {
                 table.updateHeader(); //remove header
+                fileHandler.setShowFormatRow(true);
+
             }
             dimension =  this.instance.getDimension(type);
             table.handleDisplayingElevationRows(dimension);
         },
-        confirmResetFlyout: function (blnSystems){ //TODO handle resetFlyout (systems, coords) and clearTables (coords) more properly
+        confirmResetFlyout: function (blnSystems, callback){ //TODO handle resetFlyout (systems, coords) and clearTables (coords) more properly
             var me = this;
             var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup'),
                 okBtn = Oskari.clazz.create('Oskari.userinterface.component.Button'),
@@ -196,6 +196,9 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
             okBtn.addClass('primary');
             okBtn.setHandler(function() {
                 me.resetFlyout(blnSystems);
+                if (typeof callback === "function"){
+                    callback();
+                }
                 dialog.close();
             });
             if (blnSystems === true){
@@ -208,8 +211,8 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
             var me = this;
             me.instance.getDataHandler().clearCoords();
             if(blnSystems){
-                me.inputSystem.resetSelectsToPlaceholder(true);
-                me.outputSystem.resetSelectsToPlaceholder(true);
+                me.inputSystem.resetSelections(true);
+                me.outputSystem.resetSelections(true);
             }
         },
         /**
@@ -220,9 +223,12 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
             var me = this;
             jQuery('input[type=radio][name=load]').click(function(evt) {
                 if (me.sourceSelection !== this.value && me.instance.hasInputCoords()){
+                    var selectCb = function(){
+                        jQuery(evt.target).prop("checked", true);
+                        me.handleSourceSelection(evt.target.value);
+                    }
                     evt.preventDefault();
-                    me.confirmResetFlyout(true);
-                    //TODO if yes then select radio button and handle source selection
+                    me.confirmResetFlyout(true, selectCb);
                 } else {
                     me.handleSourceSelection(this.value);
                 }
@@ -234,20 +240,19 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
             var container = me.getContainer();
             var keyboardInfoElement = container.find('.coordinateconversion-keyboardinfo');
             var mapSelectInfoElement = container.find('.coordinateconversion-mapinfo')
-            var fileInputElement = container.find('.oskari-fileinput');
 
             if (value == 'file') {
                 me.inputTable.setIsEditable(false);
                 me.importFileHandler.showFileDialogue();
                 keyboardInfoElement.hide();
                 mapSelectInfoElement.hide();
-                fileInputElement.show();
+                this.fileInput.setVisible(true);
                 me.inputSystem.disableInputSelections(false);
                 me.bindInputTableHandler(false);
             }
             else if (value == 'keyboard') {
                 me.inputTable.setIsEditable(true);
-                fileInputElement.hide();
+                this.fileInput.setVisible(false);
                 mapSelectInfoElement.hide();
                 keyboardInfoElement.show();
                 me.inputSystem.disableInputSelections(false);
@@ -256,7 +261,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
             else if (value == 'map') {
                 me.inputTable.setIsEditable(false);
                 keyboardInfoElement.hide();
-                fileInputElement.hide();
+                this.fileInput.setVisible(false);
                 mapSelectInfoElement.show();
                 me.inputSystem.selectMapProjection();
                 me.inputSystem.disableInputSelections(true);
@@ -281,6 +286,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
             var cells;
             var coord;
             var inputCoords = [];
+            var srs = me.inputSystem.getSrs();
 
             rows.each(function(){
                 coord = [];
@@ -292,7 +298,14 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
                     }
                 }
                 inputCoords.push(coord);
-                // TODO: check if epsg bbox contains coord
+                //Check that coord is in bounds
+                /*
+                if (me.helper.isCoordInBounds(srs, coord) === false){
+                    me.showMessage("Error", "Coordinate: " + coord + " isn't inside bounds.");
+                    return false;
+                }else{
+                    inputCoords.push(coord);
+                }*/
             });
             //update input coordinates and don't render input table
             me.instance.getDataHandler().setInputCoords(inputCoords, true);
@@ -318,13 +331,18 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
         handleButtons: function () {
             var me = this;
             var container = me.getContainer();
+            var validCrsSelects;
+            var inputSrs;
+            var inputCoords;
+            var checkDimensions;
 
             jQuery('.selectFromMap').on("click", function() {
-                me.instance.setMapSelectionMode(true); //TODO flyout show/hide
-                //TODO
-                var inputCoords = me.instance.getDataHandler().getInputCoords();
-                me.instance.getHelper().showMarkersOnMap(inputCoords, true);
-                //---
+                me.instance.setMapSelectionMode(true);
+                if (me.instance.hasInputCoords()){
+                    inputSrs = me.inputSystem.getSrs();
+                    inputCoords = me.instance.getDataHandler().getInputCoords();
+                    me.helper.showMarkersOnMap(inputCoords, true, inputSrs);
+                }
                 me.instance.toggleViews("MapSelection");
             });
 
@@ -332,80 +350,106 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
                 me.confirmResetFlyout(false); //don't reset coord systems
             });
             container.find('.show').on("click", function () {
-                var inputCoords = me.instance.getDataHandler().getInputCoords();
-                me.instance.getHelper().showMarkersOnMap(inputCoords);
+                inputCoords = me.instance.getDataHandler().getInputCoords();
+                inputSrs = me.inputSystem.getSrs();
+                me.helper.showMarkersOnMap(inputCoords, false, inputSrs);
                 me.instance.toggleViews("mapmarkers");
             });
             container.find('.export').on("click", function () {
-                me.exportFileHandler.showFileDialogue(me.transformToFile.bind(me));
+                validCrsSelects = me.helper.validateCrsSelections (me.getCrsOptions());
+                if (validCrsSelects === true){
+                    me.helper.checkDimensions(me.getCrsOptions(), me.handleExport.bind(me));
+                }
             });
             container.find('#transform').on("click", function () {
-                me.transformToTable();
+                validCrsSelects = me.helper.validateCrsSelections (me.getCrsOptions());
+                if (validCrsSelects === true){
+                    me.helper.checkDimensions(me.getCrsOptions(), me.transformToTable.bind(me));
+                }
             });
         },
+        handleExport: function (){
+            this.exportFileHandler.showFileDialogue(this.transformToFile.bind(this), true);
+        },
         transformToTable: function () {
-            var me = this;
-            var crsSettings = me.getCrsOptions();
-            var source = me.getSourceSelection();
+            var crsSettings = this.getCrsOptions();
+            var source = this.getSourceSelection();
             var coords;
             var validTransform;
             var fileSettings;
             var file;
             if (source === "file"){
                 fileSettings = this.importFileHandler.getSettings();
-                file = this.userFiles[0];
+                file = this.fileInput.getFiles();
+                if (file === null){ //FileInput shows error popup
+                    return;
+                }
             } else {
-                coords = me.instance.getDataHandler().getInputCoords();
-            }
-            validTransform = this.instance.getHelper().validateSelectionsForTransform (crsSettings, fileSettings, me.instance.hasInputCoords());
-            if (validTransform !== true){
-                me.showMessage(me.loc('flyout.transform.validateErrors.title'), validTransform);
-                return;
+                if (this.instance.hasInputCoords()){
+                    coords = this.instance.getDataHandler().getInputCoords();
+                } else {
+                    this.showMessage(this.loc('flyout.transform.validateErrors.title'), this.loc('flyout.transform.validateErrors.noInputData'));
+                    return;
+                }
             }
             if (source === "file"){
-                me.instance.getService().transformFileToArray( file, crsSettings, fileSettings, me.handleFileResponse.bind( me ), me.handleErrorResponse.bind(me) ); //callback
+                this.instance.getService().transformFileToArray( file, crsSettings, fileSettings, this.handleArrayResponse.bind( this ), this.handleErrorResponse.bind(this) ); //callback
             } else {
-                me.instance.getService().transformArrayToArray( coords, crsSettings, me.handleArrayResponse.bind( me ), me.handleErrorResponse.bind(me) ); //callback
+                this.instance.getService().transformArrayToArray( coords, crsSettings, this.handleArrayResponse.bind( this ), this.handleErrorResponse.bind(this) ); //callback
             }
         },
         transformToFile: function (settings){
-            var me = this;
             var crsSettings = this.getCrsOptions();
-            var fileSettings = settings;
+            var exportSettings = settings;
             var file;
             var coords;
-            var source =this.sourceSelection;
+            var source = this.sourceSelection;
             if (source === "file"){
-                fileSettings = this.exportFileHandler.getSettings();
-                file = this.userFiles[0];
+                var importSettings = this.importFileHandler.getSettings();
+                file = this.fileInput.getFiles();
+                if (file === null){ //FileInput shows error popup
+                    return;
+                }
             } else {
-                coords = this.instance.getDataHandler().getInputCoords();
+                if (this.instance.hasInputCoords()){
+                    coords = this.instance.getDataHandler().getInputCoords();
+                } else {
+                    this.showMessage(this.loc('flyout.transform.validateErrors.title'), this.loc('flyout.transform.validateErrors.noInputData'));
+                    return;
+                }
             }
-            //TODO should check on export button click
-            var validTransform = this.instance.getHelper().validateSelectionsForTransform (crsSettings, fileSettings, me.instance.hasInputCoords());
-            if (validTransform !== true){
-                me.showMessage(me.loc('flyout.transform.validateErrors.title'), validTransform);
-                return;
-            }
-
             if (source === "file"){
-                this.instance.getService().transformFileToFile(file, crsSettings, fileSettings, this.handleFileResponse.bind( this ), this.handleErrorResponse.bind(this) );
+                this.instance.getService().transformFileToFile(file, crsSettings, importSettings, exportSettings, this.handleFileResponse.bind( this ), this.handleErrorResponse.bind(this) );
             } else {
-                this.instance.getService().transformArrayToFile( coords, crsSettings, fileSettings, this.handleFileResponse.bind( this ), this.handleErrorResponse.bind(this) );
+                this.instance.getService().transformArrayToFile( coords, crsSettings, exportSettings, this.handleFileResponse.bind( this ), this.handleErrorResponse.bind(this) );
             }
         },
         handleArrayResponse: function (response) {
-            //TODO add some checking
             var coords = response.coordinates;
+            var inputCoords = response.inputCoordinates;
             //TODO check that response dimension matches
             var dimension = response.dimension;
+            var hasMoreCoordinates = response.hasMoreCoordinates;
             this.instance.getDataHandler().setResultCoords(coords);
+            if (inputCoords){
+                this.instance.getDataHandler().setInputCoords(inputCoords);
+            }
+            if (hasMoreCoordinates === true){
+                this.showMessage(this.loc('flyout.transform.responseFile.title'), this.loc('flyout.transform.responseFile.hasMoreCoordinates', {maxCoordsToArray: 100}));
+            }
         },
         handleFileResponse: function (){
             //TODO
         },
-        handleErrorResponse: function (errorCode){
-            this.showMessage(this.loc('flyout.transform.responseErrors.title'), this.loc('flyout.transform.responseErrors.errorMsg'))
+        handleErrorResponse: function (error, errorCode){
+            var errors = this.loc('flyout.transform.responseErrors');
+            var errorMsg = errors.generic;
+            if (errorCode && errors[errorCode]){
+                errorMsg = errors[errorCode];
+            } else if (error){
+                errorMsg += "<br> Error: " + error; //TODO adds backend msg. use only generic message, when localized messages are ready
+            }
+            this.showMessage(this.loc('flyout.transform.responseErrors.title'), errorMsg);
         }
     }
 );


### PR DESCRIPTION
Added missing file input and export settings/selections. 
Hide degree formating selection if coordinate system is metric based.
File input and export handling and file settings validation added.

Marker labels are now generated based on coordinate system (lonlat, latlon, NE, EN). Coordinates selected by mapclick are now rounded to integers.

Error handling: some backend error codes are now localized. Backend error message is now added to error message/popup to demonstrate what error messages and advises should be shown to user.

Source and target dimension is added to requests because 3D coordinate systems doesn't have height system (separate epsg code). Also transform type is added (A2A, A2F, F2A, F2F). If there is easy and reliable way to handle type (based on payload or settings) in the backend then there is no need to add it.

Refactoring: moved some common functionality from instance to helper. 

May conflict with and is dependent on: https://github.com/oskariorg/oskari-frontend/pull/397