### PR TITLE
Publisher2 mobile tools fix

### DIFF
--- a/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
+++ b/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
@@ -98,6 +98,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
          * @param {Boolean} forced application has started and ui should be rendered with assets that are available
          */
         redrawUI: function(mapInMobileMode, forced) {
+            var isMobile = mapInMobileMode || Oskari.util.isMobile();
             var me = this;
             var sandbox = me.getSandbox();
             var mobileDefs = this.getMobileDefs();
@@ -110,7 +111,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
             }
             this.teardownUI();
 
-            if (!toolbarNotReady && mapInMobileMode) {
+            if (!toolbarNotReady && isMobile) {
                 this.addToolbarButtons(mobileDefs.buttons, mobileDefs.buttonGroup);
             } else {
                 me._element = me._createControlElement();
@@ -123,6 +124,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
             //remove old element
             this.removeFromPluginContainer(this.getElement());
             this._instance.sandbox.postRequestByName('userinterface.UpdateExtensionRequest', [this._instance, 'close']);
+            var mobileDefs = this.getMobileDefs();
+            this.removeToolbarButtons(mobileDefs.buttons, mobileDefs.buttonGroup);
         },
 
         /**
@@ -281,6 +284,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
                 flyoutTop = parseInt(top)+parseInt(height);
 
             flyout.container.parentElement.parentElement.style.top = flyoutTop + 'px';
+        },
+        _stopPluginImpl: function (sandbox) {
+            this.teardownUI();
         }
     }, {
         'extend': ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],

--- a/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
+++ b/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
@@ -31,10 +31,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
                         if (me._flyoutOpen) {
                             var sandbox = me.getSandbox();
                             sandbox.postRequestByName('userinterface.UpdateExtensionRequest', [this._instance, 'close']);
-
+                            var el = jQuery(me.getMapModule().getMobileDiv()).find('.mobile-info-marker');
                             var toolbarRequest = sandbox.getRequestBuilder('Toolbar.SelectToolButtonRequest')(null, 'mobileToolbar-mobile-toolbar');
                             sandbox.request(me, toolbarRequest);
-                            me._resetMobileIcon(this.getElement(), this._mobileDefs.buttons['mobile-featuredata'].iconCls);
+                            me._resetMobileIcon(el, me._mobileDefs.buttons['mobile-featuredata'].iconCls);
                             me._flyoutOpen = undefined;
                             var flyout = me._instance.plugins['Oskari.userinterface.Flyout'];
                             jQuery(flyout.container.parentElement.parentElement).removeClass('mobile');

--- a/bundles/framework/publisher2/tools/AbstractPluginTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPluginTool.js
@@ -107,8 +107,10 @@ function(sandbox, mapmodule, localization, instance, handlers) {
                 me.stop();
             }
         }
-        var event = Oskari.eventBuilder('Publisher2.ToolEnabledChangedEvent')(me);
-        sandbox.notifyAll(event);
+        if (!Oskari.util.isMobile()) {
+            var event = Oskari.eventBuilder('Publisher2.ToolEnabledChangedEvent')(me);
+            sandbox.notifyAll(event);   
+        }
     },
 
     isEnabled: function () {

--- a/bundles/framework/publisher2/tools/AbstractPluginTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPluginTool.js
@@ -92,7 +92,6 @@ function(sandbox, mapmodule, localization, instance, handlers) {
         if (me.state.enabled !== undefined && me.state.enabled !== null && enabled === me.state.enabled) {
             return;
         }
-
         me.state.enabled = enabled;
         if(!me.__plugin && enabled) {
             me.__plugin = Oskari.clazz.create(tool.id, tool.config);
@@ -104,7 +103,7 @@ function(sandbox, mapmodule, localization, instance, handlers) {
             me.__started = true;
         } else {
             if(me.__started === true) {
-                me.stop();
+                me.__plugin.stopPlugin(me.__sandbox);
             }
         }
             var event = Oskari.eventBuilder('Publisher2.ToolEnabledChangedEvent')(me);

--- a/bundles/framework/publisher2/tools/AbstractPluginTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPluginTool.js
@@ -107,10 +107,8 @@ function(sandbox, mapmodule, localization, instance, handlers) {
                 me.stop();
             }
         }
-        if (!Oskari.util.isMobile()) {
             var event = Oskari.eventBuilder('Publisher2.ToolEnabledChangedEvent')(me);
             sandbox.notifyAll(event);   
-        }
     },
 
     isEnabled: function () {

--- a/bundles/framework/publisher2/tools/ControlsTool.js
+++ b/bundles/framework/publisher2/tools/ControlsTool.js
@@ -1,49 +1,63 @@
 Oskari.clazz.define('Oskari.mapframework.publisher.tool.ControlsTool',
-function() {
-}, {
-    index : 5,
+    function () {
+    }, {
+        index: 5,
+        pluginName: 'ControlsPlugin',
+        setEnabled: function (enabled) {
+            var me = this;
+            var tool = me.getTool();
+            var sandbox = me.__sandbox;
 
-    /**
-    * Get tool object.
-    * @method getTool
-    *
-    * @returns {Object} tool description
-    */
-    getTool: function() {
-        return {
-            id: 'Oskari.mapframework.mapmodule.ControlsPlugin',
-            title: 'ControlsPlugin',
-            config: {}
-        };
-    },
-    /**
-    * Get values.
-    * @method getValues
-    * @public
-    *
-    * @returns {Object} tool value object
-    */
-    getValues: function () {
-        var me = this;
-        var config = null;
+            if (me.state.enabled !== undefined && me.state.enabled !== null && enabled === me.state.enabled) {
+                return;
+            }
+            me.state.enabled = enabled;
 
-        if(!me.state.enabled) {
-          config = {
-            keyboardControls: false,
-            mouseControls: false
-          }
-        }
-        return {
-            configuration: {
-                mapfull: {
-                    conf: {
-                        plugins: [{ id: this.getTool().id, config: config }]
+            if (!me.__plugin && enabled) {
+                me.__plugin = Oskari.clazz.create(tool.id, tool.config);
+                me.__mapmodule.registerPlugin(me.__plugin);
+            }
+
+            if (enabled === true && !me.__started) {
+                me.__plugin.startPlugin(me.__sandbox);
+                me.__started = true;
+            }
+
+            var event = Oskari.eventBuilder('Publisher2.ToolEnabledChangedEvent')(me);
+            sandbox.notifyAll(event);
+        },
+        getInstance: function () {
+            return Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule').getPluginInstances(this.pluginName);
+        },
+        getTool: function () {
+            return {
+                id: 'Oskari.mapframework.mapmodule.ControlsPlugin',
+                title: 'ControlsPlugin',
+                config: {}
+            };
+        },
+        getConfig: function () {
+            var config = null;
+            if (!this.state.enabled) {
+                config = {
+                    keyboardControls: false,
+                    mouseControls: false
+                };
+            }
+            return config;
+        },
+        getValues: function () {
+            return {
+                configuration: {
+                    mapfull: {
+                        conf: {
+                            plugins: [{ id: this.getTool().id, config: this.getConfig() }]
+                        }
                     }
                 }
-            }
-        };
-    }
+            };
+        }
 }, {
-    'extend' : ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],
-    'protocol' : ['Oskari.mapframework.publisher.Tool']
+        'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],
+        'protocol': ['Oskari.mapframework.publisher.Tool']
 });

--- a/bundles/framework/publisher2/tools/FeaturedataTool.js
+++ b/bundles/framework/publisher2/tools/FeaturedataTool.js
@@ -41,7 +41,7 @@ function() {
     init: function(data) {
         var me = this;
         if (data.configuration[me.bundleName]) {
-            me.setEnabled(false);
+            me.setEnabled(true);
         }
     },
     /**

--- a/bundles/framework/publisher2/tools/FeaturedataTool.js
+++ b/bundles/framework/publisher2/tools/FeaturedataTool.js
@@ -41,7 +41,7 @@ function() {
     init: function(data) {
         var me = this;
         if (data.configuration[me.bundleName]) {
-            me.setEnabled(true);
+            me.setEnabled(false);
         }
     },
     /**

--- a/bundles/framework/publisher2/tools/ToolbarTool.js
+++ b/bundles/framework/publisher2/tools/ToolbarTool.js
@@ -319,7 +319,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ToolbarTool',
 
                         //set selected values checked
                         if (me.selectedOptionsUi[toolName]) {
-                            selectTool.find('input').attr('checked', 'checked');
+                            selectTool.find('input').attr('checked', true);
                             if (toolName === "history") {
                                 tool.__plugin.addToolButton("history_back");
                                 tool.__plugin.addToolButton("history_forward");

--- a/bundles/framework/publisher2/view/PanelMapLayers.js
+++ b/bundles/framework/publisher2/view/PanelMapLayers.js
@@ -620,7 +620,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapLayers',
             var input = tools.find('input.baselayer');
             input.attr('id', 'checkbox' + layer.getId());
             if (isChecked) {
-                input.attr('checked', 'checked');
+                input.attr('checked', true);
             }
             input.change(closureMagic(layer));
 

--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -276,7 +276,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
                         }
                         tool.config.location.classes = tools[i][layout];
                         var plugin = tools[i].getPlugin();
-                        if (plugin && plugin.setLocation && !Oskari.util.isMobile()) {
+                        if (plugin && plugin.setLocation) {
                             plugin.setLocation(tool.config.location.classes);
                         }
                     }

--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -276,7 +276,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
                         }
                         tool.config.location.classes = tools[i][layout];
                         var plugin = tools[i].getPlugin();
-                        if (plugin && plugin.setLocation) {
+                        if (plugin && plugin.setLocation && !Oskari.util.isMobile()) {
                             plugin.setLocation(tool.config.location.classes);
                         }
                     }

--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -210,10 +210,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
                 // First choice is active unless we have an active layout
                 if (me.activeToolLayout) {
                     if (me.toolLayouts[i] === me.activeToolLayout) {
-                        input.attr('checked', 'checked');
+                        input.attr('checked', true);
                     }
                 } else if (i === 0) {
-                    input.attr('checked', 'checked');
+                    input.attr('checked', true);
                 }
                 layoutContainer.find('span').html(
                     me.loc.toollayout[me.toolLayouts[i]] || me.toolLayouts[i]

--- a/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
@@ -191,6 +191,9 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
          *
          */
         setLocation: function (location) {
+            if (Oskari.util.isMobile()) {
+                return;
+            }
             var me = this,
                 el = me.getElement();
 

--- a/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPlugin.js
@@ -772,6 +772,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionP
          * @param {Boolean} forced application has started and ui should be rendered with assets that are available
          */
         redrawUI: function(mapInMobileMode, forced) {
+            var isMobile = mapInMobileMode || Oskari.util.isMobile();
             if(!this.isVisible()) {
                 // no point in drawing the ui if we are not visible
                 return;
@@ -787,7 +788,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionP
                 return true;
             }
             this.teardownUI();
-            if (!toolbarNotReady && mapInMobileMode) {
+            if (!toolbarNotReady && isMobile) {
                 this.addToolbarButtons(mobileDefs.buttons, mobileDefs.buttonGroup);
             } else {
                 // TODO: redrawUI is basically refresh, move stuff here from refresh if needed

--- a/bundles/mapping/mapmodule/plugin/publishertoolbar/PublisherToolbarPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/publishertoolbar/PublisherToolbarPlugin.js
@@ -307,6 +307,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolba
          * @param {Boolean} forced application has started and ui should be rendered with assets that are available
          */
         redrawUI: function(mapInMobileMode, forced) {
+            var isMobile = mapInMobileMode || Oskari.util.isMobile();
             if(!this.isVisible()) {
                 // no point in drawing the ui if we are not visible
                 return;
@@ -324,7 +325,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolba
 
             this.teardownUI();
 
-            me._element = me._createControlElement(mapInMobileMode);
+            me._element = me._createControlElement(isMobile);
 
             var changeToolStyle = function(toolstyle, div){
                 var div = div || me.getElement(),
@@ -355,7 +356,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolba
 
             };
 
-            if (!toolbarNotReady && mapInMobileMode) {
+            if (!toolbarNotReady && isMobile) {
                 changeToolStyle(null, me._element);
                 this.addToolbarButtons(mobileDefs.buttons, mobileDefs.buttonGroup);
             } else {

--- a/bundles/mapping/mapmodule/plugin/publishertoolbar/PublisherToolbarPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/publishertoolbar/PublisherToolbarPlugin.js
@@ -296,6 +296,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolba
                 me.popup.close(true);
                 me.popup = null;
             }
+            var mobileDefs = this.getMobileDefs();
+            this.removeToolbarButtons(mobileDefs.buttons, mobileDefs.buttonGroup);
         },
 
         /**
@@ -702,7 +704,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolba
 
         _stopPluginImpl: function (sandbox) {
             this.teardownUI();
-
         }
 
     }, {

--- a/bundles/mapping/mapmodule/plugin/search/SearchPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/search/SearchPlugin.js
@@ -746,6 +746,7 @@ Oskari.clazz.define(
          * @param {Boolean} modeChanged is the ui mode changed (mobile/desktop)
          */
         redrawUI: function (mapInMobileMode, modeChanged) {
+            var isMobile = mapInMobileMode || Oskari.util.isMobile();
             if(!this.isVisible()) {
                 // no point in drawing the ui if we are not visible
                 return;
@@ -758,7 +759,7 @@ Oskari.clazz.define(
             //remove old element
             this.teardownUI();
 
-            if (mapInMobileMode) {
+            if (isMobile) {
                 //remove old element
                 this.removeFromPluginContainer(this.getElement(), true);
 

--- a/bundles/mapping/mapmodule_ol3/plugin/controls/ControlsPlugin.js
+++ b/bundles/mapping/mapmodule_ol3/plugin/controls/ControlsPlugin.js
@@ -74,7 +74,7 @@ Oskari.clazz.define(
                 },
                 'Toolbar.ToolSelectedEvent': function (event) {
                     if (event._toolId !== 'zoombox') {
-                        this.disableMouseDragZoom();
+                        this._clearLifetimeInteractions();
                     }
                 },
                 'Publisher2.ToolEnabledChangedEvent': function (event) {

--- a/bundles/mapping/mapmodule_ol3/plugin/controls/ControlsPlugin.js
+++ b/bundles/mapping/mapmodule_ol3/plugin/controls/ControlsPlugin.js
@@ -16,12 +16,10 @@ Oskari.clazz.define(
      *
      */
     function () {
-        var me = this;
-        me._clazz =
-            'Oskari.mapframework.mapmodule.ControlsPlugin';
-        me._name = 'ControlsPlugin';
-        me.boxZoom = null;
-        me.removedInteractions = [];
+        this._clazz = 'Oskari.mapframework.mapmodule.ControlsPlugin';
+        this._name = 'ControlsPlugin';
+        this.removedInteractions = [];
+        this.addedInteractions = [];
     }, {
         /**
          * @public @method hasUI
@@ -34,36 +32,26 @@ Oskari.clazz.define(
         hasUI: function () {
             return true;
         },
-
-        /**
-         * @private @method _startPluginImpl
-         * Interface method for the plugin protocol
-         *
-         *
-         */
         _startPluginImpl: function () {
-            var me = this;
-            me._createMapInteractions();
+            this._createMapInteractions();
         },
-
+        _stopPluginImpl: function () {
+            this._clearLifetimeInteractions();
+        },
         _createEventHandlers: function () {
             return {
-                /**
-                * @method Toolbar.ToolSelectedEvent
-                * @param {Oskari.mapframework.bundle.toolbar.event.ToolSelectedEvent} event
-                */
                 'DrawingEvent': function (event) {
-                    if(event.getId() !== 'measureline' && event.getId() !== 'measurearea') {
+                    if (event.getId() !== 'measureline' && event.getId() !== 'measurearea') {
                         // this isn't about measurements, stop processing it
                         return;
                     }
 
-                    var me = this,
-                        measureValue,
-                        data = event.getData(),
-                        finished = event.getIsFinished(),
-                        geoJson = event.getGeoJson(),
-                        geomMimeType = 'application/json';
+                    var me = this;
+                    var measureValue;
+                    var data = event.getData();
+                    var finished = event.getIsFinished();
+                    var geoJson = event.getGeoJson();
+                    var geomMimeType = 'application/json';
 
                     if (data.showMeasureOnMap) {
                         return;
@@ -77,23 +65,26 @@ Oskari.clazz.define(
                     if (data.shape === 'LineString') {
                         measureValue = data.lenght;
                     } else if (data.shape === 'Polygon') {
-                         measureValue = data.area;
+                        measureValue = data.area;
                     }
                     var reqBuilder = me.getSandbox().getRequestBuilder('ShowMapMeasurementRequest');
-                    if(reqBuilder) {
+                    if (reqBuilder) {
                         me.getSandbox().request(me, reqBuilder(measureValue, finished, geoJson, geomMimeType));
                     }
                 },
-                /**
-                 * @method Toolbar.ToolSelectedEvent
-                 * @param {Oskari.mapframework.bundle.toolbar.event.ToolSelectedEvent} event
-                 */
-
                 'Toolbar.ToolSelectedEvent': function (event) {
-                    if ( event._toolId !== "zoombox" ) {
+                    if (event._toolId !== 'zoombox') {
                         this.disableMouseDragZoom();
                     }
-                    return;
+                },
+                'Publisher2.ToolEnabledChangedEvent': function (event) {
+                    if (event.getTool().getTool().id === this._clazz) {
+                        if (!event._tool.isEnabled()) {
+                            this.disableDragPan();
+                        } else {
+                            this._clearLifetimeInteractions();
+                        }
+                    }
                 }
             };
         },
@@ -107,40 +98,52 @@ Oskari.clazz.define(
                     me.getSandbox(),
                     me
                 ),
-                'EnableMapKeyboardMovementRequest' : mapMovementHandler,
-                'DisableMapKeyboardMovementRequest' : mapMovementHandler,
-                'EnableMapMouseMovementRequest' : mapMovementHandler,
-                'DisableMapMouseMovementRequest' : mapMovementHandler
+                'EnableMapKeyboardMovementRequest': mapMovementHandler,
+                'DisableMapKeyboardMovementRequest': mapMovementHandler,
+                'EnableMapMouseMovementRequest': mapMovementHandler,
+                'DisableMapMouseMovementRequest': mapMovementHandler
             };
         },
-        disableMouseDragZoom: function () {
+        _clearLifetimeInteractions: function () {
             var me = this;
-            if ( this.boxZoom ) {
-                this.getMap().removeInteraction( this.boxZoom );
-            }
-            this.removedInteractions.forEach( function ( interaction ) {
-                me.getMap().addInteraction( interaction );
+            this.addedInteractions.forEach(function (interaction) {
+                me.getMap().removeInteraction(interaction);
+            });
+            this.removedInteractions.forEach(function (interaction) {
+                me.getMap().addInteraction(interaction);
             });
             this.removedInteractions = [];
+            this.addedInteractions = [];
         },
-        mouseDragZoomInteraction: function () {
+        disableDragPan: function () {
             var me = this;
-
-            me.getMap().getInteractions().forEach( function( interaction ) {
-                if ( interaction instanceof ol.interaction.DragPan || interaction instanceof ol.interaction.DragZoom ) {
-                    me.getMap().removeInteraction( interaction );
-                    me.removedInteractions.push( interaction );
+            var disable = me.getMap().getInteractions().getArray().filter(function (interaction) {
+                if (interaction instanceof ol.interaction.DragZoom) {
+                    return interaction;
+                }
+                if (interaction instanceof ol.interaction.DragPan) {
+                    return interaction;
                 }
             });
-            if ( !this.boxZoom ) {
-                this.boxZoom = new ol.interaction.DragZoom({
-                    condition: function ( mapBrowserEvent ) {
-                        return ol.events.condition.mouseOnly( mapBrowserEvent );
+            disable.forEach(function (toDisable) {
+                me.getMap().removeInteraction(toDisable);
+                me.removedInteractions.push(toDisable);
+            });
+        },
+        mouseDragZoomInteraction: function () {
+            var boxzoom = this.getMap().getInteractions().forEach(function (interaction) {
+                if (interaction instanceof ol.interaction.DragZoom) {
+                    return interaction;
+                }
+            });
+            if (!boxzoom) {
+                boxzoom = new ol.interaction.DragZoom({
+                    condition: function (mapBrowserEvent) {
+                        return ol.events.condition.mouseOnly(mapBrowserEvent);
                     }
                 });
             }
-
-            this.getMap().addInteraction( this.boxZoom );
+            this.getMap().addInteraction(boxzoom);
         },
         /**
          * @private @method _createMapControls
@@ -149,33 +152,34 @@ Oskari.clazz.define(
          *
          */
         _createMapInteractions: function () {
-            var me = this,
-            conf = me.getConfig();
+            var me = this;
+            var conf = me.getConfig();
             var mouseInteractionRemove = [];
             var kbInteractionRemove = [];
+            var interactions = me.getMap().getInteractions();
 
             // Map movement/keyboard control
             if (conf.keyboardControls === false) {
-              me.getMap().getInteractions().forEach( function( interaction ) {
-                if ( interaction instanceof ol.interaction.KeyboardPan || interaction instanceof ol.interaction.KeyboardZoom ) {
-                  kbInteractionRemove.push( interaction );
-                }
-              });
-              kbInteractionRemove.forEach( function ( interaction ) {
-                me.getMap().removeInteraction( interaction );
-              })
+                interactions.forEach(function (interaction) {
+                    if (interaction instanceof ol.interaction.KeyboardPan || interaction instanceof ol.interaction.KeyboardZoom) {
+                        kbInteractionRemove.push(interaction);
+                    }
+                });
+                kbInteractionRemove.forEach(function (interaction) {
+                    me.getMap().removeInteraction(interaction);
+                });
             }
 
             // mouse control
             if (conf.mouseControls === false) {
-              me.getMap().getInteractions().forEach(function(interaction){
-                if (interaction instanceof ol.interaction.DragPan ||interaction instanceof ol.interaction.MouseWheelZoom || interaction instanceof ol.interaction.DoubleClickZoom || interaction instanceof ol.interaction.DragZoom ){
-                  mouseInteractionRemove.push(interaction);
-                }
-              });
-              mouseInteractionRemove.forEach(function(interaction){
-                me.getMap().removeInteraction(interaction);
-              })
+                interactions.forEach(function (interaction) {
+                    if (interaction instanceof ol.interaction.DragPan || interaction instanceof ol.interaction.MouseWheelZoom || interaction instanceof ol.interaction.DoubleClickZoom || interaction instanceof ol.interaction.DragZoom) {
+                        mouseInteractionRemove.push(interaction);
+                    }
+                });
+                mouseInteractionRemove.forEach(function (interaction) {
+                    me.getMap().removeInteraction(interaction);
+                });
             }
         }
     }, {


### PR DESCRIPTION
- Don't call Publisher2.ToolEnabledChangedEvent in mobile since it calls set location to plugins -> plugins end up on map instead of mobile toolbar