### PR TITLE
Locale scripts

### DIFF
--- a/tools/extract-locale.js
+++ b/tools/extract-locale.js
@@ -69,3 +69,5 @@ Object.keys(collection)
         ensureDirectoryExists(outputPath);
         fs.writeFileSync(outputPath, JSON.stringify(output, null, 2));
     });
+
+console.log('Extracted files succesfully to "locale" directory in repo root');

--- a/tools/extract-locale.js
+++ b/tools/extract-locale.js
@@ -1,0 +1,64 @@
+var path = require('path');
+var fs = require('fs');
+var glob = require('glob');
+var merge = require('merge');
+
+function deconstructPath(filePath, chain) {
+    chain = chain || [];
+    if (chain[0] === 'bundles') {
+        return chain.slice(1, -3);
+    }
+    chain.unshift(path.basename(filePath));
+    return deconstructPath(path.dirname(filePath), chain);
+}
+
+function ensureDirectoryExists(filePath) {
+    var dirname = path.dirname(filePath);
+    if (fs.existsSync(dirname)) {
+      return true;
+    }
+    ensureDirectoryExists(dirname);
+    fs.mkdirSync(dirname);
+  }
+
+var locale = process.argv[2];
+
+if (!locale) {
+    throw new Error('Must give locale as parameter, for example "fi"');
+}
+
+var localeFilePaths = glob.sync('/bundles/**/resources/locale/@(en|' + locale + ').js', {root: path.join(__dirname, '..')});
+
+var collection = {};
+
+localeFilePaths.forEach(function(filePath){
+    var dir = deconstructPath(filePath).join('__');
+
+    var Oskari = {
+        registerLocalization: function(loc, isOverride) {
+            var lang = loc.lang;
+            if (!lang) {
+                throw new Error('Localization file has no "lang"!');
+            }
+
+            if (!collection[dir]) {
+                collection[dir] = {};
+            }
+            collection[dir][lang] = loc.value;
+        }
+    };
+
+    var source = fs.readFileSync(filePath, 'utf8');
+    eval(source);
+});
+
+
+Object.keys(collection).forEach(function(dir){
+    var enContent = collection[dir].en || {};
+    var localeContent = collection[dir][locale] || {};
+    var output = merge.recursive(true, enContent, localeContent);
+
+    var outputPath = path.join(__dirname, '..', 'locale', dir + '__' + locale + '.json');
+    ensureDirectoryExists(outputPath);
+    fs.writeFileSync(outputPath, JSON.stringify(output, null, 2));
+});

--- a/tools/extract-locale.js
+++ b/tools/extract-locale.js
@@ -42,9 +42,12 @@ localeFilePaths.forEach(function(filePath){
             }
 
             if (!collection[dir]) {
-                collection[dir] = {};
+                collection[dir] = {content: {}};
             }
-            collection[dir][lang] = loc.value;
+            if (collection[dir].content[lang]) {
+                collection[dir].isMulti = true; // multiple calls to registerLocalization for language. Lang-overrides bundle does this.
+            }
+            collection[dir].content[lang] = loc.value;
         }
     };
 
@@ -53,12 +56,16 @@ localeFilePaths.forEach(function(filePath){
 });
 
 
-Object.keys(collection).forEach(function(dir){
-    var enContent = collection[dir].en || {};
-    var localeContent = collection[dir][locale] || {};
-    var output = merge.recursive(true, enContent, localeContent);
+Object.keys(collection)
+    .filter(function(dir){
+        return !collection[dir].isMulti;
+    })
+    .forEach(function(dir){
+        var enContent = collection[dir].content.en || {};
+        var localeContent = collection[dir].content[locale] || {};
+        var output = merge.recursive(true, enContent, localeContent);
 
-    var outputPath = path.join(__dirname, '..', 'locale', dir + '__' + locale + '.json');
-    ensureDirectoryExists(outputPath);
-    fs.writeFileSync(outputPath, JSON.stringify(output, null, 2));
-});
+        var outputPath = path.join(__dirname, '..', 'locale', dir + '__' + locale + '.json');
+        ensureDirectoryExists(outputPath);
+        fs.writeFileSync(outputPath, JSON.stringify(output, null, 2));
+    });

--- a/tools/inject-locale.js
+++ b/tools/inject-locale.js
@@ -11,7 +11,7 @@ if (!locale) {
 var jsonFilePaths = glob.sync('/locale/*' + locale + '.json', {root: path.join(__dirname, '..')});
 
 if (jsonFilePaths.length === 0) {
-    console.log('No locale JSON files found. Make sure you have something to inject under "locale" directory in repo root.')
+    console.log('No locale JSON files found for locale "' + locale + '". Make sure you have something to inject under "locale" directory in repo root.')
     process.exit(1);
 }
 
@@ -30,3 +30,5 @@ jsonFilePaths.forEach(function(filePath) {
     };
     eval(enContent);
 });
+
+console.log('Injected localization strings to locale files. Use git to inspect changes.');

--- a/tools/inject-locale.js
+++ b/tools/inject-locale.js
@@ -1,0 +1,32 @@
+var path = require('path');
+var fs = require('fs');
+var glob = require('glob');
+
+var locale = process.argv[2];
+
+if (!locale) {
+    throw new Error('Must give locale as parameter, for example "fi"');
+}
+
+var jsonFilePaths = glob.sync('/locale/*' + locale + '.json', {root: path.join(__dirname, '..')});
+
+if (jsonFilePaths.length === 0) {
+    console.log('No locale JSON files found. Make sure you have something to inject under "locale" directory in repo root.')
+    process.exit(1);
+}
+
+jsonFilePaths.forEach(function(filePath) {
+    var parts = path.basename(filePath, '.json').split('__').slice(0, -1);
+    var targetChain = [__dirname, '..', 'bundles'].concat(parts).concat(['resources', 'locale']);
+    var targetDirectory = path.join.apply(path, targetChain);
+    var enContent = fs.readFileSync(path.join(targetDirectory, 'en.js'), 'utf8');
+    var Oskari = {
+        registerLocalization: function(loc, isOverride) {
+            loc.lang = locale;
+            loc.value = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+            var override = isOverride ? ', true' : '';
+            fs.writeFileSync(path.join(targetDirectory, locale + '.js'), 'Oskari.registerLocalization(\n' + JSON.stringify(loc, null, 4) + override + ');\n', 'utf8');
+        }
+    };
+    eval(enContent);
+});

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "abbrev": {
       "version": "1.1.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/abbrev/-/abbrev-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
@@ -22,7 +22,7 @@
     },
     "acorn": {
       "version": "5.1.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/acorn/-/acorn-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
       "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
       "dev": true
     },
@@ -34,7 +34,7 @@
     },
     "after": {
       "version": "0.8.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/after/-/after-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
     },
@@ -52,7 +52,7 @@
     },
     "align-text": {
       "version": "0.1.4",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/align-text/-/align-text-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
@@ -63,13 +63,13 @@
     },
     "amdefine": {
       "version": "1.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/amdefine/-/amdefine-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
@@ -84,13 +84,13 @@
     },
     "aproba": {
       "version": "1.2.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/aproba/-/aproba-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
     "archiver": {
       "version": "0.21.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/archiver/-/archiver-0.21.0.tgz",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.21.0.tgz",
       "integrity": "sha1-Ep2gyOrhqb8IoBLYpOIEOh4pCc4=",
       "dev": true,
       "requires": {
@@ -104,9 +104,22 @@
         "zip-stream": "0.8.0"
       },
       "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -114,7 +127,7 @@
     },
     "archiver-utils": {
       "version": "0.3.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/archiver-utils/-/archiver-utils-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-0.3.0.tgz",
       "integrity": "sha1-nYU0CJL+nnxsGxtq88M2ks9ZW3A=",
       "dev": true,
       "requires": {
@@ -125,9 +138,22 @@
         "readable-stream": "2.0.6"
       },
       "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -162,7 +188,7 @@
     },
     "arr-diff": {
       "version": "2.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/arr-diff/-/arr-diff-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
@@ -171,31 +197,31 @@
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/array-find-index/-/array-find-index-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
     "array-parallel": {
       "version": "0.1.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/array-parallel/-/array-parallel-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz",
       "integrity": "sha1-j3hTCJJu1apHjEfmTRszS2wMlH0=",
       "dev": true
     },
     "array-series": {
       "version": "0.1.5",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/array-series/-/array-series-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/array-series/-/array-series-0.1.5.tgz",
       "integrity": "sha1-3103v8XC7wdV4qpPkv6ufUtaly8=",
       "dev": true
     },
     "array-unique": {
       "version": "0.2.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/array-unique/-/array-unique-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
     },
@@ -216,19 +242,19 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/async/-/async-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
     "async-foreach": {
       "version": "0.1.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/async-foreach/-/async-foreach-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
       "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
       "dev": true
     },
@@ -240,13 +266,13 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
@@ -258,31 +284,31 @@
     },
     "babylon": {
       "version": "7.0.0-beta.19",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/babylon/-/babylon-7.0.0-beta.19.tgz",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
       "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
       "dev": true
     },
     "backo2": {
       "version": "1.0.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/backo2/-/backo2-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
       "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "base64-arraybuffer": {
       "version": "0.1.5",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
       "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
       "dev": true
     },
     "base64id": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/base64id/-/base64id-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
       "dev": true
     },
@@ -298,7 +324,7 @@
     },
     "better-assert": {
       "version": "1.0.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/better-assert/-/better-assert-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
       "dev": true,
       "requires": {
@@ -307,7 +333,7 @@
     },
     "binary": {
       "version": "0.3.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/binary/-/binary-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
       "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
       "dev": true,
       "requires": {
@@ -365,13 +391,13 @@
     },
     "blob": {
       "version": "0.0.4",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/blob/-/blob-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
       "dev": true
     },
     "block-stream": {
       "version": "0.0.9",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/block-stream/-/block-stream-0.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
@@ -380,7 +406,7 @@
     },
     "bluebird": {
       "version": "3.5.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/bluebird/-/bluebird-3.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
       "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
       "dev": true
     },
@@ -405,7 +431,7 @@
     },
     "braces": {
       "version": "1.8.5",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/braces/-/braces-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
@@ -416,7 +442,7 @@
     },
     "buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
@@ -429,31 +455,31 @@
     },
     "buffers": {
       "version": "0.1.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/buffers/-/buffers-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
       "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
       "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "callsite": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/callsite/-/callsite-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
       "dev": true
     },
     "camelcase": {
       "version": "2.1.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/camelcase/-/camelcase-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
       "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
       "dev": true
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -463,13 +489,13 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "catharsis": {
       "version": "0.8.9",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/catharsis/-/catharsis-0.8.9.tgz",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
       "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
       "dev": true,
       "requires": {
@@ -478,7 +504,7 @@
     },
     "center-align": {
       "version": "0.1.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/center-align/-/center-align-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
@@ -488,7 +514,7 @@
     },
     "chainsaw": {
       "version": "0.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/chainsaw/-/chainsaw-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
       "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
       "dev": true,
       "requires": {
@@ -508,7 +534,7 @@
     },
     "cli": {
       "version": "1.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/cli/-/cli-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
       "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
       "dev": true,
       "requires": {
@@ -518,7 +544,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/glob/-/glob-7.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
@@ -534,7 +560,7 @@
     },
     "cliui": {
       "version": "3.2.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/cliui/-/cliui-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
@@ -545,7 +571,7 @@
     },
     "closure-util": {
       "version": "1.24.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/closure-util/-/closure-util-1.24.0.tgz",
+      "resolved": "https://registry.npmjs.org/closure-util/-/closure-util-1.24.0.tgz",
       "integrity": "sha512-SBdAKvU70DqWDsqWUMFnI0a/BP1HgD008lalKqc493DwutW/UsYWe8cJdSj4NIcX8RtqQfiYlFY5vxQFBo7uzA==",
       "dev": true,
       "requires": {
@@ -570,7 +596,7 @@
       "dependencies": {
         "async": {
           "version": "2.5.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/async/-/async-2.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
@@ -579,7 +605,7 @@
         },
         "fs-extra": {
           "version": "4.0.2",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/fs-extra/-/fs-extra-4.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
           "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
           "dev": true,
           "requires": {
@@ -599,7 +625,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/glob/-/glob-7.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
@@ -613,7 +639,7 @@
         },
         "jsonfile": {
           "version": "4.0.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/jsonfile/-/jsonfile-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
@@ -630,13 +656,13 @@
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/co/-/co-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
@@ -648,7 +674,7 @@
     },
     "color-convert": {
       "version": "1.9.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/color-convert/-/color-convert-1.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
       "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
       "dev": true,
       "requires": {
@@ -657,13 +683,13 @@
     },
     "color-name": {
       "version": "1.1.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/color-name/-/color-name-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
       "dev": true
     },
     "colors": {
       "version": "1.1.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/colors/-/colors-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
@@ -678,25 +704,25 @@
     },
     "component-bind": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/component-bind/-/component-bind-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
       "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
       "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/component-emitter/-/component-emitter-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
     },
     "component-inherit": {
       "version": "0.0.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/component-inherit/-/component-inherit-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
     "compress-commons": {
       "version": "0.4.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/compress-commons/-/compress-commons-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.4.2.tgz",
       "integrity": "sha1-GghHSJ8NcT0N12NDwMLQVdyc2JI=",
       "dev": true,
       "requires": {
@@ -709,7 +735,7 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
@@ -770,7 +796,7 @@
     },
     "console-browserify": {
       "version": "1.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/console-browserify/-/console-browserify-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
@@ -779,25 +805,25 @@
     },
     "console-control-strings": {
       "version": "1.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
     "cookie": {
       "version": "0.3.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/cookie/-/cookie-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "crc32-stream": {
       "version": "0.4.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/crc32-stream/-/crc32-stream-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.4.0.tgz",
       "integrity": "sha1-tU1Mbu/TW1PmU9BiswbtxjFq4m0=",
       "dev": true,
       "requires": {
@@ -807,7 +833,7 @@
     },
     "cross-spawn": {
       "version": "4.0.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/cross-spawn/-/cross-spawn-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
       "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
       "dev": true,
       "requires": {
@@ -826,7 +852,7 @@
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
@@ -842,7 +868,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
@@ -851,13 +877,13 @@
     },
     "date-now": {
       "version": "0.1.4",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/date-now/-/date-now-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
     "dateformat": {
       "version": "1.0.12",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/dateformat/-/dateformat-1.0.12.tgz",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
       "dev": true,
       "requires": {
@@ -876,13 +902,13 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "decompress-zip": {
       "version": "0.3.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/decompress-zip/-/decompress-zip-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.0.tgz",
       "integrity": "sha1-rjvLfjTGWHmt/nfhnDD4ZgK0vbA=",
       "dev": true,
       "requires": {
@@ -897,7 +923,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -911,13 +937,13 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "delegates": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/delegates/-/delegates-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
@@ -929,13 +955,13 @@
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
     "dom-serializer": {
       "version": "0.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
@@ -945,13 +971,13 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
           "dev": true
         },
         "entities": {
           "version": "1.1.1",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/entities/-/entities-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
           "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
           "dev": true
         }
@@ -959,13 +985,13 @@
     },
     "domelementtype": {
       "version": "1.3.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/domelementtype/-/domelementtype-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
       "dev": true
     },
     "domhandler": {
       "version": "2.3.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/domhandler/-/domhandler-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
@@ -974,7 +1000,7 @@
     },
     "domutils": {
       "version": "1.5.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/domutils/-/domutils-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
@@ -984,7 +1010,7 @@
     },
     "each-async": {
       "version": "1.1.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/each-async/-/each-async-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
       "dev": true,
       "requires": {
@@ -1005,7 +1031,7 @@
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
@@ -1073,7 +1099,7 @@
     },
     "entities": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/entities/-/entities-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
       "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
       "dev": true
     },
@@ -1095,19 +1121,19 @@
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "esprima": {
       "version": "2.7.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/esprima/-/esprima-2.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
       "dev": true
     },
@@ -1119,25 +1145,25 @@
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
     "exit": {
       "version": "0.1.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/exit/-/exit-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
@@ -1146,7 +1172,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -1161,7 +1187,7 @@
     },
     "extglob": {
       "version": "0.3.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/extglob/-/extglob-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
@@ -1195,7 +1221,7 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
@@ -1230,13 +1256,13 @@
     },
     "file-sync-cmp": {
       "version": "0.1.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
       "integrity": "sha1-peeo/7+kk7Q7kju9TKiaU7Y7YSs=",
       "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/filename-regex/-/filename-regex-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
     },
@@ -1255,7 +1281,7 @@
     },
     "find-up": {
       "version": "1.1.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/find-up/-/find-up-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
@@ -1265,7 +1291,7 @@
     },
     "findup-sync": {
       "version": "0.3.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/findup-sync/-/findup-sync-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
       "dev": true,
       "requires": {
@@ -1274,7 +1300,7 @@
       "dependencies": {
         "glob": {
           "version": "5.0.15",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/glob/-/glob-5.0.15.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
@@ -1289,13 +1315,13 @@
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "for-own": {
       "version": "0.1.5",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/for-own/-/for-own-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
@@ -1304,13 +1330,13 @@
     },
     "foreachasync": {
       "version": "3.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/foreachasync/-/foreachasync-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
       "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY=",
       "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
@@ -1327,13 +1353,13 @@
     },
     "fresh": {
       "version": "0.5.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/fresh/-/fresh-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
       "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
       "dev": true
     },
     "fs-extra": {
       "version": "0.26.7",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/fs-extra/-/fs-extra-0.26.7.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
       "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
       "dev": true,
       "requires": {
@@ -1346,13 +1372,13 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "fstream": {
       "version": "1.0.11",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/fstream/-/fstream-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
@@ -1364,7 +1390,7 @@
     },
     "gauge": {
       "version": "2.7.4",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/gauge/-/gauge-2.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
@@ -1395,7 +1421,7 @@
     },
     "get-down": {
       "version": "1.2.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/get-down/-/get-down-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-down/-/get-down-1.2.0.tgz",
       "integrity": "sha512-SbpdXn+fNmGN6pp/vBALveh3oCbWYTR3wb5qifauPSFhAfAVQ7TMOnAkVzQm4YZD2KABzJB3sA2kmMLaOylA2A==",
       "dev": true,
       "requires": {
@@ -1413,7 +1439,7 @@
       "dependencies": {
         "ajv": {
           "version": "4.11.8",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/ajv/-/ajv-4.11.8.tgz",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "requires": {
@@ -1423,19 +1449,19 @@
         },
         "assert-plus": {
           "version": "0.2.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/assert-plus/-/assert-plus-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
           "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
           "dev": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
           "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
           "dev": true
         },
         "form-data": {
           "version": "2.1.4",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/form-data/-/form-data-2.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
@@ -1446,13 +1472,13 @@
         },
         "har-schema": {
           "version": "1.0.5",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/har-schema/-/har-schema-1.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
           "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
           "dev": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/har-validator/-/har-validator-4.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
           "requires": {
@@ -1462,7 +1488,7 @@
         },
         "http-signature": {
           "version": "1.1.1",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/http-signature/-/http-signature-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "requires": {
@@ -1473,19 +1499,19 @@
         },
         "performance-now": {
           "version": "0.2.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/performance-now/-/performance-now-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
           "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
           "dev": true
         },
         "qs": {
           "version": "6.4.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/qs/-/qs-6.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
           "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
           "dev": true
         },
         "request": {
           "version": "2.81.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/request/-/request-2.81.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
           "requires": {
@@ -1524,7 +1550,7 @@
         },
         "tar": {
           "version": "3.1.5",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/tar/-/tar-3.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-3.1.5.tgz",
           "integrity": "sha512-TKJKz1fqBOZBaIQ/MGRKU0EnTGmKMLy4ReTRgP10AgtfOWBbj9PBg4MgY80GFpqGbs2EzcIctW5gbwbP4woDYg==",
           "dev": true,
           "requires": {
@@ -1536,7 +1562,7 @@
         },
         "yallist": {
           "version": "3.0.2",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/yallist/-/yallist-3.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "dev": true
         }
@@ -1544,19 +1570,19 @@
     },
     "get-stdin": {
       "version": "4.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/get-stdin/-/get-stdin-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
     },
     "getobject": {
       "version": "0.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/getobject/-/getobject-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
       "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
@@ -1564,11 +1590,12 @@
       }
     },
     "glob": {
-      "version": "6.0.4",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
+        "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
         "inherits": "2.0.3",
         "minimatch": "3.0.4",
@@ -1578,7 +1605,7 @@
     },
     "glob-base": {
       "version": "0.3.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/glob-base/-/glob-base-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
@@ -1588,7 +1615,7 @@
     },
     "glob-parent": {
       "version": "2.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/glob-parent/-/glob-parent-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
@@ -1608,7 +1635,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/glob/-/glob-7.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
@@ -1636,7 +1663,7 @@
     },
     "graceful-fs": {
       "version": "4.1.11",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
@@ -1667,7 +1694,7 @@
       "dependencies": {
         "glob": {
           "version": "7.0.6",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/glob/-/glob-7.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
           "dev": true,
           "requires": {
@@ -1681,7 +1708,7 @@
         },
         "grunt-cli": {
           "version": "1.2.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/grunt-cli/-/grunt-cli-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
           "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
           "dev": true,
           "requires": {
@@ -1695,7 +1722,7 @@
     },
     "grunt-cli": {
       "version": "0.1.13",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "integrity": "sha1-6evEBHYx9QEtkidww5N4EzytEPQ=",
       "dev": true,
       "requires": {
@@ -1706,7 +1733,7 @@
       "dependencies": {
         "findup-sync": {
           "version": "0.1.3",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/findup-sync/-/findup-sync-0.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
           "dev": true,
           "requires": {
@@ -1716,7 +1743,7 @@
         },
         "glob": {
           "version": "3.2.11",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/glob/-/glob-3.2.11.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
@@ -1726,19 +1753,19 @@
         },
         "lodash": {
           "version": "2.4.2",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "lru-cache": {
           "version": "2.7.3",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/lru-cache/-/lru-cache-2.7.3.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
           "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
           "dev": true
         },
         "minimatch": {
           "version": "0.3.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/minimatch/-/minimatch-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
@@ -1748,7 +1775,7 @@
         },
         "nopt": {
           "version": "1.0.10",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/nopt/-/nopt-1.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "dev": true,
           "requires": {
@@ -1757,7 +1784,7 @@
         },
         "resolve": {
           "version": "0.3.1",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/resolve/-/resolve-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
           "integrity": "sha1-NMY0R8ZkxwWY0cmxJvxDsqJDEKQ=",
           "dev": true
         }
@@ -1765,7 +1792,7 @@
     },
     "grunt-contrib-clean": {
       "version": "1.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/grunt-contrib-clean/-/grunt-contrib-clean-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-1.1.0.tgz",
       "integrity": "sha1-Vkq/LQN4qYOhW54/MO51tzjEBjg=",
       "dev": true,
       "requires": {
@@ -1775,7 +1802,7 @@
     },
     "grunt-contrib-concat": {
       "version": "1.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/grunt-contrib-concat/-/grunt-contrib-concat-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-1.0.1.tgz",
       "integrity": "sha1-YVCYYwhOhx1+ht5IwBUlntl3Rb0=",
       "dev": true,
       "requires": {
@@ -1812,7 +1839,7 @@
     },
     "grunt-contrib-copy": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
       "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
       "dev": true,
       "requires": {
@@ -1849,7 +1876,7 @@
     },
     "grunt-known-options": {
       "version": "1.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
       "integrity": "sha1-pCdO6zL6dl2lp6OxcSYXzjsUQUk=",
       "dev": true
     },
@@ -1903,13 +1930,13 @@
     },
     "grunt-trimtrailingspaces": {
       "version": "2.3.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/grunt-trimtrailingspaces/-/grunt-trimtrailingspaces-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-trimtrailingspaces/-/grunt-trimtrailingspaces-2.3.1.tgz",
       "integrity": "sha1-Gmkb9uMmlEzxRJgkwbQ0260tc0g=",
       "dev": true
     },
     "handlebars": {
       "version": "4.0.10",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/handlebars/-/handlebars-4.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "dev": true,
       "requires": {
@@ -1921,7 +1948,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
@@ -1932,13 +1959,13 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
     "har-validator": {
       "version": "5.0.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/har-validator/-/har-validator-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
@@ -1948,7 +1975,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -1966,7 +1993,7 @@
       "dependencies": {
         "isarray": {
           "version": "2.0.1",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
         }
@@ -1974,25 +2001,25 @@
     },
     "has-color": {
       "version": "0.1.7",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/has-color/-/has-color-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
       "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
       "dev": true
     },
     "has-cors": {
       "version": "1.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/has-cors/-/has-cors-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
       "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/has-unicode/-/has-unicode-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
@@ -2027,7 +2054,7 @@
     },
     "hooker": {
       "version": "0.2.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/hooker/-/hooker-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
       "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
       "dev": true
     },
@@ -2039,7 +2066,7 @@
     },
     "htmlparser2": {
       "version": "3.8.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
@@ -2052,7 +2079,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -2086,7 +2113,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
@@ -2112,13 +2139,13 @@
     },
     "in-publish": {
       "version": "2.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/in-publish/-/in-publish-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
       "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
     },
     "indent-string": {
       "version": "2.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/indent-string/-/indent-string-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
@@ -2127,13 +2154,13 @@
     },
     "indexof": {
       "version": "0.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/indexof/-/indexof-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -2143,19 +2170,19 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/inherits/-/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "invert-kv": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/invert-kv/-/invert-kv-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
@@ -2167,7 +2194,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -2176,13 +2203,13 @@
     },
     "is-dotfile": {
       "version": "1.0.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
       "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
@@ -2191,19 +2218,19 @@
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/is-extglob/-/is-extglob-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/is-finite/-/is-finite-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
@@ -2212,7 +2239,7 @@
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
@@ -2221,7 +2248,7 @@
     },
     "is-glob": {
       "version": "2.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/is-glob/-/is-glob-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
@@ -2230,13 +2257,13 @@
     },
     "is-module": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/is-module/-/is-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
       "dev": true
     },
     "is-number": {
       "version": "2.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/is-number/-/is-number-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
@@ -2245,13 +2272,13 @@
     },
     "is-posix-bracket": {
       "version": "0.1.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
       "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/is-primitive/-/is-primitive-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
@@ -2264,31 +2291,31 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/is-utf8/-/is-utf8-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
     "isarray": {
       "version": "0.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/isarray/-/isarray-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isobject": {
       "version": "2.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/isobject/-/isobject-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "dev": true,
       "requires": {
@@ -2297,7 +2324,7 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         }
@@ -2305,7 +2332,7 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
@@ -2317,7 +2344,7 @@
     },
     "js-yaml": {
       "version": "3.5.5",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/js-yaml/-/js-yaml-3.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
       "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
       "dev": true,
       "requires": {
@@ -2327,7 +2354,7 @@
     },
     "js2xmlparser": {
       "version": "3.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
       "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
       "dev": true,
       "requires": {
@@ -2336,14 +2363,14 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
     },
     "jsdoc": {
       "version": "3.5.5",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/jsdoc/-/jsdoc-3.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
       "integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
       "dev": true,
       "requires": {
@@ -2363,7 +2390,7 @@
       "dependencies": {
         "klaw": {
           "version": "2.0.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/klaw/-/klaw-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
           "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
           "dev": true,
           "requires": {
@@ -2372,13 +2399,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         },
         "underscore": {
           "version": "1.8.3",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/underscore/-/underscore-1.8.3.tgz",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
           "dev": true
         }
@@ -2405,19 +2432,19 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
@@ -2426,13 +2453,13 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
@@ -2441,13 +2468,13 @@
     },
     "jsonify": {
       "version": "0.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/jsonify/-/jsonify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
@@ -2459,7 +2486,7 @@
     },
     "junk": {
       "version": "2.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/junk/-/junk-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/junk/-/junk-2.1.0.tgz",
       "integrity": "sha1-9DG0t/By3FAKXxDOf07HGTDnATQ=",
       "dev": true
     },
@@ -2472,7 +2499,7 @@
     },
     "kind-of": {
       "version": "3.2.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/kind-of/-/kind-of-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
@@ -2481,7 +2508,7 @@
     },
     "klaw": {
       "version": "1.3.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/klaw/-/klaw-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
@@ -2490,13 +2517,13 @@
     },
     "lazy-cache": {
       "version": "1.0.4",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true
     },
     "lazystream": {
       "version": "0.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/lazystream/-/lazystream-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
       "integrity": "sha1-GyXWPHcqTCDwpe0KnXf0hLbhaSA=",
       "dev": true,
       "requires": {
@@ -2505,7 +2532,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -2519,7 +2546,7 @@
     },
     "lcid": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/lcid/-/lcid-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
@@ -2528,7 +2555,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -2547,13 +2574,13 @@
     },
     "lodash.assign": {
       "version": "4.2.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
@@ -2565,13 +2592,13 @@
     },
     "longest": {
       "version": "1.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/longest/-/longest-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
@@ -2600,7 +2627,7 @@
     },
     "map-obj": {
       "version": "1.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/map-obj/-/map-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
@@ -2618,7 +2645,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -2634,9 +2661,15 @@
         "trim-newlines": "1.0.0"
       }
     },
+    "merge": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "dev": true
+    },
     "micromatch": {
       "version": "2.3.11",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/micromatch/-/micromatch-2.3.11.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
@@ -2657,7 +2690,7 @@
     },
     "mime": {
       "version": "1.3.4",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/mime/-/mime-1.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
       "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
       "dev": true
     },
@@ -2678,7 +2711,7 @@
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/minimatch/-/minimatch-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
@@ -2687,7 +2720,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -2703,7 +2736,7 @@
       "dependencies": {
         "yallist": {
           "version": "3.0.2",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/yallist/-/yallist-3.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "dev": true
         }
@@ -2720,7 +2753,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -2729,7 +2762,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -2737,13 +2770,13 @@
     },
     "mkpath": {
       "version": "0.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/mkpath/-/mkpath-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
       "integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE=",
       "dev": true
     },
     "mout": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/mout/-/mout-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/mout/-/mout-1.0.0.tgz",
       "integrity": "sha1-m98dSvV9ZtR8s1OmM1oygQmOFQE=",
       "dev": true
     },
@@ -2761,19 +2794,19 @@
     },
     "ncp": {
       "version": "0.4.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/ncp/-/ncp-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
       "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
       "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/negotiator/-/negotiator-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
     },
     "node-fs-extra": {
       "version": "0.8.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/node-fs-extra/-/node-fs-extra-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/node-fs-extra/-/node-fs-extra-0.8.2.tgz",
       "integrity": "sha1-CfsrYNMPfXA+Nh7LYmqRQE8XCXo=",
       "dev": true,
       "requires": {
@@ -2785,19 +2818,19 @@
       "dependencies": {
         "jsonfile": {
           "version": "1.1.1",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/jsonfile/-/jsonfile-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.1.1.tgz",
           "integrity": "sha1-2k/WrXfxolUgPqY8e8Mtwx72RDM=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.3.5",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/mkdirp/-/mkdirp-0.3.5.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
           "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
           "dev": true
         },
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
           "dev": true
         }
@@ -2825,7 +2858,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/glob/-/glob-7.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
@@ -2839,7 +2872,7 @@
         },
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
@@ -2847,7 +2880,7 @@
     },
     "node-int64": {
       "version": "0.4.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/node-int64/-/node-int64-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
@@ -2899,7 +2932,7 @@
         },
         "cross-spawn": {
           "version": "3.0.1",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "dev": true,
           "requires": {
@@ -2909,7 +2942,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/glob/-/glob-7.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
@@ -2931,7 +2964,7 @@
     },
     "nomnom": {
       "version": "1.8.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/nomnom/-/nomnom-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
       "dev": true,
       "requires": {
@@ -2941,13 +2974,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "1.0.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
           "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
           "dev": true
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
@@ -2958,7 +2991,7 @@
         },
         "strip-ansi": {
           "version": "0.1.1",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
           "dev": true
         }
@@ -2966,7 +2999,7 @@
     },
     "nopt": {
       "version": "3.0.6",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/nopt/-/nopt-3.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
@@ -2975,7 +3008,7 @@
     },
     "normalize-package-data": {
       "version": "2.4.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
@@ -2987,13 +3020,13 @@
     },
     "normalize-path": {
       "version": "2.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/normalize-path/-/normalize-path-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
       "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o=",
       "dev": true
     },
     "npmlog": {
       "version": "4.1.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/npmlog/-/npmlog-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
@@ -3005,31 +3038,31 @@
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "oauth-sign": {
       "version": "0.8.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-component": {
       "version": "0.0.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/object-component/-/object-component-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
     },
     "object.omit": {
       "version": "2.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/object.omit/-/object.omit-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
@@ -3039,7 +3072,7 @@
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "dev": true,
       "requires": {
@@ -3048,7 +3081,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -3057,13 +3090,13 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
     "openlayers": {
       "version": "4.4.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/openlayers/-/openlayers-4.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/openlayers/-/openlayers-4.4.2.tgz",
       "integrity": "sha512-iHtUO2i8oUVZKx6KLfjfIeisVyIiG8+GPh4Ebx7xCuvhI/yQaRUlWwIlHXM06YYOJZfhKX3XVe8xz/MVvLkPZA==",
       "dev": true,
       "requires": {
@@ -3085,7 +3118,7 @@
       "dependencies": {
         "async": {
           "version": "2.5.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/async/-/async-2.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
@@ -3094,7 +3127,7 @@
         },
         "fs-extra": {
           "version": "4.0.2",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/fs-extra/-/fs-extra-4.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
           "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
           "dev": true,
           "requires": {
@@ -3105,7 +3138,7 @@
         },
         "jsonfile": {
           "version": "4.0.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/jsonfile/-/jsonfile-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
@@ -3116,7 +3149,7 @@
     },
     "optimist": {
       "version": "0.6.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/optimist/-/optimist-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
@@ -3126,7 +3159,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }
@@ -3134,13 +3167,13 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -3149,7 +3182,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -3165,7 +3198,7 @@
     },
     "parse-glob": {
       "version": "3.0.4",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/parse-glob/-/parse-glob-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
@@ -3177,7 +3210,7 @@
     },
     "parse-json": {
       "version": "2.2.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/parse-json/-/parse-json-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
@@ -3186,7 +3219,7 @@
     },
     "parseqs": {
       "version": "0.0.5",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/parseqs/-/parseqs-0.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
@@ -3195,7 +3228,7 @@
     },
     "parseuri": {
       "version": "0.0.5",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/parseuri/-/parseuri-0.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
@@ -3204,7 +3237,7 @@
     },
     "path-exists": {
       "version": "2.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/path-exists/-/path-exists-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
@@ -3213,7 +3246,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -3225,7 +3258,7 @@
     },
     "path-type": {
       "version": "1.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/path-type/-/path-type-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
@@ -3236,7 +3269,7 @@
     },
     "pbf": {
       "version": "3.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/pbf/-/pbf-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.1.0.tgz",
       "integrity": "sha512-/hYJmIsTmh7fMkHAWWXJ5b8IKLWdjdlAFb3IHkRBn1XUhIYBChVGfVwmHEAV3UfXTxsP/AKfYTXTS/dCPxJd5w==",
       "dev": true,
       "requires": {
@@ -3253,7 +3286,7 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
@@ -3303,19 +3336,19 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
@@ -3324,19 +3357,19 @@
     },
     "pixelworks": {
       "version": "1.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/pixelworks/-/pixelworks-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/pixelworks/-/pixelworks-1.1.0.tgz",
       "integrity": "sha1-Hwla1I3Ki/ihyCWOAJIDGkTyLKU=",
       "dev": true
     },
     "preserve": {
       "version": "0.2.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/preserve/-/preserve-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "1.0.7",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
     },
@@ -3355,19 +3388,19 @@
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "punycode": {
       "version": "1.4.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/punycode/-/punycode-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
     "q": {
       "version": "1.5.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/q/-/q-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
       "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
       "dev": true
     },
@@ -3410,13 +3443,13 @@
     },
     "range-parser": {
       "version": "1.2.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/range-parser/-/range-parser-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
       "dev": true
     },
     "rbush": {
       "version": "2.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/rbush/-/rbush-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.1.tgz",
       "integrity": "sha1-TPrKKMMGS8DudUMaG3mZDode76k=",
       "dev": true,
       "requires": {
@@ -3425,7 +3458,7 @@
     },
     "read-pkg": {
       "version": "1.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/read-pkg/-/read-pkg-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
@@ -3436,7 +3469,7 @@
     },
     "read-pkg-up": {
       "version": "1.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
@@ -3446,7 +3479,7 @@
     },
     "readable-stream": {
       "version": "2.0.6",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/readable-stream/-/readable-stream-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
       "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
       "dev": true,
       "requires": {
@@ -3460,7 +3493,7 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         }
@@ -3468,7 +3501,7 @@
     },
     "redent": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/redent/-/redent-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
@@ -3478,7 +3511,7 @@
     },
     "regex-cache": {
       "version": "0.4.4",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/regex-cache/-/regex-cache-0.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
@@ -3487,19 +3520,19 @@
     },
     "repeat-element": {
       "version": "1.1.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/repeat-element/-/repeat-element-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/repeating/-/repeating-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
@@ -3546,19 +3579,19 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
     "requizzle": {
       "version": "0.2.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/requizzle/-/requizzle-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
       "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
       "dev": true,
       "requires": {
@@ -3567,7 +3600,7 @@
     },
     "resolve": {
       "version": "1.1.7",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/resolve/-/resolve-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
     },
@@ -3582,13 +3615,13 @@
     },
     "retry": {
       "version": "0.10.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/retry/-/retry-0.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
       "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
       "dev": true
     },
     "right-align": {
       "version": "0.1.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/right-align/-/right-align-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
@@ -3597,7 +3630,7 @@
     },
     "rimraf": {
       "version": "2.6.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/rimraf/-/rimraf-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
@@ -3606,7 +3639,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/glob/-/glob-7.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
@@ -3628,7 +3661,7 @@
     },
     "rollup-plugin-cleanup": {
       "version": "1.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/rollup-plugin-cleanup/-/rollup-plugin-cleanup-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-cleanup/-/rollup-plugin-cleanup-1.0.1.tgz",
       "integrity": "sha1-ygVsdP5uoheD+ZhRljsXPL6Ok1k=",
       "dev": true,
       "requires": {
@@ -3639,7 +3672,7 @@
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/acorn/-/acorn-4.0.13.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
           "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
           "dev": true
         }
@@ -3727,7 +3760,7 @@
     },
     "sass-graph": {
       "version": "2.2.4",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/sass-graph/-/sass-graph-2.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
@@ -3739,7 +3772,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/glob/-/glob-7.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
@@ -3755,13 +3788,13 @@
     },
     "sax": {
       "version": "1.2.4",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/sax/-/sax-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "scss-tokenizer": {
       "version": "0.2.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
@@ -3771,7 +3804,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
@@ -3788,7 +3821,7 @@
     },
     "send": {
       "version": "0.15.4",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/send/-/send-0.15.4.tgz",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
       "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
       "dev": true,
       "requires": {
@@ -3809,7 +3842,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.8",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/debug/-/debug-2.6.8.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true,
           "requires": {
@@ -3820,13 +3853,13 @@
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "set-immediate-shim": {
       "version": "1.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
@@ -3838,19 +3871,19 @@
     },
     "shelljs": {
       "version": "0.3.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/shelljs/-/shelljs-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
       "dev": true
     },
     "sigmund": {
       "version": "1.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/sigmund/-/sigmund-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/signal-exit/-/signal-exit-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
@@ -3865,7 +3898,7 @@
     },
     "socket.io": {
       "version": "2.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/socket.io/-/socket.io-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.0.1.tgz",
       "integrity": "sha1-BkwSUXhGLkd6bfI9L9rRjdHFkU8=",
       "dev": true,
       "requires": {
@@ -3879,7 +3912,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
@@ -3890,13 +3923,13 @@
     },
     "socket.io-adapter": {
       "version": "1.1.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
       "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs=",
       "dev": true
     },
     "socket.io-client": {
       "version": "2.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/socket.io-client/-/socket.io-client-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.1.tgz",
       "integrity": "sha1-HVL4x0Zgxou2aVlT+hGZcRVfrZM=",
       "dev": true,
       "requires": {
@@ -3916,7 +3949,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.4",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/debug/-/debug-2.6.4.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
           "integrity": "sha1-dYaps8OXQcAoKuM0RcTorHRzT+A=",
           "dev": true,
           "requires": {
@@ -3925,7 +3958,7 @@
         },
         "ms": {
           "version": "0.7.3",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/ms/-/ms-0.7.3.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
           "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8=",
           "dev": true
         }
@@ -3945,7 +3978,7 @@
       "dependencies": {
         "isarray": {
           "version": "2.0.1",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
         }
@@ -3953,7 +3986,7 @@
     },
     "source-map": {
       "version": "0.5.7",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/source-map/-/source-map-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
@@ -4037,7 +4070,7 @@
     },
     "statuses": {
       "version": "1.3.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/statuses/-/statuses-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
@@ -4052,7 +4085,7 @@
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
@@ -4063,7 +4096,7 @@
     },
     "string_decoder": {
       "version": "0.10.31",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/string_decoder/-/string_decoder-0.10.31.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
@@ -4075,7 +4108,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -4084,7 +4117,7 @@
     },
     "strip-bom": {
       "version": "2.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/strip-bom/-/strip-bom-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
@@ -4093,7 +4126,7 @@
     },
     "strip-indent": {
       "version": "1.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/strip-indent/-/strip-indent-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
@@ -4102,7 +4135,7 @@
     },
     "strip-json-comments": {
       "version": "1.0.4",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
       "dev": true
     },
@@ -4117,13 +4150,13 @@
     },
     "taffydb": {
       "version": "2.6.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/taffydb/-/taffydb-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
       "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/tar/-/tar-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
@@ -4134,7 +4167,7 @@
     },
     "tar-stream": {
       "version": "1.3.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/tar-stream/-/tar-stream-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.3.2.tgz",
       "integrity": "sha1-ck0atIAcmzFJzep2X+jJDqcfZgY=",
       "dev": true,
       "requires": {
@@ -4146,7 +4179,7 @@
     },
     "temp": {
       "version": "0.8.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/temp/-/temp-0.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "dev": true,
       "requires": {
@@ -4156,7 +4189,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
           "dev": true
         }
@@ -4164,7 +4197,7 @@
     },
     "throttleit": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/throttleit/-/throttleit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
       "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
       "dev": true
     },
@@ -4177,7 +4210,7 @@
     },
     "tmp": {
       "version": "0.0.31",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/tmp/-/tmp-0.0.31.tgz",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
       "dev": true,
       "requires": {
@@ -4186,13 +4219,13 @@
     },
     "to-array": {
       "version": "0.1.4",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/to-array/-/to-array-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
       "dev": true
     },
     "touch": {
       "version": "0.0.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/touch/-/touch-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
       "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
       "dev": true,
       "requires": {
@@ -4201,7 +4234,7 @@
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/nopt/-/nopt-1.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "dev": true,
           "requires": {
@@ -4221,13 +4254,13 @@
     },
     "traverse": {
       "version": "0.3.9",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/traverse/-/traverse-0.3.9.tgz",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
       "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
       "dev": true
     },
     "trim-newlines": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
@@ -4238,11 +4271,26 @@
       "dev": true,
       "requires": {
         "glob": "6.0.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
       }
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
@@ -4251,7 +4299,7 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "optional": true
@@ -4265,7 +4313,7 @@
     },
     "uglify-js": {
       "version": "2.8.29",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/uglify-js/-/uglify-js-2.8.29.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "requires": {
@@ -4276,13 +4324,13 @@
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/camelcase/-/camelcase-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true
         },
         "cliui": {
           "version": "2.1.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/cliui/-/cliui-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "requires": {
@@ -4293,13 +4341,13 @@
         },
         "wordwrap": {
           "version": "0.0.2",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/wordwrap/-/wordwrap-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
           "dev": true
         },
         "yargs": {
           "version": "3.10.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/yargs/-/yargs-3.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
@@ -4313,14 +4361,14 @@
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
     },
     "uglifycss": {
       "version": "0.0.20",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/uglifycss/-/uglifycss-0.0.20.tgz",
+      "resolved": "https://registry.npmjs.org/uglifycss/-/uglifycss-0.0.20.tgz",
       "integrity": "sha1-D5U8PPmJ+f90R8uiT5mZaHyaWRA=",
       "dev": true
     },
@@ -4332,13 +4380,13 @@
     },
     "underscore": {
       "version": "1.6.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/underscore/-/underscore-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
       "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
       "dev": true
     },
     "underscore-contrib": {
       "version": "0.3.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
       "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
       "dev": true,
       "requires": {
@@ -4369,7 +4417,7 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
@@ -4398,7 +4446,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
@@ -4409,13 +4457,13 @@
     },
     "vlq": {
       "version": "0.2.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/vlq/-/vlq-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
       "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
       "dev": true
     },
     "walk": {
       "version": "2.3.9",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/walk/-/walk-2.3.9.tgz",
+      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz",
       "integrity": "sha1-MbTbZnjyrgHDnqn7hyWpAx5Vins=",
       "dev": true,
       "requires": {
@@ -4433,7 +4481,7 @@
     },
     "which-module": {
       "version": "1.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/which-module/-/which-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
       "dev": true
     },
@@ -4448,7 +4496,7 @@
     },
     "window-size": {
       "version": "0.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/window-size/-/window-size-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true
     },
@@ -4485,13 +4533,13 @@
     },
     "wordwrap": {
       "version": "0.0.3",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/wordwrap/-/wordwrap-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -4501,7 +4549,7 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
@@ -4518,7 +4566,7 @@
     },
     "xml2js": {
       "version": "0.4.19",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/xml2js/-/xml2js-0.4.19.tgz",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "dev": true,
       "requires": {
@@ -4534,7 +4582,7 @@
     },
     "xmlcreate": {
       "version": "1.0.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/xmlcreate/-/xmlcreate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
       "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
       "dev": true
     },
@@ -4546,25 +4594,25 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/xtend/-/xtend-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
     "y18n": {
       "version": "3.2.1",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/y18n/-/y18n-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
     "yallist": {
       "version": "2.1.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/yallist/-/yallist-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {
       "version": "7.1.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/yargs/-/yargs-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
       "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
       "dev": true,
       "requires": {
@@ -4585,7 +4633,7 @@
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/camelcase/-/camelcase-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         }
@@ -4593,7 +4641,7 @@
     },
     "yargs-parser": {
       "version": "5.0.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/yargs-parser/-/yargs-parser-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
       "requires": {
@@ -4602,7 +4650,7 @@
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/camelcase/-/camelcase-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         }
@@ -4620,13 +4668,13 @@
     },
     "yeast": {
       "version": "0.1.2",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/yeast/-/yeast-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
     },
     "zip-stream": {
       "version": "0.8.0",
-      "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/zip-stream/-/zip-stream-0.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.8.0.tgz",
       "integrity": "sha1-I2sv4lgjy09I6DNvW/p0OqWunb0=",
       "dev": true,
       "requires": {
@@ -4638,7 +4686,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://mmlnexus.nls.fi/nexus/repository/npm-all/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "OskariTools",
+  "name": "oskari-tools",
   "version": "0.0.1",
   "description": "Build tools for Oskari applications",
   "author": "nls-oskari",
@@ -28,6 +28,7 @@
     "adm-zip": "^0.4.7",
     "archiver": "^0.21.0",
     "fs-extra": "^0.26.7",
+    "glob": "^7.1.3",
     "gm": "^1.21.1",
     "grunt": "^1.0",
     "grunt-cli": "0.1.13",
@@ -38,6 +39,7 @@
     "grunt-trimtrailingspaces": "^2.2.0",
     "jshint": "^2.9.1",
     "lodash": "^4.12.0",
+    "merge": "^1.2.0",
     "node-fs-extra": "^0.8.1",
     "openlayers": "4.4.2",
     "uglify-js": "^2.6.2",


### PR DESCRIPTION
Added `extract-locale` and `inject-locale` scripts for pulling localizations strings into JSON and pushing them back. Both scripts take only one parameter, the locale identifier, for example "fi" or "sv".

Extract produces JSON files under `locale/`, one for each bundle.

Inject reads the JSON files from `locale/` and creates bundle locale files under `resources/locale/` for each bundle that a JSON file was found for. The operation overwrites any existing locale file for a specific locale.

Note: locale files that have multiple calls to `Oskari.registerLocalization(...)` will be skipped while extracting.