### PR TITLE
Publisher - handle toolbar visibility in small map size

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1148,7 +1148,7 @@ Oskari.clazz.define(
             var mobileDiv = this.getMobileDiv();
             var toolbar = mobileDiv.find('.mobileToolbarContent');
 
-            if (mobileDiv.children().length === 0) {
+            if (toolbar.find('.toolbar_mobileToolbar').children().length === 0) {
                 // plugins didn't add any content -> hide it so the empty bar is not visible
                 mobileDiv.hide();
             } else {


### PR DESCRIPTION
- Changed the element in which to look for tools, previous solution was always true so the toolbar displayed with no tools.