### PR TITLE
Timeseries control to publisher

### DIFF
--- a/applications/asdi/asdi_published/css/overwritten.css
+++ b/applications/asdi/asdi_published/css/overwritten.css
@@ -78,7 +78,7 @@ table {
     }
     
     .oskari-flyoutheading {
-		background-color: white !important;
+		background-color: rgb(12, 60, 98) !important;
 		border-top: 0px !important;
 		border-bottom: 0px !important;
 		height: 14px !important;
@@ -147,6 +147,42 @@ table {
 	.search .resultList div h3 {
 		font-size: 14px;	
 	}
+}
+
+div.mapplugin.timeseries .oskari-timeslider {
+    background-color: #93bbda !important;
+}
+
+.mapplugin-timeseries-popup .content {
+    background-color: #93bbda !important;
+}
+
+.mapplugin-timeseries-popup .arrow {
+    border-bottom: 15px solid #93bbda !important;
+}
+
+div.mapplugin.timeseries div.playback-button button {
+    background-color: #93bbda !important;
+}
+
+div.mapplugin.timeseries .oskari-timeslider .interval-line-highlight {
+    color: #3c3c3c !important;
+}
+
+div.mapplugin.timeseries div.playback-button button.play:after {
+    border-color: transparent transparent transparent #3c3c3c !important;
+}
+
+.mapplugin-timeseries-popup .content {
+    color: #3c3c3c !important;
+}
+
+div.mapplugin.timeseries div.playback-button button.pause:after {
+    background: #3c3c3c !important;
+}
+
+div.mapplugin.timeseries div.playback-button button.pause:before {
+    background: #3c3c3c !important;
 }
 
 /**

--- a/applications/asdi/asdi_published/minifierAppSetup.json
+++ b/applications/asdi/asdi_published/minifierAppSetup.json
@@ -85,6 +85,15 @@
             }
         }
     }, {
+        "bundlename" : "timeseries",
+        "metadata" : {
+            "Import-Bundle" : {
+                "drawtools" : {
+                    "bundlePath" : "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
         "bundlename" : "rpc",
         "metadata" : {
             "Import-Bundle" : {

--- a/bundles/framework/publisher2/resources/locale/en.js
+++ b/bundles/framework/publisher2/resources/locale/en.js
@@ -63,6 +63,7 @@ Oskari.registerLocalization(
                 "label": "Tools",
                 "tooltip": "Select available map tools. Check a placement in the map preview.",
                 "ScaleBarPlugin": "Scale bar",
+                "TimeseriesControlPlugin": "Timeseries player",
                 "IndexMapPlugin": "Index map",
                 "PanButtons": "Pan tool",
                 "Portti2Zoombar": "Zoom bar",

--- a/bundles/framework/publisher2/resources/locale/fi.js
+++ b/bundles/framework/publisher2/resources/locale/fi.js
@@ -63,6 +63,7 @@ Oskari.registerLocalization(
                 "label": "Kartalla näytettävät työkalut",
                 "tooltip": "Valitse kartalla käytettävissä olevat työkalut. Tarkista asettelu esikatselukartasta.",
                 "ScaleBarPlugin": "Mittakaavajana",
+                "TimeseriesControlPlugin": "Aikasarjatoistin",
                 "IndexMapPlugin": "Indeksikartta",
                 "PanButtons": "Kartan liikuttaminen nuolipainikkeilla",
                 "Portti2Zoombar": "Mittakaavasäädin",

--- a/bundles/framework/publisher2/resources/locale/sv.js
+++ b/bundles/framework/publisher2/resources/locale/sv.js
@@ -62,6 +62,7 @@ Oskari.registerLocalization(
                 "label": "Verktyg",
                 "tooltip": "Välj verktygen som visas på kartan. Du kan se deras placering på den förhandsvisade kartan.",
                 "ScaleBarPlugin": "Skalstock",
+                "TimeseriesControlPlugin": "Tidseriespelare",
                 "IndexMapPlugin": "Indexkarta",
                 "PanButtons": "Panoreringsverktyg",
                 "Portti2Zoombar": "Skalans glidreglage",

--- a/bundles/framework/timeseries/publisher/TimeseriesTool.js
+++ b/bundles/framework/timeseries/publisher/TimeseriesTool.js
@@ -1,0 +1,113 @@
+Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesTool',
+    function () {
+    }, {
+        index: 0,
+        allowedLocations: ['top center', 'top right', 'top left'],
+        lefthanded: 'top center',
+        righthanded: 'top center',
+        allowedSiblings: [],
+        groupedSiblings: false,
+        activeTimeseries: null,
+        /**
+         * Initialize tool
+         * @params {} state data
+         * @method init
+         * @public
+         */
+        init: function (pdata) {
+            this.setEnabled(true);
+        },
+        _getTimeseriesService: function () {
+            if (!this.service) {
+                this.service = this.__sandbox.getService('Oskari.mapframework.bundle.timeseries.TimeseriesService');
+            }
+            return this.service;
+        },
+        /**
+        * Get tool object.
+        * @method getTool
+        * @private
+        *
+        * @returns {Object} tool
+        */
+        getTool: function () {
+            return {
+                id: 'Oskari.mapframework.bundle.timeseries.TimeseriesControlPlugin',
+                title: 'TimeseriesControlPlugin',
+                config: {
+                    showControl: true,
+                    location: this.allowedLocations[0],
+                    widthMargin: 200,
+                    topMargin: '10%'
+                }
+            };
+        },
+        /**
+        * Set enabled.
+        * @method setEnabled
+        * @public
+        *
+        * @param {Boolean} enabled is tool enabled or not
+        */
+        setEnabled: function (enabled) {
+            var tool = this.getTool();
+
+            // state actually hasn't changed -> do nothing
+            if (this.state.enabled !== undefined && this.state.enabled !== null && enabled === this.state.enabled) {
+                return;
+            }
+
+            this.state.enabled = enabled;
+            if (enabled) {
+                var active = this._getTimeseriesService().getActiveTimeseries();
+                if (active) {
+                    active.conf = jQuery.extend(true, active.conf || {}, tool.config);
+                }
+                this.service.trigger('activeChanged', active);
+            } else {
+                // removes the control plugin
+                this.service.trigger('activeChanged', null);
+            }
+
+            var event = Oskari.eventBuilder('Publisher2.ToolEnabledChangedEvent')(this);
+            this.__sandbox.notifyAll(event);
+        },
+        /**
+        * Is displayed.
+        * @method isDisplayed
+        * @public
+        *
+        * @returns {Boolean} is tool displayed
+        */
+        isDisplayed: function (data) {
+            return typeof this._getTimeseriesService().getActiveTimeseries() !== 'undefined';
+        },
+        /**
+        * Get values.
+        * @method getValues
+        * @public
+        *
+        * @returns {Object} tool value object
+        */
+        getValues: function () {
+            var me = this;
+
+            if (me.state.enabled) {
+                return {
+                    configuration: {
+                        timeseries: {
+                            conf: {
+                                plugins: [{ id: this.getTool().id, config: this.getTool().config }]
+                            }
+                        }
+                    }
+                };
+            } else {
+                return null;
+            }
+        }
+    }, {
+        'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],
+        'protocol': ['Oskari.mapframework.publisher.Tool']
+    }
+);

--- a/bundles/framework/timeseries/service/TimeseriesLayerService.js
+++ b/bundles/framework/timeseries/service/TimeseriesLayerService.js
@@ -63,6 +63,15 @@ Oskari.clazz.define(
                     series.delegate.destroy();
                     this.updateTimeseriesLayers();
                 }
+            },
+            'MapLayerVisibilityChangedEvent': function (event) {
+                if (!event.getMapLayer().isVisible()) {
+                    var series = this._timeseriesService.unregisterTimeseries(event.getMapLayer().getId(), 'layer');
+                    if (series) {
+                        series.delegate.destroy();
+                    }
+                }
+                this.updateTimeseriesLayers();
             }
         },
         /**

--- a/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
@@ -20,6 +20,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
         me.loc = Oskari.getMsg.bind(null, 'timeseries');
         me._d3TimeDef = Oskari.getLocalization('timeseries').d3TimeDef;
         me._widthMargin = conf.widthMargin || 130;
+        me._topMargin = conf.topMargin || 0;
         me._waitingForFrame = false;
 
         me._delegate = delegate;
@@ -287,6 +288,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
                 me._element.append(aux);
             } else {
                 me._setWidth(me.getSandbox().getMap().getWidth(), true);
+                me._applyTopMargin(this._topMargin);
                 me._element.prepend(aux);
                 me._initMenus();
                 me._makeDraggable();
@@ -314,6 +316,30 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
                 this._timelineWidth = targetWidth;
                 if (!suppressUpdate) {
                     this._updateTimelines(this._inMobileMode);
+                }
+            }
+        },
+        /**
+         * @method _applyTopMargin
+         * @private
+         *
+         * @param  {number | string} topMargin Top margin for control as number representing px or css syntax using "px" or "%".
+         */
+        _applyTopMargin: function (topMargin) {
+            if (!this._inMobileMode) {
+                if (typeof topMargin === 'string') {
+                    if (topMargin.includes('%')) {
+                        var mapHeight = this.getSandbox().getMap().getHeight() || 200;
+                        var percetageFromTop = topMargin.substr(0, topMargin.length - 1);
+                        if (!isNaN(percetageFromTop)) {
+                            var margin = mapHeight / 100 * percetageFromTop;
+                            this._element.css('margin-top', margin + 'px');
+                        }
+                    } else {
+                        this._element.css('margin-top', topMargin);
+                    }
+                } else if (typeof topMargin === 'number') {
+                    this._element.css('margin-top', margin + 'px');
                 }
             }
         },
@@ -605,9 +631,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
          * @param {Oskari.Sandbox} sandbox
          */
         _stopPluginImpl: function (sandbox) {
-            this._setAnimationState(false);
-            this.removeFromPluginContainer(this.getElement());
-        },
+            if (this._element) {
+                this._setAnimationState(false);
+                this.removeFromPluginContainer(this.getElement());
+            }
+        }
     }, {
         'extend': ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],
         'protocol': ["Oskari.mapframework.module.Module", "Oskari.mapframework.ui.module.common.mapmodule.Plugin"]

--- a/packages/framework/bundle/timeseries/bundle.js
+++ b/packages/framework/bundle/timeseries/bundle.js
@@ -33,7 +33,10 @@ Oskari.clazz.define("Oskari.mapframework.bundle.timeseries.TimeseriesToolBundle"
             }, {
                 "type": "text/javascript",
                 "src": "../../../../bundles/framework/timeseries/view/TimeseriesControlPlugin.js"
-            },{
+            }, {
+                "type": "text/javascript",
+                "src": "../../../../bundles/framework/timeseries/publisher/TimeseriesTool.js"
+            }, {
                 "type": "text/javascript",
                 "src": "../../../../bundles/framework/timeseries/WMSAnimator.js"
             }, {

--- a/packages/framework/bundle/ui-components/bundle.js
+++ b/packages/framework/bundle/ui-components/bundle.js
@@ -104,9 +104,11 @@ Oskari.clazz.define("Oskari.userinterface.bundle.ui.ComponentsBundle", function(
             "src" : "../../../../bundles/framework/divmanazer/component/ProgressSpinner.js"
         }, {
             "type" : "text/javascript",
+            "src" : "../../../../bundles/framework/divmanazer/component/Select.js"
+        }, {
+            "type" : "text/javascript",
             "src" : "../../../../bundles/framework/divmanazer/component/SelectList.js"
-        },
-        {
+        }, {
             "type" : "text/javascript",
             "src" : "../../../../bundles/framework/divmanazer/component/ProgressBar.js"
         }, {


### PR DESCRIPTION
Adds timeseries functionality to the publisher and published maps.
Control follows timeseries layers' visibility.

Requires server PR https://github.com/oskariorg/oskari-server/pull/218