### PR TITLE
Printout scale array fix

### DIFF
--- a/bundles/framework/printout/view/BasicPrintout.js
+++ b/bundles/framework/printout/view/BasicPrintout.js
@@ -55,7 +55,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
             usedefinedscale: {
                 label: me.loc.scale.definedScale,
                 selected: false,
-                scales: me.instance.conf.scales || me.mapmodule.getScaleArray().reverse()
+                scales: me.instance.conf.scales || me.mapmodule.getScaleArray().slice().reverse()
             }
         };
 


### PR DESCRIPTION
Slice scale array into new array before reversing. Fixes the issue that scale limited maplayers didn't work after printout (map's scale array were reversed in printout if configuration didn't define scales).