### PR TITLE
Documentation changes & small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 
 Documentation available at [http://www.oskari.org].
 
-This repository holds the front-end code for Oskari. Developing the front-end requires an oskari-server to be running that responds to the XHR requests made by the front-end. You can download a pre-compiled copy of the server from  [http://www.oskari.org/download] or checkout the source code in the oskari-server repository. Any customized application should use the oskari-server-extension template as base for customized server. The front-end code is built using Webpack.
+This repository holds the frontend code and a sample application for Oskari. Developing the frontend requires an oskari-server to be running that responds to the XHR requests made by the frontend. You can download a pre-compiled copy of the server from [http://www.oskari.org/download] or checkout the source code in the oskari-server repository. Any customized application should use the oskari-server-extension template as base for customized server and create an app-specific repository for the frontend. Oskari frontend code is built using Webpack and the same build system can be easily used for customized apps.
 
 ## Preparations
 
-Make sure you have at least Node 8.x / NPM 5.x. Run `npm install` in the front-end repository root.
+Make sure you have at least Node 8.x / NPM 5.x. Run `npm install` in the frontend repository root.
 Make sure you have oskari-server running on localhost port 8080 (can be customized on webpack.config.js).
 
 ### App composition
 
-An Oskari frontend application consists of bundles that are defined in the miniferAppSetup.json for each app. Only bundles referenced here can be instantiated at runtime. If some bundles are used only in a limited part of the app (for example admin tools), you can configure these bundles to load dynamically at runtime. This will decrease the size of the main app JS bundle. To enable dynamic loading for a bundle, add `"lazy": true` on the same level as `"bundlename"` in the miniferAppSetup.json.
+An Oskari frontend application consists of bundles that are defined in the miniferAppSetup.json for each app (an example can be found under applications/sample/servlet). Only bundles referenced here can be instantiated at runtime. Bundles that are used only in a limited part of the app (for example admin tools) can be configured to load dynamically at runtime. This will decrease the size of the main app JS bundle. To enable dynamic loading for a bundle, add `"lazy": true` on the same level as `"bundlename"` in the miniferAppSetup.json.
 
 ## Run in development
 
@@ -25,8 +25,7 @@ So that the server knows to look for the JS bundle and assets from the right pla
 oskari.client.version=dist/devapp
 ```
 
-To start Webpack dev server, we point it to an application directory with subfolders having miniferAppSetup.json files for the applications we want to start, here Sample app as example:
-`npm start -- --env.appdef=applications/sample/`
+To start Webpack dev server run `npm start`. The start script in oskari-frontend package.json defaults to the sample application directory but this can be parameterized for custom apps.
 
 When you see "Compiled successfully." in the terminal, you can open the app in the browser at `localhost:8081`.
 
@@ -34,14 +33,15 @@ The dev server has automatic reloading enabled when you save changes to JS code 
 
 ## Build for production
 
-To build minifed JS and assets, run:
-`npm run build -- --env.appdef=1.49.0:applications/sample/`
+To build minifed JS and assets run: `npm run build`.
 
-The number before the colon sets the directory name, here producing files under dist/1.49.0/servlet/
+This will produce optimized files for production under `dist/devapp/servlet/`. The build script in oskari-frontend package.json again defaults to the sample application directory. It also defaults to a version named `devapp`. Both the app and version number can be parameterized for custom apps.
 
 Note: The version number given for the build command needs to match the client version (`oskari.client.version`) in Oskari-server `oskari-ext.properties`.
 
-Special case: If on your production server your application index.jsp location is mapped to something else than the root (eg. `http://yourdomain.com/my-oskari-app/`), but the assets are mapped relative to the root (eg. `http://yourdomain.com/Oskari/dist/...`), you need to add the build parameter `--env.absolutePublicPath=true`.
+Special case: If on your production server your application index.jsp location is mapped to something else than the root (eg. `http://yourdomain.com/my-oskari-app/`), but the assets are mapped relative to the root (eg. `http://yourdomain.com/Oskari/dist/...`), you need to add the build parameter `--env.absolutePublicPath=true` like this:
+
+    npm run build -- --env.absolutePublicPath=true
 
 ### Customized application icons (optional)
 
@@ -54,6 +54,10 @@ After running the production build it's possible to create a customized set of i
 Note! Requires (GraphicsMagick)[http://www.graphicsmagick.org/] to be installed on the server and the "gm" command to be usable on the cmd/bash.\
 Note! You must first run a production build for the application to create the corresponding dist-folder. With the example command the sprite will be generated under the `dist\1.49.0\servlet` folder as `icons.png` and `icons.css`.\
 Note! To use the customized icons set your HTML (JSP) on the oskari-server need to link the icons.css under the application folder (default JSP links it from under oskari-frontend/resources/icons.css).
+
+### How to setup custom frontend
+
+See https://github.com/nls-oskari/pti-frontend for an example how to separate app-specific functionality and use oskari-frontend and oskari-frontend-contrib.
 
 ### FAQ
 
@@ -69,6 +73,15 @@ In linux you can use:
 Or in Windows:
 
     set NODE_OPTIONS=--max_old_space_size=4096 && npm run build -- --env.appdef=1.49.0:applications/sample/
+
+#### Production build "freezes"
+
+CPU usage of the computer shows nothing is happening, but the bash/cmd is still executing the build command. Try setting "parallel" to false on UglifyJsPlugin configuration in webpack.config.js:
+
+    new UglifyJsPlugin({
+        sourceMap: true,
+        parallel: false
+    })
 
 # Reporting issues
 

--- a/bundles/framework/divmanazer/component/ProgressSpinner.js
+++ b/bundles/framework/divmanazer/component/ProgressSpinner.js
@@ -87,7 +87,7 @@ Oskari.clazz.define('Oskari.userinterface.component.ProgressSpinner',
                 delete data.spinner;
             }
             if (opts !== false) {
-                data.spinner = new Spinner($.extend({
+                data.spinner = new Spinner(jQuery.extend({
                     color: $el.css('color')
                 }, opts)).spin($el.get()[0]);
             }

--- a/bundles/framework/divmanazer/request/ModalDialogRequestHandler.js
+++ b/bundles/framework/divmanazer/request/ModalDialogRequestHandler.js
@@ -61,7 +61,7 @@ Oskari
             if (request.onshow) {
                 this._args.onShow = request.onshow;
             }
-            $.modal = tpl.modal(this._args);
+            jQuery.modal = tpl.modal(this._args);
         }
     }, {
         protocol: ['Oskari.mapframework.core.RequestHandler']

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "main": "grunt.js",
   "scripts": {
     "test": "eslint . --quiet",
-    "build": "webpack --mode production --env.appdef=applications/sample",
-    "start": "webpack-dev-server --hot --env.appdef=applications/sample",
+    "build": "webpack --progress --mode production --env.appdef=devapp:applications/sample",
+    "start": "webpack-dev-server --hot --env.appdef=devapp:applications/sample",
     "sprite": "node webpack/sprite.js"
   },
   "bugs": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = (env, argv) => {
         new CopyWebpackPlugin(
             [
                 { from: 'resources', to: 'resources', context: __dirname },
-                { from: 'bundles/integration/admin-layerselector', to: 'admin-layerselector', context: __dirname }
+                { from: 'bundles/integration/admin-layerselector', to: 'assets/admin-layerselector', context: __dirname }
             ]
         )
     ];


### PR DESCRIPTION
- Update readme to reflect latest build-script changes
- Replace some $ references to jQuery (as jQuery is now only exposed with the name)
- Add progress indicator for build
- Add placeholder for the default version of sample app for easier reference
- Change admin-layerselector location in build to version/assets as the bundle assumes after #678 instead of directly under version.

Sorry. Too many unrelated changes for a single PR.