### PR TITLE
Layersplugin visibility event fix

### DIFF
--- a/bundles/framework/layerselection2/instance.js
+++ b/bundles/framework/layerselection2/instance.js
@@ -221,7 +221,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.layerselection2.LayerSelectionBu
                 if (event._creator !== this.getName()) {
                     // Layer order has been changed by someone else, resort layers
                     this.plugins['Oskari.userinterface.Tile'].refresh();
-                    this.plugins['Oskari.userinterface.Flyout'].handleLayerOrderChanged(event._movedMapLayer, event._fromPosition, event._toPosition);
+                    this.plugins['Oskari.userinterface.Flyout'].handleLayerOrderChanged(event.getMovedMapLayer(), event.getFromPosition(), event.getToPosition());
                 }
             }
         },

--- a/bundles/framework/timeseries/service/TimeseriesLayerService.js
+++ b/bundles/framework/timeseries/service/TimeseriesLayerService.js
@@ -52,7 +52,7 @@ Oskari.clazz.define(
          */
         __eventHandlers: {
             'AfterRearrangeSelectedMapLayerEvent': function (event) {
-                if (event.getMapLayer().hasTimeseries()) {
+                if (event.getMovedMapLayer().hasTimeseries()) {
                     this.updateTimeseriesLayers();
                 }
             },

--- a/bundles/mapping/mapmodule/mapmodule.ol3.js
+++ b/bundles/mapping/mapmodule/mapmodule.ol3.js
@@ -99,6 +99,9 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.MapModule',
             map.on('moveend', function (evt) {
                 me.notifyMoveEnd();
             });
+            map.on('movestart', function (evt) {
+                me.notifyStartMove();
+            });
 
             map.on('singleclick', function (evt) {
                 if (me.getDrawingMode()) {

--- a/bundles/mapping/mapmodule/plugin/layers/LayersPlugin.ol3.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayersPlugin.ol3.js
@@ -28,7 +28,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin',
         this._visibilityPollingInterval = 1500;
         this._visibilityCheckOrder = 0;
         this._previousTimer = null;
-        this._lastVisibilityCheckResult = {};
     }, {
     _createEventHandlers: function () {
         var me = this;
@@ -201,13 +200,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin',
             layer;
         for (i = 0; i < layers.length; ++i) {
             layer = layers[i];
-
-            var visible = layer.isVisible();
-            var previousVisibility = this._lastVisibilityCheckResult[layer.getId()];
-            if (typeof previousVisibility !== 'undefined' && visible !== previousVisibility) {
+            if (layer.isVisible()) {
                 this.notifyLayerVisibilityChanged(layer);
             }
-            this._lastVisibilityCheckResult[layer.getId()] = visible;
         }
         this._visibilityCheckScheduled = false;
     },

--- a/bundles/mapping/mapmodule/plugin/layers/LayersPlugin.ol3.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayersPlugin.ol3.js
@@ -246,11 +246,15 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin',
             // show non-baselayer if in scale, in geometry and layer visible
             if (mapLayer && !mapLayer.getVisible()) {
                 mapLayer.setVisible(true);
+            } else {
+                return; //suppress event
             }
         } else {
             // otherwise hide non-baselayer
             if (mapLayer && mapLayer.getVisible()) {
                 mapLayer.setVisible(false);
+            } else {
+                return; //suppress event
             }
         }
         var event = this._sandbox.getEventBuilder('MapLayerVisibilityChangedEvent')(layer, scaleOk, geometryMatch);


### PR DESCRIPTION
Fixes the issue where layer's visibility didn't change when viewport were out of the layer's scale or content/bbox. Also, now map sends MapMoveStartEvent to clear visibility check timer.

Use getMovedMapLayer() instead of getMapLayer() on AfterRearrangeSelectedMapLayerEvent.