### PR TITLE
Init statslayer in render() if theres an active indicator

### DIFF
--- a/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
+++ b/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
@@ -25,6 +25,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
         if (!ind) {
             return;
         }
+        me._updateLayerProperties();
         var errorService = service.getErrorService();
 
         service.getIndicatorData(ind.datasource, ind.indicator, ind.selections, ind.series, state.getRegionset(), function (err, data) {
@@ -300,13 +301,11 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
         var state = me.service.getStateService();
         me.service.on('StatsGrid.ActiveIndicatorChangedEvent', function (event) {
             // Always show the active indicator
-            me._updateLayerProperties();
             me.render(state.getRegion());
         });
 
         me.service.on('StatsGrid.RegionsetChangedEvent', function (event) {
             // Need to update the map
-            me._updateLayerProperties();
             me.render(state.getRegion());
         });
 
@@ -319,7 +318,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
 
         me.service.on('StatsGrid.ClassificationChangedEvent', function (event) {
             // Classification changed, need update map
-            me._updateLayerProperties();
             me.render(state.getRegion());
         });
 


### PR DESCRIPTION
Fixes an issue where restoring state for statistics functionality failed to add the layer properly to show in selected layers UI.