### PR TITLE
Drawtools fix

### DIFF
--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol3.js
@@ -897,6 +897,7 @@ Oskari.clazz.define(
 
                 // stop drawing without modifying
                 if (options.allowMultipleDrawing === false && options.modifyControl === false) {
+                    me._sketch = null;
                     me.stopDrawing(me._id, false);
                 } else if (options.allowMultipleDrawing === false) {
                     // stop drawing and start modifying


### PR DESCRIPTION
Fixes an issue where drawing a box, square or lineString unnecessarily removes a coordinate point from the drawing when modifyControl is set to false.