### PR TITLE
Disable text-selection on map element

### DIFF
--- a/bundles/mapping/mapmodule/mapmodule.ol3.js
+++ b/bundles/mapping/mapmodule/mapmodule.ol3.js
@@ -40,6 +40,8 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.MapModule',
         _initImpl: function (sandbox, options, map) {
             // css references use olMap as selectors so we need to add it
             this.getMapEl().addClass('olMap');
+            // disables text-selection on map (fixes an issue in Chrome 69 where dblclick on map selects text and prevents dragging the map)
+            this.getMapEl().addClass('disable-select');
             return map;
         },
         /**

--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -1091,3 +1091,10 @@ select {
   overflow: auto;
   position: fixed !important;
 }
+
+.disable-select {
+  -webkit-user-select: none;  
+  -moz-user-select: none;    
+  -ms-user-select: none;      
+  user-select: none;
+}


### PR DESCRIPTION
- Add a generic css-class for disabling text selection: "disable-select". 
- Disables text selection on map element as it's not really needed.
- Fixes an issue on Chrome 69 where map couldn't be moved after double-clicking the map for zooming (browser makes a text selection).