### PR TITLE
Enforce "ESLint no-throw-literal" rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,7 +59,6 @@ module.exports = {
     "handle-callback-err": ["warn", "^(err|error)$" ],
     "new-cap": ["warn", { "newIsCap": true, "capIsNew": false }],
     "no-extend-native": "warn",
-    "no-throw-literal": "warn",
     "no-unmodified-loop-condition": "warn",
     "no-unneeded-ternary": ["warn", { "defaultAssignment": false }],
     "one-var": ["warn", { "initialized": "never" }],

--- a/bundles/framework/admin-users/event/RoleChangedEvent.js
+++ b/bundles/framework/admin-users/event/RoleChangedEvent.js
@@ -18,7 +18,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.admin-users.event.RoleChangedEve
         this._creator = null;
         this._role = role;
         if (!this.operations[operation]) {
-            throw "Unknown operation '" + operation + "'";
+            throw new Error("Unknown operation '" + operation + "'");
         }
         this._operation = operation;
     }, {

--- a/bundles/framework/geometryeditor/request/StartDrawFilteringRequest.js
+++ b/bundles/framework/geometryeditor/request/StartDrawFilteringRequest.js
@@ -10,7 +10,7 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.GeometryEditor.DrawFil
         } else {
         // start drawing new
             if (!this.modes[config.mode]) {
-                throw "Unknown draw filter mode '" + config.mode + "'";
+                throw new Error("Unknown draw filter mode '" + config.mode + "'");
             }
             this._mode = config.mode;
         }

--- a/bundles/framework/layerselection2/Flyout.js
+++ b/bundles/framework/layerselection2/Flyout.js
@@ -525,13 +525,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselection2.Flyout',
          */
         handleLayerOrderChanged: function (layer, fromPosition, toPosition) {
             if (!layer) {
-                throw 'handleLayerOrderChanged: No layer provided';
+                throw new Error('handleLayerOrderChanged: No layer provided');
             }
             if (isNaN(fromPosition)) {
-                throw 'handleLayerOrderChanged: fromPosition is Not a Number: ' + fromPosition;
+                throw new Error('handleLayerOrderChanged: fromPosition is Not a Number: ' + fromPosition);
             }
             if (isNaN(toPosition)) {
-                throw 'handleLayerOrderChanged: toPosition is Not a Number: ' + toPosition;
+                throw new Error('handleLayerOrderChanged: toPosition is Not a Number: ' + toPosition);
             }
 
             if (fromPosition === toPosition) {

--- a/bundles/framework/mapmodule-plugin/plugin/drawplugin/request/StartDrawingRequest.js
+++ b/bundles/framework/mapmodule-plugin/plugin/drawplugin/request/StartDrawingRequest.js
@@ -11,7 +11,7 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.mapmodule.DrawPlugin.r
         } else {
         // start drawing new
             if (!this.drawModes[config.drawMode]) {
-                throw "Unknown draw mode '" + config.drawMode + "'";
+                throw new Error("Unknown draw mode '" + config.drawMode + "'");
             }
             this._drawMode = config.drawMode;
         }

--- a/bundles/framework/rpc/instance.js
+++ b/bundles/framework/rpc/instance.js
@@ -6,6 +6,7 @@
  * See Oskari.mapframework.bundle.rpc.RemoteProcedureCall for bundle definition.
  *
  */
+/* eslint-disable no-throw-literal */
 Oskari.clazz.define(
     'Oskari.mapframework.bundle.rpc.RemoteProcedureCallInstance',
     function () {

--- a/bundles/framework/statehandler/plugin/Plugin.js
+++ b/bundles/framework/statehandler/plugin/Plugin.js
@@ -13,14 +13,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.statehandler.plugin.Plugin',
      */
 
     function () {
-        throw 'Oskari.mapframework.bundle.statehandler.Plugin should not be instantiated';
+        throw new Error('Oskari.mapframework.bundle.statehandler.Plugin should not be instantiated');
     }, {
         /**
          * @method getName
          * @throws "Implement your own"
          */
         getName: function () {
-            throw 'Implement your own';
+            throw new Error('Implement your own');
         },
         /**
          * @method setHandler
@@ -30,7 +30,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.statehandler.plugin.Plugin',
          * @throws "Implement your own"
          */
         setHandler: function (stateHandler) {
-            throw 'Implement your own';
+            throw new Error('Implement your own');
         },
         /**
          * @method startPlugin
@@ -39,7 +39,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.statehandler.plugin.Plugin',
          * @throws "Implement your own"
          */
         startPlugin: function (sandbox) {
-            throw 'Implement your own';
+            throw new Error('Implement your own');
         },
         /**
          * @method stopPlugin
@@ -48,7 +48,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.statehandler.plugin.Plugin',
          * @throws "Implement your own"
          */
         stopPlugin: function (sandbox) {
-            throw 'Implement your own';
+            throw new Error('Implement your own');
         },
         /**
          * @method getState
@@ -56,7 +56,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.statehandler.plugin.Plugin',
          * @throws "Implement your own"
          */
         getState: function () {
-            throw 'Implement your own';
+            throw new Error('Implement your own');
         },
         /**
          * @method resetState
@@ -64,7 +64,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.statehandler.plugin.Plugin',
          * @throws "Implement your own"
          */
         resetState: function () {
-            throw 'Implement your own';
+            throw new Error('Implement your own');
         },
         /**
          * @method saveState
@@ -77,6 +77,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.statehandler.plugin.Plugin',
          * @throws "Implement your own"
          */
         saveState: function (viewName, state) {
-            throw 'Implement your own';
+            throw new Error('Implement your own');
         }
     });

--- a/bundles/integration/backbone/View.js
+++ b/bundles/integration/backbone/View.js
@@ -38,7 +38,7 @@ Oskari.clazz.define('Oskari.integration.bundle.backbone.View', function (locale,
      *
      */
     'render': function () {
-        throw 'Abstract';
+        throw new Error('Abstract');
     },
 
     /**

--- a/bundles/integration/bb/View.js
+++ b/bundles/integration/bb/View.js
@@ -38,7 +38,7 @@ Oskari.clazz.define('Oskari.integration.bundle.bb.View', function (locale, insta
      *
      */
     'render': function () {
-        throw 'Abstract';
+        throw new Error('Abstract');
     },
 
     /**

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -10,7 +10,7 @@
 Oskari.AbstractFunc = function () {
     var name = arguments[0];
     return function () {
-        throw 'AbstractFuncCalled: ' + name;
+        throw new Error('AbstractFuncCalled: ' + name);
     };
 };
 
@@ -758,7 +758,7 @@ Oskari.clazz.define(
                 return this._getExactResolutionImpl(scale);
             }
 
-            throw 'Not implemented _getExactResolutionImpl function.';
+            throw new Error('Not implemented _getExactResolutionImpl function.');
         },
 
         /**
@@ -2153,16 +2153,16 @@ Oskari.clazz.define(
             var curr;
 
             if (!element) {
-                throw 'Element is non-existent.';
+                throw new Error('Element is non-existent.');
             }
             if (!containerClasses) {
-                throw 'No container classes.';
+                throw new Error('No container classes.');
             }
             if (!content || !content.length) {
-                throw 'Container with classes "' + containerClasses + '" not found.';
+                throw new Error('Container with classes "' + containerClasses + '" not found.');
             }
             if (content.length > 1) {
-                throw 'Found more than one container with classes "' + containerClasses + '".';
+                throw new Error('Found more than one container with classes "' + containerClasses + '".');
             }
 
             // Add slot to element

--- a/bundles/mapping/mapmodule/event/map.layer.js
+++ b/bundles/mapping/mapmodule/event/map.layer.js
@@ -20,7 +20,7 @@ Oskari.clazz.define('Oskari.mapframework.event.common.MapLayerEvent',
         this._creator = null;
         this._layerId = layerId;
         if (!this.operations[operation]) {
-            throw "Unknown operation '" + operation + "'";
+            throw new Error("Unknown operation '" + operation + "'");
         }
         this._operation = operation;
     }, {

--- a/bundles/mapping/mapmodule/plugin/AbstractMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/AbstractMapModulePlugin.js
@@ -52,7 +52,7 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.AbstractMapModulePlugin',
         getMapModule: function () {
             // Throw a fit if mapmodule is not set, it'd probably break things.
             if (this._mapModule === null || this._mapModule === undefined) {
-                throw 'No mapmodule provided!';
+                throw new Error('No mapmodule provided!');
             }
             return this._mapModule;
         },

--- a/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
@@ -135,7 +135,7 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
             var clazz = this._clazz;
             // Throw a fit if clazz is not set, it'd probably break things.
             if (clazz === null || clazz === undefined || clazz.length < 1) {
-                throw 'No clazz provided for ' + this.getName() + '!';
+                throw new Error('No clazz provided for ' + this.getName() + '!');
             }
             return clazz;
         },

--- a/bundles/mapping/mapmodule/plugin/Plugin.js
+++ b/bundles/mapping/mapmodule/plugin/Plugin.js
@@ -11,7 +11,7 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.mapmodule.Plugin',
  * Always extend this class, never use as is.
  */
     function () {
-        throw 'Oskari.mapframework.ui.module.common.mapmodule.Plugin should not be instantiated';
+        throw new Error('Oskari.mapframework.ui.module.common.mapmodule.Plugin should not be instantiated');
     }, {
     /**
      * @method getName
@@ -20,7 +20,7 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.mapmodule.Plugin',
      * @throws always override this
      */
         getName: function () {
-            throw 'Implement your own';
+            throw new Error('Implement your own');
         },
 
         /**
@@ -29,7 +29,7 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.mapmodule.Plugin',
      * @param {Oskari.mapframework.ui.module.common.MapModule} mapModule
      */
         setMapModule: function (mapModule) {
-            throw 'Implement your own';
+            throw new Error('Implement your own');
         },
 
         /**
@@ -37,14 +37,14 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.mapmodule.Plugin',
      * Interface method for the module protocol
      */
         register: function () {
-            throw 'Implement your own';
+            throw new Error('Implement your own');
         },
         /**
      * @method unregister
      * Interface method for the module protocol
      */
         unregister: function () {
-            throw 'Implement your own';
+            throw new Error('Implement your own');
         },
 
         /**
@@ -57,7 +57,7 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.mapmodule.Plugin',
      *          reference to application sandbox
      */
         startPlugin: function (sandbox) {
-            throw 'Implement your own';
+            throw new Error('Implement your own');
         },
         /**
      * @method stopPlugin
@@ -69,7 +69,7 @@ Oskari.clazz.define('Oskari.mapframework.ui.module.common.mapmodule.Plugin',
      *          reference to application sandbox
      */
         stopPlugin: function (sandbox) {
-            throw 'Implement your own';
+            throw new Error('Implement your own');
         },
 
         /**

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -1394,7 +1394,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
         checkForDuplicateId: function (id, name) {
             if (this._reservedLayerIds[id] === true) {
                 var foundLayer = this.findMapLayer(id);
-                throw "Trying to add map layer with id '" + id + ' (' + name + ")' but that id is already reserved for '" + foundLayer.getName() + "'";
+                throw new Error("Trying to add map layer with id '" + id + ' (' + name + ")' but that id is already reserved for '" + foundLayer.getName() + "'");
             }
         },
         /**


### PR DESCRIPTION
And change rule level to error.

Oskari RPC was not modified to keep API unchanged. File level ignore added for rule.