### PR TITLE
Add/tag lazy bundles since webpack needs to be aware of everything

### DIFF
--- a/applications/asdi/asdi_guest/minifierAppSetup.json
+++ b/applications/asdi/asdi_guest/minifierAppSetup.json
@@ -170,6 +170,7 @@
             }
         }, {
             "bundlename": "admin-layerselector",
+            "lazy": true,
             "metadata": {
                 "Import-Bundle": {
                     "admin-layerselector": {
@@ -182,6 +183,7 @@
             }
         }, {
             "bundlename": "admin-layerrights",
+            "lazy": true,
             "metadata": {
                 "Import-Bundle": {
                     "admin-layerrights": {
@@ -191,6 +193,7 @@
             }
         }, {
             "bundlename" : "admin-users",
+            "lazy": true,
             "metadata" : {
                 "Import-Bundle" : {
                     "admin-users" : {
@@ -200,10 +203,21 @@
             }
         }, {
             "bundlename" : "admin",
+            "lazy": true,
             "metadata" : {
                 "Import-Bundle" : {
                     "admin" : {
                         "bundlePath" : "../../../packages/admin/bundle/"
+                    }
+                }
+            }
+        }, {
+            "bundlename": "statsgrid",
+            "lazy": true,
+            "metadata": {
+                "Import-Bundle": {
+                    "statsgrid": {
+                        "bundlePath": "../../../packages/statistics/"
                     }
                 }
             }

--- a/applications/asdi/asdi_published/minifierAppSetup.json
+++ b/applications/asdi/asdi_published/minifierAppSetup.json
@@ -103,6 +103,16 @@
             }
         }
     }, {
+        "bundlename": "statsgrid",
+        "lazy": true,
+        "metadata": {
+            "Import-Bundle": {
+                "statsgrid": {
+                    "bundlePath": "../../../packages/statistics/"
+                }
+            }
+        }
+    }, {
         "bundlename" : "rpc",
         "metadata" : {
             "Import-Bundle" : {

--- a/applications/elf/elf_guest/minifierAppSetup.json
+++ b/applications/elf/elf_guest/minifierAppSetup.json
@@ -235,6 +235,7 @@
             }
         }, {
             "bundlename": "admin-layerselector",
+            "lazy": true,
             "metadata": {
                 "Import-Bundle": {
                     "admin-layerselector": {
@@ -247,6 +248,7 @@
             }
         }, {
             "bundlename": "admin-layerrights",
+            "lazy": true,
             "bundleinstancename": "admin-layerrights",
             "metadata": {
                 "Import-Bundle": {

--- a/applications/sample/servlet/minifierAppSetup.json
+++ b/applications/sample/servlet/minifierAppSetup.json
@@ -209,6 +209,7 @@
         }
     }, {
         "bundlename": "postprocessor",
+        "lazy": true,
         "metadata": {
             "Import-Bundle": {
                 "postprocessor": {
@@ -254,6 +255,7 @@
         }
     }, {
         "bundlename": "search-from-channels",
+        "lazy": true,
         "metadata": {
             "Import-Bundle": {
                 "search-from-channels": {
@@ -299,6 +301,7 @@
         }
     }, {
         "bundlename": "content-editor",
+        "lazy": true,
         "metadata": {
             "Import-Bundle": {
                 "content-editor": {
@@ -308,6 +311,7 @@
         }
     }, {
         "bundlename": "admin-layerselector",
+        "lazy": true,
         "metadata": {
             "Import-Bundle": {
                 "admin-layerselector": {
@@ -320,6 +324,7 @@
         }
     }, {
         "bundlename": "admin-layerrights",
+        "lazy": true,
         "metadata": {
             "Import-Bundle": {
                 "admin-layerrights": {
@@ -329,6 +334,7 @@
         }
     }, {
         "bundlename": "admin",
+        "lazy": true,
         "metadata": {
             "Import-Bundle": {
                 "admin": {
@@ -338,6 +344,7 @@
         }
     }, {
         "bundlename": "admin-users",
+        "lazy": true,
         "metadata": {
             "Import-Bundle": {
                 "admin-users": {
@@ -347,6 +354,7 @@
         }
     }, {
         "bundlename": "admin-wfs-search-channel",
+        "lazy": true,
         "metadata": {
             "Import-Bundle": {
                 "admin-wfs-search-channel": {

--- a/applications/sample/servlet_published_ol3/minifierAppSetup.json
+++ b/applications/sample/servlet_published_ol3/minifierAppSetup.json
@@ -62,6 +62,7 @@
             }
         }, {
             "bundlename": "statsgrid",
+            "lazy": true,
             "metadata": {
                 "Import-Bundle": {
                     "statsgrid": {
@@ -107,6 +108,7 @@
             }
         }, {
             "bundlename": "routingService",
+            "lazy": true,
             "metadata": {
                 "Import-Bundle": {
                     "routingService": {
@@ -116,6 +118,7 @@
             }
         }, {
             "bundlename": "maprotator",
+            "lazy": true,
             "metadata": {
                 "Import-Bundle": {
                     "maprotator": {


### PR DESCRIPTION
Tag admin bundles as "lazy" (dynamically loaded/chunked in Webpack-terms) and add missing bundles for apps.