### PR TITLE
Printout and Publisher icon info positioning

### DIFF
--- a/bundles/analysis/analyse/resources/css/style.css
+++ b/bundles/analysis/analyse/resources/css/style.css
@@ -177,7 +177,8 @@ div.basic_analyse select.settings_buffer_units, div.basic_analyse select.setting
   width: 80%; }
 
 .analyse_title_columns {
-  display: inline-block; }
+  display: inline-block;
+  width: 100%; }
 
 .analyse_settings_cont {
   margin: 10px 5px; }

--- a/bundles/analysis/analyse/resources/scss/style.scss
+++ b/bundles/analysis/analyse/resources/scss/style.scss
@@ -301,6 +301,7 @@ div.basic_analyse {
 }
 
 .analyse_title_columns {
+    width: 100%;
     display: inline-block;
 }
 

--- a/bundles/framework/printout/view/BasicPrintout.js
+++ b/bundles/framework/printout/view/BasicPrintout.js
@@ -204,7 +204,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
 
             panel.setTitle(me.loc.size.label);
             tooltipCont.attr('title', me.loc.size.tooltip);
-            contentPanel.append(tooltipCont);
+            panel.getHeader().append(tooltipCont);
             // content
             me.sizeOptions.forEach(function (option) {
                 var toolContainer = me.template.sizeOptionTool.clone();
@@ -257,7 +257,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
             // tooltip
             var tooltipCont = me.template.help.clone();
             tooltipCont.attr('title', me.loc.settings.tooltip);
-            contentPanel.append(tooltipCont);
+            panel.getHeader().append(tooltipCont);
 
             /* format options from localisations files */
             var format = me.template.format.clone();
@@ -335,7 +335,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
 
             panel.setTitle(me.loc.scale.label);
             tooltipCont.attr('title', me.loc.scale.tooltip);
-            contentPanel.append(tooltipCont);
+            panel.getHeader().append(tooltipCont);
 
             var unsupportedLayersDialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
             var okButton = unsupportedLayersDialog.createCloseButton('OK');
@@ -472,7 +472,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
             var tooltipCont = me.template.help.clone();
 
             tooltipCont.attr('title', me.loc.preview.tooltip);
-            contentPanel.append(tooltipCont);
+            panel.getHeader().append(tooltipCont);
 
             var previewContent = me.template.preview.clone();
 

--- a/bundles/framework/publisher2/resources/css/style.css
+++ b/bundles/framework/publisher2/resources/css/style.css
@@ -143,6 +143,9 @@ div.basic_publisher ul.selectedLayersList {
   div.basic_publisher ul.selectedLayersList span {
     position: absolute; }
 
+div.basic_publisher label.oskari-languageselect {
+  clear: left; }
+
 div.publisher div.startview div.content {
   margin-top: 5px; }
 

--- a/bundles/framework/publisher2/resources/scss/style.scss
+++ b/bundles/framework/publisher2/resources/scss/style.scss
@@ -221,6 +221,9 @@ div.basic_publisher {
             position: absolute;
         }
     }
+    label.oskari-languageselect {
+        clear: left;
+    }
 }
 
 div.publisher {

--- a/bundles/framework/publisher2/view/PanelGeneralInfo.js
+++ b/bundles/framework/publisher2/view/PanelGeneralInfo.js
@@ -32,7 +32,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelGeneralInfo
         };
         this.langField = {
             template: jQuery('<div class="field">' +
-                '<div class="help icon-info" title="' + localization.language.tooltip + '" helptags="portti,help,publisher,language"></div>' +
+                    '<div class="help icon-info" title="' + localization.language.tooltip + '" helptags="portti,help,publisher,language"></div>' +
+                    '<div class="language-select-wrapper"></div>' +
+                    '<div class="info-label"></div>' +
                 '</div>')
         };
         this.panel = null;
@@ -116,8 +118,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelGeneralInfo
             langField.setHandler(function (value) {
                 me._languageChanged(value);
             });
-            langElement.append(langField.getElement());
-            langElement.append('<div class="info-label"></div>');
+            langElement.find('.language-select-wrapper').append(langField.getElement());
             me.langField.field = langField;
             me.langField.element = langElement;
 

--- a/bundles/framework/publisher2/view/PanelMapLayers.js
+++ b/bundles/framework/publisher2/view/PanelMapLayers.js
@@ -272,7 +272,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapLayers',
             // layer tooltip
             var tooltipCont = this.templateHelp.clone();
             tooltipCont.attr('title', this.loc.layerselection.tooltip);
-            contentPanel.append(tooltipCont);
+            this.panel.getHeader().append(tooltipCont);
 
             var layers = this._getLayersList(),
                 i,

--- a/bundles/framework/publisher2/view/PanelMapPreview.js
+++ b/bundles/framework/publisher2/view/PanelMapPreview.js
@@ -394,7 +394,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapPreview'
             }
             panel.setTitle(me.loc.size.label);
             tooltipCont.attr('title', me.loc.size.tooltip);
-            contentPanel.append(tooltipCont);
+            panel.getHeader().append(tooltipCont);
 
             for (fkey in this.fields) {
                 if (this.fields.hasOwnProperty(fkey)) {

--- a/bundles/framework/publisher2/view/PanelMapTools.js
+++ b/bundles/framework/publisher2/view/PanelMapTools.js
@@ -123,7 +123,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
 
             panel.setTitle(me.loc[me.group].label);
             tooltipCont.attr('title', me.loc[me.group].tooltip);
-            contentPanel.append(tooltipCont);
+            panel.getHeader().append(tooltipCont);
 
             // Sort tools
             me._sortTools();

--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -199,7 +199,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
 
 
             tooltipCont.attr('title', me.loc.toollayout.tooltip);
-            contentPanel.append(tooltipCont);
+            panel.getHeader().append(tooltipCont);
 
             // content
             for (i = 0; i < me.toolLayouts.length; i += 1) {


### PR DESCRIPTION
Info icon styling changes for printout, analysis and publisher.

Publisher & printout: Add icon info element to accordion panel's header instead of content.
Analysis: Attributes in the result use 100% width.
Publisher: Language selection don't clear right.