### PR TITLE
Remove references to contrib-bundles

### DIFF
--- a/applications/sample/servlet/minifierAppSetup.json
+++ b/applications/sample/servlet/minifierAppSetup.json
@@ -24,9 +24,6 @@
                 "ui-components": {
                     "bundlePath": "../../../packages/framework/bundle/"
                 },
-                "mapanalysis": {
-                    "bundlePath": "../../../packages/mapping/ol3/"
-                },
                 "mapfull": {
                     "bundlePath": "../../../packages/framework/bundle/"
                 },
@@ -236,30 +233,11 @@
             }
         }
     }, {
-        "bundlename": "analyse",
-        "metadata": {
-            "Import-Bundle": {
-                "analyse": {
-                    "bundlePath": "../../../packages/analysis/ol3/"
-                }
-            }
-        }
-    }, {
         "bundlename": "myplacesimport",
         "metadata": {
             "Import-Bundle": {
                 "myplacesimport": {
                     "bundlePath": "../../../packages/framework/bundle/"
-                }
-            }
-        }
-    }, {
-        "bundlename": "search-from-channels",
-        "lazy": true,
-        "metadata": {
-            "Import-Bundle": {
-                "search-from-channels": {
-                    "bundlePath": "../../../packages/tampere/bundle/"
                 }
             }
         }
@@ -287,16 +265,6 @@
             "Import-Bundle": {
                 "maprotator": {
                     "bundlePath": "../../../packages/mapping/ol3/"
-                }
-            }
-        }
-    }, {
-        "bundlename": "content-editor",
-        "lazy": true,
-        "metadata": {
-            "Import-Bundle": {
-                "content-editor": {
-                    "bundlePath": "../../../packages/tampere/bundle/"
                 }
             }
         }
@@ -340,16 +308,6 @@
             "Import-Bundle": {
                 "admin-users": {
                     "bundlePath": "../../../packages/framework/bundle/"
-                }
-            }
-        }
-    }, {
-        "bundlename": "admin-wfs-search-channel",
-        "lazy": true,
-        "metadata": {
-            "Import-Bundle": {
-                "admin-wfs-search-channel": {
-                    "bundlePath": "../../../packages/tampere/bundle/"
                 }
             }
         }

--- a/applications/sample/servlet_published_ol3/minifierAppSetup.json
+++ b/applications/sample/servlet_published_ol3/minifierAppSetup.json
@@ -9,9 +9,6 @@
                     "mapwfs2": {
                         "bundlePath": "../../../packages/mapping/ol3/"
                     },
-                    "mapanalysis": {
-                        "bundlePath": "../../../packages/mapping/ol3/"
-                    },
                     "mapuserlayers": {
                         "bundlePath": "../../../packages/mapping/ol3/"
                     },
@@ -93,7 +90,7 @@
             "metadata": {
                 "Import-Bundle": {
                     "featuredata2": {
-                        "bundlePath": "../../../packages/framework/bundle/"
+                        "bundlePath": "../../../packages/framework/"
                     }
                 }
             }


### PR DESCRIPTION
Analysis and some bundles under tampere namespace are referenced in sample app, but the bundles have been moved to https://github.com/oskariorg/oskari-frontend-contrib. This fixes the build for sample app. Note that analysis needs to be removed from the sample app on oskari-server as well.