### PR TITLE
Add maprotator to minifier appsetup for ELF

### DIFF
--- a/applications/elf/elf_guest/minifierAppSetup.json
+++ b/applications/elf/elf_guest/minifierAppSetup.json
@@ -71,6 +71,15 @@
                 }
             }
         }, {
+            "bundlename": "maprotator",
+            "metadata": {
+                "Import-Bundle": {
+                    "maprotator": {
+                        "bundlePath": "../../../packages/mapping/ol3/"
+                    }
+                }
+            }
+        }, {
             "bundlename": "statehandler",
             "metadata": {
                 "Import-Bundle": {

--- a/applications/elf/elf_published/minifierAppSetup.json
+++ b/applications/elf/elf_published/minifierAppSetup.json
@@ -101,6 +101,15 @@
             }
         }
     }, {
+        "bundlename": "maprotator",
+        "metadata": {
+            "Import-Bundle": {
+                "maprotator": {
+                    "bundlePath": "../../../packages/mapping/ol3/"
+                }
+            }
+        }
+    }, {
         "bundlename" : "rpc",
         "bundleinstancename" : "rpc",
         "metadata" : {


### PR DESCRIPTION
Since maprotator links files from mapmodule in it's packages/.../bundle.js they are loaded at runtime even when they are already present in the minified code. This means changes in #441 trigger js errors like:

    class_system.js:27 Uncaught Error: Class "Oskari.mapping.mapmodule.plugin.AbstractMapModulePlugin" already defined. Use Oskari.clazz.category(...) to add methods to existing class.
    class_system.js:27 Uncaught Error: Class "Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin" already defined. Use Oskari.clazz.category(...) to add methods to existing class.

Adding maprotator to the minified code fixes this.