### PR TITLE
Fixed region set restriction check

### DIFF
--- a/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
@@ -38,7 +38,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
         if (!datasrc || datasrc === '') {
             return;
         }
-        var hasRegionSetRestriction = regionsetRestrictions !== '' && regionsetRestrictions !== null;
+        var hasRegionSetRestriction = Array.isArray(regionsetRestrictions) && regionsetRestrictions.length > 0;
 
         // start spinner
         me.spinner.start();


### PR DESCRIPTION
Fixes an issue where all indicators were left disabled, if region set filter was empty
