### PR TITLE
LayersPlugin trigger visibility event fix

### DIFF
--- a/bundles/mapping/mapmodule/request/MapLayerVisibilityRequestHandler.ol3.js
+++ b/bundles/mapping/mapmodule/request/MapLayerVisibilityRequestHandler.ol3.js
@@ -39,8 +39,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.MapLayerVisibi
             layer.setVisible(request.getVisible());
 
             // layersplugin handles ol maplayers' visibility changes
-            // and notifies other components if layer's visibility has changed
-            this.layersPlugin.handleMapLayerVisibility(layer);
+            // and notifies other components
+            this.layersPlugin.handleMapLayerVisibility(layer, true);
         },
         tryVectorLayers : function(id, blnVisible) {
             var module = this.layersPlugin.getMapModule();


### PR DESCRIPTION
MapLayerVisibilityRequestHandler calls handleMapLayerVisibility only when layer's visibility has changed. So trigger MapLayerVisibilityChangedEvent even ol maplayer's visibility hasn't change. This fixes the issue with scale limited layers when layer is set hidden in the scale and then zoomed out and tried to set layer visible again (ol layer should stay hidden because it's out of the scale, but layer's visibility change must be notified)

Also loop all ol maplayers (e.g tile and image) and check that all ol maplayers are in correct visibility state.