### PR TITLE
Fix duplicate tools in publisher

### DIFF
--- a/bundles/statistics/statsgrid2016/publisher/DiagramTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/DiagramTool.js
@@ -7,12 +7,10 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.DiagramTool', function (
     id: 'diagram',
 
     init: function (data) {
-        var me = this;
-        if (data && Oskari.util.keyExists(data, 'configuration.statsgrid.conf') && data.configuration.statsgrid.conf.diagram !== false) {
-            me.setEnabled(true);
-        } else {
-            me.setEnabled(false);
-        }
+        var enabled = data &&
+            Oskari.util.keyExists(data, 'configuration.statsgrid.conf') &&
+            data.configuration.statsgrid.conf.diagram === true;
+        this.setEnabled(enabled);
     },
     getTool: function (stateData) {
         var me = this;
@@ -29,11 +27,11 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.DiagramTool', function (
     },
     setEnabled: function (enabled) {
         var me = this;
-
+        var changed = me.state.enabled !== enabled;
         me.state.enabled = enabled;
 
         var stats = Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid');
-        if (!stats) {
+        if (!stats || !changed) {
             return;
         }
         if (enabled) {

--- a/bundles/statistics/statsgrid2016/publisher/StatsTableTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/StatsTableTool.js
@@ -15,13 +15,10 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.StatsTableTool', functio
      * @public
      */
     init: function (pdata) {
-        var me = this;
-
-        if (pdata && Oskari.util.keyExists(pdata, 'configuration.statsgrid.conf') && pdata.configuration.statsgrid.conf.grid !== false) {
-            me.setEnabled(true);
-        } else {
-            me.setEnabled(false);
-        }
+        var enabled = pdata &&
+            Oskari.util.keyExists(pdata, 'configuration.statsgrid.conf') &&
+            pdata.configuration.statsgrid.conf.grid === true;
+        this.setEnabled(enabled);
     },
     /**
     * Get tool object.
@@ -74,10 +71,11 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.StatsTableTool', functio
 
     setEnabled: function (enabled) {
         var me = this;
+        var changed = me.state.enabled !== enabled;
         me.state.enabled = enabled;
 
         var stats = Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid');
-        if (!stats) {
+        if (!stats || !changed) {
             return;
         }
         if (enabled) {


### PR DESCRIPTION
Fixes issues where user modified published map view containing a stats layer.
- Diagram tool would become enabled even if it wasn't enabled in the publication.
- Diagram and table tools had duplicate buttons.