### PR TITLE
Publisher remove margin from opacity slider

### DIFF
--- a/bundles/framework/publisher2/resources/css/style.css
+++ b/bundles/framework/publisher2/resources/css/style.css
@@ -141,8 +141,7 @@ div.basic_publisher ul.selectedLayersList {
   padding: 0;
   margin: 5px 0 0; }
   div.basic_publisher ul.selectedLayersList span {
-    position: absolute;
-    margin-left: -1.3em; }
+    position: absolute; }
 
 div.publisher div.startview div.content {
   margin-top: 5px; }

--- a/bundles/framework/publisher2/resources/scss/style.scss
+++ b/bundles/framework/publisher2/resources/scss/style.scss
@@ -219,7 +219,6 @@ div.basic_publisher {
 
         span {
             position: absolute;
-            margin-left: -1.3em;
         }
     }
 }


### PR DESCRIPTION
Same changes for publisher than made for geoportal in: https://github.com/oskariorg/oskari-frontend/pull/475