### PR TITLE
Bind function to correct scope

### DIFF
--- a/bundles/mapping/mapwfs2/service/Connection.js
+++ b/bundles/mapping/mapwfs2/service/Connection.js
@@ -195,7 +195,7 @@ Oskari.clazz.define(
                 me.cometd.batch(function () {
                     me._errorSub = me.cometd.subscribe(
                         '/error',
-                        me.getError
+                        me.getError.bind(me)
                     );
                     me.plugin.getIO().subscribe();
                     me.plugin.getIO().startup({


### PR DESCRIPTION
The getError() function refers to "this" which points to the window-object without the bind-call. The error shows in the developer console as unable to call getSandbox() of undefined. This fixes the issue.