### PR TITLE
Dont notify flyout until its initialized

### DIFF
--- a/bundles/framework/admin-users/instance.js
+++ b/bundles/framework/admin-users/instance.js
@@ -127,7 +127,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.admin-users.AdminUsersBundleInst
          * Event is handled forwarded to correct #eventHandlers if found or discarded if not.
          */
         onEvent: function (event) {
-            this.plugins['Oskari.userinterface.Flyout'].onEvent(event);
+            if (this.plugins['Oskari.userinterface.Flyout']) {
+                this.plugins['Oskari.userinterface.Flyout'].onEvent(event);
+            }
 
             var handler = this.eventHandlers[event.getName()];
             if (!handler) {


### PR DESCRIPTION
Fixes a timing issue/error when flyout isn't initialized. Without this (and having admin-users enabled) the console logs a warning:

`
    Oskari.clazz.define.__name {_creator: null, _extension: O…i.c…z.d…e.__name, viewstate: "close", viewinfo: {…}} TypeError: Cannot read property 'onEvent' of undefined
        at Oskari.clazz.define.__name.onEvent (instance.js:130)
        at e.clazz.define.getLog.notifyAll (sandbox.js:431)
        at Oskari.clazz.define.getName.notifyExtensionViewStateChange (instance.js:809)
        at Oskari.clazz.define.getName.updateExtension (instance.js:797)
        at Oskari.clazz.define.handleRequest.handleRequest (UpdateExtensionRequestHandler.js:19)
        at e.clazz.define.getLog.processRequest (sandbox.js:280)
        at s (sandbox.js:354)
`
