### PR TITLE
Fixes opening published map view in different projection

### DIFF
--- a/bundles/framework/personaldata/resources/locale/en.js
+++ b/bundles/framework/personaldata/resources/locale/en.js
@@ -10,7 +10,7 @@ Oskari.registerLocalization(
         "register": "Register",
         "projectionError": {
             "title" : "Projections are incompatible",
-            "msg": "Projection will be changed, so that the published map can be edited",
+            "msg": "The page reloads to change the projection",
             "ok": "OK",
             "cancel": "Cancel"
         },

--- a/bundles/framework/personaldata/resources/locale/fi.js
+++ b/bundles/framework/personaldata/resources/locale/fi.js
@@ -10,7 +10,7 @@ Oskari.registerLocalization(
         "register": "Rekisteröidy",
         "projectionError": {
             "title" : "Projektiot eivät ole yhteensopivia",
-            "msg": "Vaihdetaan projektiota karttajulkaisun muokkauksen mahdollistamiseksi.",
+            "msg": "Sivu ladataan uudelleen projektion vaihtamiseksi.",
             "ok": "OK",
             "cancel": "Peruuta"
         },

--- a/bundles/framework/personaldata/resources/locale/sv.js
+++ b/bundles/framework/personaldata/resources/locale/sv.js
@@ -10,7 +10,7 @@ Oskari.registerLocalization(
         "register": "Registrera dig",
         "projectionError": {
             "title" : "Projektionerna är inkompatibla",
-            "msg": "Utbytas projektionen för att redigera kartpubliceringen",
+            "msg": "Sidan laddas om för att ändra projektionen",
             "ok": "OK",
             "cancel": "Avbryt"
         },


### PR DESCRIPTION
Fixes an issue where user opened previously published map view that has different coordinate system than current map view in geoportal. The map view would not load it's layers nor location.