### PR TITLE
WMTS tile url

### DIFF
--- a/bundles/elf/elf-geolocator/instance.js
+++ b/bundles/elf/elf-geolocator/instance.js
@@ -60,7 +60,10 @@ Oskari.clazz.define("Oskari.elf.geolocator.BundleInstance",
             var sandbox = this.getSandbox(),
                 zoom =  sandbox.getMap().getZoom(),
                 srsName = sandbox.getMap().getSrsName(),
-                lonlat = new OpenLayers.LonLat(result.lon, result.lat),
+                lonlat = {
+                    lon: result.lon,
+                    lat: result.lat
+                },
                 popupId = "elf-geolocator-search-result",
                 moveReqBuilder = sandbox
                     .getRequestBuilder('MapMoveRequest'),
@@ -76,7 +79,7 @@ Oskari.clazz.define("Oskari.elf.geolocator.BundleInstance",
 
             if (moveReqBuilder) {
                 moveReq = moveReqBuilder(
-                    result.lon, result.lat, zoom, false, srsName);
+                    lonlat.lon, lonlat.lat, zoom, false, srsName);
                 sandbox.request(this, moveReq);
             }
 

--- a/bundles/mapping/mapwmts/service/WmtsLayerService.ol3.js
+++ b/bundles/mapping/mapwmts/service/WmtsLayerService.ol3.js
@@ -46,10 +46,9 @@ Oskari.clazz.define('Oskari.mapframework.wmts.service.WMTSLayerService', functio
         var caps = this.getCapabilities(url);
         if(caps) {
             // return with cached capabilities
-            success(this.__creteWMTSLayer(caps, layer));
+            success(this.__createWMTSLayer(caps, layer));
             return;
         }
-
         // gather capabilities requests
         // make ajax call just once and invoke all callbacks once finished
         var triggerAjaxBln = false;
@@ -118,15 +117,15 @@ Oskari.clazz.define('Oskari.mapframework.wmts.service.WMTSLayerService', functio
         _.each(this.requestsMap[url], function(args) {
             if(!invokeFailure) {
                 var layer = args[0];
-                args[1](this.__creteWMTSLayer(caps, layer));
+                args[1](me.__createWMTSLayer(caps, layer));
             }
             else if (args.length > 2 && typeof args[2] === 'function') {
                 args[2]();
             }
         });
     },
-    __creteWMTSLayer: function (caps, layer){
-        var config = me.__getLayerConfig(caps, layer);
+    __createWMTSLayer: function (caps, layer) {
+        var config = this.__getLayerConfig(caps, layer);
         var options = ol.source.WMTS.optionsFromCapabilities(caps, config);
         //this doesn't get merged automatically by ol3
         options.crossOrigin = config.crossOrigin;

--- a/bundles/mapping/mapwmts/service/WmtsLayerService.ol3.js
+++ b/bundles/mapping/mapwmts/service/WmtsLayerService.ol3.js
@@ -46,19 +46,7 @@ Oskari.clazz.define('Oskari.mapframework.wmts.service.WMTSLayerService', functio
         var caps = this.getCapabilities(url);
         if(caps) {
             // return with cached capabilities
-            var config = me.__getLayerConfig(caps, layer);
-            var wmtsOptions = ol.source.WMTS.optionsFromCapabilities(caps, config);
-            if(config.url) {
-                // override capabilities url with the configured one
-                wmtsOptions.urls = [config.url];
-            }
-            var wmtsLayer = new ol.layer.Tile({
-                source: new ol.source.WMTS(wmtsOptions),
-                transparent: true,
-                opacity: layer.getOpacity()/100,
-                visible: layer.isInScale(this.sandbox.getMap().getScale()) && layer.isVisible()
-            });
-            success(wmtsLayer);
+            success(this.__creteWMTSLayer(caps, layer));
             return;
         }
 
@@ -130,26 +118,32 @@ Oskari.clazz.define('Oskari.mapframework.wmts.service.WMTSLayerService', functio
         _.each(this.requestsMap[url], function(args) {
             if(!invokeFailure) {
                 var layer = args[0];
-                var config = me.__getLayerConfig(caps, layer);
-                var options = ol.source.WMTS.optionsFromCapabilities(caps, config);
-                //this doesn't get merged automatically by ol3
-                options.crossOrigin = config.crossOrigin;
-                if(config.url) {
-                    // override capabilities url with the configured one
-                    options.urls = [config.url];
-                }
-
-                var wmtsLayer = new ol.layer.Tile({
-                    opacity: layer.getOpacity() / 100.0,
-                    source : new ol.source.WMTS(options)
-                });
-                args[1](wmtsLayer);
+                args[1](this.__creteWMTSLayer(caps, layer));
             }
             else if (args.length > 2 && typeof args[2] === 'function') {
                 args[2]();
             }
         });
     },
+    __creteWMTSLayer: function (caps, layer){
+        var config = me.__getLayerConfig(caps, layer);
+        var options = ol.source.WMTS.optionsFromCapabilities(caps, config);
+        //this doesn't get merged automatically by ol3
+        options.crossOrigin = config.crossOrigin;
+        if(config.url) {
+            // override capabilities url with the configured one
+            options.urls = [config.url];
+        }
+        var wmtsLayer = new ol.layer.Tile({
+            source : new ol.source.WMTS(options),
+            opacity: layer.getOpacity() / 100.0,
+            transparent: true,
+            visible: layer.isInScale(this.sandbox.getMap().getScale()) && layer.isVisible()
+        });
+        return wmtsLayer;
+    },
+
+
     __getLayerConfig : function(caps, layer) {
 
             // default params and options

--- a/bundles/mapping/mapwmts/service/WmtsLayerService.ol3.js
+++ b/bundles/mapping/mapwmts/service/WmtsLayerService.ol3.js
@@ -46,7 +46,12 @@ Oskari.clazz.define('Oskari.mapframework.wmts.service.WMTSLayerService', functio
         var caps = this.getCapabilities(url);
         if(caps) {
             // return with cached capabilities
-            var wmtsOptions = ol.source.WMTS.optionsFromCapabilities(caps, me.__getLayerConfig(caps, layer));
+            var config = me.__getLayerConfig(caps, layer);
+            var wmtsOptions = ol.source.WMTS.optionsFromCapabilities(caps, config);
+            if(config.url) {
+                // override capabilities url with the configured one
+                wmtsOptions.urls = [config.url];
+            }
             var wmtsLayer = new ol.layer.Tile({
                 source: new ol.source.WMTS(wmtsOptions),
                 transparent: true,


### PR DESCRIPTION
OpenLayer's WMTS layer was created differently from cache. Now uses same createWMTSLayer function for cached capabilities. Fixes issue where layer's configured tile url differs from capabilities tile url and WMTS layer was added from cache (remove layer from map and add again). 

Also removed ol2 dependent code from elf-geolocator.