### PR TITLE
Fix autocomplete

### DIFF
--- a/bundles/framework/divmanazer/component/FormInput.js
+++ b/bundles/framework/divmanazer/component/FormInput.js
@@ -473,6 +473,8 @@ Oskari.clazz.define('Oskari.userinterface.component.FormInput',
                 source: results
             });
             input.autocomplete('search', input.val());
+            var widget = input.autocomplete('widget');
+            widget.css('z-index', '99999');
         },
         addClass: function(className) {
             var input = this._field.find('input');

--- a/bundles/framework/divmanazer/component/FormInput.js
+++ b/bundles/framework/divmanazer/component/FormInput.js
@@ -473,8 +473,6 @@ Oskari.clazz.define('Oskari.userinterface.component.FormInput',
                 source: results
             });
             input.autocomplete('search', input.val());
-            var widget = input.autocomplete('widget');
-            widget.css('z-index', '99999');
         },
         addClass: function(className) {
             var input = this._field.find('input');

--- a/bundles/framework/oskariui/resources/css/jquery-ui-1.12.1.custom.css
+++ b/bundles/framework/oskariui/resources/css/jquery-ui-1.12.1.custom.css
@@ -52,6 +52,7 @@
     top: 0;
     left: 0;
     cursor: default;
+    z-index: 99998;
 }
 
 /* workarounds */


### PR DESCRIPTION
Autocomplete widget didn't have z-index property.
Previous version of jquery-ui set autocomplete widget's z-index property automatically.
Fix by setting default z-index for autocomplete widget.