### PR TITLE
Coordtrans localization and ui changes

### DIFF
--- a/bundles/paikkatietoikkuna/coordinatetransformation/Flyout.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/Flyout.js
@@ -5,6 +5,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.Flyout',
         me.instance = instance;
         me.loc = Oskari.getMsg.bind(null, 'coordinatetransformation');
         me.container = null;
+        me.flyout = null;
     }, {
         getName: function () {
             return 'Oskari.coordinatetransformation.Flyout';
@@ -24,17 +25,23 @@ Oskari.clazz.define('Oskari.coordinatetransformation.Flyout',
         createUi: function () {
             this.instance.getViews().transformation.createUI(this.container);
         },
-        toggleFlyout: function (visible) {
-            if (!visible) {
-                jQuery(this.container).parent().parent().hide();
-            } else {
-                jQuery(this.container).parent().parent().show();
-            }
-        },
         startPlugin: function () {
             this.template = jQuery();
-            var elParent = this.container.parentElement.parentElement;
-            jQuery(elParent).addClass('coordinatetransformation-flyout');
+            this.flyout = jQuery(this.container.parentElement.parentElement);
+            this.flyout.addClass('coordinatetransformation-flyout');
+            this.setContainerMaxHeight(Oskari.getSandbox().getMap().getHeight());
+        },
+        setContainerMaxHeight: function (mapHeight) {
+            // calculate max-height based on map size
+            var container = this.flyout.find('.oskari-flyoutcontentcontainer');
+            var toolbarHeight = this.flyout.find('.oskari-flyouttoolbar').outerHeight(true);
+            var maxHeight = mapHeight - toolbarHeight;
+            if (container) {
+                container.css('max-height', maxHeight + 'px');
+            }
+            if (container.outerHeight(true) >= maxHeight) {
+                this.flyout.css('top', '0px');
+            }
         }
     }, {
         'extend': ['Oskari.userinterface.extension.DefaultFlyout']

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.js
@@ -182,15 +182,15 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateTable',
          */
     render: function (coords, dimension) {
         var table = this.getElements().table;
-        var row,
-            rowData = {},
-            coord;
+        var row;
+        var rowData = {};
+        var coord;
         this.emptyTableCells();
         for (var i = coords.length - 1; i >= 0; i--) {
             coord = coords[i];
             rowData.col1 = coord[0];
             rowData.col2 = coord[1];
-            if (dimension === 3) {
+            if (coord.length === 3) {
                 rowData.elev = coord[2];
             }
             row = jQuery(this.template.row({coords: rowData}));
@@ -271,17 +271,18 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateTable',
                 me.displayNumberOfDataRows( number );
             });
         }, */
-    updateHeader: function (epsgValues, elevSystem) {
+    updateHeader: function (epsgValues, elevSystem, isAxisFlip) {
         this.getElements().header.remove();
         if (!epsgValues || !epsgValues.coord) {
             return;
         }
-        var x = '',
-            y = '',
-            z = '',
-            lonFirst = epsgValues.lonFirst,
-            coordSystem = epsgValues.coord;
+        var x = '';
+        var y = '';
+        var z = '';
+        var lonFirst = isAxisFlip === true ? !epsgValues.lonFirst : epsgValues.lonFirst;
+        var coordSystem = epsgValues.coord;
         var header;
+        var temp;
 
         switch (coordSystem) {
         case 'COORD_PROJ_3D':
@@ -303,7 +304,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateTable',
             break;
         }
         if (!lonFirst) {
-            var temp = y;
+            temp = y;
             y = x;
             x = temp;
         }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/instance.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/instance.js
@@ -174,6 +174,9 @@ Oskari.clazz.define('Oskari.coordinatetransformation.instance',
                 } else if (state === 'close' || state === 'minimize') {
                     this.sandbox.postRequestByName('EnableMapKeyboardMovementRequest');
                 }
+            },
+            'MapSizeChangedEvent': function (event) {
+                this.plugins['Oskari.userinterface.Flyout'].setContainerMaxHeight(event.getHeight());
             }
         }
     }, {

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/css/coordinatetransformation.css
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/css/coordinatetransformation.css
@@ -112,7 +112,7 @@
 /* Coordinate system selections */
 .coordinatetransformation-flyout .coordinate-systems-wrapper {
     display: flex;
-    padding-bottom: 12px;
+    padding-bottom: 24px;
 }
 .coordinatetransformation-flyout .transformation-system {
     min-width: 360px;
@@ -348,6 +348,19 @@
 .coordinatetransformation-file-form .without-infolink {
     padding-right: 16px;
 }
+.precision-table-wrapper .precisionTable {
+    width: 420px;
+    margin-left: auto;
+    margin-right: auto;
+}
+.precision-table-wrapper table th:first-child, .precision-table-wrapper table td:first-child {
+    text-align: left;
+}
+.precision-table-wrapper table th, .precision-table-wrapper table td {
+    text-align: center;
+    min-width: 50px;
+}
+
 /* Helper popup */
 .coordinatetransformation-helper-popup ul {
     padding-left: 20px;
@@ -369,10 +382,15 @@
     .coordinatetransformation-flyout {
         max-width: 560px;
     }
+    .coordinatetransformation-flyout .systems-filter-wrapper {
+        width: 360px;
+        margin: 0 auto;
+    }
     .coordinatetransformation-flyout .datasource-wrapper{
         width: 360px;
         margin-left: auto;
         margin-right: auto;
+        padding-bottom: 12px;
     }
     .coordinatetransformation-flyout .coordinate-datasources-wrapper {
         flex-direction: column;
@@ -390,13 +408,18 @@
     }
     .coordinatetransformation-flyout .coordinate-tables-wrapper {
         flex-direction: column;
-        width: 322px;
+        width: 360px;
         margin-left: auto;
         margin-right: auto;
         /*align-items: center;
         flex-wrap: wrap;*/
     }
+    .coordinatetransformation-flyout .coordinate-table-wrapper {
+        width: 322px;
+        margin-right: 38px;
+    }
     .coordinate-tables-wrapper .transformation-button {
+        margin-right: 40px;
         margin-top: 12px;
         margin-bottom: 12px;
     }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
@@ -10,126 +10,130 @@ Oskari.registerLocalization(
         "flyout": {
             "title":"Coordinate Transformation",
             "filterSystems": {
-                "title": "Suodata koordinaattijärjestelmiä",
-                "epsg": "EPSG-koodilla",
-                "systems": "Datumilla ja koordinaatistolla"
+                "title": "Filter coordinate reference systems",
+                "epsg": "With EPSG code",
+                "systems": "With datum and coordinate system"
             },
             "coordinateSystem": {
-                "title": "Koordinaattijärjestelmän tiedot",
+                "title": "Coordinate reference system information",
                 "input": {
-                    "title": "Lähtö koordinaattijärjestelmän tiedot"
+                    "title": "Input coordinate reference system information"
                 },
                 "output": {
-                    "title": "Tulos koordinaattijärjestelmän tiedot"
+                    "title": "Output coordinate reference system information"
                 },
                 "noFilter": "Any option",
                 "epsgSearch": {
-                    "label": "Hae EPSG-koodilla"
+                    "label": "Search using EPSG code"
                 },
                 "geodeticDatum": {
-                    "label": "Geodeettinen datumi"
+                    "label": "Geodetic datum"
                 },
                 "coordinateSystem":{
-                    "label": "Koordinaatisto",
-                    "proj2D": "Suorakulmainen 2D (Taso)",
-                    "proj3D": "Suorakulmainen 3D",
-                    "geo2D": "Maantieteellinen 2D",
-                    "geo3D": "Maantieteellinen 3D"
+                    "label": "Coordinate system",
+                    "proj2D": "Projected 2D",
+                    "proj3D": "Projected 3D",
+                    "geo2D": "Geographic 2D",
+                    "geo3D": "Geographic 3D"
                 },
                 "mapProjection":{
-                    "label": "Karttaprojektiojärjestelmä"
+                    "label": "System of map projections"
                 },
                 "geodeticCoordinateSystem":{
-                    "label": "Geodeettinen koordinaattijärjestelmä",
-                    "choose": "Choose",
+                    "label": "Geodetic coordinate reference system",
+                    "choose": "Select", // Choose
                     "kkj": "KKJ zone {zone, number}",
                     "ykj": "KKJ zone 3 / YKJ"
                 },
                 "heightSystem":{
-                    "label": "Korkeusjärjestelmä",
+                    "label": "Vertical coordinate reference system", // Height system
                     "none": "None"
                 }
             },
             "coordinateTable": {
-                "input": "Muunnettavat koordinaatit",
-                "output": "Tuloskoordinaatit",
-                "north":"Pohjois-koordinaatti [m]",
-                "east":"Itä-koordinaatti [m]",
-                "lat":"Leveysaste",
-                "lon":"Pituusaste",
-                "elevation": "Korkeus [m]",
-                "geoX":"Geosentrinen X [m]",
-                "geoY":"Geosentrinen Y [m]",
-                "geoZ":"Geosentrinen Z [m]",
-                "ellipseElevation":"Ellipsoidinen korkeus [m]",
-                "rows": "Riviä",
-                "clearTables": "Tyhjennä taulukot",
-                "confirmClear": "Haluatko tyhjentää taulukot?"
+                "input": "Input coordinates",
+                "output": "Output coordinates",
+                "north":"Northing [m]",
+                "east":"Easting [m]",
+                "lat":"Geodetic latitude",
+                "lon":"Geodetic longitude",
+                "elevation": "Height [m]",
+                "geoX":"Geocentric X [m]",
+                "geoY":"Geocentric Y [m]",
+                "geoZ":"Geocentric Z [m]",
+                "ellipseElevation":"Ellipsoidal height [m]",
+                "rows": "Rows",
+                "clearTables": "Empty tables",
+                "confirmClear": "Are you sure you want to empty tables?"
             },
             "transform": {
                 "warnings": {
-                    "title": "Huomio!",
-                    "3DTo2D": "Valitsemissasi lähtötiedoissa on mukana korkeusarvoja, mutta tulostiedoissa ei. Tuloskoordinaatteihin ei siis tule korkeusarvoja mukaan. Haluatko jatkaa?",
-                    "2DTo3D": "Valitsemissasi lähtötiedoissa ei ole korkeusarvoja, mutta tulostiedoissa on. Lähtöaineiston korkeusarvoiksi lisätään 0 ja korkeusjärjestelmäksi N2000. Haluatko jatkaa?",
-                    "xyz": "Lähtökoordinaattijärjestelmän valinnoissa ei ole korkeusjärjestelmää. Muunnos suorakulmaiseen 3D -järjestelmään ei ole mahdollinen."
+                    "title": "Warning!",
+                    "3DTo2D": "The selected input information contains height values, but the output information does not. Output coordinates will therefore not include height values. Do you want to continue?",
+                    "2DTo3D": "The selected output information contains height values, but the input information does not. The height values 0 and height system N2000 will be added to the input information. Do you want to continue?",
+                    "xyz": "No height system has been selected for the input coordinate system. It is not possible to transform this input information into a projected 3D system.",
+                    "largeFile": "Isojen tiedostojen muuntaminen voi kestää useita minuutteja."
                 },
                 "validateErrors": {
-                    "title": "Virhe!",
-                    "message": "Valinnoissa on puutteita tai virheitä. Ota huomioon seuraavat vaatimukset ja yritä uudelleen.",
-                    "crs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna sekä lähtö- että tulostiedoissa.",
-                    "sourceHeight": "Lähtötietojen korkeusjärjestelmää ei ole valittu.",
-                    "targetHeight": "Tulostietojen korkeusjärjestelmää ei ole valittu.",
-                    "noInputData": "Ei muunnettavia koordinaatteja.",
-                    "noInputFile": "Lähtöaineiston sisältävä tiedosto pitää olla valittuna.",
-                    "noFileName": "Muodostettavalle tiedostolle pitää antaa tiedostonimi.",
-                    "decimalCount": "Desimaalien tarkkuus pitää olla 0 tai positiivnen kokonaisluku.",
-                    "headerCount": "Otsakerivien määrä pitää olla 0 tai positiivinen kokonaisluku.",
-                    "doubleComma": "Desimaali- ja koordinaattierotin eivät voi molemmat olla pilkkuja.",
+                    "title": "Error!", // Error in coordinate system selections
+                    "message": "Selections are incomplete or contain errors. Note the following requirements and try again.",
+                    "crs": "A geodetic coordinate reference system must be selected both in the input and the output information.",
+                    "noInputData": "No input coordinates.",
+                    "noInputFile": "The file containing input information must be selected.",
+                    "noFileName": "The output file must be named.",
+                    "decimalCount": "The decimal precision must be 0 or a positive integer.",
+                    "headerCount": "The number of header rows must be 0 or a positive integer.",
+                    "doubleComma": "The decimal and coordinate separators cannot both be commas.",
                     "doubleSpace": "Kulman muoto/yksikkö ei voi sisältää välilyöntejä, jos koordinaattierotin on Välilyönti.",
-                    "noFileSettings": "Tiedosto asetuksia ei ole annettu.",
-                    "noCoordinateSeparator": "Koordinaattierotin pitää olla valittuna.",
-                    "noDecimalSeparator":"Desimaalierotin pitää olla valittuna."
+                    "noFileSettings": "No file settings.",
+                    "noCoordinateSeparator": "There must be a coordinate separator..",
+                    "noDecimalSeparator":"There must be a decimal separator."
                 },
                 "responseErrors": {
-                    "title": "Virhe muunnoksessa!",
-                    "generic": "Koordinaattimuunnos epäonnistui...",
+                    "title": "Error in transformation!",
+                    "titleRead": "Virhe tiedoston lukemisessa!",
+                    "readFileError" : "Tiedostosta ei onnistuttu lukemaan kaikkia rivejä.",
+                    "transformFileError": "Tiedoston koordinaatteja ei onnistuttu muuntamaan.",
+                    "invalidLine": "The file's row {index, number} contains an invalid coordinate: {line}. Check that the selected decimal and coordinate separators and number of header rows match the contents of the file.",
+                    "generic": "Coordinate transformation failed...",
+                    //error codes
                     "invalid_coord": "Koordinaatti virheellinen. Tarkasta, että muunnettavat koordinaatit on oikeassa muodossa sekä geodeettinen koordinaatti- ja kokeusjärjestelmä ovat oikein.",
-                    "invalid_number": "Koordinaatti virheellinen. Tarkasta..",
-                    "invalid_coord_in_array": "Koordinaatti virheellinen. Tarkasta..",
-                    "no_coordinates": "Ei koordinaatteja",
-                    "invalid_file_settings": "Invalid file settings",
-                    "no_file": "No file entry",
-                    "invalid_first_coord": "Tiedostossa virheellinen koordinaatti. Tarkasta, että otsakerivit, käytä tunnistetta sekä geoodeettinen koordinaatti- ja korkeusjärjestelmä ovat määritetty oikein.",
-                    "invalid_coord_in_line": "Tiedostossa virheellinen koordinaatti {line} rivillä {index, number}."
+                    "invalid_number": "Invalid coordinate.",
+                    "invalid_coord_in_array": "Invalid coordinate.",
+                    "no_coordinates": "No coordinates.",
+                    "invalid_file_settings": "Error in file settings.",
+                    "no_file": "No file matching the request could be found.",
+                    "invalid_first_coord": "It was not possible to produce coordinates with these selections. Check that the coordinate separator, number of headers, geodetic coordinate and height system (dimension) selections as well as the option to use identifier or not match the contents of the file.",
+                    "transformation_error": "Koordinaattimuunnos epäonnistui. Koordinaattimuunnospalvelusta palautui virhe:"
                 },
                 "responseFile": {
                     "title": "Attention!",
-                    "hasMoreCoordinates": "Lähtöaineistosta ei voida muuntaa taulukkoon yli {maxCoordsToArray, number} koordinaattia. Jos haluat muuntaa kaikki koordinaatit, käytä Vie tulokset tiedostoon -toimintoa."
+                    "hasMoreCoordinates": "It is not possible to transform more than {maxCoordsToArray, number} coordinates from the input information into the table. If you want to transform all coordinates, select Output to file."
                 }
             }
         },
         "dataSource": {
-            "title": "Koordinaattitietojen lähde",
-            "confirmChange": "Muunnettavat koordinaatit tyhjennetään ja koordinaattijärjestelmän tiedot poistetaan. Haluatko jatkaa?",
+            "title": "Coordinate information source",
+            "confirmChange": "Input coordinates will be removed and the coordinate reference system information deleted. Do you want to continue?",
             "file": {
-                "label": "Tiedostosta",
-                "info":  "Valitse lähtöaineiston sisältävä tiedosto ja sen asetukset.",
-                "action": "Muokkaa"
+                "label": "From file",
+                "info":  "Select the file containing the input information and its settings.",
+                "action": "edit selections"
             },
             "keyboard": {
-                "label": "Näppäimistöltä",
-                "info": "Syötä lähtötiedot Muunnettavat koordinaatit -taulukkoon."
+                "label": "Using keyboard",
+                "info": "Put the input information into the Input coordinates table."
             },
             "map": {
-                "label": "Valitse sijainnit kartalta",
-                "info": "Valitse yksi tai useampi piste kartalta klikkaamalla.",
-                "action": "Valitse"
+                "label": "Select locations on the map",
+                "info": "Select coordinates to be transformed on the map by clicking them.",
+                "action": "select more"
             }
         },
         "mapMarkers":{
             "show":{
-                "title": "Näytä sijainnit kartalla",
-                "info" : "Tarkastele muunnettuja koordinaatteja kartalla.",
+                "title": "Show locations on the map",
+                "info" : "The projection of the map is ETRS89-TM35FIN. Coordinates have been placed on the map using this coordinate reference system. With the location, the coordinates are shown numerically in the input and/or output coordinate reference system. ",
                 "errorTitle": "Virhe sijaintien näyttämisessä",
                 "noCoordinates": "Ei koordinaatteja näytettäväksi kartalla",
                 "noSrs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna lähtötiedoissa, jotta pisteet voidaan näyttää kartalla.",
@@ -139,19 +143,16 @@ Oskari.registerLocalization(
                 "east": "E"
             },
             "select":{
-                "title": "Näytä sijainnit kartalla",
-                "info": "Valitse yksi tai useampia pisteitä kartalta klikkaamalla.",
+                "title": "Select locations on the map",
+                "info": "Click to select one or more points on the map. The projection of the map is ETRS-TM35FIN. This coordinate reference system is automatically selected for the coordinates to be transformed and it cannot be changed. When selecting coordinates, please note that selecting locations on the map is not very precise.",
                 "add": "Add markers",
                 "remove": "Remove markers"
             }
         },
         "actions": {
             "convert": "Transform",
-            "clearTable": "Clear tables",
-            "showMarkers": "Show markers on the map",
-            "export": "Transform to file",
+            "export": "Transform into file",
             "select": "Select",
-            //"selectFromMap": "Siirry valitsemaan.",
             "cancel": "Cancel",
             "done": "Done",
             "ok": "Ok",
@@ -161,22 +162,26 @@ Oskari.registerLocalization(
             "options": {
                 "decimalSeparator": "Decimal separator",
                 "coordinateSeparator": "Coordinate separator",
-                "headerCount": "Header line count",
+                "headerCount": "Number of header rows",
                 "decimalCount": "Decimal precision",
-                "reverseCoords": "Coordinates reversed",
-                "useId": "Use id infront",
-                "writeHeader": "Write a header",
+                "reverseCoordinates": "Inverted coordinates", // Coordinates reversed
+                "useId": { // Use identifier, Use id infront
+                    "input": "Coordinates include identifiers",
+                    "generate": "Generate identifiers",
+                    "fromFile": "Include identifiers from the input file"
+                },
+                "writeHeader": "Write header row into file",
                 "useCardinals": "Use cardinals (N,E,W,S)",
-                "lineEnds": "Line ends to output",
+                "lineEnds": "Include end-of-row markers in output", // Line ends to output
                 "choose": "Choose",
                 "degreeFormat":{
-                    "label": "Angle pattern",
+                    "label": "Angle pattern", // Angle shape/unit
                     "degree": "Degree",
                     "gradian": "Grade",
                     "radian": "Radian"
                 },
                 "lineSeparator": {
-                    "label": "Line separator",
+                    "label": "Line separator", // Row separator
                     "win": "Windows / DOS",
                     "unix": "Unix",
                     "mac": "MacOS"
@@ -190,160 +195,169 @@ Oskari.registerLocalization(
                 }
             },
             "export": {
-                "title": "Aineiston muodostaminen",
-                "fileName": "Tiedoston nimi"
+                "title": "Formation of output information", // or file
+                "fileName": "File name"
             },
             "import": {
-                "title": "Lähtöaineiston ominaisuudet"
+                "title": "Formation of input information" // Input information properties
             }
         },
         "infoPopup": {
-            "description": "Kuvaus",
+            "description": "Description",
             "epsgSearch": {
-                "title": "Haku EPSG-koodin perusteella",
-                "info": "Voit hakea geodeettisen koordinaattijärjestelmän EPSG-koodin avulla. Syötä koodi pelkkänä numerona esim. 3067.",
+                "title": "Search using EPSG code",
+                "info": "You can search for a geodetic coordinate reference system using the EPSG code. Input the code as a numerical value, such as 3067.",
                 "listItems": []
             },
             "geodeticDatum": {
-                "title": "Geodeettinen datumi",
-                "info": "Geodeettinen datumi: datumi, joka kuvaa kaksi- tai kolmiulotteisen koordinaatiston suhdetta Maahan.",
+                "title": "Geodetic datum",
+                "info": "Datum describing the relationship between a 2D or 3D coordinate system and the Earth.",
                 "listItems" : [
-                    "Suhde voidaan luoda määrittelemällä joukolle pisteitä konventionaaliset koordinaattiarvot",
-                    "Esimerkkejä geodeettisesta datumista ovat mm. EUREF-FIN ja kartastokoordinaattijärjestelmä."
+                    "Datum: a parameter or set of parameters defining the origin, scale and orientation of a coordinate system.",
+                    "Examples of a geodetic datum are EUREF-FIN and the KKJ coordinate reference system."
                 ]
             },
             "coordinateSystem":{
-                "title": "Koordinaatisto",
-                "info": "Koordinaatisto: matemaattisten sääntöjen joukko, jolla määritellään se, miten pisteille annetaan koordinaatit.",
+                "title": "Coordinate system",
+                "info": "A set of mathematical rules defining how points are assigned coordinates.",
                 "listItems" : [
-                    "Koordinaatisto voidaan hahmottaa koordinaattiakselien muodostamaksi mitta-akselistoksi.",
-                    "Erityyppisiä koordinaatistoja ovat esimerkiksi suorakulmainen koordinaatisto, tasokoordinaatisto, napakoordinaatisto, geodeettinen koordinaatisto, pallokoordinaatisto ja lieriökoordinaatisto.",
-                    "Geodesian alalla termi terrestrinen vertauskehys korvaa aiemmin käytetyn koordinaatisto-termin."
+                    "Diferent types of coordinate systems include rectangular coordinate systems, projected coordinate systems, polar coordinate systems, geodetic coordinate systems, spherical coordinate systems and cylindrical coordinate systems."
                 ]
             },
             "mapProjection":{
-                "title": "Karttaprojektiojärjestelmä",
-                "info": "Karttaprojektiojärjestelmä: joukko sääntöjä, joiden avulla määrätään, kuinka haluttu alue kuvataan joukolla karttaprojektioita",
+                "title": "System of map projection",
+                "info": "A set of rules determining how an area is described using a set of map projections.",
                 "listItems" : [
-                    "Säännöillä voidaan esimerkiksi sitoa käytettävät karttaprojektiot ja projektiokaistat. Projektiokaistojen osalta järjestelmä voi määrittää kaistoille esimerkiksi tunnisteet, keskimeridiaanien tai -paralleelien mittakaavan, leveyden, pituuden ja päällekkäisyyden."
+                    "Map projection: a method of describing a three-dimensional surface on a two-dimensional plane (map).",
+                    "The rules can be used to affirm map projections and projection zones. For projection zones the system can define identifiers, the scale, width, length and superimposition of central meridians or central parallels."
                 ]
             },
             "geodeticCoordinateSystem":{
-                "title": "Geodeettinen koordinaattijärjestelmä",
-                "info": "Geodeettinen koordinaattijärjestelmä: koordinaattijärjestelmä, joka perustuu geodeettiseen datumiin.",
+                "title": "Geodetic coordinate reference system",
+                "info": "Coordinate reference system based on a geodetic datum.",
                 "listItems" : [
-                    "Koordinaattijärjestelmä: järjestelmä, joka muodostuu datumin avulla reaalimaailmaan kiinnitetystä koordinaatistosta.",
-                    "Koordinaattijärjestelmän avulla kohteen sijainti voidaan ilmaista yksikäsitteisesti.",
-                    "Koordinaattijärjestelmä voi olla globaali, alueellinen (käytössä esim. yhden mantereen alueella) tai paikallinen (käytössä esim. yhden valtion tai kunnan alueella).",
-                    "Suomen valtakunnallinen tasokoordinaattijärjestelmä on ETRS-TM35FIN."
+                    "Coordinate reference system: a system consisting of a coordinate system that is tied to the real world with a datum.",
+                    "The national projected coordinate system of Finland is ETRS-TM35FIN."
                 ]
             },
             "heightSystem":{
-                "title":"Korkeusjärjestelmä",
-                "info": "Korkeusjärjestelmä: yksiulotteinen koordinaattijärjestelmä, joka perustuu korkeusdatumiin.",
+                "title":"Vertical coordinate reference system",
+                "info": "One-dimensional coordinate system based on a vertical datum.",
                 "listItems" : [
-                    "Suomessa käytetään valtakunnallisissa töissä JHS 163-suosituksen mukaista N2000-korkeusjärjestelmää."
+                    "Vertical datum: a datum defining the relationship between heights or depths related to gravity and the Earth.",
+                    "In nationwide tasks in Finland, we use the N2000 height system that is compliant with the JHS 163 recommendation."
                 ]
             },
             "fileName":{
-                "title":"Tiedoston nimi",
+                "title":"File name",
                 "info": "",
                 "paragraphs" : [],
                 "listItems" : []
             },
-            "decimalCount":{
-                "title":"Desimaalien määrä",
-                "info": "",
+            "decimalPrecision":{
+                "title":"Decimal precision",
+                "info": "Number of decimals included in the output",
                 "paragraphs": [
-                    "Ominaisuuden avulla kerrotaan ohjelmalle kuinka monta desimaalia tulosteessa halutaan olevan."
+                    "This property is used to define the decimal accuracy of coordinates in the output. The default on the form is the number of decimals matching an accuracy of 1mm. The default for showing degrees is the nearest number of decimals in the metric system matching an accuracy of 1mm."
                 ],
-                "listItems" : []
+                "listItems" : [],
+                "precisionTable": {
+                    "title": "Metristen tarkkuuksien desimaalien määrä kulman muotojen/yksikkö",
+                    "unit": "Kulman muoto/yksikkö",
+                    "deg": "Asteet, goonit ja DD",
+                    "rad": "Radiaaneissa",
+                    "min": "DDMM ja DD MM",
+                    "sec": "DDMMSS ja DD MM SS"
+                }
             },
             "coordinateSeparator":{
-                "title":"Sarake-erotin",
-                "info": "",
+                "title":"Coordinate separator",
+                "info": "Coordinate separator", // TODO
                 "paragraphs": [
-                    "Ominaisuuden avulla määritetään millainen merkkijono erottaa syötteessä koordinaattiarvot toisistaan.",
-                    "Jos koordinaatteja edeltää jokin tunniste tai seuraa jokin merkkijono, tulee nämäkin olla erotettuna samalla erottimella."
+                    "This property is used to show the column separator in the input file that is used to separate coordinate values. The input data cannot contain more than one such separator character between two coordinate values.",
+                    "If the coordinates are preceded by an identifier or followed by a character string, these must also be separated from the coordinates using the same separator."
                 ],
                 "listItems" : []
             },
             "headerLineCount":{
-                "title":"Otsakerivien määrä",
-                "info": "",
+                "title":"Number of header rows",
+                "info": "Number of lines in the beginning of the file before the first coordinate row",
                 "paragraphs": [
-                    "Ominaisuuden avulla pystyy ohjelmalle kertomaan kuinka monta riviä tiedoston alusta ohitetaan.",
-                    "Ohittamisen syynä voi olla, että tiedoston alussa on esimerkiksi sanallinen kuvaus tiedoston sisällöstä."
+                    "This property is used to assign the number of lines to be bypassed at the start of the file before reading the first coordinate row.",
+                    "The reason for bypassing can be, for example, a verbal description of the contents at the start of the file."
                 ],
                 "listItems" : []
             },
             "unitFormat":{
-                "title":"Kulman muoto/yksikkö",
-                "info": "",
+                "title":"Angle pattern",
+                "info": "Unit of a geographic coordinate expressed in degrees",
                 "paragraphs": [
-                    "Ominaisuuden avulla kerrotaan ohjelmalle missä muodossa kulma-arvot ovat. Tuettuja kulmayksikköjä ovat: Aste, Gooni (graadi) ja Radiaani.",
-                    "Lisäksi asteesta johdetut sexagesimaalimuodot ovat tuettuja. Jos näissä muodoissa esimerkiksi asteet, kaariminuutit ja kaarisekunnit ovat erotettuina, hyväksyy ohjelma erottimena tabulaattorin, pilkun ja puolipisteen, mutta ei välilyöntiä."
+                    "This property is used to define the format of angle values. Supported angle units: Degree, Grade and Radian",
+                    "Sexagesimal forms derived from the degree are also supported. If in these formats degrees, minutes of arc and seconds of arc are separated by a space (DD MM and DD MM SS), the space cannot be used as the coordinate separator."
                 ],
                 "listItems" : []
             },
             "decimalSeparator":{
-                "title":"Desimaalierotin",
-                "info": "",
+                "title":"Decimal separator",
+                "info": "This property is used to define the decimal separator.",
                 "paragraphs": [
-                    "Ominaisuuden avulla pystyy kertomaan mikä merkki toimii desimaalierotin.",
-                    "Desimaalierottimen tulee poiketa koordinaattiarvot erottavasta merkistä. Kun koordinaattiarvot erottaa esimerkiksi pilkku sekä joukko välilyöntejä, niin desimaalierottimen on oltava piste!"
+                    "This property is used to define the decimal separator.",
+                    "The decimal separator cannot be the same character as the coordinate separator. If the coordinate separator is a comma, the decimal separator must be a point."
                 ],
                 "listItems" : []
             },
             "lineSeparator":{
-                "title":"Rivin erotin",
-                "info": "",
+                "title":"Line separator",
+                "info": "Character used as row or line break in the file",
                 "paragraphs": [
-                    "Ominaisuuden avulla kerrotaan ohjelmalle mitä merkkiä/merkkijonoa käytetään erottamaan toisistaan rivit (pisteet)."
+                    "This property is used to define the character or character string used to separate rows/lines in the file. This character or character string is added to the end of each line or row in the file."
                 ],
                 "listItems" : []
             },
             "prefixId":{
-                "title":"Koordinaattiarvoja edeltää pisteen tunniste",
-                "info": "",
+                "title":"Use identifiers",
+                "info": "Coordinate row starts with identifier",
                 "paragraphs": [
-                    "Ominaisuuden avulla pystyy ohjelmalle kertomaan, että jokaisen pisteen koordinaattiarvoja edeltää samalla rivillä pisteen tunniste (ID).",
-                    "Pisteen tunnisteen tulee olla erotettuna koordinaattiarvoista samalla merkkijonolla kuin koordinaattiarvot ovat erotettuina toisistaan.",
-                    "Tunnisteen ei tarvitse olla numeerinen."
+                    "This property is used to define that the coordinate values of each point are preceded on the same line by the point's identifier (ID)",
+                    "The point identifier must be separated from the coordinate values using the same character string as that used as the coordinate value separator.",
+                    "If the input file does not contain point identifiers or the points have been imported from a table or a map, the points are assigned identifiers starting from 1 and increasing by one integer for each point.",
+                    "The identifiers in the output file do not need to be numerical."
                 ],
                 "listItems" : []
             },
             "reverseCoordinates":{
-                "title":"Koordinaatit käänteisesti",
+                "title":"Inverted coordinates",
                 "info": "",
                 "paragraphs": [
-                    "Ominaisuuden avulla pystyy määrittämään ovatko tiedoston pisteiden kaksi ensimmäistä koordinaattiarvoa käänteisessä järjestyksessä suhteessa koordinaatiston kuvailussa annettuun järjestykseen.",
-                    "Esimerkiksi kkj:n koordinaatit ovat lähtökohtaisesti jäjestyksessä, jossa ensimmäisenä on x-koordinaatti ja sitä seuraa y-koordinaatti. x-akseli osoittaa pohjoiseen ja y-akseli itään. Kun valitsee käänteisen järjestyksen, tulee tiedostossa y-koordinaatin edeltää x-koordinaattia."
+                    "This property is used to define whether the first two coordinate values of each point in the file are in reverse order in comparison with the order given in the description of the coordinate system.",
+                    "For example, koordinates in the KKJ coordinate system are by default arranged so that the N coordinate is followed by the E coordinate. If the reverse order is selected, the E coordinate must precede the N coordinate in the file."
                 ],
                 "listItems" : []
             },
             "writeHeader":{
-                "title":"Otsakerivin tulostaminen tiedostoon",
-                "info": "",
+                "title":"Include header rows",
+                "info": "Include header rows in the output",
                 "paragraphs": [
-                    "Ominaisuuden avulla käyttäjä voi kertoa haluaako tulostiedostoon metatietoa koordinaateista otsakeriville."
+                    "This property is used to include metadata about coordinates in the header row. The name of the coordinate reference system is added to the header row.",
+                    "When transforming from one file into another, any header rows in the input file in addition to the coordinate reference system information are added to the output file."
                 ],
                 "listItems" : []
             },
             "lineEnds":{
-                "title":"Tulosteeseen rivin loput",
-                "info": "",
+                "title":"Include end-of-row markers in output",
+                "info": "End-of-row characters and character strings are added to the output file",
                 "paragraphs": [
-                    "Ominaisuuden avulla pystyy kertomaan haluaako tulosteeseen kirjoitettavan myös jokaisella rivillä annetun pisteen koordinaatteja seuraavan merkkijonon."
+                    "This property is used to include any end-of-row characters or character strings from the input file to the output file. All characters following the coordinate values of a point count as the end-of-row character string for that row. The end-of-row character or character string must be separated from the coordinate values using the same character as that used as the coordinate value separator.",
+                    "This property only has an effect on the transformation from one file to another."
                 ],
                 "listItems" : []
             },
             "useCardinals":{
-                "title":"Kardinaalien käyttö",
-                "info": "",
+                "title":"Use cardinals",
+                "info": "Coordinate values are followed by points of the compass (N, E, W or S).",
                 "paragraphs": [
-                    "Ominaisuudella määritetään kirjoitetaanko tulosteeseen koordinaattiarvojen perään niiden ilmansuunnat. Tällöin miinusmerkit poistetaan koordinaattiarvoista.",
-                    "Ilmansuunnat annetaan kirjoittamalla joko N, E, W tai S koordinaattiarvon perään."
+                    "This property is used to include points of the compass after coordinate values in the output. The inverse point of the compass is added to negative values and the minus signs are removed from coordinate values. For example, the value of the E coordinate 325418 becomes 325418E and the value of the E coordinate -325418 becomes 325418W.",
+                    "Points of the compass are indicated by writing N, E, W or S after the coordinate value."
                 ],
                 "listItems" : []
             }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
@@ -114,7 +114,7 @@ Oskari.registerLocalization(
         },
         "dataSource": {
             "title": "Coordinate information source",
-            "confirmChange": "Input coordinates will be removed and the coordinate reference system information deleted. Do you want to continue?",
+            "confirmChange": "Input coordinates will be removed. Do you want to continue?",
             "file": {
                 "label": "From file",
                 "info":  "Select the file containing the input information and its settings.",
@@ -127,6 +127,7 @@ Oskari.registerLocalization(
             "map": {
                 "label": "Select locations on the map",
                 "info": "Select coordinates to be transformed on the map by clicking them.",
+                "confirmSelect": "Lähtökoordinaattijärjestelmän tiedot valitaan automaattisesti kartan käyttämän ETRS-TM35FIN -projektion mukaisiksi. Tekemäsi lähtökoordinaattijärjestelmän valinnat korvataan. Haluatko jatkaa?",
                 "action": "select more"
             }
         },
@@ -262,12 +263,12 @@ Oskari.registerLocalization(
                 ],
                 "listItems" : [],
                 "precisionTable": {
-                    "title": "Metristen tarkkuuksien desimaalien määrä kulman muotojen/yksikkö",
-                    "unit": "Kulman muoto/yksikkö",
-                    "deg": "Asteet, goonit ja DD",
-                    "rad": "Radiaaneissa",
-                    "min": "DDMM ja DD MM",
-                    "sec": "DDMMSS ja DD MM SS"
+                    "title": "Kulman muodon/yksikön desimaalien määrä metrisenä tarkkuutena",
+                    "unit": "Angle pattern", // Angle shape/unit
+                    "deg": "Degree, Grade and DD",
+                    "rad": "Radian",
+                    "min": "DDMM and DD MM",
+                    "sec": "DDMMSS and DD MM SS"
                 }
             },
             "coordinateSeparator":{

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
@@ -5,7 +5,7 @@ Oskari.registerLocalization(
     "value": {
         "title": "Koordinaattimuunnos",
         "tile": {
-            "title": "Koordinaattimuunnos"
+            "title": "Koordinaatti- muunnos"
         },
         "flyout": {
             "title":"Koordinaattimuunnos",
@@ -71,22 +71,21 @@ Oskari.registerLocalization(
                     "title": "Huomio!",
                     "3DTo2D": "Valitsemissasi lähtötiedoissa on mukana korkeusarvoja, mutta tulostiedoissa ei. Tuloskoordinaatteihin ei siis tule korkeusarvoja mukaan. Haluatko jatkaa?",
                     "2DTo3D": "Valitsemissasi lähtötiedoissa ei ole korkeusarvoja, mutta tulostiedoissa on. Lähtöaineiston korkeusarvoiksi lisätään 0 ja korkeusjärjestelmäksi N2000. Haluatko jatkaa?",
-                    "xyz": "Lähtökoordinaattijärjestelmän valinnoissa ei ole korkeusjärjestelmää. Muunnos suorakulmaiseen 3D -järjestelmään ei ole mahdollinen."
+                    "xyz": "Lähtökoordinaattijärjestelmän valinnoissa ei ole korkeusjärjestelmää. Muunnos suorakulmaiseen 3D -järjestelmään ei ole mahdollinen.",
+                    "largeFile": "Isojen tiedostojen muuntaminen voi kestää useita minuutteja."
                 },
                 "validateErrors": {
                     "title": "Virhe!",
                     "message": "Valinnoissa on puutteita tai virheitä. Ota huomioon seuraavat vaatimukset ja yritä uudelleen.",
                     "crs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna sekä lähtö- että tulostiedoissa.",
-                    //"sourceHeight": "Lähtötietojen korkeusjärjestelmää ei ole valittu.",
-                    //"targetHeight": "Tulostietojen korkeusjärjestelmää ei ole valittu.",
                     "noInputData": "Ei muunnettavia koordinaatteja.",
                     "noInputFile": "Lähtöaineiston sisältävä tiedosto pitää olla valittuna.",
                     "noFileName": "Muodostettavalle tiedostolle pitää antaa tiedostonimi.",
-                    "decimalCount": "Desimaalien tarkkuus pitää olla 0 tai positiivnen kokonaisluku.",
+                    "decimalCount": "Desimaalien tarkkuus pitää olla 0 tai positiivinen kokonaisluku.",
                     "headerCount": "Otsakerivien määrä pitää olla 0 tai positiivinen kokonaisluku.",
                     "doubleComma": "Desimaali- ja koordinaattierotin eivät voi molemmat olla pilkkuja.",
                     "doubleSpace": "Kulman muoto/yksikkö ei voi sisältää välilyöntejä, jos koordinaattierotin on Välilyönti.",
-                    "noFileSettings": "Tiedosto asetuksia ei ole annettu.",
+                    "noFileSettings": "Tiedostoasetuksia ei ole annettu.",
                     "noCoordinateSeparator": "Koordinaattierotin pitää olla valittuna.",
                     "noDecimalSeparator":"Desimaalierotin pitää olla valittuna."
                 },
@@ -95,16 +94,16 @@ Oskari.registerLocalization(
                     "titleRead": "Virhe tiedoston lukemisessa!",
                     "readFileError" : "Tiedostosta ei onnistuttu lukemaan kaikkia rivejä.",
                     "transformFileError": "Tiedoston koordinaatteja ei onnistuttu muuntamaan.",
-                    "invalidLine": "Tiedostossa on rivillä: {index, number} virheellinen koordinaattirivi: {line} <br> Tarkasta, että kyseinen rivi on kelvollinen ja vastaa valintoja.",
-                    //error codes
+                    "invalidLine": "Tiedostossa on rivillä: {index, number} virheellinen koordinaattirivi: {line} <br> Tarkasta, että kyseinen rivi on kelvollinen ja vastaa -- valintoja.", //TODO
                     "generic": "Koordinaattimuunnos epäonnistui...",
+                    //error codes
                     "invalid_coord": "Koordinaatti virheellinen. Tarkasta, että muunnettavat koordinaatit on oikeassa muodossa sekä geodeettinen koordinaatti- ja kokeusjärjestelmä ovat oikein.",
-                    "invalid_number": "Koordinaatti virheellinen. Tarkasta..", //can we get row number from file
-                    "invalid_coord_in_array": "Koordinaatti virheellinen. Tarkasta..", //can user input invalid coords in array??
+                    "invalid_number": "Koordinaatti virheellinen.",
+                    "invalid_coord_in_array": "Koordinaatti virheellinen.",
                     "no_coordinates": "Tiedostosta ei löytynyt koordinaatteja. Tarkasta tiedosto sekä asetettu otsakerivien määrä.",
-                    "invalid_file_settings": "Tiedoston asetukset virheelliset.", //can't be user's fault
-                    "no_file": "Lähetetystä pyynnöstä ei löytynyt tiedostoa.", //can't be user's fault
-                    "invalid_first_coord": "Tiedostosta ei saatu muodostettua koordinaattia annetuilla asetuksilla. Tarkasta, että koordinaatti erotin, otsakerivien määrä, käytä tunnistetta sekä geoodeettinen koordinaatti- ja korkeusjärjestelmä (dimensio) valinnat vastaavat tiedoston sisältöä.",
+                    "invalid_file_settings": "Tiedoston asetukset virheelliset.",
+                    "no_file": "Lähetetystä pyynnöstä ei löytynyt tiedostoa.",
+                    "invalid_first_coord": "Tiedostosta ei saatu muodostettua koordinaattia annetuilla asetuksilla. Tarkasta, että koordinaattierotin, otsakerivien määrä, käytä tunnistetta sekä geoodeettinen koordinaatti- ja korkeusjärjestelmä (dimensio) -valinnat vastaavat tiedoston sisältöä.",
                     "transformation_error": "Koordinaattimuunnos epäonnistui. Koordinaattimuunnospalvelusta palautui virhe:"
                 },
                 "responseFile": {
@@ -127,7 +126,7 @@ Oskari.registerLocalization(
             },
             "map": {
                 "label": "Valitse sijainnit kartalta",
-                "info": "Voit valita muunnettavia koordinaatteja kartalta sijainteja klikkaamalla.",
+                "info": "Voit valita muunnettavia koordinaatteja kartalta klikkaamalla.",
                 "action": "valitse lisää"
             }
         },
@@ -135,7 +134,7 @@ Oskari.registerLocalization(
             "show":{
                 "title": "Näytä sijainnit kartalla",
                 "info": "Kartta on ETRS89-TM35FIN -projektiossa. Koordinaatit on sijoitettu kartalle kyseistä koordinaattijärjestelmää käyttäen. Sijaintimerkinnän yhteydessä näytään lähtö- ja/tai tuloskoordinaattijärjestelmän mukaiset koordinaatit lukemina. ",
-                //"errorTitle": "Virhe sijaintien näyttämisessä",
+                "errorTitle": "Virhe sijaintien näyttämisessä",
                 "noCoordinates": "Ei koordinaatteja näytettäväksi kartalla",
                 "noSrs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna lähtötiedoissa, jotta pisteet voidaan näyttää kartalla.",
                 "lon": "Lon",
@@ -145,18 +144,15 @@ Oskari.registerLocalization(
             },
             "select":{
                 "title": "Valitse sijainnit kartalta",
-                "info": "Valitse yksi tai useampi piste kartalta klikkaamalla. Kartta on {mapSrs} -projektiossa. Tämä koordinaattijärjestelmä valitaan automaattisesti eikä sitä voi muutta. Valinnoissa on syytä huomioida, että kartalta sijaintien valinta ei ole kovin tarkkaa ja valitut koordinaatit pyöristetään kokonaisluvuiksi.",
+                "info": "Valitse yksi tai useampi piste kartalta klikkaamalla. Kartta on ETRS-TM35FIN-projektiossa. Tämä koordinaattijärjestelmä valitaan automaattisesti eikä sitä voi muutta. Valinnoissa on syytä huomioida, että kartalta sijaintien valinta ei ole kovin tarkkaa ja valitut koordinaatit pyöristetään kokonaisluvuiksi.",
                 "add": "Lisää merkintöjä",
                 "remove": "Poista merkintöjä"
             }
         },
         "actions": {
             "convert": "Muunna",
-            //"clearTable": "Tyhjennä taulukot",
-            //"showMarkers": "Näytä sijainnit kartalla",
             "export": "Muunna tiedostoon",
             "select": "Valitse",
-            //"selectFromMap": "Siirry valitsemaan.",
             "cancel": "Peruuta",
             "done": "Valmis",
             "ok": "Ok",
@@ -167,9 +163,13 @@ Oskari.registerLocalization(
                 "decimalSeparator": "Desimaalierotin",
                 "coordinateSeparator": "Koordinaattierotin",
                 "headerCount": "Otsakerivien määrä",
-                "decimalCount": "Desimaalien tarkkuus",
-                "reverseCoords": "Koordinaatit käänteisesti",
-                "useId": "Käytä tunnistetta",
+                "decimalPrecision": "Desimaalien tarkkuus",
+                "reverseCoordinates": "Koordinaatit käänteisesti",
+                "useId": {
+                    "input": "Koordinaatit sisältää tunnisteet",
+                    "generate": "Luo tunnisteet",
+                    "fromFile": "Lisää lähtötiedoston tunnisteet"
+                },
                 "writeHeader": "Kirjoita otsakerivi tiedostoon",
                 "useCardinals": "Käytä kardinaaleja (N,E,W,S)",
                 "lineEnds": "Rivin loput tulokseen",
@@ -254,13 +254,21 @@ Oskari.registerLocalization(
                 "paragraphs" : [],
                 "listItems" : []
             },
-            "decimalCount":{
-                "title":"Desimaalien määrä",
-                "info": "Tukokseen tulevien desimaalien määrä",
+            "decimalPrecision":{
+                "title":"Desimaalien tarkkuus",
+                "info": "Tulokseen tulevien desimaalien määrä",
                 "paragraphs": [
-                    "Ominaisuuden avulla kerrotaan ohjelmalle kuinka monen desimaalin tarkkuudella koordinaatit halutaan tulokseen."
+                    "Ominaisuuden avulla kerrotaan ohjelmalle millä tarkkuudella koordinaatit halutaan tulokseen. Oletusarvona lomakkeella on 1mm tarkkuutta vastaava desimaalimäärä. Asteen esitysmuodoille oletusarvo on metristä järjestelmää vastaava lähin desimaalimäärä 1mm tarkkuuteen."
                 ],
-                "listItems" : []
+                "listItems": [],
+                "precisionTable": {
+                    "title": "Metristen tarkkuuksien desimaalien määrä kulman muotojen/yksikkö",
+                    "unit": "Kulman muoto/yksikkö",
+                    "deg": "Asteet, goonit ja DD",
+                    "rad": "Radiaaneissa",
+                    "min": "DDMM ja DD MM",
+                    "sec": "DDMMSS ja DD MM SS"
+                }
             },
             "coordinateSeparator":{
                 "title":"Sarake-erotin",
@@ -293,8 +301,8 @@ Oskari.registerLocalization(
                 "title":"Desimaalierotin",
                 "info": "Desimaaliosan erottamiseen käytetty merkki",
                 "paragraphs": [
-                    "Ominaisuuden avulla pystyy kertomaan mikä merkki toimii desimaalierotin.",
-                    "Desimaalierottimen tulee poiketa koordinaattiarvot erottavasta merkistä. Kun koordinaattiarvot erottaa esimerkiksi pilkku sekä joukko välilyöntejä, niin desimaalierottimen on oltava piste!"
+                    "Ominaisuuden avulla pystyy kertomaan mikä merkki toimii desimaalierotin.", //TODO
+                    "Desimaalierottimen tulee poiketa koordinaattiarvot erottavasta merkistä. Kun koordinaattiarvot erottaa esimerkiksi pilkku sekä joukko välilyöntejä, niin desimaalierottimen on oltava piste."
                 ],
                 "listItems" : []
             },
@@ -312,6 +320,7 @@ Oskari.registerLocalization(
                 "paragraphs": [
                     "Ominaisuuden avulla pystyy ohjelmalle kertomaan, että jokaisen pisteen koordinaattiarvoja edeltää samalla rivillä pisteen tunniste (ID).",
                     "Pisteen tunnisteen tulee olla erotettuna koordinaattiarvoista samalla merkkijonolla kuin koordinaattiarvot ovat erotettuina toisistaan.",
+                    "Jos tuodussa tiedostossa ei ole pisteiden tunnisteita tai pisteet on tuotu taulukosta tai kartalta, niin tulostiedoston pisteiden tunnisteiksi luodaan yhdellä arvolla kasvava kokonaisluku alkaen arvosta 1.",
                     "Tunnisteen ei tarvitse olla numeerinen."
                 ],
                 "listItems" : []
@@ -321,12 +330,12 @@ Oskari.registerLocalization(
                 "info": "X- ja Y-Koordinaattiakselien järjestys poikkeaa määritetystä järjestyksestä",
                 "paragraphs": [
                     "Ominaisuuden avulla pystyy määrittämään ovatko tiedoston pisteiden kaksi ensimmäistä koordinaattiarvoa käänteisessä järjestyksessä suhteessa koordinaatiston kuvailussa annettuun järjestykseen.",
-                    "Esimerkiksi kkj:n koordinaatit ovat lähtökohtaisesti jäjestyksessä, jossa ensimmäisenä on x-koordinaatti ja sitä seuraa y-koordinaatti. x-akseli osoittaa pohjoiseen ja y-akseli itään. Kun valitsee käänteisen järjestyksen, tulee tiedostossa y-koordinaatin edeltää x-koordinaattia."
+                    "Esimerkiksi kkj:n koordinaatit ovat lähtökohtaisesti järjestyksessä, jossa ensimmäisenä on x-koordinaatti ja sitä seuraa y-koordinaatti. x-akseli osoittaa pohjoiseen ja y-akseli itään. Kun valitsee käänteisen järjestyksen, tulee tiedostossa y-koordinaatin edeltää x-koordinaattia."
                 ],
                 "listItems" : []
             },
             "writeHeader":{
-                "title":"Otsakerivin tulostaminen tiedostoon",
+                "title":"Lisää otsakerivit",
                 "info": "Tuloksen alkuun otsakerivit mukaan",
                 "paragraphs": [
                     "Ominaisuuden avulla käyttäjä voi kertoa haluaako tulostiedostoon metatietoa koordinaateista otsakeriville.",

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
@@ -114,7 +114,7 @@ Oskari.registerLocalization(
         },
         "dataSource": {
             "title": "Koordinaattitietojen lähde",
-            "confirmChange": "Muunnettavat koordinaatit tyhjennetään ja koordinaattijärjestelmän tiedot poistetaan. Haluatko jatkaa?",
+            "confirmChange": "Muunnettavat koordinaatit tyhjennetään. Haluatko jatkaa?",
             "file": {
                 "label": "Tiedostosta",
                 "info":  "Valitse lähtöaineiston sisältävä tiedosto ja sen asetukset.",
@@ -127,6 +127,7 @@ Oskari.registerLocalization(
             "map": {
                 "label": "Valitse sijainnit kartalta",
                 "info": "Voit valita muunnettavia koordinaatteja kartalta klikkaamalla.",
+                "confirmSelect": "Lähtökoordinaattijärjestelmän tiedot valitaan automaattisesti kartan käyttämän ETRS-TM35FIN -projektion mukaisiksi. Tekemäsi lähtökoordinaattijärjestelmän valinnat korvataan. Haluatko jatkaa?",
                 "action": "valitse lisää"
             }
         },
@@ -168,7 +169,7 @@ Oskari.registerLocalization(
                 "useId": {
                     "input": "Koordinaatit sisältää tunnisteet",
                     "generate": "Luo tunnisteet",
-                    "fromFile": "Lisää lähtötiedoston tunnisteet"
+                    "fromFile": "Lisää tunnisteet"
                 },
                 "writeHeader": "Kirjoita otsakerivi tiedostoon",
                 "useCardinals": "Käytä kardinaaleja (N,E,W,S)",
@@ -262,10 +263,10 @@ Oskari.registerLocalization(
                 ],
                 "listItems": [],
                 "precisionTable": {
-                    "title": "Metristen tarkkuuksien desimaalien määrä kulman muotojen/yksikkö",
+                    "title": "Kulman muodon/yksikön desimaalien määrä metrisenä tarkkuutena",
                     "unit": "Kulman muoto/yksikkö",
-                    "deg": "Asteet, goonit ja DD",
-                    "rad": "Radiaaneissa",
+                    "deg": "Aste, gooni ja DD",
+                    "rad": "Radiaanit",
                     "min": "DDMM ja DD MM",
                     "sec": "DDMMSS ja DD MM SS"
                 }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
@@ -3,132 +3,137 @@ Oskari.registerLocalization(
     "lang": "sv",
     "key": "coordinatetransformation",
     "value": {
-        "title": "Coordinateconversion",
+        "title": "Koordinatomvandling",
         "tile": {
-            "title": "Coordinateconversion"
+            "title": "Koordinatomvandling"
         },
         "flyout": {
-            "title":"Coordinateconversion",
+            "title":"Koordinatomvandling",
             "filterSystems": {
-                "title": "Suodata koordinaattijärjestelmiä",
-                "epsg": "EPSG-koodilla",
-                "systems": "Datumilla ja koordinaatistolla"
+                "title": "Filtrera referenssystem för koordinater",
+                "epsg": "Med EPSG-kod",
+                "systems": "Med datum och koordinatsystem"
             },
             "coordinateSystem": {
-                "title": "Koordinaattijärjestelmän tiedot",
+                "title": "Uppgifter om referenssystemet för koordinater",
                 "input": {
-                    "title": "Från-system"
+                    "title": "Utgångsuppgifter om referenssystemet för koordinater"
                 },
                 "output": {
-                    "title": "Till-system"
+                    "title": "Resultatuppgifter om referenssystemet för koordinater"
                 },
-                "noFilter": "Mikä tahansa",
+                "noFilter": "Vad som helst",
                 "epsgSearch": {
-                    "label": "Hae EPSG-koodilla"
+                    "label": "Sök med EPSG-kod"
                 },
                 "geodeticDatum": {
                     "label": "Geodetiskt datum"
                 },
                 "coordinateSystem":{
                     "label": "Koordinatsystem",
-                    "proj2D": "Suorakulmainen 2D (Taso)",
-                    "proj3D": "Suorakulmainen 3D",
-                    "geo2D": "Maantieteellinen 2D",
-                    "geo3D": "Maantieteellinen 3D"
+                    "proj2D": "Projicerat 2D (Plan)",
+                    "proj3D": "Projicerat 3D",
+                    "geo2D": "Geografiskt 2D",
+                    "geo3D": "Geografiskt 3D"
                 },
                 "mapProjection":{
                     "label": "Kartprojektionssystem"
                 },
                 "geodeticCoordinateSystem":{
-                    "label": "Geodetiskt koordinatsystem",
+                    "label": "Geodetiskt referenssystem för koordinater", // Geodetiskt koordinatsystem
                     "choose": "Valitse",
                     "kkj": "KKS zon {zone, number}",
-                    "ykj": "KKS zon 3 / ?YKJ?"
+                    "ykj": "KKS zon 3 / EKS"
                 },
                 "heightSystem":{
-                    "label": "Höjdsystemet",
-                    "none": "Ei mitään"
+                    "label": "Höjdsystem",
+                    "none": "Ingenting"
                 }
             },
             "coordinateTable": {
-                "input": "Muunnettavat koordinaatit",
-                "output": "Tuloskoordinaatit",
-                "north":"Pohjois-koordinaatti [m]",
-                "east":"Itä-koordinaatti [m]",
-                "lat":"Leveysaste",
-                "lon":"Pituusaste",
-                "elevation": "Korkeus [m]",
-                "geoX":"Geosentrinen X [m]",
-                "geoY":"Geosentrinen Y [m]",
-                "geoZ":"Geosentrinen Z [m]",
-                "ellipseElevation":"Ellipsoidinen korkeus [m]",
+                "input": "Koordinater som ska omvandlas",
+                "output": "Resultatkoordinater",
+                "north":"Nord-koordinat [m]",
+                "east":"Öst-koordinat [m]",
+                "lat":"Latitud",
+                "lon":"Longitud",
+                "elevation": "Höjd [m]",
+                "geoX":"Geocentriskt X [m]",
+                "geoY":"Geocentriskt Y [m]",
+                "geoZ":"Geocentriskt Z [m]",
+                "ellipseElevation":"Höjd över ellipsoiden [m]",
                 "rows": "Rader",
-                "clearTables": "Haluatko tyhjentää taulukot?",
-                "confirmClear": "Haluatko tyhjentää taulukot?"
+                "clearTables": "Töm tabellerna",
+                "confirmClear": "Är du säker på att du vill tömma tabellerna?"
             },
             "transform": {
                 "warnings": {
-                    "title": "Huomio!",
-                    "3DTo2D": "Valitsemissasi lähtötiedoissa on mukana korkeusarvoja, mutta tulostiedoissa ei. Tuloskoordinaatteihin ei siis tule korkeusarvoja mukaan. Haluatko jatkaa?",
-                    "2DTo3D": "Valitsemissasi lähtötiedoissa ei ole korkeusarvoja, mutta tulostiedoissa on. Lähtöaineiston korkeusarvoiksi lisätään 0 ja korkeusjärjestelmäksi N2000. Haluatko jatkaa?"
+                    "title": "Observera!",
+                    "3DTo2D": "I de utgångsuppgifter du valt finns höjdvärden, men inte i resultatuppgifterna. Höjvärden ingår alltså inte i resultatkoordinaterna. Vill du fortsätta?",
+                    "2DTo3D": "I de resultatuppgifter du valt finns höjdvärden, men inte i utgångsuppgifterna. Utgångsmaterialet ges höjdvärdet 0 och höjdsystemet N2000. Vill du fortsätta?",
+                    "xyz": "I valen som berör utgångsreferenssystemet för koordinater finns inget höjdsystem. En omvandling till ett rätvinkligt 3D-system kan inte göras.",
+                    "largeFile": "Isojen tiedostojen muuntaminen voi kestää useita minuutteja."
                 },
                 "validateErrors": {
-                    "title": "Virhe!",
-                    "message": "Valinnoissa on puutteita tai virheitä. Ota huomioon seuraavat vaatimukset ja yritä uudelleen.",
-                    "crs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna sekä lähtö- että tulostiedoissa.",
-                    "sourceHeight": "Lähtötietojen korkeusjärjestelmää ei ole valittu.",
-                    "targetHeight": "Tulostietojen korkeusjärjestelmää ei ole valittu.",
-                    "noInputData": "Ei muunnettavia koordinaatteja.",
-                    "noInputFile": "Lähtöaineiston sisältävä tiedosto pitää olla valittuna.",
-                    "noFileName": "Muodostettavalle tiedostolle pitää antaa tiedostonimi.",
-                    "decimalCount": "Desimaalien tarkkuus pitää olla 0 tai positiivnen kokonaisluku.",
-                    "headerCount": "Otsakerivien määrä pitää olla 0 tai positiivinen kokonaisluku.",
-                    "doubleComma": "Desimaali- ja koordinaattierotin eivät voi molemmat olla pilkkuja.",
+                    "title": "Fel!",
+                    "message": "Det finns brister eller fel i valen. Beakta följande krav och försök på nytt.",
+                    "crs": "Ett geodetiskt referenssystem för koordinater ska vara valt både i utgångs- och resultatuppgifterna.",
+                    "noInputData": "Det finns inga koordinater som kan omvandlas.",
+                    "noInputFile": "Filen som innehåller utgångsmaterial ska vara vald.",
+                    "noFileName": "Filen som bildas ska ges ett filnamn.",
+                    "decimalCount": "Decimalernas noggrannhet ska vara 0 eller ett positivt heltal.",
+                    "headerCount": "Antalet rubrikrader ska vara 0 eller ett positivt heltal.",
+                    "doubleComma": "Skiljetecknen för decimaler och koordinater kan inte båda vara kommatecken.",
                     "doubleSpace": "Kulman muoto/yksikkö ei voi sisältää välilyöntejä, jos koordinaattierotin on Välilyönti.",
-                    "noFileSettings": "Tiedosto asetuksia ei ole annettu.",
-                    "noCoordinateSeparator": "Koordinaattierotin pitää olla valittuna.",
-                    "noDecimalSeparator":"Desimaalierotin pitää olla valittuna."
+                    "noFileSettings": "Inga filinställningar har angetts..",
+                    "noCoordinateSeparator": "Skiljetecknet för koordinater ska vara valt.",
+                    "noDecimalSeparator": "Skiljetecknet för decimaler ska vara valt."
                 },
                 "responseErrors": {
-                    "title": "Virhe muunnoksessa!",
-                    "generic": "Koordinaattimuunnos epäonnistui...",
+                    "titleTransform": "Fel i omvandlingen!",
+                    "titleRead": "Virhe tiedoston lukemisessa!",
+                    "readFileError" : "Tiedostosta ei onnistuttu lukemaan kaikkia rivejä.",
+                    "transformFileError": "Tiedoston koordinaatteja ei onnistuttu muuntamaan.",
+                    "invalidLine": "I filen finns på rad: {index, number} felaktig koordinatrad: {line} Kontrollera att valen av skiljetecknen för decimaler och koordinater samt antalet rubrikrader motsvarar filens innehåll.",
+                    "generic": "Koordinatomvandlingen misslyckades...",
+                    //error codes
                     "invalid_coord": "Koordinaatti virheellinen. Tarkasta, että muunnettavat koordinaatit on oikeassa muodossa sekä geodeettinen koordinaatti- ja kokeusjärjestelmä ovat oikein.",
                     "invalid_number": "Koordinaatti virheellinen. Tarkasta..",
                     "invalid_coord_in_array": "Koordinaatti virheellinen. Tarkasta..",
                     "no_coordinates": "Ei koordinaatteja",
-                    "invalid_file_settings": "Invalid file settings",
-                    "no_file": "No file entry",
-                    "invalid_first_coord": "Tiedostossa virheellinen koordinaatti. Tarkasta, että otsakerivit, käytä tunnistetta sekä geoodeettinen koordinaatti- ja korkeusjärjestelmä ovat määritetty oikein.",
-                    "invalid_coord_in_line": "Tiedostossa virheellinen koordinaatti {line} rivillä {index, number}."
+                    "invalid_file_settings": "Felaktiga filinställningar.",
+                    "no_file": "Det fanns ingen fil för begäran.",
+                    "invalid_first_coord": "Det var inte möjligt att bilda en koordinat med de angivna inställningarna. Kontrollera att valen av skiljetecken för koordinater, antalet rubrikrader, huruvida identifierare används eller inte samt geodetiska referenssystem för koordinater och höjdsystem (dimension) motsvarar filens innehåll.",
+                    "transformation_error": "Koordinaattimuunnos epäonnistui. Koordinaattimuunnospalvelusta palautui virhe:"
                 },
                 "responseFile": {
-                    "title": "Huomio!",
-                    "hasMoreCoordinates": "Lähtöaineistosta ei voida muuntaa taulukkoon yli {maxCoordsToArray, number} koordinaattia. Jos haluat muuntaa kaikki koordinaatit, käytä Vie tulokset tiedostoon -toimintoa."
+                    "title": "Observera!",
+                    "hasMoreCoordinates": "Det är inte möjligt att från utgångsmaterialet omvandla fler än {maxCoordsToArray, number} koordinater i tabellen. Om du vill omvandla alla koordinater, använd funktionen För in resultaten i en fil."
                 }
             }
         },
         "dataSource": {
-            "title": "Koordinaattitietojen lähde",
-            "confirmChange": "Muunnettavat koordinaatit tyhjennetään ja koordinaattijärjestelmän tiedot poistetaan. Haluatko jatkaa?",
+            "title": "Källa för koordinatuppgifter",
+            "confirmChange": "Koordinaterna som ska omvandlas töms och uppgifterna om referenssystemet för koordinater tas bort. Vill du fortsätta?",
             "file": {
-                "label": "Tiedostosta",
-                "info":  "Valitse lähtöaineiston sisältävä tiedosto ja sen asetukset.",
-                "action": "Muokkaa"
+                "label": "Från fil",
+                "info":  "Välj filen med utgångsmaterialet och dess inställningar.",
+                "action": "redigera dina val"
             },
             "keyboard": {
-                "label": "Näppäimistöltä",
-                "info": "Syötä lähtötiedot Muunnettavat koordinaatit -taulukkoon."
+                "label": "Med tangentbordet",
+                "info": "Mata in utgångsuppgifter i tabellen Koordinater som ska omvandlas."
             },
             "map": {
-                "label": "Valitse sijainnit kartalta",
-                "info": "Valitse yksi tai useampi piste kartalta klikkaamalla.",
-                "action": "Valitse"
+                "label": "Välj lägen på kartan",
+                "info": "Du kan välja koordinater som ska omvandlas genom att klicka på kartan",
+                "action": "välj fler"
             }
         },
         "mapMarkers":{
             "show":{
-                "title": "Näytä sijainnit kartalla",
-                "info" : "Tarkastele muunnettuja koordinaatteja kartalla.",
+                "title": "Visa lägen på kartan",
+                "info" : "Kartans projektion är ETRS-TM35FIN. Koordinaterna har placerats på kartan med hjälp av detta referenssystem för koordinater. I samband med lägesanteckningen anges koordinaterna enligt utgångs- och/eller resultatreferenssystemet i siffror.",
                 "errorTitle": "Virhe sijaintien näyttämisessä",
                 "noCoordinates": "Ei koordinaatteja näytettäväksi kartalla",
                 "noSrs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna lähtötiedoissa, jotta pisteet voidaan näyttää kartalla.",
@@ -138,44 +143,45 @@ Oskari.registerLocalization(
                 "east": "E"
             },
             "select":{
-                "title": "Näytä sijainnit kartalla",
-                "info": "Valitse yksi tai useampia pisteitä kartalta klikkaamalla.",
+                "title": "Välj lägen på kartan",
+                "info": "Välj en eller flera punkter på kartan genom att klicka på dem. Kartans projektion är ETRS-TM35FIN. Detta referenssystem för koordinater väljs automatiskt för de koordinater som omvandlas och kan inte ändras. Beakta vid val av koordinater att valet av läge inte är exakt.",
                 "add": "Lisää merkintöjä",
                 "remove": "Poista merkintöjä"
             }
         },
         "actions": {
-            "convert": "Transformera",
-            "clearTable": "Tyhjennä taulukot",
-            "showMarkers": "Näytä sijainnit kartalla",
-            "export": "Muunna tiedostoon",
-            "select": "Valitse",
-            "selectFromMap": "Siirry valitsemaan.",
-            "cancel": "Ångra",
+            "convert": "Omvandla", //Transformera
+            "export": "Omvandla i en fil",
+            "select": "Välj",
+            "cancel": "Avbryt", //Ångra
             "done": "Färdig",
             "ok": "Ok",
-            "close": "Sulje"
+            "close": "Stäng"
         },
         "fileSettings": {
             "options": {
-                "decimalSeparator": "Desimaalierotin",
-                "coordinateSeparator": "Koordinaattierotin",
-                "headerCount": "Otsakerivien määrä",
-                "decimalCount": "Desimaalien tarkkuus",
-                "reverseCoords": "Koordinaatit käänteisesti",
-                "useId": "Käytä tunnistetta",
-                "writeHeader": "Kirjoita otsakerivi tiedostoon",
-                "useCardinals": "Käytä kardinaaleja (N,E,W,S)",
-                "lineEnds": "Tulosteeseen rivin loput",
-                "choose": "Valitse",
+                "decimalSeparator": "Skiljetecken för decimaler",
+                "coordinateSeparator": "Skiljetecken för koordinater",
+                "headerCount": "Antal rubrikrader",
+                "decimalCount": "Decimalernas precision",
+                "reverseCoordinates": "Omvända koordinater",
+                "useId": { // Använd identifierare
+                    "input": "Koordinaatit sisältää tunnisteet",
+                    "generate": "Luo tunnisteet",
+                    "fromFile": "Lisää lähtötiedoston tunnisteet"
+                },
+                "writeHeader": "Skriv rubrikraden i filen",
+                "useCardinals": "Använd kardinalväderstreck (N,E,W,S)",
+                "lineEnds": "Ta med radavslutningarna i resultatet",
+                "choose": "Välj",
                 "degreeFormat":{
-                    "label": "Kulman muoto/yksikkö",
-                    "degree": "Aste",
-                    "gradian": "Gooni (graadi)",
-                    "radian": "Radiaani"
+                    "label": "Vinkelns form/enhet",
+                    "degree": "Grad",
+                    "gradian": "Gon (nygrad)",
+                    "radian": "Radian"
                 },
                 "lineSeparator": {
-                    "label": "Rivin erotin",
+                    "label": "Radavskiljare",
                     "win": "Windows / DOS",
                     "unix": "Unix",
                     "mac": "MacOS"
@@ -183,166 +189,175 @@ Oskari.registerLocalization(
                 "delimeters":{
                     "point": "Punkt",
                     "comma": "Kommatecken",
-                    "tab": "Tabulaattori",
-                    "space": "Utslutning",
+                    "tab": "Tabulator",
+                    "space": "Mellanslag", //Utslutning
                     "semicolon": "Semikolon"
                 }
             },
             "export": {
-                "title": "Aineiston muodostaminen",
+                "title": "Bildande av datamaterial",
                 "fileName": "Filnamn"
             },
             "import": {
-                "title": "Lähtöaineiston ominaisuudet"
+                "title": "Utgångsmaterialets egenskaper"
             }
         },
         "infoPopup": {
-            "description": "Kuvaus",
+            "description": "Beskrivning",
             "epsgSearch": {
-                "title": "Haku EPSG-koodin perusteella",
-                "info": "Voit hakea geodeettisen koordinaattijärjestelmän EPSG-koodin avulla. Syötä koodi pelkkänä numerona esim. 3067.",
+                "title": "Sök med EPSG-kod",
+                "info": "Du kan söka ett geodetiskt referenssystem för koordinater med EPSG-kod. Mata in koden enbart i sifferform, t.ex. 3067.",
                 "listItems": []
             },
             "geodeticDatum": {
                 "title": "Geodetiskt datum",
-                "info": "Geodeettinen datumi: datumi, joka kuvaa kaksi- tai kolmiulotteisen koordinaatiston suhdetta Maahan.",
+                "info": "Ett datum som beskriver förhållandet mellan jorden och ett två- eller tredimensionellt koordinatsystem.",
                 "listItems" : [
-                    "Suhde voidaan luoda määrittelemällä joukolle pisteitä konventionaaliset koordinaattiarvot",
-                    "Esimerkkejä geodeettisesta datumista ovat mm. EUREF-FIN ja kartastokoordinaattijärjestelmä."
+                    "Datum: en parameter eller parametermängd som definierar koordinatsystemets origo, skala och orientation.",
+                    "Exempel på geodetiska datum är bl.a. EUREF-FIN och kartverkskoordinatsystemet."
                 ]
             },
             "coordinateSystem":{
                 "title": "Koordinatsystem",
-                "info": "Koordinaatisto: matemaattisten sääntöjen joukko, jolla määritellään se, miten pisteille annetaan koordinaatit.",
+                "info": "En mängd matematiska regler som bestämmer hur koordinater för punkter definieras.",
                 "listItems" : [
-                    "Koordinaatisto voidaan hahmottaa koordinaattiakselien muodostamaksi mitta-akselistoksi.",
-                    "Erityyppisiä koordinaatistoja ovat esimerkiksi suorakulmainen koordinaatisto, tasokoordinaatisto, napakoordinaatisto, geodeettinen koordinaatisto, pallokoordinaatisto ja lieriökoordinaatisto.",
-                    "Geodesian alalla termi terrestrinen vertauskehys korvaa aiemmin käytetyn koordinaatisto-termin."
+                    "Olika typer av koordinatsystem är bl.a. rätvinkligt koordinatsystem, plankoordinatsystem, polärt koordinatsystem, geodetiskt koordinatsystem, sfäriskt koordinatsystem och cylindriskt koordinatsystem."
                 ]
             },
             "mapProjection":{
                 "title": "Kartprojektionssystem",
-                "info": "Karttaprojektiojärjestelmä: joukko sääntöjä, joiden avulla määrätään, kuinka haluttu alue kuvataan joukolla karttaprojektioita",
+                "info": "En mängd regler som bestämmer hur ett önskat område beskrivs med hjälp av en mängd kartprojektioner.",
                 "listItems" : [
-                    "Säännöillä voidaan esimerkiksi sitoa käytettävät karttaprojektiot ja projektiokaistat. Projektiokaistojen osalta järjestelmä voi määrittää kaistoille esimerkiksi tunnisteet, keskimeridiaanien tai -paralleelien mittakaavan, leveyden, pituuden ja päällekkäisyyden."
+                    "Kartprojektion: en metod för att beskriva jordklotets tredimensionella yta på ett tvådimensionellt kartplan.",
+                    "Med hjälp av reglerna kan man bestämma kartprojektioner och projektionszoner. För projektionszoner kan systemet bestämma identiferare, medelmeridianernas eller medelparallellernas skala, bredd, längd och överlappning."
                 ]
             },
             "geodeticCoordinateSystem":{
                 "title": "Geodetiskt koordinatsystem",
-                "info": "Geodeettinen koordinaattijärjestelmä: koordinaattijärjestelmä, joka perustuu geodeettiseen datumiin.",
+                "info": "Ett referenssystem för koordinater som baserar sig på ett geodetiskt datum.",
                 "listItems" : [
-                    "Koordinaattijärjestelmä: järjestelmä, joka muodostuu datumin avulla reaalimaailmaan kiinnitetystä koordinaatistosta.",
-                    "Koordinaattijärjestelmän avulla kohteen sijainti voidaan ilmaista yksikäsitteisesti.",
-                    "Koordinaattijärjestelmä voi olla globaali, alueellinen (käytössä esim. yhden mantereen alueella) tai paikallinen (käytössä esim. yhden valtion tai kunnan alueella).",
-                    "Suomen valtakunnallinen tasokoordinaattijärjestelmä on ETRS-TM35FIN."
+                    "Referenssystem för koordinater: ett koordinatsystem som har bundits till den verkliga världen med hjälp av ett datum.",
+                    "Finlands riksomfattande projicerade koordinatsystem är ETRS-TM35FIN."
                 ]
             },
             "heightSystem":{
-                "title":"Höjdsystemet",
-                "info": "Korkeusjärjestelmä: yksiulotteinen koordinaattijärjestelmä, joka perustuu korkeusdatumiin.",
+                "title":"Höjdsystem",
+                "info": "Ett endimensionerat koordinatsystem som baserar sig på ett höjddatum.",
                 "listItems" : [
-                    "Suomessa käytetään valtakunnallisissa töissä JHS 163-suosituksen mukaista N2000-korkeusjärjestelmää."
+                    "Höjddatum: datum som definierar förhållandet mellan höjder och djup i anslutning till tyngdkraften och Jorden.",
+                    "I Finland används höjdsystemet N2000 som är förenlig med rekommendationen JHS 163 i riksomfattande arbeten."
                 ]
             },
             "fileName":{
-                "title":"Tiedoston nimi",
+                "title":"Filnamn",
                 "info": "",
                 "paragraphs" : [],
                 "listItems" : []
             },
-            "decimalCount":{
-                "title":"Desimaalien määrä",
-                "info": "",
+            "decimalPrecision":{
+                "title":"Decimalernas precision",
+                "info": "Antalet decimaler som visas i resultatet.",
                 "paragraphs": [
-                    "Ominaisuuden avulla kerrotaan ohjelmalle kuinka monta desimaalia tulosteessa halutaan olevan."
+                    "Med denna egenskap kan man ange med hur många decimalers noggrannhet koordinaterna visas i resultatet. Det förvalda värdet på blanketten motsvarar ett antal decimaler som ger en 1 mm precision. Det förvalda värdet för gradangivelser är det närmaste antalet decimaler som i det metriska sytemet motsvarar 1 mm."
                 ],
-                "listItems" : []
+                "listItems" : [],
+                "precisionTable": {
+                    "title": "Metristen tarkkuuksien desimaalien määrä kulman muotojen/yksikkö",
+                    "unit": "Kulman muoto/yksikkö",
+                    "deg": "Asteet, goonit ja DD",
+                    "rad": "Radiaaneissa",
+                    "min": "DDMM ja DD MM",
+                    "sec": "DDMMSS ja DD MM SS"
+                }
             },
             "coordinateSeparator":{
-                "title":"Sarake-erotin",
-                "info": "",
+                "title":"Skiljetecken för koordinater",
+                "info": "Skiljetecken för koordinater", // TODO
                 "paragraphs": [
-                    "Ominaisuuden avulla määritetään millainen merkkijono erottaa syötteessä koordinaattiarvot toisistaan.",
-                    "Jos koordinaatteja edeltää jokin tunniste tai seuraa jokin merkkijono, tulee nämäkin olla erotettuna samalla erottimella."
+                    "Med denna egenskap anges vilket skiljetecken som använts för kolumner i utgångsmaterialet mellan koordinatvärden. I utgångsmaterialet får det finnas endast ett sådant skiljetecken mellan två koordinatvärden.",
+                    "Om koordinaterna föregås av en identifierare eller följs av en teckensträng, ska även dessa vara åtskilda med samma skiljetecken."
                 ],
                 "listItems" : []
             },
             "headerLineCount":{
-                "title":"Otsakerivien määrä",
-                "info": "",
+                "title":"Antal rubrikrader",
+                "info": "Antalet rader i början av filen före den första koordinatraden.",
                 "paragraphs": [
-                    "Ominaisuuden avulla pystyy ohjelmalle kertomaan kuinka monta riviä tiedoston alusta ohitetaan.",
-                    "Ohittamisen syynä voi olla, että tiedoston alussa on esimerkiksi sanallinen kuvaus tiedoston sisällöstä."
+                    "Med denna egenskap kan man ange hur många rader i början av filen som applikationen kan förbise innan den ska läsa in den första koordinatraden.",
+                    "Orsaken till förbiseendet kan vara exempelvis en beskrivning i ord av filens innehåll i början av filen."
                 ],
                 "listItems" : []
             },
             "unitFormat":{
-                "title":"Kulman muoto/yksikkö",
-                "info": "",
+                "title":"Vinkelns form/enhet",
+                "info": "Enhet för geografiska koordinater i gradformat",
                 "paragraphs": [
-                    "Ominaisuuden avulla kerrotaan ohjelmalle missä muodossa kulma-arvot ovat. Tuettuja kulmayksikköjä ovat: Aste, Gooni (graadi) ja Radiaani.",
-                    "Lisäksi asteesta johdetut sexagesimaalimuodot ovat tuettuja. Jos näissä muodoissa esimerkiksi asteet, kaariminuutit ja kaarisekunnit ovat erotettuina, hyväksyy ohjelma erottimena tabulaattorin, pilkun ja puolipisteen, mutta ei välilyöntiä."
+                    "Med denna egenskap anges formatet för gradvärden. Gradenheter som applikationen stöder: Grad, Gon (nygrad) och Radian.",
+                    "Dessutom stöds sexagesimalformat som härletts ur grader. Om man i dessa format har avskiljt grader, bågminuter och bågsekunder med mellanslag (DD MM och DD MM SS), kan mellanslaget inte användas som skiljetecken för koordinater."
                 ],
                 "listItems" : []
             },
             "decimalSeparator":{
-                "title":"Desimaalierotin",
-                "info": "",
+                "title":"Skiljetecken för decimaler",
+                "info": "Med denna egenskap anges skiljetecknet för decimaler.",
                 "paragraphs": [
-                    "Ominaisuuden avulla pystyy kertomaan mikä merkki toimii desimaalierotin.",
-                    "Desimaalierottimen tulee poiketa koordinaattiarvot erottavasta merkistä. Kun koordinaattiarvot erottaa esimerkiksi pilkku sekä joukko välilyöntejä, niin desimaalierottimen on oltava piste!"
+                    "Skiljetecknet för decimaler får inte vara samma som skiljetecknet för koordinatvärden. Om kommatecken använts som skiljetecken för koordinatvärden, ska skiljetecknet för decimaler vara en punkt."
                 ],
                 "listItems" : []
             },
             "lineSeparator":{
-                "title":"Rivin erotin",
-                "info": "",
+                "title":"Radavskiljare",
+                "info": "Tecken som i filen anger radbyte.",
                 "paragraphs": [
-                    "Ominaisuuden avulla kerrotaan ohjelmalle mitä merkkiä/merkkijonoa käytetään erottamaan toisistaan rivit (pisteet)."
+                    "Med denna egenskap anges vilket tecken eller vilken teckensträng används för att ange radbyte. Detta tecken eller denna teckensträng läggs alltså till slutet av varje rad."
                 ],
                 "listItems" : []
             },
             "prefixId":{
-                "title":"Koordinaattiarvoja edeltää pisteen tunniste",
-                "info": "",
+                "title":"Använd identifierare",
+                "info": "Koordinatraden börjar med identifieraruppgift",
                 "paragraphs": [
-                    "Ominaisuuden avulla pystyy ohjelmalle kertomaan, että jokaisen pisteen koordinaattiarvoja edeltää samalla rivillä pisteen tunniste (ID).",
-                    "Pisteen tunnisteen tulee olla erotettuna koordinaattiarvoista samalla merkkijonolla kuin koordinaattiarvot ovat erotettuina toisistaan.",
-                    "Tunnisteen ei tarvitse olla numeerinen."
+                    "Med denna egenskap anges att koordinatvärdena för respektive punkt föregås av punktens identifierare (ID) på samma rad",
+                    "Punktens identifierare ska vara avskilt från koordinatvärdena med samma teckensträng som skiljer koordinatvärdena från varandra.",
+                    "Om den importerade filen saknar punktidentifierare eller punkterna har hämtats från en tabell eller karta, ges resultatfilernas punkter identifierare som börjar från 1 och växer med ett heltal per punkt.",
+                    "I utgångsfilen behöver identifierare inte vara numeriska."
                 ],
                 "listItems" : []
             },
             "reverseCoordinates":{
-                "title":"Koordinaatit käänteisesti",
-                "info": "",
+                "title":"Omvända koordinater",
+                "info": "X- och Y-koordinataxlarnas ordning avviker från den definierade ordningen.",
                 "paragraphs": [
-                    "Ominaisuuden avulla pystyy määrittämään ovatko tiedoston pisteiden kaksi ensimmäistä koordinaattiarvoa käänteisessä järjestyksessä suhteessa koordinaatiston kuvailussa annettuun järjestykseen.",
-                    "Esimerkiksi kkj:n koordinaatit ovat lähtökohtaisesti jäjestyksessä, jossa ensimmäisenä on x-koordinaatti ja sitä seuraa y-koordinaatti. x-akseli osoittaa pohjoiseen ja y-akseli itään. Kun valitsee käänteisen järjestyksen, tulee tiedostossa y-koordinaatin edeltää x-koordinaattia."
+                    "Med denna egenskap kan man definiera om de två första koordinatvärdena för punkterna i filen är i motsatt ordning jämfört med den ordning som anges i koordinatsystemets beskrivning.",
+                    "Exempelvis visas KKS-koordinater så att nordkoordinaten är först och östkoordinaten följer. När man väljer omvänd ordning, ska östkoordinaten vara först i filen och sedan nordkoordinaten."
                 ],
                 "listItems" : []
             },
             "writeHeader":{
-                "title":"Otsakerivin tulostaminen tiedostoon",
-                "info": "",
+                "title":"Skriv rubrikraden i filen",
+                "info": "Inkludera rubrikraderna i början av resultatfilen",
                 "paragraphs": [
-                    "Ominaisuuden avulla käyttäjä voi kertoa haluaako tulostiedostoon metatietoa koordinaateista otsakeriville."
+                    "Med denna egenskap kan användaren ta med metadata om koordinaterna på rubrikraden i resultatfilen. Namnet på referenssystemet för koordinater läggs till på rubrikraden.",
+                    "I omvandlingen från en fil till en annan läggs utöver uppgifterna om referenssystemet för koordinater även eventuella rubrikrader i utgångsfilen till i resultatfilen."
                 ],
                 "listItems" : []
             },
             "lineEnds":{
-                "title":"Tulosteeseen rivin loput",
-                "info": "",
+                "title":"Ta med radavslutningarna i resultatet",
+                "info": "Inkludera radsluten i utgångsfilen i resultatfilen",
                 "paragraphs": [
-                    "Ominaisuuden avulla pystyy kertomaan haluaako tulosteeseen kirjoitettavan myös jokaisella rivillä annetun pisteen koordinaatteja seuraavan merkkijonon."
+                    "Med denna egenskap kan man ange om man vill ha eventuella radslut i utgångsfilen i resultatfilen. Som radslut läser applikationen in alla tecken efter punktens koordinatvärden på raden. Radslutet ska vara avskilt från koordinatvärdena med samma tecken som skiljer koordinatvärdena från varandra.",
+                    "Denna egenskap påverkar endast omvandlingar från en fil till en annan."
+                    
                 ],
                 "listItems" : []
             },
             "useCardinals":{
-                "title":"Kardinaalien käyttö",
-                "info": "",
+                "title":"Använd kardinalväderstreck",
+                "info": "Lägg till väderstrecken (N, E, W eller S) efter koordinatvärdena",
                 "paragraphs": [
-                    "Ominaisuudella määritetään kirjoitetaanko tulosteeseen koordinaattiarvojen perään niiden ilmansuunnat. Tällöin miinusmerkit poistetaan koordinaattiarvoista.",
-                    "Ilmansuunnat annetaan kirjoittamalla joko N, E, W tai S koordinaattiarvon perään."
+                    "Med denna egenskap anges om koordinatvärdenas väderstreck skrivs ut efter koordinatvärdena i en utskrift. På värden med förtecknet minus läggs det motsatta väderstrecket till och minustecknen tas bort från koordinatvärdena. Exempel: värdet på östkoordinaten 325418 blir 325418E och på östkoordinaten -325418 blir värdet 325418W.",
+                    "Väderstrecken anges genom att skriva N, E, W eller S efter respektive koordinatvärde."
                 ],
                 "listItems" : []
             }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
@@ -114,7 +114,7 @@ Oskari.registerLocalization(
         },
         "dataSource": {
             "title": "Källa för koordinatuppgifter",
-            "confirmChange": "Koordinaterna som ska omvandlas töms och uppgifterna om referenssystemet för koordinater tas bort. Vill du fortsätta?",
+            "confirmChange": "Koordinaterna som ska omvandlas töms. Vill du fortsätta?",
             "file": {
                 "label": "Från fil",
                 "info":  "Välj filen med utgångsmaterialet och dess inställningar.",
@@ -127,6 +127,7 @@ Oskari.registerLocalization(
             "map": {
                 "label": "Välj lägen på kartan",
                 "info": "Du kan välja koordinater som ska omvandlas genom att klicka på kartan",
+                "confirmSelect": "Lähtökoordinaattijärjestelmän tiedot valitaan automaattisesti kartan käyttämän ETRS-TM35FIN -projektion mukaisiksi. Tekemäsi lähtökoordinaattijärjestelmän valinnat korvataan. Haluatko jatkaa?",
                 "action": "välj fler"
             }
         },
@@ -262,12 +263,12 @@ Oskari.registerLocalization(
                 ],
                 "listItems" : [],
                 "precisionTable": {
-                    "title": "Metristen tarkkuuksien desimaalien määrä kulman muotojen/yksikkö",
-                    "unit": "Kulman muoto/yksikkö",
-                    "deg": "Asteet, goonit ja DD",
-                    "rad": "Radiaaneissa",
-                    "min": "DDMM ja DD MM",
-                    "sec": "DDMMSS ja DD MM SS"
+                    "title": "Kulman muodon/yksikön desimaalien määrä metrisenä tarkkuutena",
+                    "unit": "Vinkelns form/enhet",
+                    "deg": "Grad, gon och DD",
+                    "rad": "Radian",
+                    "min": "DDMM och DD MM",
+                    "sec": "DDMMSS och DD MM SS"
                 }
             },
             "coordinateSeparator":{

--- a/bundles/paikkatietoikkuna/coordinatetransformation/util/CoordinateDataHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/util/CoordinateDataHandler.js
@@ -193,8 +193,8 @@ Oskari.clazz.define('Oskari.coordinatetransformation.CoordinateDataHandler', fun
         this.trigger('ResultCoordsChanged', this.resultCoords);
     },
     checkCoordsArrays: function () {
-        var input = this.inputCoords.length,
-            result = this.resultCoords.length;
+        var input = this.inputCoords.length;
+        var result = this.resultCoords.length;
         if (input !== 0 && result !== 0) {
             return input === result;
         }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/util/helper.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/util/helper.js
@@ -755,6 +755,9 @@ Oskari.clazz.define('Oskari.coordinatetransformation.helper', function () {
     },
     getDecimalCount: function (decimals, unit) {
         decimals = parseInt(decimals);
+        if (isNaN(decimals)) {
+            return 0;
+        }
         switch (unit) {
         case 'metric':
             return decimals;

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/CoordinateSystemInformation.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/CoordinateSystemInformation.js
@@ -9,7 +9,18 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.CoordinateSystemInform
                     '</div>'),
         list: jQuery('<ul class="info-list"></ul>'),
         listItem: jQuery('<li></li>'),
-        paragraph: jQuery('<p></p>')
+        paragraph: jQuery('<p></p>'),
+        precisionTable: _.template('<div class="precision-table-wrapper">' +
+                '<h5 class="precision-table"><%= title %></h5>' +
+                '<table class="precisionTable">' +
+                    '<tr><th><%= unit %></th><th>~1 m</th><th>~0.1 m</th><th>~1 cm</th><th>~1 mm</th><th>~0.1 mm</th></tr>' +
+                    '<tr><td><%= deg %></td><td>5</td><td>6</td><td>7</td><td>8</td><td>9</td></tr>' +
+                    '<tr><td><%= rad %></td><td>7</td><td>8</td><td>9</td><td>10</td><td>11</td></tr>' +
+                    '<tr><td><%= min %></td><td>4</td><td>5</td><td>6</td><td>7</td><td>8</td></tr>' +
+                    '<tr><td><%= sec %></td><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td></tr>' +
+                '</table>' +
+            '</div>'
+        )
     },
     setElement: function (el) {
         this.element = el;
@@ -32,25 +43,35 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.CoordinateSystemInform
         dialog.show(title, content, [btn]);
         dialog.moveTo(parentElement);
         dialog.makeDraggable();
+
         this.dialog = dialog;
+    },
+    addPrecisionTable: function (toElem) {
+        var headers = this.loc('infoPopup.decimalPrecision.precisionTable');
+        var table = this._template.precisionTable(headers);
+        toElem.append(table);
     },
     _createContent: function (key, skipInfo) {
         var me = this;
         var content = this._template.content.clone();
         var infoLoc = this.loc('infoPopup')[key];
+        var infoContent = content.find('.info-content');
         content.find('.info-description').html(this.loc('infoPopup.description'));
         if (skipInfo !== true) {
-            content.find('.info-content').html(infoLoc.info);
+            infoContent.html(infoLoc.info);
         }
         if (Array.isArray(infoLoc.paragraphs) && infoLoc.paragraphs.length !== 0) {
             infoLoc.paragraphs.forEach(function (item) {
                 var paragraph = me._template.paragraph.clone();
                 paragraph.text(item);
-                content.append(paragraph);
+                infoContent.append(paragraph);
             });
         }
         if (Array.isArray(infoLoc.listItems) && infoLoc.listItems.length !== 0) {
-            content.find('.info-content').append(this._createList(infoLoc.listItems));
+            infoContent.append(this._createList(infoLoc.listItems));
+        }
+        if (key === 'decimalPrecision') {
+            this.addPrecisionTable(infoContent);
         }
         return content;
     },


### PR DESCRIPTION
Updated localization files. 

Changed ui order. Now coordinate system selections are made before source selections. Flyout's max height is calculated based on the map's height. Decimal count changed to metric precision and precision table added to info popup. Hide pointless export options if transform isn't file to file. 

If file is selected before crs settings and contains z-values input table didn't show z-values when crs settings are selected. Now input dimension is forced to 3 if crs settings aren't selected. This affects only for reading file to input table (not for transformation).

Added reversed epsg-codes (same values but reversed axis order). Also added replaced GK-codes. These are not listed in the dropdown but can be selected with find/filter with EPSG-code. Frontend uses epsg code listed in dropdown and replaces it to transformation params.