### PR TITLE
Layerfilter publisher add layer fix

### DIFF
--- a/bundles/framework/layerselector2/request/ShowFilteredLayerListRequestHandler.js
+++ b/bundles/framework/layerselector2/request/ShowFilteredLayerListRequestHandler.js
@@ -27,7 +27,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.request.ShowFilte
             this.instance.filteredLayerListOpenedByRequest = true;
 
             if(request.getSelectedFilter()){
-                layerSelectorFlyout.activateFilter(request.getSelectedFilter());
+                layerSelectorFlyout.setActiveFilter(request.getSelectedFilter());
             }
 
             if(request.getOpenLayerList() && request.getOpenLayerList() === true){


### PR DESCRIPTION
When the layerfiltering was updated the "add layer" in the publisher was overlooked, now it's fixed.