### PR TITLE
Fix legend opacity in publiser

### DIFF
--- a/bundles/statistics/statsgrid2016/publisher/OpacityTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/OpacityTool.js
@@ -7,6 +7,10 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.OpacityTool', function (
     allowedSiblings: [],
 
     init: function (data) {
+        var enabled = data &&
+            Oskari.util.keyExists(data, 'configuration.statsgrid.conf') &&
+            data.configuration.statsgrid.conf.transparent === true;
+        this.setEnabled(enabled);
     },
     getTool: function (stateData) {
         var me = this;


### PR DESCRIPTION
Fixes an issue where stats layer's classification legend opacity state would not be preserved when editing existing publication.