### PR TITLE
Regionset config for statistical maps

### DIFF
--- a/bundles/statistics/statsgrid2016/instance.js
+++ b/bundles/statistics/statsgrid2016/instance.js
@@ -49,6 +49,8 @@ Oskari.clazz.define(
                 me.statsService.setMapModes(['wms', 'vector']);
             }
             statsService.addDatasource(conf.sources);
+            statsService.addRegionset(conf.regionsets);
+
 
             // initialize flyoutmanager
             this.flyoutManager = Oskari.clazz.create('Oskari.statistics.statsgrid.FlyoutManager', this, statsService);
@@ -212,7 +214,7 @@ Oskari.clazz.define(
             },
             'StatsGrid.ActiveIndicatorChangedEvent': function (evt) {
                 this.statsService.notifyOskariEvent(evt);
-                
+
                 if (evt.current && evt.current.series) {
                     if (this.seriesControlPlugin) {
                         if (!this.seriesControlPlugin.getElement()) {

--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -18,6 +18,7 @@
 
         // pushed from instance
         this.datasources = [];
+        this.regionsets = [];
         // attach on, off, trigger functions
         Oskari.makeObservable(this);
 
@@ -180,23 +181,34 @@
             });
             return found;
         },
+        addRegionset: function (regionset) {
+            if (!regionset) {
+                // log error message
+                return;
+            }
+            var me = this;
+            if (Array.isArray(regionset)) {
+                // if(typeof regionset === 'array') -> loop and add all
+                regionset.forEach(function (item) {
+                    me.addRegionset(item);
+                });
+                return;
+            }
+            if (regionset.id && regionset.name) {
+                this.regionsets.push(regionset);
+            } else {
+                _log.info('Ignoring regionset without id or name:', regionset);
+            }
+        },
         /**
          * Returns regionsets that are available to user.
          * Based on maplayers of type STATS.
          */
         getRegionsets: function (includeOnlyIds) {
-            var service = this.sandbox.getService('Oskari.mapframework.service.MapLayerService');
-            var layers = service.getLayersOfType('STATS');
-            if (!layers || layers.length === 0) {
+            var list = this.regionsets || [];
+            if (!list || list.length === 0) {
                 return [];
             }
-            var list = [];
-            layers.forEach(function (regionset) {
-                list.push({
-                    id: regionset.getId(),
-                    name: regionset.getName()
-                });
-            });
             var singleValue = typeof includeOnlyIds === 'number' || typeof includeOnlyIds === 'string';
             if (singleValue) {
                 // wrap to an array


### PR DESCRIPTION
Statsgrid-bundle has previously determined the available regionsets from maplayers (layers of type "statslayer"). These layers don't function properly outside the statistical functionality, but are listed on the maplayer listing anyway. This change makes statsgrid determine the regionsets from it's config instead of the layers. The configuration change for server has been made in oskariorg/oskari-server#233.

After this change the mapstats-bundle can be removed as the frontend no longer requires "statslayers" as maplayers.