### PR TITLE
Deprecation migration part 3

### DIFF
--- a/bundles/admin/admin-hierarchical-layerlist/models/layerModel.js
+++ b/bundles/admin/admin-hierarchical-layerlist/models/layerModel.js
@@ -1,26 +1,3 @@
-// polyfill for bind - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind -> polyfill
-if (!Function.prototype.bind) {
-    Function.prototype.bind = function(oThis) {
-        if (typeof this !== "function") {
-            // closest thing possible to the ECMAScript 5 internal IsCallable function
-            throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
-        }
-
-        var aArgs = Array.prototype.slice.call(arguments, 1),
-            fToBind = this,
-            fNOP = function() {},
-            fBound = function() {
-                return fToBind.apply(this instanceof fNOP && oThis ? this : oThis,
-                    aArgs.concat(Array.prototype.slice.call(arguments)));
-            };
-
-        fNOP.prototype = this.prototype;
-        fBound.prototype = new fNOP();
-
-        return fBound;
-    };
-}
-// actual model - uses bind to make Oskari layer object functions call BackBone model.attributes
 (function() {
     define(function() {
         return Backbone.Model.extend({
@@ -92,7 +69,7 @@ if (!Function.prototype.bind) {
              */
             _setupFromCapabilitiesValues: function(capabilitiesNode) {
                 var sb = Oskari.getSandbox();
-                sb.printDebug("Found:", capabilitiesNode);
+                Oskari.log('admin-hierarchical-layerlist~layerModel').debug("Found:", capabilitiesNode);
                 var mapLayerService = sb.getService('Oskari.mapframework.service.MapLayerService'),
                     mapLayer = mapLayerService.createMapLayer(capabilitiesNode),
                     dataToKeep = null;

--- a/bundles/analysis/analyse/instance.js
+++ b/bundles/analysis/analyse/instance.js
@@ -30,6 +30,7 @@ Oskari.clazz.define(
         this.state = undefined;
         this.conf = {};
         this.personalDataTab = undefined;
+        this._log = Oskari.log(this.getName());
     }, {
         /**
          * @static @property __name
@@ -221,7 +222,7 @@ Oskari.clazz.define(
             MapLayerVisibilityChangedEvent: function (event) {
                 if (this.analyse && this.analyse.isEnabled && this.isMapStateChanged) {
                     this.isMapStateChanged = false;
-                    this.getSandbox().printDebug('ANALYSE REFRESH');
+                    this._log.debug('ANALYSE REFRESH');
                     //this.analyse.refreshAnalyseData();
                 }
             },

--- a/bundles/analysis/analyse/request/AnalyseRequestHandler.js
+++ b/bundles/analysis/analyse/request/AnalyseRequestHandler.js
@@ -2,10 +2,11 @@ Oskari.clazz.define('Oskari.analysis.bundle.analyse.request.AnalyseRequestHandle
 
     this.sandbox = sandbox;
     this.cb = handlerFunc;
+    this._log = Oskari.log('AnalyseRequestHandler');
 }, {
     handleRequest: function (core, request) {
         var selections = request.getSelections();
-        this.sandbox.printDebug("[Oskari.analysis.bundle.analyse.request.AnalyseRequestHandler] analyse requested");
+        this._log.debug("Analyse requested");
         this.cb(selections);
     }
 }, {

--- a/bundles/catalogue/metadatacatalogue/request/AddSearchResultActionRequestHandler.js
+++ b/bundles/catalogue/metadatacatalogue/request/AddSearchResultActionRequestHandler.js
@@ -13,6 +13,7 @@
 Oskari.clazz.define('Oskari.catalogue.bundle.metadatacatalogue.request.AddSearchResultActionRequestHandler', function(sandbox, instance) {
     this.sandbox = sandbox;
     this.instance = instance;
+    this._log = Oskari.log('AddSearchResultActionRequestHandler');
 }, {
     /**
      * @method handleRequest
@@ -29,7 +30,7 @@ Oskari.clazz.define('Oskari.catalogue.bundle.metadatacatalogue.request.AddSearch
             actionTextElement = request.getActionTextElement(),
             actionText = request.getActionText(),
             showAction = request.getShowAction();
-        this.sandbox.printDebug("[Oskari.catalogue.bundle.metadatacatalogue.request.AddSearchResultActionRequest]");
+        this._log.debug("Handling reguest");
         this.instance.addSearchResultAction(actionElement, actionTextElement, callback, bindCallbackTo, actionText, showAction);
     }
 }, {

--- a/bundles/digiroad/digiroad-featureselector/plugin/VectorLayerPlugin.js
+++ b/bundles/digiroad/digiroad-featureselector/plugin/VectorLayerPlugin.js
@@ -14,6 +14,7 @@ Oskari.clazz.define('Oskari.digiroad.bundle.featureselector.plugin.VectorLayerPl
             multipleSymbolizers : false,
             namedLayersAsArray : true
         });
+        this._log = Oskari.log(this.__name);
     }, {
         __name : 'DigiroadVectorLayerPlugin',
 
@@ -137,7 +138,7 @@ Oskari.clazz.define('Oskari.digiroad.bundle.featureselector.plugin.VectorLayerPl
             if (!layer.isLayerOfType(this._layerType))
                 continue;
 
-            sandbox.printDebug("preselecting " + layerId);
+            this._log.debug("preselecting " + layerId);
             this.addMapLayerToMap(layer,true,layer.isBaseLayer());
         }
 
@@ -232,7 +233,7 @@ Oskari.clazz.define('Oskari.digiroad.bundle.featureselector.plugin.VectorLayerPl
 /*                      var sldSpec = layer.getStyledLayerDescriptor();
 
         if (sldSpec) {
-            this._sandbox.printDebug(sldSpec);
+            this._log.debug(sldSpec);
             var styleInfo = this._sldFormat.read(sldSpec);
 
             window.styleInfo = styleInfo;
@@ -258,8 +259,7 @@ Oskari.clazz.define('Oskari.digiroad.bundle.featureselector.plugin.VectorLayerPl
         this._controls[layerId]['getFeature'] = this.activateGetFeature(layer, openLayer, protocol, filter);
         this._controls[layerId]['selectFeature'] = this.activateSelectFeature(openLayer);
 
-        this._sandbox
-                .printDebug("#!#! CREATED VECTOR / OPENLAYER.LAYER.VECTOR for "
+        this._log.debug("#!#! CREATED VECTOR / OPENLAYER.LAYER.VECTOR for "
                         + layer.getId());
 
         if (keepLayerOnTop) {

--- a/bundles/digiroad/digiroad-myplaces2/instance.js
+++ b/bundles/digiroad/digiroad-myplaces2/instance.js
@@ -17,6 +17,7 @@ function() {
     this.myPlacesService = undefined;
     this.idPrefix = 'myplaces';
     this.queryUrl = undefined;
+    this._log = Oskari.log(this.getName());
 }, {
     __name : 'DigiroadMyPlaces2',
     /**
@@ -134,7 +135,7 @@ function() {
         this.sandbox = sandbox;
 
         var me = this;
-        sandbox.printDebug("Initializing my places module...");
+        this._log.debug("Initializing my places module...");
 
         // handles toolbar buttons related to my places
         this.buttons = Oskari.clazz.create("Oskari.digiroad.bundle.myplaces2.ButtonHandler", this);

--- a/bundles/elf/elf-license/service/LicenseService.js
+++ b/bundles/elf/elf-license/service/LicenseService.js
@@ -28,6 +28,7 @@ Oskari.clazz.define('Oskari.elf.license.service.LicenseService',
                 timestamp: null
             }
         };
+        this._log = Oskari.log(this.getName());
     }, {
         __name: 'elf-license.LicenseService',
         __qname: 'Oskari.elf.license.service.LicenseService',
@@ -94,7 +95,7 @@ Oskari.clazz.define('Oskari.elf.license.service.LicenseService',
             if (!jqhr) {
                 return;
             }
-            me.sandbox.printDebug("[elf-license.LicenseService] Abort jqhr ajax request");
+            me._log.debug("Abort jqhr ajax request");
             jqhr.abort();
             jqhr = null;
             me._pendingAjaxQuery[requestName].busy = false;
@@ -120,7 +121,7 @@ Oskari.clazz.define('Oskari.elf.license.service.LicenseService',
             me._pendingAjaxQuery[requestName].busy = false;
             me._pendingAjaxQuery[requestName].jqhr = null;
 
-            me.sandbox.printDebug("[elf-license.LicenseService] finished jqhr ajax request");
+            me._log.debug("finished jqhr ajax request");
         },
         /**
          * Do license search
@@ -139,7 +140,7 @@ Oskari.clazz.define('Oskari.elf.license.service.LicenseService',
 
             if (me._pendingAjaxQuery['licenseInformation'].busy && me._pendingAjaxQuery['licenseInformation'].timestamp &&
                 dteMs - me._pendingAjaxQuery['licenseInformation'].timestamp < 500) {
-                me.sandbox.printDebug("[elf-license.LicenseService] License information request NOT SENT (time difference < 500ms)");
+                me._log.debug("License information request NOT SENT (time difference < 500ms)");
                 return;
             }
 
@@ -191,7 +192,7 @@ Oskari.clazz.define('Oskari.elf.license.service.LicenseService',
 
             if (me._pendingAjaxQuery['getPrice'].busy && me._pendingAjaxQuery['getPrice'].timestamp &&
                 dteMs - me._pendingAjaxQuery['getPrice'].timestamp < 500) {
-                me.sandbox.printDebug("[elf-license.LicenseService] License information request NOT SENT (time difference < 500ms)");
+                me._log.debug("License information request NOT SENT (time difference < 500ms)");
                 return;
             }
 
@@ -243,7 +244,7 @@ Oskari.clazz.define('Oskari.elf.license.service.LicenseService',
 
             if (me._pendingAjaxQuery['concludeLicense'].busy && me._pendingAjaxQuery['concludeLicense'].timestamp &&
                 dteMs - me._pendingAjaxQuery['concludeLicense'].timestamp < 500) {
-                me.sandbox.printDebug("[elf-license.LicenseService] License information request NOT SENT (time difference < 500ms)");
+                me._log.debug("License information request NOT SENT (time difference < 500ms)");
                 return;
             }
 
@@ -295,7 +296,7 @@ Oskari.clazz.define('Oskari.elf.license.service.LicenseService',
 
             if (me._pendingAjaxQuery['deactivateLicense'].busy && me._pendingAjaxQuery['deactivateLicense'].timestamp &&
                 dteMs - me._pendingAjaxQuery['deactivateLicense'].timestamp < 500) {
-                me.sandbox.printDebug("[elf-license.LicenseService] License information request NOT SENT (time difference < 500ms)");
+                me._log.debug("License information request NOT SENT (time difference < 500ms)");
                 return;
             }
 

--- a/bundles/framework/backendstatus/instance.js
+++ b/bundles/framework/backendstatus/instance.js
@@ -33,7 +33,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.backendstatus.BackendStatusBundl
 
         /* maplayerservice */
         this._mapLayerService = null;
-
+        this._log = Oskari.log(this.getName());
     }, {
         ajaxSettings: {
             defaultTimeThreshold: 15000
@@ -320,7 +320,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.backendstatus.BackendStatusBundl
             if (!jqhr) {
                 return;
             }
-            this._sandbox.printDebug("[BackendStatus] Abort jqhr ajax request");
+            this._log.debug("Abort jqhr ajax request");
             jqhr.abort();
             jqhr = null;
             me._pendingAjaxQuery.busy = false;
@@ -335,11 +335,11 @@ Oskari.clazz.define("Oskari.mapframework.bundle.backendstatus.BackendStatusBundl
             var me = this;
             me._pendingAjaxQuery.busy = false;
             me._pendingAjaxQuery.jqhr = null;
-            this._sandbox.printDebug("[BackendStatus] finished jqhr ajax request");
+            this._log.debug("finished jqhr ajax request");
         },
         _notifyAjaxFailure: function () {
             var me = this;
-            me._sandbox.printDebug("[BackendStatus] BackendStatus AJAX failed");
+            this._log.debug("BackendStatus AJAX failed");
             me._processResponse({
                 backendstatus: []
             });
@@ -351,16 +351,15 @@ Oskari.clazz.define("Oskari.mapframework.bundle.backendstatus.BackendStatusBundl
         updateBackendStatus: function (allKnown) {
             var me = this;
             me.gotStartupProcessCall = me.gotStartupProcessCall || allKnown;
-            var sandbox = me._sandbox;
             if (!allKnown && me._pendingAjaxQuery.busy) {
-                sandbox.printDebug("[BackendStatus] updateBackendStatus NOT SENT previous query is busy");
+                this._log.debug("updateBackendStatus NOT SENT previous query is busy");
                 return;
             }
             var dte = new Date();
             var dteMs = dte.getTime();
 
             if (!allKnown && me._pendingAjaxQuery.timestamp && dteMs - me._pendingAjaxQuery.timestamp < me.timeInterval) {
-                sandbox.printDebug("[BackendStatus] updateBackendStatus NOT SENT (time difference < " + me.timeInterval + "ms)");
+                this._log.debug("updateBackendStatus NOT SENT (time difference < " + me.timeInterval + "ms)");
                 return;
             }
 
@@ -405,14 +404,14 @@ Oskari.clazz.define("Oskari.mapframework.bundle.backendstatus.BackendStatusBundl
             var me = this;
             var sandbox = this._sandbox;
             if (!resp) {
-                sandbox.printDebug("[BackendStatus] empty data from server");
+                this._log.debug("empty data from server");
                 return;
             }
 
             var backendStatusArr = resp.backendstatus;
             // FIXME use ===
             if (!backendStatusArr || backendStatusArr.length === undefined) {
-                sandbox.printDebug("[BackendStatus] backendStatus NO data");
+                this._log.debug("backendStatus NO data");
                 return;
             }
 
@@ -435,7 +434,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.backendstatus.BackendStatusBundl
                         changed: true
                     };
                     extendedStatuses[layerId] = data;
-                    /*sandbox.printDebug("[BackendStatus] "+layerId+" new alert");*/
+                    /*this._log.debug(layerId+" new alert");*/
                     // FIXME use !==
                 } else if (this.backendStatus[layerId].status !== data.status) {
                     changeNotifications[layerId] = {
@@ -443,7 +442,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.backendstatus.BackendStatusBundl
                         changed: true
                     };
                     extendedStatuses[layerId] = data;
-                    /*sandbox.printDebug("[BackendStatus] "+layerId+" changed alert");*/
+                    /*this._log.debug(layerId+" changed alert");*/
                 } else {
                     changeNotifications[layerId] = {
                         status: data.status,
@@ -461,7 +460,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.backendstatus.BackendStatusBundl
                             status: null,
                             changed: true
                         };
-                        /*sandbox.printDebug("[BackendStatus] "+p+" alert closed");*/
+                        /*this._log.debug(p+" alert closed");*/
                     }
                 }
             }

--- a/bundles/framework/divmanazer/extension/DefaultFlyout.js
+++ b/bundles/framework/divmanazer/extension/DefaultFlyout.js
@@ -25,8 +25,7 @@ Oskari.clazz.define('Oskari.userinterface.extension.DefaultFlyout',
         this.container = null;
 
         this._sidetool = null;
-
-
+        this._log = Oskari.log(this.getName());
     }, {
         __temp:{
             sideTool:_.template(
@@ -252,14 +251,14 @@ Oskari.clazz.define('Oskari.userinterface.extension.DefaultFlyout',
          * Hook function for bundle specific op. Called when flyout is opened.
          */
         onOpen : function() {
-            this.getSandbox().printDebug('Opened flyout ' + this.getName());
+            this._log.debug('Opened flyout ' + this.getName());
         },
 
         /**
          * Hook function for bundle specific op. Called when flyout is closed.
          */
         onClose : function() {
-            this.getSandbox().printDebug('Closed flyout' + this.getName());
+            this._log.debug('Closed flyout' + this.getName());
         }
 
     }, {

--- a/bundles/framework/geometryeditor/request/StartDrawFilteringRequestHandler.js
+++ b/bundles/framework/geometryeditor/request/StartDrawFilteringRequestHandler.js
@@ -2,10 +2,11 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.GeometryEditor.DrawFil
 
     this.sandbox = sandbox;
     this.drawFilterPlugin = drawFilterPlugin;
+    this._log = Oskari.log('StartDrawFilteringRequestPluginHandler');
 }, {
     handleRequest : function(core, request) {
         var drawMode = request.getMode();
-        this.sandbox.printDebug("[Oskari.mapframework.ui.module.common.GeometryEditor.DrawFilterPlugin.request.StartDrawFilteringRequestPluginHandler] Start Drawing: " + drawMode);
+        this._log.debug("Start Drawing: " + drawMode);
         this.drawFilterPlugin.startDrawFiltering({
             drawMode : request.getMode(),
             geometry : request.getGeometry(),

--- a/bundles/framework/geometryeditor/request/StopDrawFilteringRequestHandler.js
+++ b/bundles/framework/geometryeditor/request/StopDrawFilteringRequestHandler.js
@@ -4,10 +4,11 @@ Oskari.clazz.define(
         function(sandbox, drawFilterPlugin) {
             this.sandbox = sandbox;
             this.drawFilterPlugin = drawFilterPlugin;
+            this._log = Oskari.log('StopDrawFilteringRequestPluginHandler');
         },
         {
             handleRequest: function(core,request) {
-                this.sandbox.printDebug("[Oskari.mapframework.ui.module.common.GeometryEditor.DrawFilterPlugin.request.StopDrawFilteringRequestPluginHandler] Stop draw filtering");
+                this._log.debug('Stop draw filtering');
                 if(request.isCancel()) {
                     // we wish to clear the drawing without sending further events
                     this.drawFilterPlugin.stopDrawFiltering();

--- a/bundles/framework/mapmodule-plugin/plugin/drawplugin/request/GetGeometryRequestHandler.js
+++ b/bundles/framework/mapmodule-plugin/plugin/drawplugin/request/GetGeometryRequestHandler.js
@@ -2,10 +2,11 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.mapmodule.DrawPlugin.r
 
     this.sandbox = sandbox;
     this.drawPlugin = drawPlugin;
+    this._log = Oskari.log('GetGeometryRequestPluginHandler');
 }, {
     handleRequest : function(core, request) {
         var callBack = request.getCallBack();
-        this.sandbox.printDebug("[Oskari.mapframework.ui.module.common.mapmodule.DrawPlugin.request.GetGeometryRequestPluginHandler] geometry requested");
+        this._log.debug('geometry requested');
         var drawing = this.drawPlugin.getDrawing();
         callBack(drawing.geometry);
     }

--- a/bundles/framework/mapmodule-plugin/plugin/drawplugin/request/StartDrawingRequestHandler.js
+++ b/bundles/framework/mapmodule-plugin/plugin/drawplugin/request/StartDrawingRequestHandler.js
@@ -2,10 +2,11 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.mapmodule.DrawPlugin.r
 
     this.sandbox = sandbox;
     this.drawPlugin = drawPlugin;
+    this._log = Oskari.log('StartDrawingRequestPluginHandler');
 }, {
     handleRequest : function(core, request) {
         var drawMode = request.getDrawMode();
-        this.sandbox.printDebug("[Oskari.mapframework.ui.module.common.mapmodule.DrawPlugin.request.StartDrawingRequestPluginHandler] Start Drawing: " + drawMode);
+        this._log.debug('Start Drawing: ' + drawMode);
         this.drawPlugin.startDrawing({
             drawMode : request.getDrawMode(),
             geometry : request.getGeometry(),

--- a/bundles/framework/mapmodule-plugin/plugin/drawplugin/request/StopDrawingRequestHandler.js
+++ b/bundles/framework/mapmodule-plugin/plugin/drawplugin/request/StopDrawingRequestHandler.js
@@ -4,11 +4,10 @@ Oskari.clazz.define(
     function (sandbox, drawPlugin) {
         this.sandbox = sandbox;
         this.drawPlugin = drawPlugin;
+        this._log = Oskari.log('StopDrawingRequestPluginHandler');
     }, {
         handleRequest: function (core, request) {
-            this.sandbox.printDebug(
-                '[Oskari.mapframework.ui.module.common.mapmodule.DrawPlugin.request.StopDrawingRequestPluginHandler] Stop drawing'
-            );
+            this._log.debug('Stop drawing');
             if (request.isCancel()) {
                 // we wish to clear the drawing without sending further events
                 this.drawPlugin.stopDrawing();

--- a/bundles/framework/mapmyplaces/plugin/MyPlacesLayerPlugin.js
+++ b/bundles/framework/mapmyplaces/plugin/MyPlacesLayerPlugin.js
@@ -24,6 +24,7 @@ Oskari.clazz.define(
         if (me._config && me._config.ajaxUrl) {
             me.ajaxUrl = me._config.ajaxUrl;
         }
+        this._log = Oskari.log('MyPlacesLayerPlugin');
     }, {
 
         /** @static @property _layerType type of layers this plugin handles */
@@ -126,7 +127,7 @@ Oskari.clazz.define(
                     continue;
                 }
 
-                sandbox.printDebug('preselecting ' + layerId);
+                this._log.debug('preselecting ' + layerId);
                 this.addMapLayerToMap(layer, true, layer.isBaseLayer());
             }
         },
@@ -710,7 +711,7 @@ Oskari.clazz.define(
 
             this.layers[openLayerId] = myLayersGroup;
 
-            this.getSandbox().printDebug(
+            this._log.debug(
                 '#!#! CREATED OPENLAYER.LAYER.WMS for MyPlacesLayer ' +
                 layer.getId()
             );

--- a/bundles/framework/metadata/instance.js
+++ b/bundles/framework/metadata/instance.js
@@ -14,6 +14,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.metadata.MetadataSearchInstance'
 
     function () {
         this.buttons = {};
+        this._log = Oskari.log(this.getName());
     }, {
         __name: 'MetadataSearch',
 
@@ -52,7 +53,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.metadata.MetadataSearchInstance'
             }
             me.sandbox = sandbox;
 
-            sandbox.printDebug('Initializing metadata module...');
+            this._log.debug('Initializing metadata module...');
             me.setupToolbar();
 
             // register plugin for map (drawing for selection box)

--- a/bundles/framework/myplaces2/instance.js
+++ b/bundles/framework/myplaces2/instance.js
@@ -18,6 +18,7 @@ Oskari.clazz.define(
         this.myPlacesService = undefined;
         this.featureNS = undefined;
         this.idPrefix = 'myplaces';
+        this._log = Oskari.log(this.getName());
     }, {
         __name: 'MyPlaces2',
         /**
@@ -176,7 +177,7 @@ Oskari.clazz.define(
                 return;
             }
 
-            sandbox.printDebug("Initializing my places module...");
+            this._log.debug("Initializing my places module...");
 
             // handles toolbar buttons related to my places
             this.buttons = Oskari.clazz.create("Oskari.mapframework.bundle.myplaces2.ButtonHandler", this);

--- a/bundles/framework/myplaces2/request/EditRequestHandler.js
+++ b/bundles/framework/myplaces2/request/EditRequestHandler.js
@@ -16,6 +16,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces2.request.EditRequestHan
     function (sandbox, instance) {
         this.sandbox = sandbox;
         this.instance = instance;
+        this._log = Oskari.log('myplaces2.request.EditRequestHandler');
     }, {
         /**
          * @method handleRequest
@@ -40,7 +41,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces2.request.EditRequestHan
             }
         },
         _handleEditPlace: function (sandbox, request) {
-            this.sandbox.printDebug("[Oskari.mapframework.bundle.myplaces2.request.EditRequestHandler] edit requested for place " + request.getId());
+            this._log.debug("edit requested for place " + request.getId());
             var service = this.instance.getService(),
                 place = service.findMyPlace(request.getId());
             if (place) {
@@ -63,7 +64,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces2.request.EditRequestHan
             }
         },
         _handleDeletePlace: function (sandbox, request) {
-            this.sandbox.printDebug("[Oskari.mapframework.bundle.myplaces2.request.DeleteRequestHandler] delete requested for place " + request.getId());
+            this._log.debug("delete requested for place " + request.getId());
             /* let's refresh map also if there */
             var categoryId = request.getId(),
                 layerId = 'myplaces_' + categoryId,
@@ -85,7 +86,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces2.request.EditRequestHan
             this.instance.getMainView().cleanupPopup();
         },
         _handleEditCategory: function (sandbox, request) {
-            this.sandbox.printDebug("[Oskari.mapframework.bundle.myplaces2.request.EditRequestHandler] edit requested for category " + request.getId());
+            this._log.debug("edit requested for category " + request.getId());
             var service = this.instance.getService(),
                 category = service.findCategory(request.getId());
             if (category) {
@@ -93,7 +94,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces2.request.EditRequestHan
             }
         },
         _handleDeleteCategory: function (sandbox, request) {
-            this.sandbox.printDebug("[Oskari.mapframework.bundle.myplaces2.request.EditRequestHandler] delete requested for category " + request.getId());
+            this._log.debug("delete requested for category " + request.getId());
             var service = this.instance.getService(),
                 category = service.findCategory(request.getId());
             if (category) {
@@ -101,7 +102,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces2.request.EditRequestHan
             }
         },
         _handlePublishCategory: function (sandbox, request) {
-            this.sandbox.printDebug("[Oskari.mapframework.bundle.myplaces2.request.EditRequestHandler] (un/)publish requested for category " + request.getId());
+            this._log.debug("(un/)publish requested for category " + request.getId());
             var service = this.instance.getService(),
                 category = service.findCategory(request.getId());
             if (category) {

--- a/bundles/framework/printout/instance.js
+++ b/bundles/framework/printout/instance.js
@@ -38,7 +38,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.printout.PrintoutBundleInstance"
                 "image/png": ""
             }
         };
-
+        this._log = Oskari.log(this.getName());
     }, {
         /**
          * @static
@@ -188,7 +188,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.printout.PrintoutBundleInstance"
                 /* we might get 9 of these if 9 layers would have been selected */
                 if (this.printout && this.printout.isEnabled && this.isMapStateChanged) {
                     this.isMapStateChanged = false;
-                    this.getSandbox().printDebug("PRINTOUT REFRESH");
+                    this._log.debug("PRINTOUT REFRESH");
                     this.printout.refresh(true);
                 }
             },

--- a/bundles/framework/printout/request/PrintMapRequestHandler.js
+++ b/bundles/framework/printout/request/PrintMapRequestHandler.js
@@ -2,10 +2,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.request.PrintMapRequest
 
     this.sandbox = sandbox;
     this.cb = handlerFunc;
+    this._log = Oskari.log('PrintMapRequestHandler');
 }, {
     handleRequest : function(core, request) {
         var selections = request.getSelections();
-        this.sandbox.printDebug("[Oskari.mapframework.bundle.printout.request.PrintMapRequestHandler] printout requested");
+        this._log.debug('printout requested');
         this.cb(selections);
     }
 }, {

--- a/bundles/framework/publishedmyplaces2/ButtonHandler.js
+++ b/bundles/framework/publishedmyplaces2/ButtonHandler.js
@@ -17,6 +17,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.publishedmyplaces.ButtonHandler"
         me.ignoreEvents = false;
         me.dialog = null;
         me.conf = instance.conf || {};
+        this._log = Oskari.log(this.getName());
 
         me.buttons = {
             'point': {
@@ -117,7 +118,7 @@ Oskari.clazz.define("Oskari.mapframework.bundle.publishedmyplaces.ButtonHandler"
                     sandbox.request(me, reqBuilder(tool, me.buttonGroup, me.buttons[tool]));
                 }
             } else {
-                sandbox.printDebug("Missing toolbar.");
+                this._log.debug("Missing toolbar.");
             }
 
             if (!Oskari.user().isLoggedIn() && me.conf.allowGuest !== true) {

--- a/bundles/framework/publishedmyplaces2/instance.js
+++ b/bundles/framework/publishedmyplaces2/instance.js
@@ -17,6 +17,7 @@ function() {
     this.myPlacesService = undefined;
     this.featureNS = undefined;
     this.idPrefix = 'myplaces';
+    this._log = Oskari.log(this.getName());
 }, {
     __name : 'PublishedMyPlaces',
     /**
@@ -157,7 +158,7 @@ function() {
             return;
         }
 
-        sandbox.printDebug("Initializing my places module...");
+        this._log.debug("Initializing my places module...");
 
         // handles toolbar buttons related to my places
         this.buttons = Oskari.clazz.create("Oskari.mapframework.bundle.publishedmyplaces.ButtonHandler", this);

--- a/bundles/framework/publishedstatehandler/instance.js
+++ b/bundles/framework/publishedstatehandler/instance.js
@@ -21,6 +21,7 @@ Oskari.clazz.define(
         this._historyPrevious = [];
         this._historyNext = [];
         this._historyEnabled = true;
+        this._log = Oskari.log(this.getName());
 
         // TODO: default view from conf?
         this._defaultViewId = 1;
@@ -228,7 +229,7 @@ Oskari.clazz.define(
         registerPlugin: function (plugin) {
             plugin.setHandler(this);
             var pluginName = plugin.getName();
-            this.sandbox.printDebug('[' + this.getName() + ']' + ' Registering ' + pluginName);
+            this._log.debug('Registering ' + pluginName);
             this._pluginInstances[pluginName] = plugin;
         },
         /**
@@ -241,7 +242,7 @@ Oskari.clazz.define(
          */
         unregisterPlugin: function (plugin) {
             var pluginName = plugin.getName();
-            this.sandbox.printDebug('[' + this.getName() + ']' + ' Unregistering ' + pluginName);
+            this._log.debug('Unregistering ' + pluginName);
             this._pluginInstances[pluginName] = undefined;
             plugin.setHandler(null);
         },
@@ -255,7 +256,7 @@ Oskari.clazz.define(
         startPlugin: function (plugin) {
             var pluginName = plugin.getName();
 
-            this.sandbox.printDebug('[' + this.getName() + ']' + ' Starting ' + pluginName);
+            this._log.debug('Starting ' + pluginName);
             plugin.startPlugin(this.sandbox);
         },
         /**
@@ -268,7 +269,7 @@ Oskari.clazz.define(
         stopPlugin: function (plugin) {
             var pluginName = plugin.getName();
 
-            this.sandbox.printDebug('[' + this.getName() + ']' + ' Starting ' + pluginName);
+            this._log.debug('Starting ' + pluginName);
             plugin.stopPlugin(this.sandbox);
         },
 
@@ -338,10 +339,7 @@ Oskari.clazz.define(
                     prevLayer = prevLayers[ln];
                     nextLayer = nextLayers[ln];
 
-                    me.sandbox.printDebug(
-                        '[StateHandler] comparing layer state ' +
-                        prevLayer.id + ' vs ' + nextLayer.id
-                    );
+                    me._log.debug('comparing layer state ' + prevLayer.id + ' vs ' + nextLayer.id);
 
 
                     if (prevLayer.id !== nextLayer.id) {
@@ -374,13 +372,9 @@ Oskari.clazz.define(
                 cmp;
             for (sc = 0; sc < me._stateComparators.length; sc += 1) {
                 cmp = me._stateComparators[sc];
-                me.sandbox.printDebug(
-                    '[StateHandler] comparing state ' + cmp.rule
-                );
+                me._log.debug('comparing state ' + cmp.rule);
                 if (cmp.cmp.apply(this, [prevState, nextState])) {
-                    me.sandbox.printDebug(
-                        '[StateHandler] comparing state MATCH ' + cmp.rule
-                    );
+                    me._log.debug('comparing state MATCH ' + cmp.rule);
                     cmpResult.result = true;
                     cmpResult.rule = cmp.rule;
                     cmpResult.rulesMatched[cmp.rule] = cmp.rule;
@@ -415,7 +409,7 @@ Oskari.clazz.define(
                     prevState = history.length === 0 ? null : history[history.length - 1],
                     cmpResult = me._compareState(prevState, state, true);
                 if (cmpResult.result) {
-                    me.sandbox.printDebug('[StateHandler] PUSHING state');
+                    me._log.debug('PUSHING state');
                     state.rule = cmpResult.rule;
                     me._historyPrevious.push(state);
                     me._historyNext = [];
@@ -516,7 +510,7 @@ Oskari.clazz.define(
 
             // setting state
             if (state.selectedLayers && cmpResult.rulesMatched.layers) {
-                sandbox.printDebug('[StateHandler] restoring LAYER state');
+                this._log.debug('restoring LAYER state');
                 this._teardownState(mapmodule);
 
                 var rbAdd = sandbox.getRequestBuilder('AddMapLayerRequest'),
@@ -544,7 +538,7 @@ Oskari.clazz.define(
             }
 
             if (state.east) {
-                sandbox.printDebug('[StateHandler] restoring LOCATION state');
+                this._log.debug('restoring LOCATION state');
                 this.getSandbox().getMap().moveTo(
                     state.east,
                     state.north,

--- a/bundles/framework/statehandler/instance.js
+++ b/bundles/framework/statehandler/instance.js
@@ -20,6 +20,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.statehandler.StateHandlerBundleI
         this._historyPrevious = [];
         this._historyNext = [];
         this._historyEnabled = true;
+        this._log = Oskari.log(this.getName());
 
         // TODO: default view from conf?
         this._defaultViewId = 1;
@@ -226,7 +227,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.statehandler.StateHandlerBundleI
         registerPlugin: function (plugin) {
             plugin.setHandler(this);
             var pluginName = plugin.getName();
-            this.sandbox.printDebug('[' + this.getName() + ']' + ' Registering ' + pluginName);
+            this._log.debug('Registering ' + pluginName);
             this._pluginInstances[pluginName] = plugin;
         },
         /**
@@ -239,7 +240,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.statehandler.StateHandlerBundleI
          */
         unregisterPlugin: function (plugin) {
             var pluginName = plugin.getName();
-            this.sandbox.printDebug('[' + this.getName() + ']' + ' Unregistering ' + pluginName);
+            this._log.debug('Unregistering ' + pluginName);
             this._pluginInstances[pluginName] = undefined;
             plugin.setHandler(null);
         },
@@ -253,7 +254,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.statehandler.StateHandlerBundleI
         startPlugin: function (plugin) {
             var pluginName = plugin.getName();
 
-            this.sandbox.printDebug('[' + this.getName() + ']' + ' Starting ' + pluginName);
+            this._log.debug('Starting ' + pluginName);
             plugin.startPlugin(this.sandbox);
         },
         /**
@@ -266,7 +267,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.statehandler.StateHandlerBundleI
         stopPlugin: function (plugin) {
             var pluginName = plugin.getName();
 
-            this.sandbox.printDebug('[' + this.getName() + ']' + ' Starting ' + pluginName);
+            this._log.debug('Starting ' + pluginName);
             plugin.stopPlugin(this.sandbox);
         },
 
@@ -336,7 +337,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.statehandler.StateHandlerBundleI
                         prevLayer = prevLayers[ln];
                         nextLayer = nextLayers[ln];
 
-                        me.sandbox.printDebug('[StateHandler] comparing layer state ' + prevLayer.id + ' vs ' + nextLayer.id);
+                        me._log.debug('comparing layer state ' + prevLayer.id + ' vs ' + nextLayer.id);
 
 
                         if (prevLayer.id !== nextLayer.id) {
@@ -389,9 +390,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.statehandler.StateHandlerBundleI
                 cmp;
             for (sc = 0; sc < me._stateComparators.length; sc += 1) {
                 cmp = me._stateComparators[sc];
-                me.sandbox.printDebug('[StateHandler] comparing state ' + cmp.rule);
+                me._log.debug('comparing state ' + cmp.rule);
                 if (cmp.cmp.apply(this, [prevState, nextState])) {
-                    me.sandbox.printDebug('[StateHandler] comparing state MATCH ' + cmp.rule);
+                    me._log.debug('comparing state MATCH ' + cmp.rule);
                     cmpResult.result = true;
                     cmpResult.rule = cmp.rule;
                     cmpResult.rulesMatched[cmp.rule] = cmp.rule;
@@ -426,7 +427,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.statehandler.StateHandlerBundleI
                     prevState = history.length === 0 ? null : history[history.length - 1],
                     cmpResult = me._compareState(prevState, state, true);
                 if (cmpResult.result) {
-                    me.sandbox.printDebug('[StateHandler] PUSHING state');
+                    me._log.debug('PUSHING state');
                     state.rule = cmpResult.rule;
                     me._historyPrevious.push(state);
                     me._historyNext = [];

--- a/bundles/framework/statehandler/state-methods.js
+++ b/bundles/framework/statehandler/state-methods.js
@@ -18,6 +18,7 @@ Oskari.clazz.category('Oskari.mapframework.bundle.statehandler.StateHandlerBundl
             return [];
         }
         this.sandbox.useState(state);
+        this._log = Oskari.log('StateHandlerBundleInstance');
     },
 
     /**
@@ -41,7 +42,7 @@ Oskari.clazz.category('Oskari.mapframework.bundle.statehandler.StateHandlerBundl
 
         for (pluginName in me._pluginInstances) {
             if (me._pluginInstances.hasOwnProperty(pluginName)) {
-                me.sandbox.printDebug('[' + me.getName() + ']' + ' resetting state on ' + pluginName);
+                me._log.debug('resetting state on ' + pluginName);
                 me._pluginInstances[pluginName].resetState();
             }
         }
@@ -134,7 +135,7 @@ Oskari.clazz.category('Oskari.mapframework.bundle.statehandler.StateHandlerBundl
             }
             return;
         }
-        this.sandbox.printDebug('[' + this.getName() + ']' + ' saving state with ' + pluginName);
+        this._log.debug('saving state with ' + pluginName);
         this._pluginInstances[pluginName].saveState(view);
     },
     /**

--- a/bundles/framework/userguide/request/ShowUserGuideRequestHandler.js
+++ b/bundles/framework/userguide/request/ShowUserGuideRequestHandler.js
@@ -8,11 +8,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.userguide.request.ShowUserGuideR
 
 	/** @property instance */
 	this.instance = instance;
+	this._log = Oskari.log('ShowUserGuideRequestHandler');
 }, {
 
 	/** @method handleRequest dispatches processing to instance */
 	handleRequest : function(core, request) {
-		this.sandbox.printDebug("[Oskari.mapframework.bundle.userguide.request.ShowUserGuideRequestHandler] Show UserGuide: " + request.getUuid());
+		this._log.debug('Show UserGuide: ' + request.getUuid());
 		this.instance.scheduleShowUserGuide(request);
 	}
 }, {

--- a/bundles/integration/admin-layerselector/models/layerModel.js
+++ b/bundles/integration/admin-layerselector/models/layerModel.js
@@ -70,7 +70,7 @@
              */
             _setupFromCapabilitiesValues: function (capabilitiesNode) {
                 var sb = Oskari.getSandbox();
-                sb.printDebug("Found:", capabilitiesNode);
+                Oskari.log('admin-layerselector~layerModel').debug("Found:", capabilitiesNode);
                 var mapLayerService = sb.getService('Oskari.mapframework.service.MapLayerService'),
                     mapLayer = mapLayerService.createMapLayer(capabilitiesNode),
                     dataToKeep = null;

--- a/bundles/mapping/heatmap/instance.js
+++ b/bundles/mapping/heatmap/instance.js
@@ -8,7 +8,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.heatmap.HeatmapBundleInstance',
      * @method create called automatically on construction
      * @static
      */
-    function() {}, {
+    function() {
+        this._log = Oskari.log(this.getName());
+    }, {
         __idCounter : 1,
         /**
          * @static
@@ -122,7 +124,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.heatmap.HeatmapBundleInstance',
             layer.setColorSetup(values.colorSetup);
             layer.setSelectedTheme(values.selectedTheme);
             if(isNew) {
-                this.sandbox.printDebug('Register and setup heatmap with values', values, layer);
+                this._log.debug('Register and setup heatmap with values', values, layer);
                 var service = this.getLayerService();
                 // adding layer to service so it can be referenced with id
                 service.addLayer(layer);
@@ -131,7 +133,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.heatmap.HeatmapBundleInstance',
                 this.sandbox.request(this, rbAdd(layer.getId(), true));
             }
             else {
-                this.sandbox.printDebug('Update heatmap with values', values, layer);
+                this._log.debug('Update heatmap with values', values, layer);
                 // request update for the layer
                 var rbUpdate = this.sandbox.getRequestBuilder('MapModulePlugin.MapLayerUpdateRequest');
                 this.sandbox.request(this, rbUpdate(layer.getId(), true));

--- a/bundles/mapping/heatmap/plugin/HeatmapLayerPlugin.ol2.js
+++ b/bundles/mapping/heatmap/plugin/HeatmapLayerPlugin.ol2.js
@@ -5,6 +5,7 @@
 Oskari.clazz.define(
     'Oskari.mapframework.heatmap.HeatmapLayerPlugin',
     function () {
+        this._log = Oskari.log('HeatmapLayerPlugin');
     }, {
         /**
          * Adds a single WMS layer to this map
@@ -77,7 +78,7 @@ Oskari.clazz.define(
 
             this.getMap().addLayer(openLayer, !keepLayerOnTop);
             this.setOLMapLayers(layer.getId(), openLayer);
-            this.getSandbox().printDebug(
+            this._log.debug(
                 '#!#! CREATED OPENLAYER.LAYER.WMS for ' + layer.getId()
             );
         }

--- a/bundles/mapping/heatmap/plugin/HeatmapLayerPlugin.ol3.js
+++ b/bundles/mapping/heatmap/plugin/HeatmapLayerPlugin.ol3.js
@@ -8,6 +8,7 @@ import olSourceImageWMS from 'ol/source/ImageWMS';
 Oskari.clazz.define(
     'Oskari.mapframework.heatmap.HeatmapLayerPlugin',
     function () {
+        this._log = Oskari.log('HeatmapLayerPlugin');
     }, {
         /**
          * Adds a single WMS layer to this map
@@ -74,7 +75,7 @@ Oskari.clazz.define(
 
             this.getMapModule().addLayer(openlayer, !keepLayerOnTop);
             this.setOLMapLayers(layer.getId(), openlayer);
-            this.getSandbox().printDebug(
+            this._log.debug(
                 '#!#! CREATED OPENLAYER.LAYER.WMS for ' + layer.getId()
             );
         },

--- a/bundles/mapping/mapanalysis/plugin/AnalysisLayerPlugin.ol2.js
+++ b/bundles/mapping/mapanalysis/plugin/AnalysisLayerPlugin.ol2.js
@@ -15,6 +15,7 @@ Oskari.clazz.define(
         if (me._config && me._config.ajaxUrl) {
             me.ajaxUrl = me._config.ajaxUrl;
         }
+        this._log = Oskari.log(this.getName());
     }, {
         __name : 'AnalysisLayerPlugin',
         _clazz : 'Oskari.mapframework.bundle.mapanalysis.plugin.AnalysisLayerPlugin',
@@ -107,7 +108,7 @@ Oskari.clazz.define(
             // store reference to layers
             this.setOLMapLayers(layer.getId(), openLayer);
 
-            me.getSandbox().printDebug(
+            me._log.debug(
                 '#!#! CREATED OPENLAYER.LAYER.WMS for AnalysisLayer ' +
                 layer.getId()
             );

--- a/bundles/mapping/mapanalysis/plugin/AnalysisLayerPlugin.ol3.js
+++ b/bundles/mapping/mapanalysis/plugin/AnalysisLayerPlugin.ol3.js
@@ -18,6 +18,7 @@ Oskari.clazz.define(
         if (me._config && me._config.ajaxUrl) {
             me.ajaxUrl = me._config.ajaxUrl;
         }
+        this._log = Oskari.log(this.getName());
     }, {
         __name : 'AnalysisLayerPlugin',
         _clazz : 'Oskari.mapframework.bundle.mapanalysis.plugin.AnalysisLayerPlugin',
@@ -107,7 +108,7 @@ Oskari.clazz.define(
             // store reference to layers
             this.setOLMapLayers(layer.getId(), openlayer);
 
-            me.getSandbox().printDebug(
+            me._log.debug(
                 '#!#! CREATED OPENLAYER.LAYER.WMS for AnalysisLayer ' +
                 layer.getId()
             );

--- a/bundles/mapping/maparcgis/plugin/ArcGisLayerPlugin.ol2.js
+++ b/bundles/mapping/maparcgis/plugin/ArcGisLayerPlugin.ol2.js
@@ -17,6 +17,7 @@ Oskari.clazz.define('Oskari.arcgis.bundle.maparcgis.plugin.ArcGisLayerPlugin',
         me._name = 'ArcGisLayerPlugin';
 
         me._layer = {};
+        this._log = Oskari.log(this.getName());
     }, {
 
         /** @static @property _layerType type of layers this plugin handles */
@@ -100,7 +101,7 @@ Oskari.clazz.define('Oskari.arcgis.bundle.maparcgis.plugin.ArcGisLayerPlugin',
                 layerId = layer.getId();
 
                 if (layer.isLayerOfType(this._layerType) || layer.isLayerOfType(this._layerType2) ) {
-                    sandbox.printDebug('preselecting ' + layerId);
+                    this._log.debug('preselecting ' + layerId);
                     this.addMapLayerToMap(layer, true, layer.isBaseLayer());
                 }
             }
@@ -170,7 +171,7 @@ Oskari.clazz.define('Oskari.arcgis.bundle.maparcgis.plugin.ArcGisLayerPlugin',
 
             });
 
-            me.getSandbox().printDebug(
+            me._log.debug(
                 '#!#! CREATED OPENLAYER.LAYER.ArcGis for ArcGisLayer ' +
                 layer.getId()
             );
@@ -212,7 +213,7 @@ Oskari.clazz.define('Oskari.arcgis.bundle.maparcgis.plugin.ArcGisLayerPlugin',
             // Set queryable
             layer.setQueryable(true);
 
-            me.getSandbox().printDebug(
+            me._log.debug(
                 '#!#! CREATED OPENLAYER.LAYER.ArcGis93Rest for ArcGisLayer ' +
                 layer.getId()
             );
@@ -301,7 +302,7 @@ Oskari.clazz.define('Oskari.arcgis.bundle.maparcgis.plugin.ArcGisLayerPlugin',
                 return;
             }
 
-            this.getSandbox().printDebug(
+            this._log.debug(
                 'Setting Layer Opacity for ' + layer.getId() + ' to ' +
                 layer.getOpacity()
             );

--- a/bundles/mapping/maparcgis/plugin/ArcGisLayerPlugin.ol3.js
+++ b/bundles/mapping/maparcgis/plugin/ArcGisLayerPlugin.ol3.js
@@ -14,6 +14,7 @@ Oskari.clazz.define('Oskari.arcgis.bundle.maparcgis.plugin.ArcGisLayerPlugin',
      */
 
     function () {
+        this._log = Oskari.log(this.getName());
     }, {
         __name : 'ArcGisLayerPlugin',
         _clazz : 'Oskari.arcgis.bundle.maparcgis.plugin.ArcGisLayerPlugin',
@@ -128,7 +129,7 @@ Oskari.clazz.define('Oskari.arcgis.bundle.maparcgis.plugin.ArcGisLayerPlugin',
             // store reference to layers
             this.setOLMapLayers(layer.getId(), openlayer);
 
-            me.getSandbox().printDebug(
+            me._log.debug(
                 '#!#! CREATED ' + layerType + ' for ArcGisLayer ' +
                 layer.getId()
             );

--- a/bundles/mapping/mapmodule/AbstractMapLayerPlugin.js
+++ b/bundles/mapping/mapmodule/AbstractMapLayerPlugin.js
@@ -16,6 +16,7 @@ Oskari.clazz.define(
 
         this.tileSize = [256, 256];
         this._layerImplRefs = {};
+        this._log = Oskari.log(this.getName());
     }, {
         /** @static @property __name plugin name */
         __name: 'OVERRIDETHIS',
@@ -245,7 +246,7 @@ Oskari.clazz.define(
          * @param {Boolean} isBaseMap
          */
         addMapLayerToMap: function (layer, keepLayerOnTop, isBaseMap) {
-            this.getSandbox().printDebug('TODO: addMapLayerToMap() not implemented on ' + this.getName());
+            this._log.debug('TODO: addMapLayerToMap() not implemented on ' + this.getName());
         },
 
         /**
@@ -260,7 +261,7 @@ Oskari.clazz.define(
                 return;
             }
 
-            this.getSandbox().printDebug('Removing Layer from map ' + layer.getId());
+            this._log.debug('Removing Layer from map ' + layer.getId());
             for (var i = 0; i < olLayers.length; ++i) {
                 var loopLayer = olLayers[i];
                 this.getMapModule().removeLayer(loopLayer, layer);
@@ -284,7 +285,7 @@ Oskari.clazz.define(
                 return;
             }
 
-            this.getSandbox().printDebug(
+            this._log.debug(
                 'Setting Layer Opacity for ' + layer.getId() + ' to ' +
                 layer.getOpacity()
             );
@@ -299,7 +300,7 @@ Oskari.clazz.define(
          *            event
          */
         _afterChangeMapLayerStyleEvent: function (event) {
-            this.getSandbox().printDebug('TODO: handle layer style chance');
+            this._log.debug('TODO: handle layer style chance');
         },
         /**
          * Update the layer on map if style etc was changed when administrating layers
@@ -307,7 +308,7 @@ Oskari.clazz.define(
          * @param  {Oskari.mapframework.domain.AbstractLayer} layer [description]
          */
         _updateLayer: function (layer) {
-            this.getSandbox().printDebug('TODO: update layer on map');
+            this._log.debug('TODO: update layer on map');
         },
         /**
          * @method updateLayerParams

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol2.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol2.js
@@ -16,6 +16,7 @@ Oskari.clazz.define(
             multipleSymbolizers: false,
             namedLayersAsArray: true
         });
+        this._log = Oskari.log(this.getName());
 
         this._olLayers = {};
         this._features = {};
@@ -160,7 +161,7 @@ Oskari.clazz.define(
                     continue;
                 }
 
-                sandbox.printDebug('preselecting ' + layerId);
+                this._log.debug('preselecting ' + layerId);
                 this.addMapLayerToMap(layer, true, layer.isBaseLayer());
             }
         },
@@ -654,7 +655,7 @@ Oskari.clazz.define(
                 me = this;
 
             if (sldSpec) {
-                this.getSandbox().printDebug(sldSpec);
+                this._log.debug(sldSpec);
                 var styleInfo = this._sldFormat.read(sldSpec),
                     styles = styleInfo.namedLayers[0].userStyles,
                     style = styles[0];
@@ -667,7 +668,7 @@ Oskari.clazz.define(
                 return;
             }
 
-            this.getSandbox().printDebug(
+            this._log.debug(
                 '#!#! CREATED VECTOR / OPENLAYER.LAYER.VECTOR for ' +
                 layer.getId()
             );
@@ -707,7 +708,7 @@ Oskari.clazz.define(
                 return;
             }
 
-            this.getSandbox().printDebug(
+            this._log.debug(
                 'Setting Layer Opacity for ' + layer.getId() + ' to ' +
                 layer.getOpacity()
             );

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol3.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol3.js
@@ -55,6 +55,7 @@ Oskari.clazz.define(
         this._nextFeatureId = 0;
         this._hoverOverlay = undefined;
         this._hoverFeature = undefined;
+        this._log = Oskari.log('VectorLayerPlugin');
     }, {
         /**
          * @method register
@@ -164,7 +165,7 @@ Oskari.clazz.define(
                 return;
             }
 
-            this.getSandbox().printDebug(
+            this._log.debug(
                 'Setting Layer Opacity for ' + layer.getId() + ' to ' +
                 layer.getOpacity()
             );

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/request/AddFeaturesToMapRequestHandler.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/request/AddFeaturesToMapRequestHandler.js
@@ -12,7 +12,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.AddFeaturesToM
      */
 	function (sandbox, vectorLayerPlugin) {
 	    this.sandbox = sandbox;
-	    this.vectorLayerPlugin = vectorLayerPlugin;
+        this.vectorLayerPlugin = vectorLayerPlugin;
+        this._log = Oskari.log('AddFeaturesToMapRequestHandler');
 	}, {
 		/**
          * @method handleRequest
@@ -21,7 +22,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.AddFeaturesToM
          * @param {Oskari.mapframework.bundle.mapmodule.request.AddFeaturesToMapRequest} request request to handle
          */
 	    handleRequest: function (core, request) {
-	        this.sandbox.printDebug('[Oskari.mapframework.bundle.mapmodule.request.AddFeaturesToMapRequestHandler] Add Features');
+	        this._log.debug('Add Features');
 			this.vectorLayerPlugin.addFeaturesToMap(request.getGeometry(), request.getOptions());
 	    }
 	}, {

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/request/RemoveFeaturesFromMapRequestHandler.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/request/RemoveFeaturesFromMapRequestHandler.js
@@ -12,7 +12,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.RemoveFeatures
      */
 	function (sandbox, vectorLayerPlugin) {
 	    this.sandbox = sandbox;
-	    this.vectorLayerPlugin = vectorLayerPlugin;
+        this.vectorLayerPlugin = vectorLayerPlugin;
+        this._log = Oskari.log('RemoveFeaturesFromMapRequestHandler');
 	}, {
 		/**
          * @method handleRequest
@@ -21,7 +22,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.RemoveFeatures
          * @param {Oskari.mapframework.bundle.mapmodule.request.RemoveFeaturesFromMapRequest} request request to handle
          */
 	    handleRequest: function (core, request) {
-	        this.sandbox.printDebug('[Oskari.mapframework.bundle.mapmodule.request.RemoveFeaturesFromMapRequestHandler] Remove Features');
+	        this._log.debug('Remove Features');
 	        this.vectorLayerPlugin.removeFeaturesFromMap(request.getIdentifier(), request.getValue(), request.getLayer());
 	    }
 	}, {

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/request/ZoomToFeaturesRequestHandler.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/request/ZoomToFeaturesRequestHandler.js
@@ -12,7 +12,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.ZoomToFeatures
      */
 	function (sandbox, vectorLayerPlugin) {
 	    this.sandbox = sandbox;
-	    this.vectorLayerPlugin = vectorLayerPlugin;
+        this.vectorLayerPlugin = vectorLayerPlugin;
+        this._log = Oskari.log('ZoomToFeaturesRequestHandler');
 	}, {
 		/**
          * @method handleRequest
@@ -21,7 +22,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.ZoomToFeatures
          * @param {Oskari.mapframework.bundle.mapmodule.request.ZoomToFeaturesRequest} request request to handle
          */
 	    handleRequest: function (core, request) {
-	        this.sandbox.printDebug('[Oskari.mapframework.bundle.mapmodule.request.ZoomToFeaturesRequestHandler] Zoom to Features');
+	        this._log.debug('Zoom to Features');
 			this.vectorLayerPlugin.zoomToFeatures(request.getLayer(), request.getOptions());
 	    }
 	}, {

--- a/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol2.js
+++ b/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol2.js
@@ -9,6 +9,7 @@ Oskari.clazz.define(
      * @static @method create called automatically on construction
      */
     function () {
+        this._log = Oskari.log(this.getName());
     },
     {
         __name : 'WmsLayerPlugin',
@@ -121,7 +122,7 @@ Oskari.clazz.define(
                 // gather references to layers
                 olLayers.push(openLayer);
 
-                sandbox.printDebug('#!#! CREATED OPENLAYER.LAYER.WMS for ' + oskariLayer.getId());
+                me._log.debug('#!#! CREATED OPENLAYER.LAYER.WMS for ' + oskariLayer.getId());
 
 
             });
@@ -224,7 +225,7 @@ Oskari.clazz.define(
                         olLayerList[i].mergeNewParams(params);
                     }
                 }
-                sandbox.printDebug("[MapLayerUpdateRequestHandler] WMS layer / merge new params: " + layer.getId() + ", found " + count);
+                this._log.debug("WMS layer / merge new params: " + layer.getId() + ", found " + count);
             }
         }
     },

--- a/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol3.js
+++ b/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol3.js
@@ -17,6 +17,7 @@ Oskari.clazz.define(
      * @static @method create called automatically on construction
      */
     function () {
+        this._log = Oskari.log(this.getName());
     },
     {
         __name : 'WmsLayerPlugin',
@@ -135,7 +136,7 @@ Oskari.clazz.define(
                 // gather references to layers
                 olLayers.push(layerImpl);
 
-                this.getSandbox().printDebug("#!#! CREATED ol/layer/TileLayer for " + _layer.getId());
+                this._log.debug("#!#! CREATED ol/layer/TileLayer for " + _layer.getId());
             }
             // store reference to layers
             this.setOLMapLayers(layer.getId(), olLayers);

--- a/bundles/mapping/mapmodule/request/AddMarkerRequestHandler.js
+++ b/bundles/mapping/mapmodule/request/AddMarkerRequestHandler.js
@@ -1,9 +1,10 @@
 Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.AddMarkerRequestHandler', function (sandbox, markersPlugin) {
     this.sandbox = sandbox;
     this.markersPlugin = markersPlugin;
+    this._log = Oskari.log('AddMarkerRequestHandler');
 }, {
     handleRequest: function (core, request) {
-        this.sandbox.printDebug('[Oskari.mapframework.bundle.mapmodule.request.AddMarkerRequestHandler] Add Marker');
+        this._log.debug('Add Marker');
 
         // Check debricated data
         var data = request.getData();

--- a/bundles/mapping/mapmodule/request/GetUserLocationRequestHandler.js
+++ b/bundles/mapping/mapmodule/request/GetUserLocationRequestHandler.js
@@ -5,9 +5,10 @@
 Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.GetUserLocationRequestHandler', function (sandbox, mapmodule) {
     this.sandbox = sandbox;
     this.mapmodule = mapmodule;
+    this._log = Oskari.log('GetUserLocationRequestHandler');
 }, {
     handleRequest: function (core, request) {
-        this.sandbox.printDebug('[Oskari.mapframework.bundle.mapmodule.request.GetUserLocationRequestHandler] Get user location');
+        this._log.debug('Get user location');
         var mapmodule = this.mapmodule;
         var cb = undefined;
         // if request.getCenterMap() is truthy: also move map

--- a/bundles/mapping/mapmodule/request/MarkerVisibilityRequestHandler.js
+++ b/bundles/mapping/mapmodule/request/MarkerVisibilityRequestHandler.js
@@ -1,9 +1,10 @@
 Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.MarkerVisibilityRequestHandler', function (sandbox, markersPlugin) {
     this.sandbox = sandbox;
     this.markersPlugin = markersPlugin;
+    this._log = Oskari.log('MarkerVisibilityRequestHandler');
 }, {
     handleRequest: function (core, request) {
-        this.sandbox.printDebug('[Oskari.mapframework.bundle.mapmodule.request.MarkerVisibilityRequestHandler] Change Marker Visibility');
+        this._log.debug('Change Marker Visibility');
 
         this.markersPlugin.changeMapMarkerVisibility(request.isVisible(),request.getID());
     }

--- a/bundles/mapping/mapmodule/request/RegisterStyleRequestHandler.js
+++ b/bundles/mapping/mapmodule/request/RegisterStyleRequestHandler.js
@@ -1,9 +1,10 @@
 Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.RegisterStyleRequestHandler', function (sandbox, mapmodule) {
     this.sandbox = sandbox;
     this.mapModule = mapmodule;
+    this._log = Oskari.log('RegisterStyleRequestHandler');
 }, {
     handleRequest: function (core, request) {
-        this.sandbox.printDebug('[Oskari.mapframework.bundle.mapmodule.request.RegisterStyleRequestHandler] Register style "'+ request.getKey() +'" for styles: ', request.getStyles());
+        this._log.debug('Register style "'+ request.getKey() +'" for styles: ', request.getStyles());
 
         if(request.getKey() && request.getStyles()) {
             this.mapModule.registerWellknownStyle(request.getKey(), request.getStyles());

--- a/bundles/mapping/mapmodule/request/RemoveMarkersRequestHandler.js
+++ b/bundles/mapping/mapmodule/request/RemoveMarkersRequestHandler.js
@@ -1,9 +1,10 @@
 Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.RemoveMarkersRequestHandler', function (sandbox, markersPlugin) {
     this.sandbox = sandbox;
     this.markersPlugin = markersPlugin;
+    this._log = Oskari.log('RemoveMarkersRequestHandler');
 }, {
     handleRequest: function (core, request) {
-        this.sandbox.printDebug("[Oskari.mapframework.bundle.mapmodule.request.RemoveMarkersRequestHandler] Remove markers");
+        this._log.debug('Remove markers');
         this.markersPlugin.removeMarkers(false, request.getId());
     }
 }, {

--- a/bundles/mapping/mapmodule/request/ShowProgressSpinnerRequestHandler.js
+++ b/bundles/mapping/mapmodule/request/ShowProgressSpinnerRequestHandler.js
@@ -1,9 +1,10 @@
 Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.ShowProgressSpinnerRequestHandler', function (sandbox) {
     this.sandbox = sandbox;
     this.mapModule = this.sandbox.findRegisteredModuleInstance('MainMapModule');
+    this._log = Oskari.log('ShowProgressSpinnerRequestHandler');
 }, {
     handleRequest: function (core, request) {
-        this.sandbox.printDebug('[Oskari.mapframework.bundle.mapmodule.request.ShowProgressSpinnerRequestHandler] Show progress spinner');
+        this._log.debug('Show progress spinner');
         if (!this.mapModule._progressSpinner) {
             this.mapModule._progressSpinner = Oskari.clazz.create(
                 'Oskari.userinterface.component.ProgressSpinner'

--- a/bundles/mapping/mapuserlayers/plugin/UserLayersLayerPlugin.ol2.js
+++ b/bundles/mapping/mapuserlayers/plugin/UserLayersLayerPlugin.ol2.js
@@ -10,6 +10,7 @@ Oskari.clazz.define(
      *
      */
     function () {
+        this._log = Oskari.log(this.getName());
     }, {
         __name : 'UserLayersLayerPlugin',
         _clazz : 'Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin',
@@ -82,7 +83,7 @@ Oskari.clazz.define(
             // store reference to layers
             this.setOLMapLayers(layer.getId(), openLayer);
 
-            this.getSandbox().printDebug(
+            this._log.debug(
                 '#!#! CREATED OPENLAYER.LAYER.WMS for UserLayer ' +
                 layer.getId()
             );

--- a/bundles/mapping/mapuserlayers/plugin/UserLayersLayerPlugin.ol3.js
+++ b/bundles/mapping/mapuserlayers/plugin/UserLayersLayerPlugin.ol3.js
@@ -13,6 +13,7 @@ Oskari.clazz.define(
      *
      */
     function () {
+        this._log = Oskari.log(this.getName());
     }, {
         __name : 'UserLayersLayerPlugin',
         _clazz : 'Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin',
@@ -94,7 +95,7 @@ Oskari.clazz.define(
             // store reference to layers
             this.setOLMapLayers(layer.getId(), openlayer);
 
-            me.getSandbox().printDebug(
+            me._log.debug(
                 '#!#! CREATED OPENLAYER.LAYER.WMS for UserLayer ' +
                 layer.getId()
             );

--- a/bundles/mapping/mapwfs2/plugin/WfsLayerPlugin.ol2.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsLayerPlugin.ol2.js
@@ -51,6 +51,7 @@ Oskari.clazz.define(
                 count: 0
             }
         };
+        this._log = Oskari.log(this.getName());
 
         me.activeHighlightLayers = [];
     }, {
@@ -363,7 +364,7 @@ Oskari.clazz.define(
                  */
                 AfterMapMoveEvent: function (event) {
                     if (me.getConfig() && me.getConfig().deferSetLocation) {
-                        me.getSandbox().printDebug(
+                        me._log.debug(
                             'setLocation deferred (to aftermapmove)'
                         );
                         return;
@@ -850,7 +851,7 @@ Oskari.clazz.define(
             );
 
             if (layer.isVisible() && this.getConfig() && this.getConfig().deferSetLocation) {
-                this.getSandbox().printDebug(
+                this._log.debug(
                     'sending deferred setLocation'
                 );
                 this.mapMoveHandler(layer.getId());
@@ -1091,8 +1092,8 @@ Oskari.clazz.define(
                 layers,
                 function (layer) {
                     if (layer.hasFeatureData()) {
-                        this.getSandbox().printDebug(
-                            '[WfsLayerPlugin] preselecting ' + layer.getId()
+                        this._log.debug(
+                            'preselecting ' + layer.getId()
                         );
                     }
                 }

--- a/bundles/mapping/mapwfs2/plugin/WfsLayerPlugin.ol3.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsLayerPlugin.ol3.js
@@ -62,6 +62,7 @@ Oskari.clazz.define(
 
         me.__layersByName = {};
 
+        me._log = Oskari.log(me.getName());
     }, {
         __layerPrefix: 'wfs_layer_',
         __typeHighlight: 'highlight',
@@ -354,7 +355,7 @@ Oskari.clazz.define(
                  */
                 AfterMapMoveEvent: function () {
                     if (me.getConfig() && me.getConfig().deferSetLocation) {
-                        me.getSandbox().printDebug(
+                        me._log.debug(
                             'setLocation deferred (to aftermapmove)'
                         );
                         return;
@@ -817,7 +818,7 @@ Oskari.clazz.define(
                 );
 
                 if (event.getMapLayer().isVisible() && this.getConfig() && this.getConfig().deferSetLocation) {
-                    this.getSandbox().printDebug(
+                    this._log.debug(
                         'sending deferred setLocation'
                     );
                     this.mapMoveHandler(event.getMapLayer().getId());
@@ -1019,8 +1020,8 @@ Oskari.clazz.define(
                 layers,
                 function (layer) {
                     if (layer.hasFeatureData()) {
-                        this.getSandbox().printDebug(
-                            '[WfsLayerPlugin] preselecting ' + layer.getId()
+                        this._log.debug(
+                            'preselecting ' + layer.getId()
                         );
                     }
                 }

--- a/bundles/mapping/mapwfs2/service/Mediator.js
+++ b/bundles/mapping/mapwfs2/service/Mediator.js
@@ -39,7 +39,7 @@ Oskari.clazz.define(
         'Oskari.mapframework.bundle.mapwfs2.service.StatusHandler', plugin.getSandbox());
 
         this.WFSLayerService = plugin.getSandbox().getService('Oskari.mapframework.bundle.mapwfs2.service.WFSLayerService');
-
+        this._log = Oskari.log('Oskari.mapframework.bundle.mapwfs2.service.Mediator');
     }, {
 
         /**
@@ -523,7 +523,7 @@ Oskari.clazz.category('Oskari.mapframework.bundle.mapwfs2.service.Mediator', 'ge
                 imageUrl = this.rootURL + data.data.url + '&session=' + this.session.session;
             }
         } catch (error) {
-            this.plugin.getSandbox().printDebug(error);
+            this._log.debug(error);
         }
         var layerType = data.data.type.toLowerCase(), // "highlight" | "normal"
             boundaryTile = data.data.boundaryTile,

--- a/bundles/mapping/mapwmts/plugin/WmtsLayerPlugin.ol2.js
+++ b/bundles/mapping/mapwmts/plugin/WmtsLayerPlugin.ol2.js
@@ -9,6 +9,7 @@ Oskari.clazz.define('Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin',
         me._clazz = 'Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin';
         me._name = 'WmtsLayerPlugin';
         me._supportedFormats = {};
+        me._log = Oskari.log(me.getName());
     }, {
 
         register: function () {
@@ -125,7 +126,7 @@ Oskari.clazz.define('Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin',
                 layer = layers[i];
 
                 if (layer.isLayerOfType('WMTS')) {
-                    sandbox.printDebug('preselecting ' + layer.getId());
+                    this._log.debug('preselecting ' + layer.getId());
                     this.addMapLayerToMap(layer, true, layer.isBaseLayer());
                 }
             }
@@ -142,7 +143,7 @@ Oskari.clazz.define('Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin',
             map.addLayer(wmtsHolderLayer);
             index = map.layers.length;
                 this.service.getCapabilitiesForLayer(layer, function(wmtsLayer) {
-                    me.getSandbox().printDebug("[WmtsLayerPlugin] created WMTS layer " + wmtsLayer);
+                    me._log.debug('created WMTS layer ' + wmtsLayer);
                     // Get the reserved current index for wmts layer
                     var holderLayerIndex = map.getLayerIndex(wmtsHolderLayer);
                     map.removeLayer(wmtsHolderLayer);

--- a/bundles/mapping/mapwmts/plugin/WmtsLayerPlugin.ol3.js
+++ b/bundles/mapping/mapwmts/plugin/WmtsLayerPlugin.ol3.js
@@ -7,6 +7,7 @@ import olLayerVector from 'ol/layer/Vector';
  */
 Oskari.clazz.define('Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin',
     function () {
+        this._log = Oskari.log(this.getName());
     }, {
         __name : 'WmtsLayerPlugin',
         _clazz : 'Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin',
@@ -54,7 +55,7 @@ Oskari.clazz.define('Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin',
             map.addLayer(wmtsHolderLayer);
             this.setOLMapLayers(layer.getId(), wmtsHolderLayer);
             this.service.getCapabilitiesForLayer(layer, function(wmtsLayer) {
-                me.getSandbox().printDebug("[WmtsLayerPlugin] created WMTS layer " + wmtsLayer);
+                me._log.debug("created WMTS layer " + wmtsLayer);
                 me._registerLayerEvents(wmtsLayer, layer);
 
                 // Get the reserved current index for wmts layer


### PR DESCRIPTION
printDebug -> Oskari.log(...).debug

Removed Function.bind polyfill as it is supported natively in targeted browsers.

Did not update code in namespaces (unsupported bundles):
bundles/harava/
bundles/liikennevirasto/
bundles/lupapiste/