### PR TITLE
Lonlat in extent validation

### DIFF
--- a/bundles/mapping/mapmodule/mapmodule.ol3.js
+++ b/bundles/mapping/mapmodule/mapmodule.ol3.js
@@ -466,8 +466,10 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.MapModule',
          *     wanting to notify at end of the chain for performance reasons or similar) (optional)
          */
         centerMap: function (lonlat, zoom, suppressEnd) {
-            // TODO: we have isValidLonLat(); maybe use it here
             lonlat = this.normalizeLonLat(lonlat);
+            if (!this.isValidLonLat(lonlat.lon, lonlat.lat)) {
+                return;
+            }
             this.getMap().getView().setCenter([lonlat.lon, lonlat.lat]);
             if (zoom === null || zoom === undefined) {
                 zoom = this.getMapZoom();


### PR DESCRIPTION
Restrict centering map outside it's max extent.
- Fixes an issue where browser's geolocation would center the map outside it's extent resulting in a fully white map view.