### PR TITLE
Stats - fix error message on classification change

### DIFF
--- a/bundles/statistics/statsgrid2016/components/Legend.js
+++ b/bundles/statistics/statsgrid2016/components/Legend.js
@@ -275,7 +275,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Legend', function (sandbox, loc
         var legendElement = this._element.find('.active-legend');
         legendElement.empty();
 
-        this._createLegend(ind.hash, function (legend) {
+        this._createLegend(ind, function (legend) {
             legendElement.append(legend);
         });
     },


### PR DESCRIPTION
- _updateLegend called _createLegend with only the indicator hash which is not enough for the service to fetch the data -> now whole indicator is sent to the function.