### PR TITLE
Restore any indicators from disabled state when regional divisions filter is cleared

### DIFF
--- a/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
@@ -267,6 +267,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
             if (regionFilterSelect.getValue() === null || regionFilterSelect.getValue().length === 0) {
                 var keepSelectedValue = true;
                 dsSelect.reset(keepSelectedValue);
+                indicSelect.disableOptions([]);
                 return;
             }
             var unsupportedSelections = me.service.getUnsupportedDatasetsList(regionFilterSelect.getValue());


### PR DESCRIPTION
Previously indicator list could have previously disabled items (based on regional division filter) when the filter was removed after the indicator list had been populated.