### PR TITLE
Sprite script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1514,6 +1514,18 @@
         "es-abstract": "^1.7.0"
       }
     },
+    "array-parallel": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz",
+      "integrity": "sha1-j3hTCJJu1apHjEfmTRszS2wMlH0=",
+      "dev": true
+    },
+    "array-series": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/array-series/-/array-series-0.1.5.tgz",
+      "integrity": "sha1-3103v8XC7wdV4qpPkv6ufUtaly8=",
+      "dev": true
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -3875,6 +3887,19 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs-extra": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+      "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -4592,6 +4617,45 @@
           "version": "4.17.10",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
           "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "gm": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/gm/-/gm-1.23.1.tgz",
+      "integrity": "sha1-Lt7rlYCE0PjqeYjl2ZWxx9/BR3c=",
+      "dev": true,
+      "requires": {
+        "array-parallel": "~0.1.3",
+        "array-series": "~0.1.5",
+        "cross-spawn": "^4.0.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         }
       }
     },
@@ -5434,6 +5498,15 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -5479,6 +5552,15 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
         "is-buffer": "^1.1.5"
+      }
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
       }
     },
     "lcid": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "webpack --mode production",
     "start": "webpack-dev-server --hot",
     "paikkis": "webpack-dev-server --hot --env.appdef=applications/paikkatietoikkuna.fi",
-    "asdi": "webpack-dev-server --hot --env.appdef=applications/asdi"
+    "asdi": "webpack-dev-server --hot --env.appdef=applications/asdi",
+    "sprite": "node webpack/sprite.js"
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,10 @@
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
-    "merge": "^1.2.0"
+    "merge": "^1.2.0",
+    "fs-extra": "^0.26.7",
+    "lodash": "^4.12.0",
+    "gm": "^1.21.1"
   },
   "private": true
 }

--- a/webpack/sprite.js
+++ b/webpack/sprite.js
@@ -93,8 +93,8 @@ function getIconArrays (files) {
 
 function getConfig (opts) {
     var defaultOptions = {
-        baseIconsDir: './resources/icons',
-        targetDir: './resources',
+        baseIconsDir: path.resolve(__dirname, '../resources/icons'),
+        targetDir: path.resolve(__dirname, '../resources'),
         result: {
             css: 'icons.css',
             img: 'icons.png'

--- a/webpack/sprite.js
+++ b/webpack/sprite.js
@@ -1,0 +1,304 @@
+var fs = require('fs-extra');
+var path = require('path');
+var _ = require('lodash');
+var gm = require('gm');
+var async = require('async');
+// constants
+var HOVERPOSTFIX = '_hover';
+var COMBINEDPOSTFIX = '_combined';
+
+function failWarn (msg) {
+    console.error(msg);
+    process.exit(1);
+}
+
+function validateIconDirectories (cfg) {
+    var stats;
+    var appOverrideDirStats;
+    try {
+        stats = fs.statSync(cfg.baseIconsDir);
+    } catch (e) {
+        failWarn('Default icons directory (' + cfg.baseIconsDir + ') was NOT found. Please provide a proper baseIconsDir!');
+        return;
+    }
+    if (stats && !stats.isDirectory()) {
+        failWarn('Default icons directory (' + cfg.baseIconsDir + ') is NOT a directory. Please provide a proper baseIconsDir!');
+    }
+    // check application overrides
+    if (!cfg.appIconsDir) {
+        // no override
+        return;
+    }
+    try {
+        appOverrideDirStats = fs.statSync(cfg.appIconsDir);
+    } catch (e) {
+        // doesn't exist -> act as not given 
+        console.warn('Application icons override directory (' + cfg.appIconsDir + ') was NOT found. Please provide a proper appIconsDir!');
+        delete cfg.appIconsDir;
+        return;
+    }
+    if (!appOverrideDirStats) {
+        // no app overrides
+        return;
+    }
+    if (appOverrideDirStats && !appOverrideDirStats.isDirectory()) {
+        failWarn('Application icons override directory (' + cfg.appIconsDir + ') is NOT a directory. Please provide a proper appIconsDir!');
+    }
+}
+
+function copyPngIcons (src, dest) {
+    try {
+        fs.copySync(src, dest, {
+            // overwrite any existing file
+            clobber: true,
+            // dereference symlinks
+            dereference: true,
+            // only include png files
+            filter: function (file) {
+                return file.endsWith('.png');
+            }
+        });
+    } catch (e) {
+        console.log('Error copying icon files from ' + src);
+    }
+}
+
+function getIconArrays (files) {
+    var hoverIcons = [];
+    var icons = [];
+    var current;
+    var next;
+
+    for (var i = 0, j = 1, ilen = files.length; i < ilen; i++, j++) {
+        current = files[i];
+        next = files[j];
+        if (next && (next.indexOf(HOVERPOSTFIX) > 0)) {
+            // separate images with _hover images to separate array
+            hoverIcons.push(next);
+            // remove path so that only the filename remains
+            next = next.substring(next.lastIndexOf('/') + 1);
+            // add the future generated combined icon
+            icons.push(next.replace(HOVERPOSTFIX, COMBINEDPOSTFIX));
+        } else if (current.indexOf(HOVERPOSTFIX) > 0) {
+            // skip _hover images as these have already been handled
+        } else {
+            icons.push(current);
+        }
+    }
+    return {
+        icons: icons,
+        hover: hoverIcons
+    };
+}
+
+function getConfig (opts) {
+    var defaultOptions = {
+        baseIconsDir: './resources/icons',
+        targetDir: './resources',
+        result: {
+            css: 'icons.css',
+            img: 'icons.png'
+        }
+    };
+
+    var options = _.cloneDeep(defaultOptions);
+    _.assignIn(options, opts);
+    // force temp dir
+    options.tmpDir = 'tmp_sprite_dir_remove_it_' + Math.random().toString(36).substring(7);
+    var relative = path.relative(path.dirname(options.result.css), path.dirname(options.result.img));
+    if (relative.length) {
+        // force / separator instead of os specific
+        relative = relative.split(path.sep).join('/');
+        // add final / since we will append the filename
+        relative = relative + '/';
+    }
+    options.result.pathToSprite = relative + path.basename(options.result.img);
+    return options;
+}
+
+function runSprite (opts) {
+    var starttime = (new Date()).getTime();
+    var cfg = getConfig(opts);
+
+    // Run some sync stuff.
+    console.log('Generating CSS Sprite...');
+
+    // remove sprite if exists and then create temporary directory where generated sprite stuff goes
+    validateIconDirectories(cfg);
+    fs.mkdirSync(cfg.tmpDir, '755');
+    try {
+        // default icons
+        copyPngIcons(cfg.baseIconsDir, cfg.tmpDir);
+        // application overrides if configured
+        if (cfg.appIconsDir) {
+            copyPngIcons(cfg.appIconsDir, cfg.tmpDir);
+        }
+    } catch (e) {
+        cleanUp(cfg.tmpDir);
+        failWarn('Couldn\'t copy icons to temp dir "Oskari/tools/' + cfg.tmpDir + '"!');
+    }
+    // read all the icons that we have for the sprite, the are now in the tmpDir
+    var files = fs.readdirSync(cfg.tmpDir);
+    // icons include any non-hover icons and generated hover-combined filenames
+    var filtered = getIconArrays(files);
+    /*
+    { icons : icons,
+        hover : hoverIcons }
+    */
+    // create an image with normal + hover icon as "combined icon" for any icon having hover support
+    createHoverCombinedIcons(cfg.tmpDir, filtered.hover, function () {
+        // attach image sizes for any icons that will be included in sprite (non-hover and combined)
+        detectImageSizes(cfg.tmpDir, filtered.icons, function (icons) {
+            // write the actual sprite and css
+            writeSpriteImage(cfg, icons, function () {
+                // remove tmp dir
+                cleanUp(cfg.tmpDir);
+            });
+        });
+    });
+
+    function createHoverCombinedIcons (tmpDirectory, files, next) {
+        var outputDirectory = tmpDirectory + '/';
+        async.map(files, function (current, callback) {
+            var icon = current.substring(current.lastIndexOf('/') + 1);
+            var original = outputDirectory + current.replace(HOVERPOSTFIX, '');
+            var combined = outputDirectory + icon.replace(HOVERPOSTFIX, COMBINEDPOSTFIX);
+
+            // appends another.jpg to img.png from top-to-bottom
+            gm(original).append(outputDirectory + current, false).write(combined, callback);
+        }, function (err, results) {
+            if (!err && results) {
+                next();
+            } else {
+                console.log("createHoverCombinedIcons didn't work. Error", err);
+            }
+        });
+    }
+
+    function detectImageSizes (tmpDirectory, icons, next) {
+        async.map(icons, function (icon, callback) {
+            // get sizes for all icons
+            gm(tmpDirectory + '/' + icon).size(callback);
+        }, function (err, results) {
+            // results are objects with sizes of images
+            if (!err) {
+                for (var i = 0, ilen = results.length; i < ilen; i++) {
+                    results[i].file = icons[i];
+                }
+                next(results);
+            } else {
+                console.log("detectImageSizes didn't work.");
+                next();
+            }
+        });
+    }
+
+    function writeSpriteImage (config, iconImages, next) {
+        var tmpDirectory = config.tmpDir;
+        var spritePath = path.normalize([config.targetDir, config.result.img].join('/'));
+        var cssFile = path.normalize([config.targetDir, config.result.css].join('/'));
+        var relativeUrlToSprite = config.result.pathToSprite;
+        if (!iconImages) {
+            next();
+            return;
+        }
+        var sprite = null;
+        var offsetX = 0;
+
+        for (var i = 0, ilen = iconImages.length; i < ilen; i++) {
+            var currentIcon = tmpDirectory + '/' + iconImages[i].file;
+
+            // calculate offset for sprite
+            iconImages[i].offsetX = offsetX;
+            // Note negative on purpose
+            offsetX -= iconImages[i].width;
+            if (currentIcon.indexOf(COMBINEDPOSTFIX) > -1) {
+                // the icon has a hover state
+                // Note negative on purpose
+                iconImages[i].offsetY = -(iconImages[i].height / 2);
+            } else {
+                iconImages[i].offsetY = 0;
+            }
+
+            if (sprite === null) {
+                sprite = gm(currentIcon);
+            } else {
+                // appends another.jpg to img.png from left-to-right
+                sprite.append(currentIcon, true);
+            }
+        }
+
+        // write sprite if directory has been created or exists
+        sprite.write(spritePath, function (err) {
+            if (!err) {
+                writeSpriteCSS(iconImages, cssFile, relativeUrlToSprite, next);
+            } else {
+                console.log("writeSpriteImage didn't work. Error", err);
+            }
+        });
+    }
+
+    function writeSpriteCSS (iconImages, cssPath, relativeUrlToSprite, next) {
+        var icon;
+        var file;
+        var className;
+        var css = '';
+
+        for (var i = 0, ilen = iconImages.length; i < ilen; i++) {
+            icon = iconImages[i];
+            file = icon.file;
+            className = file.substring(file.lastIndexOf('/') + 1, file.lastIndexOf('.')).replace(COMBINEDPOSTFIX, '');
+
+            if (file.indexOf(COMBINEDPOSTFIX) === -1) {
+                // generate CSS style declarations
+                css += generateCSS(relativeUrlToSprite, className, icon.width, icon.height, icon.offsetX, 0);
+            } else {
+                // generate CSS style declarations
+                css += generateCSS(relativeUrlToSprite, className, icon.width, icon.height / 2, icon.offsetX, 0);
+
+                // add hover style
+                css += generateCSS(relativeUrlToSprite, className + ':hover', icon.width, icon.height / 2, icon.offsetX, icon.offsetY);
+            }
+        }
+
+        // write CSS
+        fs.writeFile(cssPath, css, function (err) {
+            if (!err) {
+                next();
+            } else {
+                console.log("writeSpriteCSS didn't work. ", err);
+                console.log('You probably need to manually remove the temporary directory.');
+            }
+        });
+    }
+
+    function generateCSS (relativeUrlToSprite, className, width, height, offsetX, offsetY) {
+        var spriteBackgroundImage = "    background-image: url('" + relativeUrlToSprite + "') !important;\n";
+        var backgroundRepeat = '    background-repeat: no-repeat !important;\n';
+        var css = '';
+
+        css += '.' + className + ' {\n';
+        css += '    width: ' + width + 'px;\n';
+        css += '    height: ' + height + 'px;\n';
+        css += spriteBackgroundImage;
+        css += backgroundRepeat;
+        css += '    background-position: ' + offsetX + 'px ' + offsetY + 'px !important;\n';
+        css += '}\n\n';
+
+        return css;
+    }
+
+    function cleanUp (tmpDirectory) {
+        fs.remove(tmpDirectory, function (err, result) {
+            if (!err) {
+                var endtime = (new Date()).getTime();
+                console.log('CSS Sprite completed in ' + ((endtime - starttime) / 1000) + ' seconds');
+            } else {
+                console.log("cleanUp didn't work. ", err);
+                console.log('You probably need to manually remove the temporary directory ', tmpDirectory);
+            }
+        });
+    }
+}
+
+runSprite({});


### PR DESCRIPTION
Ported grunt based script to independent node script. Generates icon PNG & CSS fror all appsetups for given app. For example: `npm run sprite -- 1.49:applications/paikkatietoikkuna.fi`.

Only generates icons for appsetup if `icons` directory is found inside appsetup directory.