### PR TITLE
Allow websocket proxying only to cometd

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -114,11 +114,16 @@ module.exports = (env, argv) => {
     config.devServer = {
       port: 8081,
       proxy: [{
-        context: ['**', `!Oskari/dist/${version}/${appName}/**`, '!sockjs-node/**'],
-        target: 'http://localhost:8080',
+        context: ['/transport/cometd'],
+        target: 'ws://localhost:8080',
         secure: false,
         changeOrigin: true,
         ws: true
+      }, {
+        context: ['**', `!/Oskari/dist/${version}/${appName}/**`],
+        target: 'http://localhost:8080',
+        secure: false,
+        changeOrigin: true
       }]
     };
   }


### PR DESCRIPTION
Fixes Webpack hot reload