### PR TITLE
Configurable public path prefix for Webpack build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ const proxyPort = 8081;
 module.exports = (env, argv) => {
     const isProd = argv.mode === 'production';
 
-    const {version, pathParam} = parseParams(env);
+    const {version, pathParam, publicPathPrefix} = parseParams(env);
 
     const isDirectory = source => lstatSync(source).isDirectory();
     const getDirectories = source => readdirSync(source).map(name => path.join(source, name)).filter(isDirectory);
@@ -55,7 +55,7 @@ module.exports = (env, argv) => {
         devtool: isProd ? 'source-map' : 'cheap-module-eval-source-map',
         output: {
             path: path.resolve(`dist/${version}/`),
-            publicPath: `/Oskari/dist/${version}/`,
+            publicPath: `${publicPathPrefix}Oskari/dist/${version}/`,
             filename: '[name]/oskari.min.js'
         },
         module: {

--- a/webpack/parseParams.js
+++ b/webpack/parseParams.js
@@ -23,6 +23,7 @@ module.exports = function parseParams(env) {
 
     return {
         version,
-        pathParam
+        pathParam,
+        publicPathPrefix: env.absolutePublicPath === 'true' ? '/' : ''
     };
 }


### PR DESCRIPTION
Enable absolute path with `--env.absolutePublicPath=true`