### PR TITLE
Fix empty year and reseting ds

### DIFF
--- a/bundles/framework/divmanazer/component/SelectList.js
+++ b/bundles/framework/divmanazer/component/SelectList.js
@@ -96,7 +96,7 @@ Oskari.clazz.define('Oskari.userinterface.component.SelectList', function (id) {
      */
     selectLastValue: function () {
         var chosen = this.element.find('select');
-        chosen.find('option:last-child').attr('selected', 'selected');
+        chosen.find('option:last-child').prop('selected', 'selected');
         this.update();
     },
     resetToPlaceholder: function () {
@@ -167,7 +167,7 @@ Oskari.clazz.define('Oskari.userinterface.component.SelectList', function (id) {
     disableOptions: function (ids) {
         var chosen = this.element.find('select');
 
-        this.reset();
+        this.reset(true);
 
         var isDisabledOption = function (optionId) {
             return ids.some(function (id) {
@@ -177,6 +177,7 @@ Oskari.clazz.define('Oskari.userinterface.component.SelectList', function (id) {
         chosen.find('option').each(function (index, opt) {
             if (isDisabledOption(opt.value)) {
                 jQuery(opt).prop('disabled', true);
+                jQuery(opt).prop('selected', false);
             }
         });
         this.update();
@@ -184,7 +185,7 @@ Oskari.clazz.define('Oskari.userinterface.component.SelectList', function (id) {
     reset: function (supressEvent) {
         var state = this.getOptions();
         for (var i = 0; i < state.disabled.length; i++) {
-            jQuery(state.disabled[i]).attr('disabled', false);
+            jQuery(state.disabled[i]).prop('disabled', false);
         }
         if (!supressEvent) {
             this.resetToPlaceholder();

--- a/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
@@ -210,6 +210,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
         });
 
         me.selectClassRef.push(regionFilterSelect);
+        me.selectClassRef.push(dsSelect);
 
         dsSelector.on('change', function () {
             me._params.clean();
@@ -263,7 +264,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
 
         regionsetFilterElement.on('change', function (evt) {
             if (regionFilterSelect.getValue() === null || regionFilterSelect.getValue().length === 0) {
-                dsSelect.reset();
+                var keepSelectedValue = true;
+                dsSelect.reset(keepSelectedValue);
                 return;
             }
             var unsupportedSelections = me.service.getUnsupportedDatasetsList(regionFilterSelect.getValue());

--- a/bundles/statistics/statsgrid2016/service/StateService.js
+++ b/bundles/statistics/statsgrid2016/service/StateService.js
@@ -336,7 +336,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
         getHash: function (datasrc, indicator, selections, series) {
             var hash = datasrc + '_' + indicator;
             var seriesKey = '';
-            if (typeof series === 'object') {
+            if (typeof series === 'object' && series !== null) {
                 seriesKey = series.id;
                 hash += '_' + series.id + '=' + series.values[0] + '-' + series.values[series.values.length - 1];
             }

--- a/bundles/statistics/statsgrid2016/view/SearchFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/SearchFlyout.js
@@ -79,27 +79,34 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
             }
 
             var newActiveIndicator = false;
+            var activeSelections = values.selections;
 
             selectedIndicators.forEach(function (indicator) {
-                var added;
                 if (indicator === '') {
                     return;
                 }
+                var added;
+                var hasMultiselectValues = false;
                 if (!values.series) {
                     // Multiselect selections are not supported for series layer
                     Object.keys(values.selections).forEach(function (key) {
                         var selection = values.selections[key];
                         if (Array.isArray(selection)) {
+                            hasMultiselectValues = true;
                             selection.forEach(function (item) {
                                 var current = jQuery.extend(true, {}, values.selections);
                                 current[key] = item;
-                                added = me.service.getStateService().addIndicator(values.datasource, indicator, current);
+                                var newlyAdded = me.service.getStateService().addIndicator(values.datasource, indicator, current);
+                                if (newlyAdded) {
+                                    added = newlyAdded;
+                                    activeSelections = current;
+                                }
                             });
                         }
                     });
                 }
-                if (!added) {
-                    added = me.service.getStateService().addIndicator(values.datasource, indicator, values.selections, values.series);
+                if (!hasMultiselectValues) {
+                    added = me.service.getStateService().addIndicator(values.datasource, indicator, activeSelections, values.series);
                 }
                 if (added) {
                     newActiveIndicator = indicator;
@@ -108,7 +115,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
 
             if (newActiveIndicator !== false) {
                 // already added, set as active instead
-                var hash = me.service.getStateService().getHash(values.datasource, newActiveIndicator, values.selections, values.series);
+                var hash = me.service.getStateService().getHash(values.datasource, newActiveIndicator, activeSelections, values.series);
                 me.service.getStateService().setActiveIndicator(hash);
             }
             me.service.getStateService().setRegionset(values.regionset);


### PR DESCRIPTION
Fixes an issue where an extra indicator was added with an empty year value.
Also fixes clearing region filter that caused all values to be cleared in the search form.