### PR TITLE
Statsgrid fixes

### DIFF
--- a/bundles/statistics/statsgrid2016/components/EditClassification.js
+++ b/bundles/statistics/statsgrid2016/components/EditClassification.js
@@ -257,17 +257,19 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function (
                 }
             });
         });
-        var min = classification.min || me._rangeSlider.defaultValues[0];
-        var max = classification.max || me._rangeSlider.defaultValues[1];
-        var updateClassification = false;
+        if (mapStyle !== 'choropleth') {
+            var min = classification.min || me._rangeSlider.defaultValues[0];
+            var max = classification.max || me._rangeSlider.defaultValues[1];
+            var updateClassification = false;
 
-        if (max - min < classification.count * (me._rangeSlider.step || 1)) {
-            min = me._rangeSlider.defaultValues[0];
-            max = me._rangeSlider.defaultValues[1];
-            updateClassification = true;
+            if (max - min < classification.count * (me._rangeSlider.step || 1)) {
+                min = me._rangeSlider.defaultValues[0];
+                max = me._rangeSlider.defaultValues[1];
+                updateClassification = true;
+            }
+            me._rangeSlider.element.slider('values', [min, max]);
+            me._rangeSlider.element.attr('data-count', classification.count || amountRange[0]);
         }
-        me._rangeSlider.element.slider('values', [min, max]);
-        me._rangeSlider.element.attr('data-count', classification.count || amountRange[0]);
         me._showNumericValueCheckButton.setChecked((typeof classification.showValues === 'boolean') ? classification.showValues : false);
 
         if (updateClassification) {

--- a/bundles/statistics/statsgrid2016/components/EditClassification.js
+++ b/bundles/statistics/statsgrid2016/components/EditClassification.js
@@ -9,7 +9,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function (
         me.setValues(event.getCurrent());
     });
     me.service.on('AfterChangeMapLayerOpacityEvent', function (event) {
-        me.setLayerOpacityValue(event.getMapLayer());
+        me.setLayerOpacityValue(event.getMapLayer().getId(), event.getMapLayer().getOpacity());
     });
     this.__templates = {
         classification: jQuery('<div class="classifications">' +
@@ -148,17 +148,17 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function (
         me._element.find('.visible-map-style-choropleth').hide();
         me._element.find('.visible-map-style-' + style).show();
     },
-    setLayerOpacityValue: function (layer) {
+    setLayerOpacityValue: function (layerId, opacity) {
         var me = this;
         if (me.hasSelectChange) {
             me.hasSelectChange = false;
             return;
         }
-        if (layer.getId() === me.LAYER_ID) {
+        if (layerId === me.LAYER_ID) {
             var transparencyEl = me._element.find('select.transparency-value');
             transparencyEl.find('option#hiddenvalue').remove();
-            var hiddenOption = jQuery('<option id="hiddenvalue" disabled hidden>' + layer.getOpacity() + ' %' + '</option>');
-            hiddenOption.attr('value', layer.getOpacity());
+            var hiddenOption = jQuery('<option id="hiddenvalue" disabled hidden>' + opacity + ' %' + '</option>');
+            hiddenOption.attr('value', opacity);
             hiddenOption.hide();
             hiddenOption.attr('selected', 'selected');
             transparencyEl.append(hiddenOption);
@@ -277,6 +277,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function (
         }
 
         if (classification.transparency) {
+            this.setLayerOpacityValue(me.LAYER_ID, classification.transparency)
             me.sb.postRequestByName('ChangeMapLayerOpacityRequest', [me.LAYER_ID, classification.transparency]);
         }
     },

--- a/bundles/statistics/statsgrid2016/components/EditClassification.js
+++ b/bundles/statistics/statsgrid2016/components/EditClassification.js
@@ -306,7 +306,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function (
         if (values.mapStyle !== 'points') {
             delete values.min;
             delete values.max;
-            delete values.transparency;
         } else {
             delete values.type;
         }
@@ -385,7 +384,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function (
 
         me._colorSelect.setHandler(updateClassification);
         me._element.find('select').on('change', updateClassification);
-        me._element.find('select.decimal-place').on('change', function() {
+        me._element.find('select.decimal-place').on('change', function () {
             var stateService = me.service.getStateService();
             var indicator = stateService.getActiveIndicator();
             stateService.setActiveIndicator(indicator.hash);

--- a/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
+++ b/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
@@ -121,7 +121,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
                         optionalStyles: optionalStyles,
                         layerId: me.LAYER_ID,
                         prio: index,
-                        opacity: classification.opacity || 100
+                        opacity: classification.transparency || 100
                     }];
 
                     sandbox.postRequestByName(

--- a/bundles/statistics/statsgrid2016/instance.js
+++ b/bundles/statistics/statsgrid2016/instance.js
@@ -302,6 +302,12 @@ Oskari.clazz.define(
             },
             AfterChangeMapLayerOpacityEvent: function (evt) {
                 this.statsService.notifyOskariEvent(evt);
+                // record opacity for published map etc
+                var ind = this.statsService.getStateService().getActiveIndicator();
+                if (!ind || !ind.classification) {
+                    return;
+                }
+                ind.classification.transparency = evt.getMapLayer().getOpacity();
             }
         },
 

--- a/bundles/statistics/statsgrid2016/instance.js
+++ b/bundles/statistics/statsgrid2016/instance.js
@@ -259,7 +259,9 @@ Oskari.clazz.define(
                 }
                 if (wasClosed) {
                     me.getTile().hideExtensions();
-                    me.createClassficationView(false);
+                    if (!this.isEmbedded()) {
+                        me.createClassficationView(false);
+                    }
                 } else {
                     me.getTile().showExtensions();
                 }

--- a/bundles/statistics/statsgrid2016/service/StateService.js
+++ b/bundles/statistics/statsgrid2016/service/StateService.js
@@ -199,6 +199,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
             var me = this;
 
             clearTimeout(me._timers.setActiveIndicator);
+            if (me.getActiveIndicator() && indicatorHash === me.getActiveIndicator().hash) {
+                // trying to reset the same indicator
+                return;
+            }
 
             // This must be on some way to discard set active indicator if calling repeatly.
             // Because of published map editing, active indicator is changed always when adding indicator.


### PR DESCRIPTION
- Don't teardown legend when in published mode (fixes an issue where publisher added the legend on map but because of timing issue the statsgrid cleaned it away while publisher was being opened)
- Only call slider when needed == for points (fixes a js error for choropleth maps where slider is not present)
- Only set active indicator if it changes (Fixes an issue where active indicator change event is spammed)
- Opacity is now correctly saved to and restored from state