### PR TITLE
Tampere search channel changes for ol2 to ol4

### DIFF
--- a/bundles/tampere/search-from-channels/instance.js
+++ b/bundles/tampere/search-from-channels/instance.js
@@ -812,7 +812,7 @@ Oskari.clazz.define(
                 },
                 stroke: {
                   color: '#FF0000',
-                  width: 10
+                  width: 1
                 },
                 text : {
                   scale : 1.3,
@@ -822,8 +822,7 @@ Oskari.clazz.define(
                   stroke : {
                     color : 'rgba(255,255,255,0.8)',
                     width : 2
-                  },
-                  labelProperty: 'test_property'
+                  }
                 }
               };
               return featureStyle;

--- a/bundles/tampere/search-from-channels/instance.js
+++ b/bundles/tampere/search-from-channels/instance.js
@@ -806,16 +806,27 @@ Oskari.clazz.define(
          */
         _getVectorLayerStyle: function(){
 
-            var style = OpenLayers.Util.applyDefaults(style, OpenLayers.Feature.Vector.style['default']);
-            style.pointRadius = 8;
-            style.strokeColor = '#D3BB1B';
-            style.fillColor = '#FFDE00';
-            style.fillOpacity = 0.6;
-            style.strokeOpacity = 0.8;
-            style.strokeWidth = 2;
-            style.cursor = 'pointer';
-
-            return style;
+            var featureStyle = {
+                fill: {
+                  color: 'rgb(153,204,0,0.3)',
+                },
+                stroke: {
+                  color: '#FF0000',
+                  width: 10
+                },
+                text : {
+                  scale : 1.3,
+                  fill : {
+                    color : 'rgba(0,0,0,1)'
+                  },
+                  stroke : {
+                    color : 'rgba(255,255,255,0.8)',
+                    width : 2
+                  },
+                  labelProperty: 'test_property'
+                }
+              };
+              return featureStyle;
         },
         /**
          * [_zoomMapToResults description] Zooms map into results
@@ -831,9 +842,11 @@ Oskari.clazz.define(
             me._clearMapFromResults();
             me._closeMapPopup();
 
+            var source = new ol.source.Vector({useSpatialIndex:true});
+
             //Fake layer for zoomin event
-            var olLayer = new OpenLayers.Layer.Vector('templayer'),
-                format = new OpenLayers.Format.WKT({}),
+            var olLayer = new ol.layer.Vector('templayer'),
+                format = new ol.format.WKT({}),
                 feature,
                 geometry,
                 mapMoveRequest,
@@ -843,17 +856,19 @@ Oskari.clazz.define(
 
             jQuery.each(result.locations, function( i, value ){
                 if(showAll){
-                    me.sandbox.postRequestByName(rn, [value.GEOMETRY, 'WKT', {id:value.id}, null, null, true, me._getVectorLayerStyle(), false]);
-                    feature = format.read(value.GEOMETRY);
-                    olLayer.addFeatures([feature]);
+                    me.sandbox.postRequestByName(rn, [value.GEOMETRY, {id:value.id}, null, null, true, me._getVectorLayerStyle(), false]);
+                    feature = format.readFeature(value.GEOMETRY);
+                    source.addFeatures([feature]);
+                    olLayer.setSource(source);                   
                     isSelected = true;
                 }else{
                     var row = tableBody.find("tr[name="+value.id+"]");
                     var firstCell = row.find("td:first-child");
                     if(firstCell.find("input").is(":checked")){
-                        me.sandbox.postRequestByName(rn, [value.GEOMETRY, 'WKT', {id:value.id}, null, null, true, me._getVectorLayerStyle(), false]);
-                        feature = format.read(value.GEOMETRY);
-                        olLayer.addFeatures([feature]);
+                        me.sandbox.postRequestByName(rn, [value.GEOMETRY, {id:value.id}, null, null, true, me._getVectorLayerStyle(), false]);
+                        feature = format.readFeature(value.GEOMETRY);
+                        source.addFeatures([feature]);
+                        olLayer.setSource(source);   
                         isSelected = true;
                     }
                 }
@@ -861,11 +876,11 @@ Oskari.clazz.define(
             });
 
             if(isSelected){
-
-            bounds = olLayer.getDataExtent();
-            center = bounds.getCenterLonLat();
-
-            mapmoveRequest = me.sandbox.getRequestBuilder('MapMoveRequest')(center.lon, center.lat, bounds);
+                      
+            bounds = source.getExtent();                        
+            center = ol.extent.getCenter(bounds);            
+            
+            mapmoveRequest = me.sandbox.getRequestBuilder('MapMoveRequest')(center[0], center[1],bounds);
             me.sandbox.request(me, mapmoveRequest);
 
             }else{
@@ -942,7 +957,7 @@ Oskari.clazz.define(
 
             if(drawVector){
                 var rn = 'MapModulePlugin.AddFeaturesToMapRequest';
-                sandbox.postRequestByName(rn, [result.GEOMETRY, 'WKT', {id:result.id}, null, 'replace', true, me._getVectorLayerStyle(), false]);
+                sandbox.postRequestByName(rn, [result.GEOMETRY, {id:result.id}, null, 'replace', true, me._getVectorLayerStyle(), false]);
             }
 
             var loc = me.getLocalization('resultBox');
@@ -966,14 +981,14 @@ Oskari.clazz.define(
             var options = {
                 hidePrevious: true
             };
-
+            
             var rN = 'InfoBox.ShowInfoBoxRequest',
                 rB = sandbox.getRequestBuilder(rN),
                 request = rB(
                     popupId,
                     loc.title,
                     content,
-                    new OpenLayers.LonLat(result.lon, result.lat),
+                    {lon: result.lon,lat: result.lat},
                     options
                 );
 

--- a/bundles/tampere/search-from-channels/instance.js
+++ b/bundles/tampere/search-from-channels/instance.js
@@ -877,10 +877,20 @@ Oskari.clazz.define(
 
             if(isSelected){
                       
-            bounds = source.getExtent();                        
-            center = ol.extent.getCenter(bounds);            
-            
-            mapmoveRequest = me.sandbox.getRequestBuilder('MapMoveRequest')(center[0], center[1],bounds);
+            bounds = source.getExtent();
+            center = ol.extent.getCenter(bounds);
+
+            var topLeft =  ol.extent.getTopLeft(bounds);
+            var bottomRight =  ol.extent.getBottomRight(bounds); 
+
+            var zoom = {
+                top: topLeft[1],
+                left: topLeft[0],
+                right: bottomRight[0],
+                bottom: bottomRight[1]
+            }
+
+            mapmoveRequest = me.sandbox.getRequestBuilder('MapMoveRequest')(center[0], center[1], zoom);            
             me.sandbox.request(me, mapmoveRequest);
 
             }else{


### PR DESCRIPTION
Ported ol2 functions to ol4 but this is only partial solution. There is a problem with the MapMoveRequest. Old implementation provided bounding box to the request and it seemed to work. The API has changed since and it requires zoomLevel (0-12) as attribute and not bounding box. 

This commit includes the request with bounding box and it does not zoom correctly. Is it possible to have old request functionality with bbox back? 