### PR TITLE
Publisher plugin state fixes when stopping / starting

### DIFF
--- a/bundles/framework/publisher2/tools/AbstractPluginTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPluginTool.js
@@ -104,7 +104,7 @@ function(sandbox, mapmodule, localization, instance, handlers) {
             me.__started = true;
         } else {
             if(me.__started === true) {
-                me.__plugin.stopPlugin(me.__sandbox);
+                me.stop();
             }
         }
         var event = Oskari.eventBuilder('Publisher2.ToolEnabledChangedEvent')(me);

--- a/bundles/framework/publisher2/tools/LayerSelectionTool.js
+++ b/bundles/framework/publisher2/tools/LayerSelectionTool.js
@@ -64,41 +64,6 @@ function() {
         }
     },
     /**
-    * Set enabled.
-    * @method setEnabled
-    * @public
-    *
-    * @param {Boolean} enabled is tool enabled or not
-    */
-    setEnabled : function(enabled) {
-        var me = this,
-            tool = me.getTool(),
-            sandbox = me.__sandbox;
-        //state actually hasn't changed -> do nothing
-        if (me.state.enabled !== undefined && me.state.enabled !== null && enabled === me.state.enabled) {
-            return;
-        }
-
-        me.state.enabled = enabled;
-        if(!me.__plugin && enabled) {
-            me.__plugin = Oskari.clazz.create(tool.id, tool.config);
-            me.__mapmodule.registerPlugin(me.__plugin);
-        }
-
-        if(enabled === true) {
-            me.__plugin.startPlugin(me.__sandbox);
-            me.__started = true;
-            setTimeout(function() {
-                me._checkLayerSelections();
-            }, 300);
-        } else if(me.__started === true) {
-            me.__plugin.stopPlugin(me.__sandbox);
-        }
-
-        var event = sandbox.getEventBuilder('Publisher2.ToolEnabledChangedEvent')(me);
-        sandbox.notifyAll(event);
-    },
-    /**
      * Check layer selections
      * @method  @private _checkLayerSelections
      */
@@ -304,9 +269,14 @@ function() {
         me.data = data;
 
         if (data.configuration && data.configuration.mapfull && data.configuration.mapfull.conf && data.configuration.mapfull.conf.plugins) {
-            _.each(data.configuration.mapfull.conf.plugins, function(plugin) {
+            _.each(data.configuration.mapfull.conf.plugins, function (plugin) {
                 if (me.getTool().id === plugin.id) {
                     me.setEnabled(true);
+                    if (me.__started) {
+                        setTimeout(function () {
+                            me._checkLayerSelections();
+                        }, 300);
+                    }
                 }
             });
         }

--- a/bundles/mapping/mapmodule/plugin/zoombar/Portti2Zoombar.js
+++ b/bundles/mapping/mapmodule/plugin/zoombar/Portti2Zoombar.js
@@ -186,7 +186,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar'
                 max: mapModule.getMaxZoomLevel(),
                 value: mapModule.getMapZoom(),
                 slide: function (event, ui) {
-                   me.getMapModule().setZoomLevel(ui.value);
+                me.getMapModule().setZoomLevel(ui.value);
                 }
             });
 
@@ -414,6 +414,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar'
             }
             var me = this;
             var mobileDefs = this.getMobileDefs();
+            this.teardownUI();
 
             // don't do anything now if request is not available.
             // When returning false, this will be called again when the request is available
@@ -421,7 +422,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar'
             if (!forced && toolbarNotReady) {
                 return true;
             }
-            this.teardownUI();
 
             if (!toolbarNotReady && mapInMobileMode) {
                 this.addToolbarButtons(mobileDefs.buttons, mobileDefs.buttonGroup);

--- a/bundles/mapping/mapmodule/plugin/zoombar/Portti2Zoombar.js
+++ b/bundles/mapping/mapmodule/plugin/zoombar/Portti2Zoombar.js
@@ -33,7 +33,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar'
         this._suppressEvents = false;
 
         this._mobileDefs = {
-            buttons:  {
+            buttons: {
                 'mobile-zoom-in': {
                     iconCls: 'mobile-zoom-in',
                     tooltip: '',
@@ -43,8 +43,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar'
                         var mapModule = me.getMapModule();
                         var currentZoom = mapModule.getMapZoom();
                         var maxZoomLevel = mapModule.getMaxZoomLevel();
-                        if(currentZoom<maxZoomLevel) {
-                            me.getMapModule().setZoomLevel(currentZoom+1);
+                        if (currentZoom < maxZoomLevel) {
+                            me.getMapModule().setZoomLevel(currentZoom + 1);
                         }
                     }
                 },
@@ -56,8 +56,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar'
                     callback: function (el) {
                         var mapModule = me.getMapModule();
                         var currentZoom = mapModule.getMapZoom();
-                        if(currentZoom>0) {
-                            me.getMapModule().setZoomLevel(currentZoom-1);
+                        if (currentZoom > 0) {
+                            me.getMapModule().setZoomLevel(currentZoom - 1);
                         }
                     }
                 }
@@ -186,7 +186,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar'
                 max: mapModule.getMaxZoomLevel(),
                 value: mapModule.getMapZoom(),
                 slide: function (event, ui) {
-                me.getMapModule().setZoomLevel(ui.value);
+                    me.getMapModule().setZoomLevel(ui.value);
                 }
             });
 
@@ -220,15 +220,15 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar'
          *
          */
         refresh: function () {
-            var me = this,
-                conf = me.getConfig();
+            var me = this;
+            var conf = me.getConfig();
             // Change the style if in the conf
             if (conf && conf.toolStyle) {
                 me.changeToolStyle(conf.toolStyle, me.getElement());
             } else {
                 var toolStyle = me.getToolStyleFromMapModule();
                 if (!toolStyle) {
-                    toolStyle = "default";
+                    toolStyle = 'default';
                 }
                 if (toolStyle !== null && toolStyle !== undefined) {
                     me.changeToolStyle(me.toolStyles[toolStyle], me.getElement());
@@ -249,7 +249,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar'
             if (me._slider) {
                 // disable events in "onChange"
                 me._suppressEvents = true;
-                /*me._slider.setValue(value);*/
                 me._slider.slider('value', value);
                 me._suppressEvents = false;
             }
@@ -298,9 +297,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar'
                 return;
             }
             if (!style) {
-                style = this.toolStyles["default"];
-            } else if (!style.hasOwnProperty("widthCenter")) {
-                style = this.toolStyles[style] ? this.toolStyles[style] : this.toolStyles["default"];
+                style = this.toolStyles['default'];
+            } else if (!style.hasOwnProperty('widthCenter')) {
+                style = this.toolStyles[style] ? this.toolStyles[style] : this.toolStyles['default'];
             }
             var imgUrl = this.getImagePath();
             var styleName = style.val;


### PR DESCRIPTION
- Call the abstract stop on all plugins when stopping
- LayerSelectionTool - overriding setEnabled function removed because it messed up the state handling.