### PR TITLE
Force 100% width for chosen.js search input

### DIFF
--- a/bundles/framework/divmanazer/component/SelectList.js
+++ b/bundles/framework/divmanazer/component/SelectList.js
@@ -79,7 +79,7 @@ Oskari.clazz.define('Oskari.userinterface.component.SelectList', function (id) {
             allow_single_deselect: options.allow_single_deselect ? options.allow_single_deselect : false
         });
         // Fixes an issue where placeholder is cut off with the input field width set as pixel value even if options.width is %
-        // https://github.com/harvesthq/chosen/issues/109
+        // https://github.com/harvesthq/chosen/issues/1162
         el.find('li.search-field input').css('width', '100%');
         return el;
     },

--- a/bundles/framework/divmanazer/component/SelectList.js
+++ b/bundles/framework/divmanazer/component/SelectList.js
@@ -78,6 +78,9 @@ Oskari.clazz.define('Oskari.userinterface.component.SelectList', function (id) {
             disable_search_threshold: options.disable_search_threshold ? options.disable_search_threshold : 10,
             allow_single_deselect: options.allow_single_deselect ? options.allow_single_deselect : false
         });
+        // Fixes an issue where placeholder is cut off with the input field width set as pixel value even if options.width is %
+        // https://github.com/harvesthq/chosen/issues/109
+        el.find('li.search-field input').css('width', '100%');
         return el;
     },
     /** @method selectFirstValue


### PR DESCRIPTION
Otherwise placeholder might be cut off (as in regional division filter in statistics search UI). Chosen.js uses the width value as pixels when setting width instead of percentage value by default (harvesthq/chosen#1162)