### PR TITLE
Reduced shininess of 3d tiles material

### DIFF
--- a/bundles/paikkatietoikkuna/mapmodule/mapmodule.olcs.js
+++ b/bundles/paikkatietoikkuna/mapmodule/mapmodule.olcs.js
@@ -57,8 +57,10 @@ class MapModuleOlCesium extends MapModuleOl {
 
         me._setupMapEvents(map);
 
+        var time = Cesium.JulianDate.fromIso8601('2017-07-11T12:00:00Z');
         this._map3d = new OLCesium({
             map: map,
+            time: () => time,
             sceneOptions: {
                 showCredit: false
             }

--- a/bundles/paikkatietoikkuna/tiles3d/plugin/Tiles3DLayerPlugin.js
+++ b/bundles/paikkatietoikkuna/tiles3d/plugin/Tiles3DLayerPlugin.js
@@ -1,22 +1,6 @@
 import Tiles3DModelBuilder from './Tiles3DModelBuilder';
 
-const oldUpdate = Cesium.Model.prototype.update;
-
-Cesium.Model.prototype.update = function (frameState) {
-    if (!this._oskariOverride && this.gltf) {
-        if (Array.isArray(this.gltf.materials)) {
-            this.gltf.materials.forEach(function (mat) {
-                if (!mat.pbrMetallicRoughness) {
-                    return;
-                }
-                mat.pbrMetallicRoughness.metallicFactor = 0;
-                mat.pbrMetallicRoughness.roughnessFactor = 1;
-            });
-        }
-        this._oskariOverride = true;
-    }
-    oldUpdate.call(this, frameState);
-};
+import '../util/overrideCesiumMaterial'; // for side effects only
 
 /**
  * @class Oskari.map3dtiles.bundle.tiles3d.plugin.Tiles3DLayerPlugin

--- a/bundles/paikkatietoikkuna/tiles3d/plugin/Tiles3DLayerPlugin.js
+++ b/bundles/paikkatietoikkuna/tiles3d/plugin/Tiles3DLayerPlugin.js
@@ -1,5 +1,23 @@
 import Tiles3DModelBuilder from './Tiles3DModelBuilder';
 
+const oldUpdate = Cesium.Model.prototype.update;
+
+Cesium.Model.prototype.update = function (frameState) {
+    if (!this._oskariOverride && this.gltf) {
+        if (Array.isArray(this.gltf.materials)) {
+            this.gltf.materials.forEach(function (mat) {
+                if (!mat.pbrMetallicRoughness) {
+                    return;
+                }
+                mat.pbrMetallicRoughness.metallicFactor = 0;
+                mat.pbrMetallicRoughness.roughnessFactor = 1;
+            });
+        }
+        this._oskariOverride = true;
+    }
+    oldUpdate.call(this, frameState);
+};
+
 /**
  * @class Oskari.map3dtiles.bundle.tiles3d.plugin.Tiles3DLayerPlugin
  * Provides functionality to draw 3D tiles on the map

--- a/bundles/paikkatietoikkuna/tiles3d/util/overrideCesiumMaterial.js
+++ b/bundles/paikkatietoikkuna/tiles3d/util/overrideCesiumMaterial.js
@@ -1,0 +1,17 @@
+const oldUpdate = Cesium.Model.prototype.update;
+
+Cesium.Model.prototype.update = function (frameState) {
+    if (this.gltf) {
+        if (Array.isArray(this.gltf.materials)) {
+            this.gltf.materials.forEach(function (mat) {
+                if (!mat.pbrMetallicRoughness) {
+                    return;
+                }
+                mat.pbrMetallicRoughness.metallicFactor = 0;
+                mat.pbrMetallicRoughness.roughnessFactor = 1;
+            });
+        }
+        this.update = oldUpdate;
+    }
+    oldUpdate.call(this, frameState);
+};


### PR DESCRIPTION
The tileset material produced by FME has a metallic component that causes unnecessary shininess in the 3D visualisation. This material **should** be corrected in the production side of the dataset, but in the mean time we override it in the client.

Run-time modification of the Cesium `Model` class prototype was unfortunately the only way to achieve the result.

3D view time is now configured to be always daytime (used client current time before).