### PR TITLE
Dynamic import

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This repository holds the front-end code for Oskari. Developing the front-end re
 Make sure you have at least Node 8.x / NPM 5.x. Run `npm install` in the front-end repository root.
 Make sure you have oskari-server running on localhost port 8080 (can be customized on webpack.config.js).
 
+### App composition
+
+An Oskari frontend application consists of bundles that are defined in the miniferAppSetup.json for each app. Only bundles referenced here can be instantiated at runtime. If some bundles are used only in a limited part of the app (for example admin tools), you can configure these bundles to load dynamically at runtime. This will decrease the size of the main app JS bundle. To enable dynamic loading for a bundle, add `"lazy": true` on the same level as `"bundlename"` in the miniferAppSetup.json.
+
 ## Run in development
 
 Webpack dev server is used to serve the JS bundle and assets when running in local development. XHR calls will be proxied to the Java backend assumed to be running on localhost:8080.

--- a/applications/paikkatietoikkuna.fi/full-map/minifierAppSetup.json
+++ b/applications/paikkatietoikkuna.fi/full-map/minifierAppSetup.json
@@ -372,6 +372,7 @@
             }
         }, {
             "bundlename": "admin-layerselector",
+            "lazy": true,
             "metadata": {
                 "Import-Bundle": {
                     "admin-layerselector": {
@@ -384,6 +385,7 @@
             }
         }, {
             "bundlename": "admin-layerrights",
+            "lazy": true,
             "metadata": {
                 "Import-Bundle": {
                     "admin-layerrights": {

--- a/bundles/asdi/asdi-guided-tour/instance.js
+++ b/bundles/asdi/asdi-guided-tour/instance.js
@@ -3,14 +3,7 @@
  *
  * Add this to startupsequence to get this bundle started
  {
-   bundlename : 'asdi-guided-tour',
-   metadata : {
-   "Import-Bundle" : {
-   "asdi-guided-tour" : {
-   bundlePath : '/Oskari/packages/asdi/bundle/'
-   }
-   }
-   }
+   bundlename : 'asdi-guided-tour'
  }
  */
 Oskari.clazz.define(

--- a/bundles/asdi/asdi-projection-change/instance.js
+++ b/bundles/asdi/asdi-projection-change/instance.js
@@ -2,10 +2,7 @@
  * @class Oskari.projection.change.instance
  * 
  *      var obj = {
-            "bundlename":"asdi-projection-change" ,
-            "metadata": {
-                "Import-Bundle": { "asdi-projection-change": { "bundlePath": "/Oskari/packages/asdi/bundle/" } }
-            }
+            "bundlename":"asdi-projection-change"
         }
         appSetup.startupSequence.push(obj);
  */

--- a/bundles/framework/guidedtour/instance.js
+++ b/bundles/framework/guidedtour/instance.js
@@ -3,22 +3,8 @@
  *
  * Add this to startupsequence to get this bundle started
      {
-     title : 'guidedtour',
-     fi : 'guidedtour',
-     sv : '?',
-     en : '?',
      bundlename : 'guidedtour',
-     bundleinstancename : 'guidedtour',
-     metadata : {
-     "Import-Bundle" : {
-     "guidedtour" : {
-     bundlePath : '/<path to>/packages/framework/bundle/'
-     }
-     },
-     "Require-Bundle-Instance" : []
-     },
-     instanceProps : {}
-     }
+     bundleinstancename : 'guidedtour'
  */
 Oskari.clazz.define(
     'Oskari.framework.bundle.guidedtour.GuidedTourBundleInstance',

--- a/bundles/framework/system-message/instance.js
+++ b/bundles/framework/system-message/instance.js
@@ -1,14 +1,7 @@
 /* Add this to startupsequence to get this bundle started
 Oskari.app.playBundle(
 {
-  bundlename : 'system-message',
-  metadata : {
-  "Import-Bundle" : {
-  "system-message" : {
-  bundlePath : '/Oskari/packages/framework/bundle/'
-  }
-  }
-  }
+  bundlename : 'system-message'
 });
 */
 /*

--- a/bundles/integration/backbone/Adapter.js
+++ b/bundles/integration/backbone/Adapter.js
@@ -9,21 +9,8 @@
  *
  * Add this to startupsequence to get this bundle started
  {
- title : 'bb',
- fi : 'bb',
- sv : '?',
- en : '?',
- bundlename : 'bb',
- bundleinstancename : 'bb',
- metadata : {
- "Import-Bundle" : {
- "bb" : {
- bundlePath : '/<path to>/packages/integration/bundle/'
- }
- },
- "Require-Bundle-Instance" : []
- },
- instanceProps : {}
+   bundlename : 'bb',
+   bundleinstancename : 'bb',
  }
  */
 Oskari.clazz.define('Oskari.integration.bundle.backbone.AdapterBundleInstance',

--- a/bundles/integration/bb/Adapter.js
+++ b/bundles/integration/bb/Adapter.js
@@ -9,21 +9,8 @@
  *
  * Add this to startupsequence to get this bundle started
  {
- title : 'bb',
- fi : 'bb',
- sv : '?',
- en : '?',
  bundlename : 'bb',
- bundleinstancename : 'bb',
- metadata : {
- "Import-Bundle" : {
- "bb" : {
- bundlePath : '/<path to>/packages/integration/bundle/'
- }
- },
- "Require-Bundle-Instance" : []
- },
- instanceProps : {}
+ bundleinstancename : 'bb'
  }
  */
 Oskari.clazz.define('Oskari.integration.bundle.bb.AdapterBundleInstance',

--- a/bundles/mapping/maprotator/instance.js
+++ b/bundles/mapping/maprotator/instance.js
@@ -1,14 +1,7 @@
 /*
 Oskari.app.playBundle(
 {
-  bundlename : 'maprotator',
-  metadata : {
-  "Import-Bundle" : {
-  "maprotator" : {
-  bundlePath : '/Oskari/packages/mapping/ol3/'
-  }
-  }
-  }
+  bundlename : 'maprotator'
 });
 */
 Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorBundleInstance',

--- a/bundles/paikkatietoikkuna/coordinatetransformation/instance.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/instance.js
@@ -2,20 +2,10 @@
 Ways to start the bundle in console:
 * Oskari.app.playBundle(
     {
-    bundlename : 'coordinatetransformation',
-        metadata : {
-            "Import-Bundle" : {
-                "coordinatetransformation" : {
-                    bundlePath : '/Oskari/packages/paikkatietoikkuna/bundle/'
-                }
-            }
-        }
+    bundlename : 'coordinatetransformation'
 });
        var obj = {
-            "bundlename":"coordinatetransformation" ,
-            "metadata": {
-                "Import-Bundle": { "coordinatetransformation": { "bundlePath": "/Oskari/packages/paikkatietoikkuna/bundle/" } }
-            }
+            "bundlename":"coordinatetransformation"
         }
         appSetup.startupSequence.push(obj);
 */

--- a/bundles/sample/myfirstbundle/instance.js
+++ b/bundles/sample/myfirstbundle/instance.js
@@ -6,21 +6,8 @@
  *
  * Add this to startupsequence to get this bundle started
  {
-            title : 'myfirstbundle',
-            fi : 'myfirstbundle',
-            sv : '?',
-            en : '?',
             bundlename : 'myfirstbundle',
-            bundleinstancename : 'myfirstbundle',
-            metadata : {
-                "Import-Bundle" : {
-                    "myfirstbundle" : {
-                        bundlePath : '/<path to>/packages/sample/bundle/'
-                    }
-                },
-                "Require-Bundle-Instance" : []
-            },
-            instanceProps : {}
+            bundleinstancename : 'myfirstbundle'
         }
  */
 Oskari.clazz.define('Oskari.sample.bundle.myfirstbundle.SimpleHelloWorldBundleInstance',

--- a/bundles/sample/myfourthbundle/instance.js
+++ b/bundles/sample/myfourthbundle/instance.js
@@ -6,21 +6,8 @@
  *
  * Add this to startupsequence to get this bundle started
  {
-            title : 'myfourthbundle',
-            fi : 'myfourthbundle',
-            sv : '?',
-            en : '?',
             bundlename : 'myfourthbundle',
-            bundleinstancename : 'myfourthbundle',
-            metadata : {
-                "Import-Bundle" : {
-                    "myfourthbundle" : {
-                        bundlePath : '/<path to>/packages/sample/bundle/'
-                    }
-                },
-                "Require-Bundle-Instance" : []
-            },
-            instanceProps : {}
+            bundleinstancename : 'myfourthbundle'
         }
  */
 Oskari.clazz.define('Oskari.sample.bundle.myfourthbundle.ToolbarRequestBundleInstance',

--- a/bundles/sample/mysecondbundle/instance.js
+++ b/bundles/sample/mysecondbundle/instance.js
@@ -5,23 +5,10 @@
  * registering itself to sandbox as a module.
  *
  * Add this to startupsequence to get this bundle started
- {
-            title : 'mysecondbundle',
-            fi : 'mysecondbundle',
-            sv : '?',
-            en : '?',
-            bundlename : 'mysecondbundle',
-            bundleinstancename : 'mysecondbundle',
-            metadata : {
-                "Import-Bundle" : {
-                    "mysecondbundle" : {
-                        bundlePath : '/<path to>/packages/sample/bundle/'
-                    }
-                },
-                "Require-Bundle-Instance" : []
-            },
-            instanceProps : {}
-        }
+    {
+        bundlename : 'mysecondbundle',
+        bundleinstancename : 'mysecondbundle'
+    }
  */
 Oskari.clazz.define('Oskari.sample.bundle.mysecondbundle.ModuleHelloWorldBundleInstance',
 

--- a/bundles/sample/mythirdbundle/instance.js
+++ b/bundles/sample/mythirdbundle/instance.js
@@ -2,23 +2,10 @@
  * @class Oskari.sample.bundle.mythirdbundle.FlyoutHelloWorldBundleInstance
  *
  * Add this to startupsequence to get this bundle started
- {
-            title : 'mythirdbundle',
-            fi : 'mythirdbundle',
-            sv : '?',
-            en : '?',
-            bundlename : 'mythirdbundle',
-            bundleinstancename : 'mythirdbundle',
-            metadata : {
-                "Import-Bundle" : {
-                    "mythirdbundle" : {
-                        bundlePath : '/<path to>/packages/sample/bundle/'
-                    }
-                },
-                "Require-Bundle-Instance" : []
-            },
-            instanceProps : {}
-        }
+    {  
+        bundlename : 'mythirdbundle',
+        bundleinstancename : 'mythirdbundle'
+    }
  */
 Oskari.clazz.define('Oskari.sample.bundle.mythirdbundle.FlyoutHelloWorldBundleInstance',
 

--- a/src/bundle_manager.js
+++ b/src/bundle_manager.js
@@ -23,6 +23,7 @@
         me.sources = {};
         me.bundleInstances = {};
         me.bundles = {};
+        me.dynamicLoaders = {};
 
         /*
          * CACHE for lookups state management
@@ -254,6 +255,31 @@
             bundleInstance = null;
 
             return bundleInstance;
+        },
+        /**
+         * @method registerDynamic
+         * Register bundle for run-time loading with ES import()
+         *
+         * @param {string} bundlename Bundle name
+         * @param {Function} loader function that returns an Array of promises that resolve to the modules to be loaded
+         */
+        registerDynamic: function(bundlename, loader) {
+            this.dynamicLoaders[bundlename] = loader;
+        },
+        /**
+         * @method loadDynamic
+         * Called to start dynamic loading of a bundle
+         *
+         * @param {string} bundlename Bundle name
+         *
+         * @return Promise that resolves when all modules have loaded
+         */
+        loadDynamic: function(bundlename) {
+            const loader = this.dynamicLoaders[bundlename];
+            if (loader) {
+                return Promise.all(loader());
+            }
+            return null;
         }
     };
 

--- a/src/loader.js
+++ b/src/loader.js
@@ -29,7 +29,10 @@
     };
 }(Oskari));
 /**
- * File loader/startupsequence processor for Oskari.
+ * Startupsequence processor for Oskari. Bundles have ether been bundled/minfied
+ * into the application JS file or separate chunks. In both cases bundles must be
+ * declared in miniferAppSetup.json
+ * 
  * Usage:
  *
  *     var startupSequence = [...bundles to load/start... ];
@@ -40,10 +43,6 @@
  *         // application started
  *     });
  *
- * Also provides file linking like:
- *
- *     Oskari.loader.linkFile('/my.css');
- *     Oskari.loader.linkFile('/my.html', 'import', 'text/html');
  */
 (function (o) {
     if (!o) {
@@ -66,6 +65,10 @@
     /**
      * Loader
      * @param  {Object[]} startupSequence sequence of bundles to load/start
+     *         {
+     *              "bundleinstancename": "openlayers-default-theme",
+     *              "bundlename": "openlayers-default-theme"
+     *         }
      * @param  {Object}   config          configuration for bundles
      */
     var loader = function (startupSequence, config) {
@@ -91,12 +94,8 @@
         });
 
         return {
-            /**
-             * {
-                    "bundleinstancename": "openlayers-default-theme",
-                    "bundlename": "openlayers-default-theme"
-                }
-             * @param  {Object} sequence see above
+            /** 
+             * @param  {Function} done callback
              */
             processSequence: function (done) {
                 var me = this;

--- a/src/loader.js
+++ b/src/loader.js
@@ -63,31 +63,6 @@
         importParentElement.appendChild(linkElement);
     };
 
-    // http://stackoverflow.com/questions/14780350/convert-relative-path-to-absolute-using-javascript
-    var absolute = function (base, relative) {
-        var stack = base.split('/');
-        var parts = relative.split('/');
-        stack.pop(); // remove current file name (or empty string)
-        // (omit if "base" is the current folder without trailing slash)
-        for (var i = 0; i < parts.length; i++) {
-            if (parts[i] === '.') { continue; }
-
-            if (parts[i] === '..') {
-                stack.pop();
-            } else { stack.push(parts[i]); }
-        }
-        return stack.join('/');
-    };
-
-    var getPath = function (base, src) {
-        // handle case where src start with /
-        var path = src;
-        // handle relative ../../ case with src
-        if (src.indexOf('/') !== 0) {
-            path = absolute(base, src);
-        }
-        return path.split('//').join('/');
-    };
     /**
      * Loader
      * @param  {Object[]} startupSequence sequence of bundles to load/start
@@ -119,17 +94,7 @@
             /**
              * {
                     "bundleinstancename": "openlayers-default-theme",
-                    "bundlename": "openlayers-default-theme",
-                    "metadata": {
-                        "Import-Bundle": {
-                            "openlayers-default-theme": {
-                                "bundlePath": "../../../packages/openlayers/bundle/"
-                            },
-                            "openlayers-full-map": {
-                                "bundlePath": "../../../packages/openlayers/bundle/"
-                            }
-                        }
-                    }
+                    "bundlename": "openlayers-default-theme"
                 }
              * @param  {Object} sequence see above
              */
@@ -151,14 +116,6 @@
                     this.processSequence(done);
                     return;
                 }
-                if (typeof seqToLoad.metadata !== 'object' ||
-                    typeof seqToLoad.metadata['Import-Bundle'] !== 'object') {
-                    // log warning: "Nothing to load"
-                    log.warn('StartupSequence item doesn\'t contain the structure item.metadata["Import-Bundle"]. Skipping ', seqToLoad);
-                    // iterate to next
-                    this.processSequence(done);
-                    return;
-                }
 
                 var bundleToStart = seqToLoad.bundlename;
                 if (!bundleToStart) {
@@ -170,52 +127,28 @@
                 // if bundleinstancename is missing, use bundlename for config key.
                 var configId = seqToLoad.bundleinstancename || bundleToStart;
                 var config = appConfig[configId] || {};
-                var bundlesToBeLoaded = seqToLoad.metadata['Import-Bundle'];
-                var paths = [];
-                var bundles = [];
-                for (var id in bundlesToBeLoaded) {
-                    var value = bundlesToBeLoaded[id];
-                    if (typeof value !== 'object' ||
-                        typeof value.bundlePath !== 'string') {
-                        // log warning: bundlePath not defined
-                        log.warn('StartupSequence import doesn\'t contain bundlePath. Skipping! Item is ' + bundleToStart + ' import is ' + id);
-                        continue;
-                    }
-                    var basepath = value.bundlePath + '/' + id;
-                    var path = basepath + '/bundle.js';
-                    paths.push(path.split('//').join('/'));
-                    bundles.push({
-                        id: id,
-                        path: basepath
-                    });
-                }
+
                 if (Oskari.bundle(bundleToStart)) {
                     log.debug('Bundle preloaded ' + bundleToStart);
                     me.startBundle(bundleToStart, config, configId);
                     this.processSequence(done);
                     return;
                 }
-                // load all bundlePaths mentioned in sequence-block
-                window.require(paths, function () {
-                    // if loaded undefined - find from Oskari.instalBundle register with id
-                    for (var i = 0; i < arguments.length; ++i) {
-                        if (typeof arguments[i] !== 'undefined') {
-                            // this would be a bundle.js with amd support
-                            log.warn('Support for AMD-bundles is not yet implemented', arguments[i]);
-                        }
-                    }
-                    log.debug('Loaded bundles', bundles);
-                    // the loaded files have resulted in calls to
-                    // Oskari.bundle_manager.installBundleClass(id, "Oskari.mapframework.domain.Bundle");
-                    // loop all bundles and require sources from installs
-                    me.processBundleJS(bundles, function () {
+                let bundlePromise = Oskari.bundle_manager.loadDynamic(bundleToStart);
+                if (!bundlePromise) {
+                    log.warn('Bundle wasn\'t preloaded nor registered as dynamic. Skipping ', bundleToStart);
+                    this.processSequence(done);
+                    return;
+                }
+                bundlePromise
+                    .then(() => {
                         me.startBundle(bundleToStart, config, configId);
+                        this.processSequence(done);
+                    })
+                    .catch((err) => {
+                        log.error('Error loading bundle ' + bundleToStart, err);
                         me.processSequence(done);
                     });
-                }, function (err) {
-                    log.error('Error loading bundles for ' + bundleToStart, err);
-                    me.processSequence(done);
-                });
             },
             startBundle: function (bundleId, config, instanceId) {
                 var bundle = Oskari.bundle(bundleId);
@@ -243,105 +176,6 @@
                     log.error('Couldn\'t start bundle with id ' + bundleId + '. Error was: ', err);
                     throw err;
                 }
-            },
-            processBundleJS: function (bundles, callback) {
-                var me = this;
-                var loading = [];
-                var done = function (id) {
-                    // remove id from loading array
-                    var index = loading.indexOf(id);
-                    loading.splice(index, 1);
-                    // once loading is empty - call callback
-                    if (loading.length === 0) {
-                        callback();
-                    }
-                };
-                bundles.forEach(function (item) {
-                    var bundle = Oskari.bundle(item.id);
-                    if (!bundle.clazz || !bundle.metadata || !bundle.metadata.source) {
-                        return;
-                    }
-                    loading.push(item.id);
-                    me.handleBundleLoad(item.path, bundle.metadata.source, item.id, function () {
-                        done(item.id);
-                    });
-                });
-            },
-            handleBundleLoad: function (basePath, src, bundleId, callback) {
-                var files = [];
-                function registerGlobalExpose(expose, path) {
-                    if (!expose) {
-                        return;
-                    }
-                    globalExpose[path] = expose;
-                }
-
-                // src.locales
-                if (src.locales) {
-                    src.locales.forEach(function (file) {
-                        if (file.lang && file.lang !== Oskari.getLang()) {
-                            // dont load locale files that have declared language 
-                            // and are not the language Oskari is started with.
-                            return;
-                        }
-                        if (file.src.endsWith('.js')) {
-                            var path = getPath(basePath, file.src);
-                            files.push(path);
-                            registerGlobalExpose(file.expose, path);
-                        }
-                    });
-                }
-                // src.resources
-                if (src.resources) {
-                    src.resources.forEach(function (file) {
-                        if (file.src.endsWith('.js')) {
-                            files.push(getPath(basePath, file.src));
-                        }
-                    });
-                }
-                // src.scripts
-                if (src.scripts) {
-                    src.scripts.forEach(function (file) {
-                        var path = getPath(basePath, file.src);
-
-                        if (file.src.endsWith('.js')) {
-                            files.push(path);
-                            registerGlobalExpose(file.expose, path);
-                        } else if (file.src.endsWith('.css')) {
-                            linkFile(path);
-                        }
-                    });
-                }
-
-                // src.links
-                if (src.links) {
-                    src.links.forEach(function (file) {
-                        if (file.rel.toLowerCase() === 'import') {
-                            linkFile(getPath(basePath, file.href), file.rel, 'text/html');
-                        }
-                    });
-                }
-                window.require(files, function () {
-                    for (var i = 0; i < arguments.length; ++i) {
-                        if (typeof arguments[i] !== 'undefined') {
-                            // this would be a linked file.js with amd support
-                            var key = globalExpose[files[i]];
-                            if (key) {
-                                if(typeof window[key] !== 'undefined') {
-                                    log.error('Global variable ' + key + ' is being overwritten with new value as a result of bundle.js expose: ', files[i], ' by ' + bundleId);
-                                }
-                                window[key] = arguments[i];
-                                log.info(bundleId + ' exposed ' + key + ' from ' + files[i]);
-                            } else {
-                                log.warn('Support for AMD-files is not yet implemented. Bundles need to have an "expose" statement in bundle.js to register libs as globals.', files[i]);
-                            }
-                        }
-                    }
-                    callback();
-                }, function (err) {
-                    log.error('Error loading files', files, err);
-                    callback();
-                });
             }
         };
     };

--- a/webpack/minifierLoader.js
+++ b/webpack/minifierLoader.js
@@ -22,6 +22,10 @@ module.exports = function(source) {
     });
 
     let output = bundlePaths.map(bundlePath => `import 'oskaribundle-loader!${bundlePath}';`).join('\n') + '\n';
-    output += dynamicBundles.map(b => `Oskari.bundle_manager.registerDynamic('${b.name}', () => [\n${b.paths.map(p => `    import(/* webpackChunkName: "chunk_${b.name}" */'oskaribundle-loader!${p}')`).join(',\n')}\n]);`).join('\n');
+    output += dynamicBundles.map(b => {
+        const dependencies = b.paths.map(p => `    import(/* webpackChunkName: "chunk_${b.name}" */'oskaribundle-loader!${p}')`);
+        return `Oskari.bundle_manager.registerDynamic('${b.name}', () => [\n${dependencies.join(',\n')}\n]);`
+    }).join('\n');
+    
     return output;
 }


### PR DESCRIPTION
Replace requirejs bundle loader with dynamic import based.

Use `"lazy": true` in minifierAppSetup.json to configure bundle to be lazy loaded.

After this change, all bundles used in the app must be referenced in minifierAppSetup.json. Bundles cannot be loaded based only on DB defined path or path given in `Oskari.app.playBundle(...)`.

Also cleaned up comments referencing to `Import-Bundle`