### PR TITLE
Localization fallback for Webpack build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5417,6 +5417,12 @@
         }
       }
     },
+    "merge": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "dev": true
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-standard": "^3.0.1"
+    "eslint-plugin-standard": "^3.0.1",
+    "merge": "^1.2.0"
   },
   "private": true
 }

--- a/webpack/localizationPlugin.js
+++ b/webpack/localizationPlugin.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const merge = require('merge');
 
 const fileRex = /^(.{2})\.js$/;
 
@@ -35,32 +36,52 @@ class LocalizationPlugin {
             this.prevTimestamps = compilation.fileTimestamps;
 
             const parsed = new Map();
+            const allKeys = new Set();
             const Oskari = {
                 registerLocalization: (loc) => {
                     const lang = loc.lang;
                     if (!lang) {
                         throw new Error('Localization file has no "lang"!');
                     }
-                    let agg = [];
+                    let agg = new Map();
                     if (parsed.has(lang)) {
                         agg = parsed.get(lang);
                     } else {
                         parsed.set(lang, agg);
                     }
-                    agg.push(loc);
+                    agg.set(loc.key, loc);
+                    allKeys.add(loc.key);
                 }
             }
             localeFiles
-                .filter(path => changedLanguages.has(this.langFromPath(path)))
+                .filter(path => {
+                    const lang = this.langFromPath(path);
+                    return lang === 'en' || changedLanguages.has(lang); // Always process English as it might be needed as fallback
+                })
                 .forEach(path => {
                     const source = fs.readFileSync(path, 'utf8');
                     eval(source);
                 });
 
 
+            const english = parsed.get('en') || new Map();
             for (let entry of parsed.entries()) {
-                let fileContent = entry[1].map(def => `Oskari.registerLocalization(${JSON.stringify(def)});`).join('\n');
-                compilation.assets[`oskari_lang_${entry[0]}.js`] = {
+                const lang = entry[0];
+                const contents = entry[1];
+                
+                const keyContents = Array.from(allKeys)
+                    .filter(key => english.has(key) || contents.has(key))
+                    .map(key => {
+                        const fallback = english.get(key);
+                        const locForKey = contents.get(key);
+                        if (locForKey && fallback) {
+                            return merge.recursive(true, fallback, locForKey);
+                        }
+                        return locForKey || {lang: lang, key: key, value: fallback.value};
+                    });
+
+                let fileContent = keyContents.map(content => `Oskari.registerLocalization(${JSON.stringify(content)});`).join('\n');
+                compilation.assets[`oskari_lang_${lang}.js`] = {
                     source() {
                         return fileContent;
                     },


### PR DESCRIPTION
English is used as fallback for localization keys that do not exist for a given language. Language overrides (`Oskari.registerLocalization(..., true)`) are now compiled into the produced language file, reducing its size and removing the need to apply overrides at runtime.