### PR TITLE
Classification legend fixes

### DIFF
--- a/bundles/statistics/statsgrid2016/components/EditClassification.js
+++ b/bundles/statistics/statsgrid2016/components/EditClassification.js
@@ -288,6 +288,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function (
     getSelectedValues: function () {
         var me = this;
         var range = me._rangeSlider.element.slider('values');
+        var transparencyEl = me._element.find('select.transparency-value');
+        var transparencyVal = transparencyEl.val() !== null ? transparencyEl.val() : transparencyEl.find('option#hiddenvalue').val();
         var values = {
             method: me._element.find('select.method').val(),
             count: parseFloat(me._element.find('select.amount-class').val()),
@@ -299,7 +301,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.EditClassification', function (
             // only used for points vector
             min: range[0],
             max: range[1],
-            transparency: me._element.find('select.transparency-value').val(),
+            transparency: transparencyVal,
             showValues: (me._showNumericValueCheckButton.getValue() === 'on'),
             fractionDigits: parseInt(me._element.find('select.decimal-place').val())
         };

--- a/bundles/statistics/statsgrid2016/instance.js
+++ b/bundles/statistics/statsgrid2016/instance.js
@@ -264,6 +264,9 @@ Oskari.clazz.define(
                     }
                 } else {
                     me.getTile().showExtensions();
+                    if (!this.isEmbedded() && this.statsService.getStateService().getIndicators().length !== 0) {
+                        this.createClassficationView(true);
+                    }
                 }
             },
             AfterMapLayerRemoveEvent: function (event) {
@@ -419,7 +422,7 @@ Oskari.clazz.define(
             return state;
         },
         createClassficationView: function (enabled) {
-            var config = this.getConfiguration();
+            var config = jQuery.extend(true, {}, this.getConfiguration());
             var sandbox = this.getSandbox();
             var locale = Oskari.getMsg.bind(null, 'StatsGrid');
             var mapModule = sandbox.findRegisteredModuleInstance('MainMapModule');
@@ -428,14 +431,19 @@ Oskari.clazz.define(
                 if (this.classificationPlugin) {
                     mapModule.unregisterPlugin(this.classificationPlugin);
                     mapModule.stopPlugin(this.classificationPlugin);
+                    this.classificationPlugin = null;
                 }
                 return;
             }
             if (!this.classificationPlugin) {
                 this.classificationPlugin = Oskari.clazz.create('Oskari.statistics.statsgrid.ClassificationPlugin', this, config, locale, sandbox);
             }
-            mapModule.registerPlugin(this.classificationPlugin);
-            mapModule.startPlugin(this.classificationPlugin);
+            if (mapModule.getPluginInstances()[this.classificationPlugin.getName()]) {
+                this.classificationPlugin.redrawUI();
+            } else {
+                mapModule.registerPlugin(this.classificationPlugin);
+                mapModule.startPlugin(this.classificationPlugin);
+            }
             // get the plugin order straight in mobile toolbar even for the tools coming in late
             if (Oskari.util.isMobile() && this.classificationPlugin.hasUI()) {
                 mapModule.redrawPluginUIs(true);

--- a/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
@@ -159,6 +159,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
                     'max-height': (height * 0.8 - headerHeight) + 'px'
                 });
             }
+        },
+        hasUI: function () {
+            return false;
         }
     }, {
         'extend': ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],

--- a/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
@@ -161,6 +161,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
             }
         },
         hasUI: function () {
+            // Plugin has ui element but returns false, because
+            // otherwise publisher would stop this plugin and start it again when leaving the publisher,
+            // resulting a misfuctioning duplicate classification element on screen.
             return false;
         }
     }, {

--- a/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
@@ -115,6 +115,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationTool', fun
         var stats = Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid');
         if (stats) {
             stats.enableClassification(true);
+            stats.createClassficationView(false);
         }
     }
 }, {


### PR DESCRIPTION
- Fixes an issue where layer opacity was set to 100% when classification was modified.
- Fixes an issue where classification events would stop firing after closing stats map tile and opening it again.
- Fixes an issue where classification legend was in wrong location after exiting publisher.