### PR TITLE
Wait before starting the animation

### DIFF
--- a/bundles/statistics/statsgrid2016/service/SeriesService.js
+++ b/bundles/statistics/statsgrid2016/service/SeriesService.js
@@ -133,21 +133,28 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SeriesService',
             return true;
         },
         setAnimating: function (shouldAnimate) {
-            if (shouldAnimate !== this.animating) {
-                if (shouldAnimate) {
-                    // check possibility to start animation
-                    if (this.getSelectedIndex() === -1) {
-                        return;
-                    }
-                    if (this.getSelectedIndex() === this.values.length - 1) {
-                        this.setSelectedValue(this.values[0]);
-                    }
-                    this.animating = shouldAnimate;
-                    this._throttleAnimation();
-                    return;
-                }
-                this.animating = shouldAnimate;
+            if (shouldAnimate === this.animating) {
+                return;
             }
+            if (!shouldAnimate) {
+                this.animating = false;
+                return;
+            }
+            // check possibility to start animation
+            if (this.getSelectedIndex() === -1) {
+                return;
+            }
+            // Step to the beginning, if the series is on the last value
+            const isLastValue = this.getSelectedIndex() === this.values.length - 1;
+            if (isLastValue) {
+                this._setSelectedValue(this.values[0]);
+                this.animating = true;
+                // Wait frameInterval before starting the animation
+                setTimeout(this._throttleAnimation, this.frameInterval);
+                return;
+            }
+            this.animating = true;
+            this._throttleAnimation();
         },
         isAnimating: function () {
             return this.animating;


### PR DESCRIPTION
Fixes an issue where animation would move on too hastily from the first step of the series.
Improved readability.