### PR TITLE
Don't assume there's a datasource for user indicators

### DIFF
--- a/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
@@ -75,7 +75,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
             if (result.complete) {
                 me.spinner.stop();
                 var userDatasource = me.service.getUserDatasource();
-                var isUserDatasource = !!userDatasource && '' + me.service.getUserDatasource().id === '' + datasrc;
+                var isUserDatasource = !!userDatasource && '' + userDatasource.id === '' + datasrc;
                 if (!isUserDatasource && result.indicators.length === 0) {
                     // show notification about empty indicator list for non-myindicators datasource
                     errorService.show(locale('errors.title'), locale('errors.indicatorListIsEmpty'));

--- a/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
@@ -74,7 +74,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
             }
             if (result.complete) {
                 me.spinner.stop();
-                var isUserDatasource = '' + me.service.getUserDatasource().id === '' + datasrc;
+                var userDatasource = me.service.getUserDatasource();
+                var isUserDatasource = !!userDatasource && '' + me.service.getUserDatasource().id === '' + datasrc;
                 if (!isUserDatasource && result.indicators.length === 0) {
                     // show notification about empty indicator list for non-myindicators datasource
                     errorService.show(locale('errors.title'), locale('errors.indicatorListIsEmpty'));


### PR DESCRIPTION
Datasource selection resulted in a js error if user indicators datasource was not enabled. This fixes the issue.