### PR TITLE
Fix npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "eslint . --quiet",
     "build": "webpack --mode production",
-    "start": "webpack-dev-server --hot",
+    "start": "webpack-dev-server --hot --env.appdef=applications/sample",
     "paikkis": "webpack-dev-server --hot --env.appdef=applications/paikkatietoikkuna.fi",
     "asdi": "webpack-dev-server --hot --env.appdef=applications/asdi",
     "sprite": "node webpack/sprite.js"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "eslint . --quiet",
     "build": "webpack --mode production",
-    "start": "webpack-dev-server --hot --env.appdef=applications/sample",
+    "start": "webpack-dev-server --hot",
     "paikkis": "webpack-dev-server --hot --env.appdef=applications/paikkatietoikkuna.fi",
     "asdi": "webpack-dev-server --hot --env.appdef=applications/asdi",
     "sprite": "node webpack/sprite.js"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,14 +11,11 @@ const proxyPort = 8081;
 module.exports = (env, argv) => {
     const isProd = argv.mode === 'production';
 
-    const parts = parseParams(env);
-
-    const version = parts.length > 1 ? parts[0] : 'devapp';
-    const appsetupPath = parts.length > 1 ? parts[1] : parts[0];
+    const {version, pathParam} = parseParams(env);
 
     const isDirectory = source => lstatSync(source).isDirectory();
     const getDirectories = source => readdirSync(source).map(name => path.join(source, name)).filter(isDirectory);
-    const appsetupPaths = getDirectories(path.resolve(appsetupPath));
+    const appsetupPaths = getDirectories(path.resolve(pathParam));
 
     const entries = {};
     const plugins = [

--- a/webpack/parseParams.js
+++ b/webpack/parseParams.js
@@ -1,8 +1,15 @@
-const exampleCommand = 'npm run build -- --env.appdef=44.6:applications/paikkatietoikkuna.fi';
+const exampleCommand = `
+-----------------------------------------------------------
+Development (version defaults to "devapp"):
+    npm start -- --env.appdef=applications/sample
+Production (version example 44.6):
+    npm run build -- --env.appdef=44.6:applications/sample
+-----------------------------------------------------------
+`;
 
 module.exports = function parseParams(env) {
     if (!env || !env.appdef) {
-        throw new Error('Must give "appdef" env variable, eg.: ' + exampleCommand);
+        throw new Error('Must give "appdef" env variable, eg.:' + exampleCommand);
     }
 
     const parts = env.appdef.split(':');
@@ -11,5 +18,11 @@ module.exports = function parseParams(env) {
         throw new Error('Format for "appdef" is "version:pathToAppsetupDirectory", eg.: ' + exampleCommand);
     }
 
-    return parts;
+    const version = parts.length > 1 ? parts[0] : 'devapp';
+    const pathParam = parts.length > 1 ? parts[1] : parts[0];
+
+    return {
+        version,
+        pathParam
+    };
 }


### PR DESCRIPTION
- Clarification for parameter error messages that can be given to npm start/npm run build. 
- Changed appsetupPath variable name to pathParam as it was difficult to notice from another variable appsetupPaths with an s at the end.
- Moved default version selection to parseParams.js
- env.appdef could default to applications/sample to make the cli command shorter/nicer to use, but this way we get to advertise that you shouldn't use the sample app for customized apps.