### PR TITLE
Statsgrid indicator form fixes

### DIFF
--- a/bundles/statistics/statsgrid2016/components/IndicatorDataForm.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorDataForm.js
@@ -19,7 +19,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorDataForm', function (l
                             '</div>'),
         row: _.template('<tr data-id="${regionId}">' +
                             '<td class="region" style=" border: 1px solid black ;">${regionName}</td>' +
-                            '<td class="uservalue" style=" border: 1px solid black ;"> <div style="width:100%; height:100%;" contenteditable="true"> ${value} </div></td>' +
+                            '<td class="uservalue" style="border: 1px solid black ;"> <div contenteditable="true">${value}</div></td>' +
                         '</tr> '),
         import: _.template('<div class="user-indicator-import"><textarea placeholder="${placeholder}"></textarea></div>')
     },
@@ -69,7 +69,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorDataForm', function (l
         data.forEach(function (iteration) {
             table.find('tr').each(function (index, tr) {
                 if (tr.innerText.trim().toLowerCase() === iteration.name.toLowerCase() || tr.dataset.id === iteration.name) {
-                    var uservalue = jQuery(tr).find('td.uservalue');
+                    var uservalue = jQuery(tr).find('td.uservalue div');
                     uservalue.text(iteration.value);
                 }
             });
@@ -94,12 +94,22 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorDataForm', function (l
             tableRef.append(me.__templates.row({
                 regionId: region.id,
                 regionName: region.name,
-                value: region.value || ''
+                value: region.value || '<br>' // firefox uses <br> for empty contenteditable
             }));
         });
         this.getElement().append(tableRef);
+
+        var inputElems = tableRef.find('tr td.uservalue div');
         // Focus on the first input cell
-        tableRef.find('tr td.uservalue div')[0].focus();
+        inputElems[0].focus();
+        // prevent KeyboardPan
+        inputElems.on('keydown', function (e) {
+            e.stopPropagation();
+        });
+        // prevent KeyboardZoom
+        inputElems.on('keypress', function (e) {
+            e.stopPropagation();
+        });
 
         this.buttons.forEach(function (btn) {
             btn.setVisible(true);
@@ -119,9 +129,13 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorDataForm', function (l
                 name: columns[0].innerText,
                 value: columns[1].innerText.trim()
             };
-            if (dataItem.value !== '' && !isNaN(dataItem.value)) {
-                // only include rows with values and cast value to number as legend expects it to be a number
-                dataItem.value = dataItem.value.replace(/,/g, '.');
+            // only include rows with values
+            if (dataItem.value === '') {
+                return;
+            }
+            // replace commas and cast value to number as legend expects it to be a number
+            dataItem.value = dataItem.value.replace(/,/g, '.');
+            if (!isNaN(dataItem.value)) {
                 dataItem.value = Number(dataItem.value);
                 data.values.push(dataItem);
             }

--- a/bundles/statistics/statsgrid2016/components/IndicatorDataForm.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorDataForm.js
@@ -19,7 +19,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorDataForm', function (l
                             '</div>'),
         row: _.template('<tr data-id="${regionId}">' +
                             '<td class="region" style=" border: 1px solid black ;">${regionName}</td>' +
-                            '<td class="uservalue" style="border: 1px solid black ;"> <div contenteditable="true">${value}</div></td>' +
+                            '<td class="uservalue" style="border: 1px solid black ;"><div contenteditable="true">${value}</div></td>' +
                         '</tr> '),
         import: _.template('<div class="user-indicator-import"><textarea placeholder="${placeholder}"></textarea></div>')
     },
@@ -94,7 +94,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorDataForm', function (l
             tableRef.append(me.__templates.row({
                 regionId: region.id,
                 regionName: region.name,
-                value: region.value || '<br>' // firefox uses <br> for empty contenteditable
+                value: region.value === undefined ? '<br>' : region.value // firefox uses <br> for empty contenteditable
             }));
         });
         this.getElement().append(tableRef);
@@ -177,13 +177,14 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorDataForm', function (l
             // separator can be tabulator, comma or colon
             var matches = line.match(/([^\t;,]+) *[\t;,]+ *(.*)/);
             if (matches && matches.length === 3) {
-                area = matches[1];
+                area = matches[1].trim();
                 value = (matches[2] || '').replace(',', '.').replace(/\s/g, '');
+
+                validRows.push({
+                    'name': area,
+                    'value': value
+                });
             }
-            validRows.push({
-                'name': area.trim(),
-                'value': value
-            });
         });
         return validRows;
     }

--- a/bundles/statistics/statsgrid2016/components/IndicatorDataForm.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorDataForm.js
@@ -181,8 +181,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorDataForm', function (l
                 value = (matches[2] || '').replace(',', '.').replace(/\s/g, '');
 
                 validRows.push({
-                    'name': area,
-                    'value': value
+                    name: area,
+                    value: value
                 });
             }
         });

--- a/bundles/statistics/statsgrid2016/components/IndicatorForm.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorForm.js
@@ -5,9 +5,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorForm', function (local
     __templates: {
         form: _.template('<form class="stats-indicator-details">' +
                             // should there be a datasource row here?
-                            '   <input class="stats-indicator-form-item" type="text" name="name" placeholder="${name}"><br>' +
-                            '   <textarea class="stats-indicator-form-item" name="description" form="stats-user-indicator" placeholder="${description}"></textarea> ' +
-                            '   <input class="stats-indicator-form-item" type="text" name="datasource" placeholder="${source}"><br>' +
+                            '   <input class="stats-indicator-form-item" type="text" name="name" placeholder="${name}">' +
+                            '   <textarea class="stats-indicator-form-item" name="description" form="stats-user-indicator" placeholder="${description}"></textarea>' +
+                            '   <input class="stats-indicator-form-item" type="text" name="datasource" placeholder="${source}">' +
                             '</form>')
     },
     getElement: function () {

--- a/bundles/statistics/statsgrid2016/components/IndicatorParametersList.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorParametersList.js
@@ -32,7 +32,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParametersList', funct
             '</tr>'
         ),
         form: '<div class="userchoice-container"></div>',
-        input: _.template('<input type="text" name="${name}" placeholder="${label}"><br />')
+        input: _.template('<input type="text" name="${name}" placeholder="${label}">')
     },
     getElement: function () {
         return this.element;
@@ -145,8 +145,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParametersList', funct
         showTableBtn.insertTo(btnContainer);
         showTableBtn.setHandler(function (event) {
             var errors = false;
-
-            if (input.val().length === 0) {
+            var year = input.val().trim();
+            if (year.length === 0 || isNaN(year)) {
                 me.errorService.show(me.locale('errors.title'), me.locale('errors.myIndicatorYearInput'));
                 errors = true;
             }
@@ -158,7 +158,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParametersList', funct
             if (!errors) {
                 me.removeAddDatasetForm();
                 me.trigger('insert.data', {
-                    year: input.val(),
+                    year: year,
                     regionset: Number(me.select.getValue())
                 });
             }

--- a/bundles/statistics/statsgrid2016/components/IndicatorParametersList.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorParametersList.js
@@ -15,7 +15,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParametersList', funct
     Oskari.makeObservable(this);
 }, {
     __templates: {
-        main: _.template('<div class="user-indicator-main"><div class="my-indicator"></div><div class="new-indicator-dataset-params"><div class="util-row"></div></div></div>'),
+        main: _.template('<div class="user-indicator-main"><div class="my-indicator"></div><div class="new-indicator-dataset-params"></div></div>'),
         table: '<table><tbody></tbody></table>',
         tableHeader: _.template(
             '<thead>' +
@@ -32,7 +32,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParametersList', funct
             '</tr>'
         ),
         form: '<div class="userchoice-container"></div>',
-        input: _.template('<input type="text" style="width: 40%; height: 1.6em" name="${name}" placeholder="${label}"><br />')
+        input: _.template('<input type="text" name="${name}" placeholder="${label}"><br />')
     },
     getElement: function () {
         return this.element;
@@ -121,10 +121,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParametersList', funct
             name: 'year',
             label: this.locale('parameters.year')
         }));
-        var formContainer = this.removeAddDatasetForm();
-        var userChoiceContainer = jQuery(this.__templates.form);
+        var userChoiceContainer = this.removeAddDatasetForm();
         userChoiceContainer.append(input);
-        formContainer.append(userChoiceContainer);
 
         var regionsetContainer = jQuery('<div class="regionset-container"></div>');
         regionsetContainer.append('<div>' + this.locale('panels.newSearch.selectRegionsetPlaceholder') + '</div>');
@@ -138,8 +136,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParametersList', funct
         userChoiceContainer.append(regionsetContainer);
 
         // create buttons
-        var btnContainer = jQuery('<div style="display:flex"></div>');
-        formContainer.append(btnContainer);
+        var btnContainer = jQuery('<div></div>');
+        userChoiceContainer.append(btnContainer);
 
         var me = this;
         var showTableBtn = Oskari.clazz.create('Oskari.userinterface.component.buttons.AddButton');

--- a/bundles/statistics/statsgrid2016/components/SelectedIndicatorsMenu.js
+++ b/bundles/statistics/statsgrid2016/components/SelectedIndicatorsMenu.js
@@ -46,7 +46,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SelectedIndicatorsMenu', functi
             var dropdown = select.create(options, dropdownOptions);
             me.dropdown = dropdown;
             dropdown.css({
-                width: '100%'
+                width: '100%',
+                'max-width': '400px'
             });
             select.adjustChosen();
 

--- a/bundles/statistics/statsgrid2016/resources/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/resources/scss/style.scss
@@ -1058,7 +1058,7 @@ div.tab-material-controls div.title {
     min-width: 365px;
   }
   .statsgrid-user-indicator-flyout .oskari-flyoutcontentcontainer {
-    overflow:unset;
+    overflow: visible;
     max-height:100%;
   }
   // user indicator form
@@ -1082,53 +1082,75 @@ margin-bottom: 0.5em;
 padding: 0.3125em;
 max-width: 31.25em; // 500px
 }
-.stats-user-indicator-form div.accordion div.accordion_panel {
-border:none;
-}
-.stats-user-indicator-form div.accordion div.accordion_panel.open {
-border:none;
-}
 .user-indicator-main {
     padding: 0.3125em;
     max-width: 31.25em;
 }
-.user-indicator-main > table {
+.stats-user-indicator-form {
+    .accordion {
+        .accordion_panel {
+            border:none;
+            &.open {
+                border:none;
+            }
+        }
+    }
+    .new-indicator-dataset-params {
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+
+        input {
+            margin: 0;
+        }
+        input[type="text"] {
+            width: 80px;
+            height: 22px;
+        }
+        .regionset-container {
+            display:flex;
+            flex-direction:column;
+            margin-top: -8px;
+            width: 150px;
+        }
+    }
+}
+.user-indicator-table {
     display: table;
- }
- .user-indicator-main > table > tbody {
-    overflow: auto;
-    max-height: 33em;
-    display: block;
-}
-.user-indicator-table td {
-text-align: center;
-}
-.user-indicator-table td:first-child {
-text-align: center;
-width: 17%;
+    tbody {
+        //max-width: 430px;
+        overflow: auto;
+        max-height: 33em;
+        display: block;
+    }
+    .uservalue {
+        text-align: center;
+        padding: 0;
+        height: 0;
+        div {
+            padding: 8px 5px 7px;
+            min-height: 18px;
+            width: 240px;
+            height: 100%;
+            overflow-wrap: break-word;
+            overflow-y: auto;
+        }
+    }
+    .region {
+        padding: 8px 5px 7px;
+        min-width: 100px;
+        max-width: 170px;
+        text-align: center;
+    }
 }
 .user-indicator-specification {
 padding: 0.3125em;
 color:white;
 background-color: #888888;
 }
-.new-indicator-dataset-params {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-}
 .user-indicator-import > textarea {
     width: 300px;
     height: 150px;
-  }
-  .regionset-container {
-    display:flex;
-    flex-direction:column;
-    margin-top: -8px
-  }
-  .userchoice-container {
-    display:flex;
-    justify-content: space-evenly;
   }
 .user-dataset {
     text-align: center;

--- a/bundles/statistics/statsgrid2016/resources/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/resources/scss/style.scss
@@ -549,14 +549,13 @@ div.oskari-flyout {
             position: relative;
             padding: $flyoutPadding;
             flex: 1;
-            overflow-y: scroll;
+            overflow-y: auto;
         }
         .chart-controls {
             display:flex;
             justify-content: center;
             align-items: center;
-            padding-bottom: 7px;
-            padding-top: 7px;
+            padding: 7px;
 
            .dropdown {
                 display: flex;
@@ -572,7 +571,7 @@ div.oskari-flyout {
 }
 
 .statsgrid-diagram-flyout .oskari-flyoutcontentcontainer {
-    overflow: hidden;
+    overflow: visible;
     display: flex;
 }
 
@@ -1053,15 +1052,20 @@ div.tab-material-controls div.title {
 .statsgrid-diagram-flyout .oskari-flyoutcontentcontainer {
     max-width:700px;
   }
-  .statsgrid-user-indicator-flyout {
+
+/* ********************************************
+ * User indicator form
+ * ********************************************/
+.statsgrid-user-indicator-flyout {
     height:auto;
     min-width: 365px;
-  }
-  .statsgrid-user-indicator-flyout .oskari-flyoutcontentcontainer {
-    overflow: visible;
-    max-height:100%;
-  }
-  // user indicator form
+
+    .oskari-flyoutcontentcontainer {
+        overflow: visible;
+        max-height: 100%;
+    }
+}
+
 
 .stats-indicator-form {
 min-height: 18.75em;
@@ -1069,7 +1073,7 @@ padding: 0.9375em;
 }
 .stats-indicator-form-item {
 width: 96%;
-margin-bottom: 0.3125em;
+margin-bottom: 6px;
 }
 .stats-ind-selector {
     display: flex;
@@ -1094,6 +1098,16 @@ max-width: 31.25em; // 500px
                 border:none;
             }
         }
+    }
+    textarea {
+        resize: none;
+        background: #FAFAFA;
+        overflow: auto;
+        height: 3em;
+    }
+    .stats-indicator-details {
+        display: flex;
+        flex-flow: column;
     }
     .new-indicator-dataset-params {
         display: flex;


### PR DESCRIPTION
Prevent KeyboardPan and KeyboardZoom and fix replace commas on table cells input. 
Assign space for empty contenteditable (br-tag and min-height). Fixes the issue where user can't activate contenteditable on click. Check that own indicator's year is number. Add only valid rows.

UI changes:
- more space for region column (input indicator data)
- disable textarea resize
- remove diagram flyout's scroll bar
- fix own indicator flex container in IE
- set max-width for indicator select 
- allow dropdown to flow over flyout