### PR TITLE
Featuredata2 grid intial size

### DIFF
--- a/bundles/framework/featuredata2/Flyout.js
+++ b/bundles/framework/featuredata2/Flyout.js
@@ -770,7 +770,11 @@ Oskari.clazz.define(
                         parseInt(tabContent.css('padding-bottom') || 0) +
                         (flyout.find('.exporter').height() || 0) + 10;
 
-                    tabContent.css('height', (parent.height() - paddings) + 'px');
+                    if (parent.height() === null) {
+                        tabContent.css('max-height', '100%');
+                    } else {
+                        tabContent.css('height', (parent.height() - paddings) + 'px');
+                    }
                     flyout.css('max-width', mapdiv.width().toString() + 'px');
                 }
                 if (me.resizable) {


### PR DESCRIPTION
Use a max-height value of 100% if no parent element is available yet