### PR TITLE
Fix statsgrid layer not visible

### DIFF
--- a/bundles/statistics/statsgrid2016/components/Legend.js
+++ b/bundles/statistics/statsgrid2016/components/Legend.js
@@ -93,6 +93,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Legend', function (sandbox, loc
             var legendContainer = container.find('.active-legend');
             headerContainer.empty();
             legendContainer.empty();
+            container.find('.legend-noactive').empty();
 
             // create inidicator dropdown if we have more than one indicator
             if (me.service.getStateService().getIndicators().length > 1) {

--- a/bundles/statistics/statsgrid2016/components/SelectedIndicatorsMenu.js
+++ b/bundles/statistics/statsgrid2016/components/SelectedIndicatorsMenu.js
@@ -49,8 +49,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SelectedIndicatorsMenu', functi
             });
             select.adjustChosen();
 
-            if (me.service.getStateService().activeIndicator) {
-                me.service.getStateService().activeIndicator.hash ? select.setValue(me.service.getStateService().activeIndicator.hash) : select.selectFirstValue();
+            var activeIndicator = me.service.getStateService().getActiveIndicator();
+            if (activeIndicator) {
+                activeIndicator.hash ? select.setValue(activeIndicator.hash) : select.selectFirstValue();
                 me._select = select;
             }
 


### PR DESCRIPTION
Fixes an issue where map would not populate when an empty dataset was previously added indicator.