### PR TITLE
Minor fixes in Statsgrid & oskari-core

### DIFF
--- a/bundles/statistics/statsgrid2016/components/EditClassification.js
+++ b/bundles/statistics/statsgrid2016/components/EditClassification.js
@@ -161,6 +161,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function (
             // not rendered yet
             return;
         }
+        me._rangeSlider.element.slider();
+
         var service = me.service;
         var state = service.getStateService();
         var ind = state.getActiveIndicator();

--- a/src/class_system.js
+++ b/src/class_system.js
@@ -31,7 +31,7 @@
 
     function checkFinalized(classInfo) {
         if (!classInfo.finalized) {
-            throw new Error('Definitions missing for "' + className + '"! Make sure class and its super classes are loaded.');
+            throw new Error('Definitions missing for "' + classInfo.className + '"! Make sure class and its super classes are loaded.');
         }
     }
 


### PR DESCRIPTION
- Stats - jQuery ui slider gave an error message breaking the classification plugin when going to publisher mode - initialize empty slider
- class_system - fixed unknown variable className