### PR TITLE
Use only ES5 functions in loader output

### DIFF
--- a/webpack/minifierLoader.js
+++ b/webpack/minifierLoader.js
@@ -24,7 +24,7 @@ module.exports = function(source) {
     let output = bundlePaths.map(bundlePath => `import 'oskaribundle-loader!${bundlePath}';`).join('\n') + '\n';
     output += dynamicBundles.map(b => {
         const dependencies = b.paths.map(p => `    import(/* webpackChunkName: "chunk_${b.name}" */'oskaribundle-loader!${p}')`);
-        return `Oskari.bundle_manager.registerDynamic('${b.name}', () => [\n${dependencies.join(',\n')}\n]);`
+        return `Oskari.bundle_manager.registerDynamic('${b.name}', function() { return [\n${dependencies.join(',\n')}\n];});`
     }).join('\n');
     
     return output;


### PR DESCRIPTION
Fixes dynamic bundles on IE11.