### PR TITLE
Add a front slash only if pathname does not end with it

### DIFF
--- a/src/sandbox/sandbox.js
+++ b/src/sandbox/sandbox.js
@@ -880,7 +880,12 @@
                 if(baseUrl.indexOf('/') === 0) {
                     return serverUrl + baseUrl;
                 }
-                return serverUrl + window.location.pathname + '/' + baseUrl;
+                // Add a front slash only if pathname does not end with it
+                if (window.location.pathname[window.location.pathname.length - 1] === '/') {
+                    return serverUrl + window.location.pathname + baseUrl;
+                } else {
+                    return serverUrl + window.location.pathname + '/' + baseUrl;
+                }
             },
             /**
              * Ensures that the given parameter has ? character and appends & to the end if


### PR DESCRIPTION
Fixes an issue where URL is constructed with an extra front slash