### PR TITLE
Update sample and ELF apps to use OpenLayers 4

### DIFF
--- a/applications/elf/elf_guest/minifierAppSetup.json
+++ b/applications/elf/elf_guest/minifierAppSetup.json
@@ -9,64 +9,37 @@
                     }
                 }
             }
-        },
-        {
-            "bundlename": "oskariui",
-            "metadata": {
-                "Import-Bundle": {
-                    "oskariui": {
-                        "bundlePath": "../../../packages/framework/bundle/"
-                    }
-                }
-            }
         }, {
-            "bundlename": "openlayers-default-theme",
-            "metadata": {
-                "Import-Bundle": {
-                    "openlayers-default-theme": {
-                        "bundlePath": "../../../packages/openlayers/bundle/"
-                    },
-                    "openlayers-full-map": {
-                        "bundlePath": "../../../packages/openlayers/bundle/"
-                    }
-                }
-            }
-        },
-        {
             "bundlename": "mapfull",
             "metadata": {
                 "Import-Bundle": {
-                    "mapwmts": {
+                    "mapmyplaces": {
+                        "bundlePath": "../../../packages/mapping/ol3/"
+                    },
+                    "maparcgis": {
+                        "bundlePath": "../../../packages/mapping/ol3/"
+                    },
+                    "mapmodule": {
+                        "bundlePath": "../../../packages/mapping/ol3/"
+                    },
+                    "oskariui": {
                         "bundlePath": "../../../packages/framework/bundle/"
                     },
                     "mapwfs2": {
-                        "bundlePath": "../../../packages/framework/bundle/"
-                    },
-                    "mapmyplaces": {
-                        "bundlePath": "../../../packages/framework/bundle/"
+                        "bundlePath": "../../../packages/mapping/ol3/"
                     },
                     "mapuserlayers": {
-                        "bundlePath": "../../../packages/framework/bundle/"
+                        "bundlePath": "../../../packages/mapping/ol3/"
                     },
-                    "maparcgis": {
-                        "bundlePath": "../../../packages/arcgis/bundle/"
-                    },
-                    "mapmodule-plugin": {
+                    "ui-components": {
                         "bundlePath": "../../../packages/framework/bundle/"
                     },
                     "mapfull": {
                         "bundlePath": "../../../packages/framework/bundle/"
                     },
-                    "ui-components": {
-                        "bundlePath": "../../../packages/framework/bundle/"
-                    },
-                    "mapanalysis": {
-                        "bundlePath": "../../../packages/framework/bundle/"
-                    },
-                    "mapstats": {
-                        "bundlePath": "../../../packages/framework/bundle/"
+                    "mapwmts": {
+                        "bundlePath": "../../../packages/mapping/ol3/"
                     }
-
                 }
             }
         }, {
@@ -79,11 +52,21 @@
                 }
             }
         }, {
+            "bundlename" : "drawtools",
+            "bundleinstancename" : "drawtools",
+            "metadata" : {
+                "Import-Bundle" : {
+                    "drawtools" : {
+                        "bundlePath" : "../../../packages/mapping/ol3/"
+                    }
+                }
+            }
+        }, {
             "bundlename": "toolbar",
             "metadata": {
                 "Import-Bundle": {
                     "toolbar": {
-                        "bundlePath": "../../../packages/framework/bundle/"
+                        "bundlePath": "../../../packages/mapping/ol3/"
                     }
                 }
             }
@@ -101,7 +84,7 @@
             "metadata": {
                 "Import-Bundle": {
                     "infobox": {
-                        "bundlePath": "../../../packages/framework/bundle/"
+                        "bundlePath": "../../../packages/mapping/ol3/"
                     }
                 }
             }
@@ -119,7 +102,7 @@
             "metadata": {
                 "Import-Bundle": {
                     "metadatacatalogue": {
-                        "bundlePath": "../../../packages/catalogue/bundle/"
+                        "bundlePath": "../../../packages/catalogue/"
                     }
                 }
             }
@@ -205,10 +188,10 @@
                 }
             }
         }, {
-            "bundlename": "myplaces2",
+            "bundlename": "myplaces3",
             "metadata": {
                 "Import-Bundle": {
-                    "myplaces2": {
+                    "myplaces3": {
                         "bundlePath": "../../../packages/framework/bundle/"
                     }
                 }

--- a/applications/elf/elf_guest/minifierAppSetup.json
+++ b/applications/elf/elf_guest/minifierAppSetup.json
@@ -183,7 +183,7 @@
             "metadata": {
                 "Import-Bundle": {
                     "featuredata2": {
-                        "bundlePath": "../../../packages/framework/bundle/"
+                        "bundlePath": "../../../packages/framework/"
                     }
                 }
             }

--- a/applications/paikkatietoikkuna.fi/full-map/minifierAppSetup.json
+++ b/applications/paikkatietoikkuna.fi/full-map/minifierAppSetup.json
@@ -1,5 +1,5 @@
 {
-	"startupSequence": [
+    "startupSequence": [
         {
             "bundlename": "lang-overrides",
             "metadata": {
@@ -9,250 +9,236 @@
                     }
                 }
             }
-		}, {
+        }, {
             "bundlename": "mapfull",
             "metadata": {
                 "Import-Bundle": {
-					"mapmyplaces": {
-						"bundlePath": "../../../packages/mapping/ol3/"
-					},
-					"maparcgis": {
-						"bundlePath": "../../../packages/mapping/ol3/"
-					},
-					"mapmodule": {
-						"bundlePath": "../../../packages/mapping/ol3/"
-					},
-					"oskariui": {
-						"bundlePath": "../../../packages/framework/bundle/"
-					},
-					"mapwfs2": {
-						"bundlePath": "../../../packages/mapping/ol3/"
-					},
-					"mapstats": {
-						"bundlePath": "../../../packages/mapping/ol3/"
-					},
-					"mapuserlayers": {
-						"bundlePath": "../../../packages/mapping/ol3/"
-					},
-					"ui-components": {
-						"bundlePath": "../../../packages/framework/bundle/"
-					},
-					"mapanalysis": {
-						"bundlePath": "../../../packages/mapping/ol3/"
-					},
-					"mapfull": {
-						"bundlePath": "../../../packages/framework/bundle/"
-					},
-					"mapwmts": {
-						"bundlePath": "../../../packages/mapping/ol3/"
-					}
+                    "mapmyplaces": {
+                        "bundlePath": "../../../packages/mapping/ol3/"
+                    },
+                    "maparcgis": {
+                        "bundlePath": "../../../packages/mapping/ol3/"
+                    },
+                    "mapmodule": {
+                        "bundlePath": "../../../packages/mapping/ol3/"
+                    },
+                    "oskariui": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    },
+                    "mapwfs2": {
+                        "bundlePath": "../../../packages/mapping/ol3/"
+                    },
+                    "mapstats": {
+                        "bundlePath": "../../../packages/mapping/ol3/"
+                    },
+                    "mapuserlayers": {
+                        "bundlePath": "../../../packages/mapping/ol3/"
+                    },
+                    "ui-components": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    },
+                    "mapanalysis": {
+                        "bundlePath": "../../../packages/mapping/ol3/"
+                    },
+                    "mapfull": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    },
+                    "mapwmts": {
+                        "bundlePath": "../../../packages/mapping/ol3/"
+                    }
                 }
             }
-		}, {
-			"bundlename": "divmanazer",
-			"metadata": {
-				"Import-Bundle": {
-					"divmanazer": {
-						"bundlePath": "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-	        "bundlename" : "drawtools",
-	        "bundleinstancename" : "drawtools",
-	        "metadata" : {
-	            "Import-Bundle" : {
-	                "drawtools" : {
-	                    "bundlePath" : "../../../packages/mapping/ol3/"
-	                }
-	            }
-	        }
-	    }, {
-			"bundlename": "toolbar",
-			"metadata": {
-				"Import-Bundle": {
-					"toolbar": {
-						"bundlePath": "../../../packages/mapping/ol3/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "statehandler",
-			"metadata": {
-				"Import-Bundle": {
-					"statehandler": {
-						"bundlePath": "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "infobox",
-			"metadata": {
-				"Import-Bundle": {
-					"infobox": {
-						"bundlePath": "../../../packages/mapping/ol3/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "search",
-			"metadata": {
-				"Import-Bundle": {
-					"search": {
-						"bundlePath": "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "metadatacatalogue",
-			"metadata": {
-				"Import-Bundle": {
-					"metadatacatalogue": {
-						"bundlePath": "../../../packages/catalogue/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "layerselector2",
-			"metadata": {
-				"Import-Bundle": {
-					"layerselector2": {
-						"bundlePath": "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "layerselection2",
-			"metadata": {
-				"Import-Bundle": {
-					"layerselection2": {
-						"bundlePath": "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "personaldata",
-			"metadata": {
-				"Import-Bundle": {
-					"personaldata": {
-						"bundlePath": "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-			"title": "Karttajulkaisu",
-			"bundleinstancename": "publisher2",
-			"bundlename": "publisher2",
-			"metadata": {
-				"Import-Bundle": {
-					"publisher2": {
-						"bundlePath": "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "maplegend",
-			"metadata": {
-				"Import-Bundle": {
-					"maplegend": {
-						"bundlePath": "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "userguide",
-			"metadata": {
-				"Import-Bundle": {
-					"userguide": {
-						"bundlePath": "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "metadataflyout",
-			"metadata": {
-				"Import-Bundle": {
-					"metadataflyout": {
-						"bundlePath": "../../../packages/catalogue/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "featuredata2",
-			"metadata": {
-				"Import-Bundle": {
-					"featuredata2": {
-						"bundlePath": "../../../packages/framework/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "myplaces3",
-			"metadata": {
-				"Import-Bundle": {
-					"myplaces3": {
-						"bundlePath": "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "guidedtour",
-			"metadata": {
-				"Import-Bundle": {
-					"guidedtour": {
-						"bundlePath": "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "backendstatus",
-			"metadata": {
-				"Import-Bundle": {
-					"backendstatus": {
-						"bundlePath": "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "printout",
-			"metadata": {
-				"Import-Bundle": {
-					"printout": {
-						"bundlePath": "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "postprocessor",
-			"metadata": {
-				"Import-Bundle": {
-					"postprocessor": {
-						"bundlePath": "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "statsgrid",
-			"metadata": {
-				"Import-Bundle": {
-					"statsgrid": {
-						"bundlePath": "../../../packages/statistics/"
-					}
-				}
-			}
-		}, {
-			"bundlename": "admin-layerselector",
-			"metadata": {
-				"Import-Bundle": {
-					"admin-layerselector": {
-						"bundlePath": "../../../packages/integration/bundle/"
-					},
-					"bb": {
-						"bundlePath": "../../../packages/integration/bundle/"
-					}
-				}
-			}
-		}, {
+        }, {
+            "bundlename": "divmanazer",
+            "metadata": {
+                "Import-Bundle": {
+                    "divmanazer": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename" : "drawtools",
+            "bundleinstancename" : "drawtools",
+            "metadata" : {
+                "Import-Bundle" : {
+                    "drawtools" : {
+                        "bundlePath" : "../../../packages/mapping/ol3/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "toolbar",
+            "metadata": {
+                "Import-Bundle": {
+                    "toolbar": {
+                        "bundlePath": "../../../packages/mapping/ol3/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "statehandler",
+            "metadata": {
+                "Import-Bundle": {
+                    "statehandler": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "infobox",
+            "metadata": {
+                "Import-Bundle": {
+                    "infobox": {
+                        "bundlePath": "../../../packages/mapping/ol3/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "search",
+            "metadata": {
+                "Import-Bundle": {
+                    "search": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "metadatacatalogue",
+            "metadata": {
+                "Import-Bundle": {
+                    "metadatacatalogue": {
+                        "bundlePath": "../../../packages/catalogue/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "layerselector2",
+            "metadata": {
+                "Import-Bundle": {
+                    "layerselector2": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "layerselection2",
+            "metadata": {
+                "Import-Bundle": {
+                    "layerselection2": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "personaldata",
+            "metadata": {
+                "Import-Bundle": {
+                    "personaldata": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "publisher2",
+            "metadata": {
+                "Import-Bundle": {
+                    "publisher2": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "maplegend",
+            "metadata": {
+                "Import-Bundle": {
+                    "maplegend": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "userguide",
+            "metadata": {
+                "Import-Bundle": {
+                    "userguide": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "metadataflyout",
+            "metadata": {
+                "Import-Bundle": {
+                    "metadataflyout": {
+                        "bundlePath": "../../../packages/catalogue/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "featuredata2",
+            "metadata": {
+                "Import-Bundle": {
+                    "featuredata2": {
+                        "bundlePath": "../../../packages/framework/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "myplaces3",
+            "metadata": {
+                "Import-Bundle": {
+                    "myplaces3": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "guidedtour",
+            "metadata": {
+                "Import-Bundle": {
+                    "guidedtour": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "backendstatus",
+            "metadata": {
+                "Import-Bundle": {
+                    "backendstatus": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "printout",
+            "metadata": {
+                "Import-Bundle": {
+                    "printout": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "postprocessor",
+            "metadata": {
+                "Import-Bundle": {
+                    "postprocessor": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "statsgrid",
+            "metadata": {
+                "Import-Bundle": {
+                    "statsgrid": {
+                        "bundlePath": "../../../packages/statistics/"
+                    }
+                }
+            }
+        }, {
             "bundlename": "analyse",
             "metadata": {
                 "Import-Bundle": {
@@ -262,123 +248,96 @@
                 }
             }
         }, {
-        	"bundlename": "admin-layerrights",
-        	"metadata": {
-        		"Import-Bundle": {
-        			"admin-layerrights": {
-        				"bundlePath": "../../../packages/framework/bundle/"
-        			}
-        		}
-        	}
+            "bundlename" : "myplacesimport",
+            "metadata" : {
+                "Import-Bundle" : {
+                    "myplacesimport" : {
+                        "bundlePath" : "../../../packages/framework/bundle/"
+                    }
+                }
+            }
         }, {
-		    "bundlename" : "myplacesimport",
-		    "metadata" : {
-		        "Import-Bundle" : {
-		            "myplacesimport" : {
-		                "bundlePath" : "../../../packages/framework/bundle/"
-		            }
-		        }
-		    }
-		}, {
-		    "bundlename" : "routesearch",
-		    "metadata" : {
-		        "Import-Bundle" : {
-		            "routesearch" : {
-		                "bundlePath" : "../../../packages/paikkatietoikkuna/bundle/"
-		            }
-		        }
-		    }
-		}, {
-		    "bundlename" : "register",
-		    "metadata" : {
-		        "Import-Bundle" : {
-		            "register" : {
-		                "bundlePath" : "../../../packages/paikkatietoikkuna/bundle/"
-		            }
-		        }
-		    }
-		}, {
-		    "bundlename" : "admin",
-		    "metadata" : {
-		        "Import-Bundle" : {
-		            "admin" : {
-		                "bundlePath" : "../../../packages/admin/bundle/"
-		            }
-		        }
-		    }
-		}, {
-			"bundlename" : "findbycoordinates",
-			"metadata" : {
-				"Import-Bundle" : {
-					"findbycoordinates" : {
-						"bundlePath" : "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename" : "terrain-profile",
-			"metadata" : {
-				"Import-Bundle" : {
-					"terrain-profile" : {
-						"bundlePath" : "../../../packages/paikkatietoikkuna/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename" : "heatmap",
-			"metadata" : {
-				"Import-Bundle" : {
-					"heatmap" : {
-						"bundlePath" : "../../../packages/mapping/ol3/"
-					}
-				}
-			}
-		}, {
-			"bundlename" : "coordinatetool",
-			"metadata" : {
-				"Import-Bundle" : {
-					"coordinatetool" : {
-						"bundlePath" : "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename" : "routingUI",
-			"metadata" : {
-				"Import-Bundle" : {
-					"routingUI" : {
-						"bundlePath" : "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename" : "routingService",
-			"metadata" : {
-				"Import-Bundle" : {
-					"routingService" : {
-						"bundlePath" : "../../../packages/framework/bundle/"
-					}
-				}
-			}
-		}, {
-			"bundlename" : "feedbackService",
-			"metadata" : {
-			  "Import-Bundle" : {
-				"feedbackService" : {
-				  "bundlePath" : "../../../packages/framework/bundle/"
-				}
-			  }
-			}
-	  	}, {
-		    "bundlename" : "metrics",
-		    "metadata" : {
-		        "Import-Bundle" : {
-		            "metrics" : {
-		                "bundlePath" : "../../../packages/admin/bundle/"
-		            }
-		        }
-		    }
-		}, {
+            "bundlename" : "routesearch",
+            "metadata" : {
+                "Import-Bundle" : {
+                    "routesearch" : {
+                        "bundlePath" : "../../../packages/paikkatietoikkuna/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename" : "register",
+            "metadata" : {
+                "Import-Bundle" : {
+                    "register" : {
+                        "bundlePath" : "../../../packages/paikkatietoikkuna/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename" : "findbycoordinates",
+            "metadata" : {
+                "Import-Bundle" : {
+                    "findbycoordinates" : {
+                        "bundlePath" : "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename" : "terrain-profile",
+            "metadata" : {
+                "Import-Bundle" : {
+                    "terrain-profile" : {
+                        "bundlePath" : "../../../packages/paikkatietoikkuna/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename" : "heatmap",
+            "metadata" : {
+                "Import-Bundle" : {
+                    "heatmap" : {
+                        "bundlePath" : "../../../packages/mapping/ol3/"
+                    }
+                }
+            }
+        }, {
+            "bundlename" : "coordinatetool",
+            "metadata" : {
+                "Import-Bundle" : {
+                    "coordinatetool" : {
+                        "bundlePath" : "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename" : "routingUI",
+            "metadata" : {
+                "Import-Bundle" : {
+                    "routingUI" : {
+                        "bundlePath" : "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename" : "routingService",
+            "metadata" : {
+                "Import-Bundle" : {
+                    "routingService" : {
+                        "bundlePath" : "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename" : "feedbackService",
+            "metadata" : {
+              "Import-Bundle" : {
+                "feedbackService" : {
+                  "bundlePath" : "../../../packages/framework/bundle/"
+                }
+              }
+            }
+          }, {
             "bundlename": "timeseries",
             "metadata": {
                 "Import-Bundle": {
@@ -388,32 +347,71 @@
                 }
             }
         }, {
-	        "bundlename": "maprotator",
-	        "metadata": {
-	            "Import-Bundle": {
-	                "maprotator": {
-	                    "bundlePath": "../../../packages/mapping/ol3/"
-	                }
-	            }
-	        }
-	    }, {
-			"bundlename" : "telemetry",
-			"metadata" : {
-				"Import-Bundle" : {
-					"telemetry" : {
-						"bundlePath" : "../../../packages/paikkatietoikkuna/bundle/"
-					}
-				}
-			}
-		}, {
-		    "bundlename" : "appsetup",
-		    "metadata" : {
-		        "Import-Bundle" : {
-		            "appsetup" : {
-		                "bundlePath" : "../../../packages/admin/bundle/"
-		            }
-		        }
-		    }
-		}
-	]
+            "bundlename": "maprotator",
+            "metadata": {
+                "Import-Bundle": {
+                    "maprotator": {
+                        "bundlePath": "../../../packages/mapping/ol3/"
+                    }
+                }
+            }
+        }, {
+            "bundlename" : "telemetry",
+            "metadata" : {
+                "Import-Bundle" : {
+                    "telemetry" : {
+                        "bundlePath" : "../../../packages/paikkatietoikkuna/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "admin-layerselector",
+            "metadata": {
+                "Import-Bundle": {
+                    "admin-layerselector": {
+                        "bundlePath": "../../../packages/integration/bundle/"
+                    },
+                    "bb": {
+                        "bundlePath": "../../../packages/integration/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "admin-layerrights",
+            "metadata": {
+                "Import-Bundle": {
+                    "admin-layerrights": {
+                        "bundlePath": "../../../packages/framework/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename" : "admin",
+            "metadata" : {
+                "Import-Bundle" : {
+                    "admin" : {
+                        "bundlePath" : "../../../packages/admin/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename" : "metrics",
+            "metadata" : {
+                "Import-Bundle" : {
+                    "metrics" : {
+                        "bundlePath" : "../../../packages/admin/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename" : "appsetup",
+            "metadata" : {
+                "Import-Bundle" : {
+                    "appsetup" : {
+                        "bundlePath" : "../../../packages/admin/bundle/"
+                    }
+                }
+            }
+        }
+    ]
 }

--- a/applications/sample/servlet/minifierAppSetup.json
+++ b/applications/sample/servlet/minifierAppSetup.json
@@ -170,7 +170,7 @@
         "metadata": {
             "Import-Bundle": {
                 "featuredata2": {
-                    "bundlePath": "../../../packages/framework/bundle/"
+                    "bundlePath": "../../../packages/framework/"
                 }
             }
         }

--- a/applications/sample/servlet/minifierAppSetup.json
+++ b/applications/sample/servlet/minifierAppSetup.json
@@ -1,416 +1,361 @@
 {
-	"startupSequence": [{
-		"bundlename": "openlayers-default-theme",
-		"metadata": {
-			"Import-Bundle": {
-				"openlayers-default-theme": {
-					"bundlePath": "../../../packages/openlayers/bundle/"
-				},
-				"openlayers-full-map": {
-					"bundlePath": "../../../packages/openlayers/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "mapfull",
-		"metadata": {
-			"Import-Bundle": {
-				"mapwmts": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				},
-				"mapmodule-plugin": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				},
-				"ui-components": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				},
-				"mapfull": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				},
-				"oskariui": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				},
-				"mapwfs2": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				},
-				"mapuserlayers": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				},
-				"mapstats": {
-					"bundlePath": "../../../packages/mapping/ol2/"
-				},
-				"mapmyplaces": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				},
-				"mapanalysis": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				},
-				"maparcgis": {
-					"bundlePath": "../../../packages/arcgis/bundle/"
-				}
-			}
-		}
-	}, {
-		"instanceProps": {},
-		"title": "Oskari DIV Manazer",
-		"bundleinstancename": "divmanazer",
-		"fi": "Oskari DIV Manazer",
-		"sv": "Oskari DIV Manazer",
-		"en": "Oskari DIV Manazer",
-		"bundlename": "divmanazer",
-		"metadata": {
-			"Import-Bundle": {
-				"divmanazer": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			},
-			"Require-Bundle-Instance": []
-		}
-	}, {
-		"instanceProps": {},
-		"title": "Toolbar",
-		"bundleinstancename": "toolbar",
-		"fi": "toolbar",
-		"sv": "toolbar",
-		"en": "toolbar",
-		"bundlename": "toolbar",
-		"metadata": {
-			"Import-Bundle": {
-				"toolbar": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			},
-			"Require-Bundle-Instance": []
-		}
-	}, {
-		"instanceProps": {},
-		"title": "Info Box",
-		"bundleinstancename": "infobox",
-		"fi": "infobox",
-		"sv": "infobox",
-		"en": "infobox",
-		"bundlename": "infobox",
-		"metadata": {
-			"Import-Bundle": {
-				"infobox": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			},
-			"Require-Bundle-Instance": []
-		}
-	}, {
-		"instanceProps": {},
-		"title": "StateHandler",
-		"bundleinstancename": "statehandler",
-		"fi": "jquery",
-		"sv": "jquery",
-		"en": "jquery",
-		"bundlename": "statehandler",
-		"metadata": {
-			"Import-Bundle": {
-				"statehandler": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			},
-			"Require-Bundle-Instance": []
-		}
-	}, {
-		"instanceProps": {},
-		"title": "Haku",
-		"bundleinstancename": "search",
-		"fi": "search",
-		"sv": "search",
-		"en": "search",
-		"bundlename": "search",
-		"metadata": {
-			"Import-Bundle": {
-				"search": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			},
-			"Require-Bundle-Instance": []
-		}
-	}, {
-		"instanceProps": {},
-		"title": "Karttatasot",
-		"bundleinstancename": "layerselector2",
-		"fi": "layerselector",
-		"sv": "layerselector",
-		"en": "layerselector",
-		"bundlename": "layerselector2",
-		"metadata": {
-			"Import-Bundle": {
-				"layerselector2": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			},
-			"Require-Bundle-Instance": []
-		}
-	}, {
-		"instanceProps": {},
-		"title": "Valitut karttatasot",
-		"bundleinstancename": "layerselection2",
-		"fi": "layerselection",
-		"sv": "layerselection",
-		"en": "layerselection",
-		"bundlename": "layerselection2",
-		"metadata": {
-			"Import-Bundle": {
-				"layerselection2": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			},
-			"Require-Bundle-Instance": []
-		}
-	}, {
-		"bundlename": "coordinatetool",
-		"bundleinstancename": "coordinatetool",
-		"metadata": {
-			"Import-Bundle": {
-				"coordinatetool": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "metadataflyout",
-		"metadata": {
-			"Import-Bundle": {
-				"metadataflyout": {
-					"bundlePath": "../../../packages/catalogue/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "featuredata2",
-		"metadata": {
-			"Import-Bundle": {
-				"featuredata2": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "publisher2",
-		"metadata": {
-			"Import-Bundle": {
-				"publisher2": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "personaldata",
-		"metadata": {
-			"Import-Bundle": {
-				"personaldata": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "metadatacatalogue",
-		"metadata": {
-			"Import-Bundle": {
-				"metadatacatalogue": {
-					"bundlePath": "../../../packages/catalogue/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "myplaces2",
-		"metadata": {
-			"Import-Bundle": {
-				"myplaces2": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "maplegend",
-		"metadata": {
-			"Import-Bundle": {
-				"maplegend": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "userguide",
-		"metadata": {
-			"Import-Bundle": {
-				"userguide": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "guidedtour",
-		"metadata": {
-			"Import-Bundle": {
-				"guidedtour": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "backendstatus",
-		"metadata": {
-			"Import-Bundle": {
-				"backendstatus": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "printout",
-		"metadata": {
-			"Import-Bundle": {
-				"printout": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "postprocessor",
-		"metadata": {
-			"Import-Bundle": {
-				"postprocessor": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "admin-layerselector",
-		"metadata": {
-			"Import-Bundle": {
-				"admin-layerselector": {
-					"bundlePath": "../../../packages/integration/bundle/"
-				},
-				"bb": {
-					"bundlePath": "../../../packages/integration/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "analyse",
-		"metadata": {
-			"Import-Bundle": {
-				"analyse": {
-					"bundlePath": "../../../packages/analysis/bundle/"
-				},
-				"geometryeditor": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "admin-layerrights",
-		"metadata": {
-			"Import-Bundle": {
-				"admin-layerrights": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "myplacesimport",
-		"metadata": {
-			"Import-Bundle": {
-				"myplacesimport": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "admin",
-		"metadata": {
-			"Import-Bundle": {
-				"admin": {
-					"bundlePath": "../../../packages/admin/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "admin-users",
-		"metadata": {
-			"Import-Bundle": {
-				"admin-users": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "admin-wfs-search-channel",
-		"metadata": {
-			"Import-Bundle": {
-				"admin-wfs-search-channel": {
-					"bundlePath": "../../../packages/tampere/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "search-from-channels",
-		"metadata": {
-			"Import-Bundle": {
-				"search-from-channels": {
-					"bundlePath": "../../../packages/tampere/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "heatmap",
-		"metadata": {
-			"Import-Bundle": {
-				"heatmap": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "timeseries",
-		"metadata": {
-			"Import-Bundle": {
-				"timeseries": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "statsgrid",
-		"metadata": {
-			"Import-Bundle": {
-				"statsgrid": {
-					"bundlePath": "../../../packages/statistics/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "maprotator",
-		"metadata": {
-			"Import-Bundle": {
-				"maprotator": {
-					"bundlePath": "../../../packages/mapping/ol3/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "selected-featuredata",
-		"metadata": {
-			"Import-Bundle": {
-				"selected-featuredata": {
-					"bundlePath": "../../../packages/framework/bundle/"
-				}
-			}
-		}
-	}, {
-		"bundlename": "content-editor",
-		"metadata": {
-			"Import-Bundle": {
-				"content-editor": {
-					"bundlePath": "../../../packages/tampere/bundle/"
-				}
-			}
-		}
-	}]
+    "startupSequence": [{
+        "bundlename": "mapfull",
+        "metadata": {
+            "Import-Bundle": {
+                "mapmyplaces": {
+                    "bundlePath": "../../../packages/mapping/ol3/"
+                },
+                "maparcgis": {
+                    "bundlePath": "../../../packages/mapping/ol3/"
+                },
+                "mapmodule": {
+                    "bundlePath": "../../../packages/mapping/ol3/"
+                },
+                "oskariui": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                },
+                "mapwfs2": {
+                    "bundlePath": "../../../packages/mapping/ol3/"
+                },
+                "mapstats": {
+                    "bundlePath": "../../../packages/mapping/ol3/"
+                },
+                "mapuserlayers": {
+                    "bundlePath": "../../../packages/mapping/ol3/"
+                },
+                "ui-components": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                },
+                "mapanalysis": {
+                    "bundlePath": "../../../packages/mapping/ol3/"
+                },
+                "mapfull": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                },
+                "mapwmts": {
+                    "bundlePath": "../../../packages/mapping/ol3/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "divmanazer",
+        "metadata": {
+            "Import-Bundle": {
+                "divmanazer": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename" : "drawtools",
+        "bundleinstancename" : "drawtools",
+        "metadata" : {
+            "Import-Bundle" : {
+                "drawtools" : {
+                    "bundlePath" : "../../../packages/mapping/ol3/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "toolbar",
+        "metadata": {
+            "Import-Bundle": {
+                "toolbar": {
+                    "bundlePath": "../../../packages/mapping/ol3/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "statehandler",
+        "metadata": {
+            "Import-Bundle": {
+                "statehandler": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "infobox",
+        "metadata": {
+            "Import-Bundle": {
+                "infobox": {
+                    "bundlePath": "../../../packages/mapping/ol3/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "search",
+        "metadata": {
+            "Import-Bundle": {
+                "search": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "metadatacatalogue",
+        "metadata": {
+            "Import-Bundle": {
+                "metadatacatalogue": {
+                    "bundlePath": "../../../packages/catalogue/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "layerselector2",
+        "metadata": {
+            "Import-Bundle": {
+                "layerselector2": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "layerselection2",
+        "metadata": {
+            "Import-Bundle": {
+                "layerselection2": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "personaldata",
+        "metadata": {
+            "Import-Bundle": {
+                "personaldata": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "publisher2",
+        "metadata": {
+            "Import-Bundle": {
+                "publisher2": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "maplegend",
+        "metadata": {
+            "Import-Bundle": {
+                "maplegend": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "userguide",
+        "metadata": {
+            "Import-Bundle": {
+                "userguide": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "metadataflyout",
+        "metadata": {
+            "Import-Bundle": {
+                "metadataflyout": {
+                    "bundlePath": "../../../packages/catalogue/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "featuredata2",
+        "metadata": {
+            "Import-Bundle": {
+                "featuredata2": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "myplaces3",
+        "metadata": {
+            "Import-Bundle": {
+                "myplaces3": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "guidedtour",
+        "metadata": {
+            "Import-Bundle": {
+                "guidedtour": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "backendstatus",
+        "metadata": {
+            "Import-Bundle": {
+                "backendstatus": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "printout",
+        "metadata": {
+            "Import-Bundle": {
+                "printout": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "postprocessor",
+        "metadata": {
+            "Import-Bundle": {
+                "postprocessor": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "statsgrid",
+        "metadata": {
+            "Import-Bundle": {
+                "statsgrid": {
+                    "bundlePath": "../../../packages/statistics/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "coordinatetool",
+        "metadata": {
+            "Import-Bundle": {
+                "coordinatetool": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "analyse",
+        "metadata": {
+            "Import-Bundle": {
+                "analyse": {
+                    "bundlePath": "../../../packages/analysis/ol3/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "myplacesimport",
+        "metadata": {
+            "Import-Bundle": {
+                "myplacesimport": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "search-from-channels",
+        "metadata": {
+            "Import-Bundle": {
+                "search-from-channels": {
+                    "bundlePath": "../../../packages/tampere/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename" : "heatmap",
+        "metadata" : {
+            "Import-Bundle" : {
+                "heatmap" : {
+                    "bundlePath" : "../../../packages/mapping/ol3/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "timeseries",
+        "metadata": {
+            "Import-Bundle": {
+                "timeseries": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "maprotator",
+        "metadata": {
+            "Import-Bundle": {
+                "maprotator": {
+                    "bundlePath": "../../../packages/mapping/ol3/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "selected-featuredata",
+        "metadata": {
+            "Import-Bundle": {
+                "selected-featuredata": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "content-editor",
+        "metadata": {
+            "Import-Bundle": {
+                "content-editor": {
+                    "bundlePath": "../../../packages/tampere/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "admin-layerselector",
+        "metadata": {
+            "Import-Bundle": {
+                "admin-layerselector": {
+                    "bundlePath": "../../../packages/integration/bundle/"
+                },
+                "bb": {
+                    "bundlePath": "../../../packages/integration/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "admin-layerrights",
+        "metadata": {
+            "Import-Bundle": {
+                "admin-layerrights": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "admin",
+        "metadata": {
+            "Import-Bundle": {
+                "admin": {
+                    "bundlePath": "../../../packages/admin/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "admin-users",
+        "metadata": {
+            "Import-Bundle": {
+                "admin-users": {
+                    "bundlePath": "../../../packages/framework/bundle/"
+                }
+            }
+        }
+    }, {
+        "bundlename": "admin-wfs-search-channel",
+        "metadata": {
+            "Import-Bundle": {
+                "admin-wfs-search-channel": {
+                    "bundlePath": "../../../packages/tampere/bundle/"
+                }
+            }
+        }
+    }]
 }


### PR DESCRIPTION
Updates the minifierAppSetup.jsons to include OpenLayers 4 implementations of bundles instead of OpenLayers 2 due to oskariorg/oskari-server#219 and oskariorg/oskari-docs#63

ASDI and PTI apps already use OL4. The others are not maintained by NLS Finland so leaving them as is.