### PR TITLE
Removed broken OpenLayers version check

### DIFF
--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol3.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol3.js
@@ -847,12 +847,12 @@ Oskari.clazz.define(
             if (!layer.isLayerOfType('VECTOR')) {
                 return null;
             }
-            var ol = this.getLayerById(layer.getId());
-            if (!ol) {
+            var olLayer = this.getLayerById(layer.getId());
+            if (!olLayer) {
                 return null;
             }
             // only single layer/id, wrap it in an array
-            return [ol];
+            return [olLayer];
         },
         getLayerById: function(id) {
             if (!id) {

--- a/bundles/mapping/maprotator/instance.js
+++ b/bundles/mapping/maprotator/instance.js
@@ -55,10 +55,6 @@ Oskari.clazz.define("Oskari.mapping.maprotator.MapRotatorBundleInstance",
       }
       var conf = this.conf || {};
       var plugin = Oskari.clazz.create('Oskari.mapping.maprotator.MapRotatorPlugin', conf);
-      if ( !plugin.isSupported() ) {
-        // don't create plugin if ol4 is not supported
-        return;
-      }
       this._mapmodule.registerPlugin(plugin);
       this._mapmodule.startPlugin(plugin);
       this.plugin = plugin;

--- a/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
+++ b/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
@@ -30,9 +30,6 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
         };
         me._log = Oskari.log('Oskari.mapping.maprotator.MapRotatorPlugin');
     }, {
-        isSupported: function () {
-            return typeof ol !== 'undefined';
-        },
         handleEvents: function () {
             var me = this;
             var DragRotate = new olInteractionDragRotate();
@@ -72,10 +69,6 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
 
             this._locale = Oskari.getLocalization('maprotator', Oskari.getLang() || Oskari.getDefaultLanguage()).display;
 
-            if (!this.isSupported() && this.hasUi()) {
-                return compass;
-            }
-
             compass.attr('title', this._locale.tooltip.tool);
 
             if (!this.hasUi()) {
@@ -90,9 +83,7 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
         },
         _createUI: function () {
             this._element = this._createControlElement();
-            if (this.isSupported()) {
-                this.handleEvents();
-            }
+            this.handleEvents();
             this.addToPluginContainer(this._element);
         },
         _createMobileUI: function () {
@@ -102,9 +93,6 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
             this.handleEvents();
         },
         setRotation: function (deg) {
-            if (!this.isSupported()) {
-                return;
-            }
             // if deg is number then transform degrees to radians otherwise use 0
             var rot = (typeof deg === 'number') ? deg / 57.3 : 0;
             // if deg is number use it for degrees otherwise use 0


### PR DESCRIPTION
Check is not needed, as only OL3+ is supported by Oskari now.

Also removed usage of 'ol' variable name.

