### PR TITLE
Map link showMarker and showIntro params

### DIFF
--- a/bundles/framework/guidedtour/instance.js
+++ b/bundles/framework/guidedtour/instance.js
@@ -78,28 +78,27 @@ Oskari.clazz.define(
             if (!this._localization) {
                 this._localization = Oskari.getLocalization(this.getName());
             }
-
+            var state = this.state || {};
             // Check cookie 'pti_tour_seen'. Value '1' means that tour
             // is not to be started
             // jQuery cookie plugin:
             //   resources/framework/bundle/guidedtour/js/jquery.cookie.js
             //   github.com/carhartl/jquery-cookie/
-            if (jQuery.cookie('pti_tour_seen') !== '1') {
-                var me = this,
-                    conf = me.conf, // Should this not come as a param?
-                    sandboxName = (conf ? conf.sandbox : 'sandbox'),
-                    sandbox = Oskari.getSandbox(sandboxName);
-                // register to sandbox as a module
-                sandbox.register(me);
-                // register request handlers
-                sandbox.requestHandler(
-                    'Guidedtour.AddToGuidedTourRequest',
-                    Oskari.clazz.create('Oskari.framework.bundle.guidedtour.AddToGuidedTourRequestHandler', me)
-                );
-                me.sandbox = sandbox;
-
-                me._startGuide();
+            if (jQuery.cookie('pti_tour_seen') === '1' || state.showIntro === false) {
+                return;
             }
+
+            var sandbox = Oskari.getSandbox();
+            // register to sandbox as a module
+            sandbox.register(this);
+            // register request handlers
+            sandbox.requestHandler(
+                'Guidedtour.AddToGuidedTourRequest',
+                Oskari.clazz.create('Oskari.framework.bundle.guidedtour.AddToGuidedTourRequestHandler', this)
+            );
+            this.sandbox = sandbox;
+
+            this._startGuide();
         },
         _startGuide: function () {
             var me = this,

--- a/bundles/mapping/toolbar/resources/locale/en.js
+++ b/bundles/mapping/toolbar/resources/locale/en.js
@@ -7,8 +7,11 @@ Oskari.registerLocalization(
             "link": {
                 "tooltip": "Make a link to the map view.",
                 "ok": "OK",
+                "copy": "Copy the link to the clipboard",
                 "title": "Link to Map View",
-                "cannot": "This map view cannot be linked to. Create a new map view and try again."
+                "cannot": "This map view cannot be linked to. Create a new map view and try again.",
+                "addMarker": "Show map focal marker",
+                "skipInfo": "Do not show quick guide"
             },
             "history": {
                 "reset": "Move to the default map view.",

--- a/bundles/mapping/toolbar/resources/locale/fi.js
+++ b/bundles/mapping/toolbar/resources/locale/fi.js
@@ -7,8 +7,11 @@ Oskari.registerLocalization(
             "link": {
                 "tooltip": "Tee linkki karttanäkymään.",
                 "ok": "OK",
+                "copy": "Kopioi linkki leikepöydälle",
                 "title": "Linkki karttanäkymään",
-                "cannot": "Karttalinkkiä ei voida luoda tähän näkymään. Luo uusi näkymä ja yritä uudelleen."
+                "cannot": "Karttalinkkiä ei voida luoda tähän näkymään. Luo uusi näkymä ja yritä uudelleen.",
+                "addMarker": "Näytä kartan keskipisteen merkki",
+                "skipInfo": "Älä näytä pikaopasta"
             },
             "history": {
                 "reset": "Siirry oletusnäkymään.",

--- a/bundles/mapping/toolbar/resources/locale/sv.js
+++ b/bundles/mapping/toolbar/resources/locale/sv.js
@@ -7,8 +7,11 @@ Oskari.registerLocalization(
             "link": {
                 "tooltip": "Länk",
                 "ok": "OK",
+                "copy": "Kopiera länken till klippbordet",
                 "title": "Gör en länk till kartvyn.",
-                "cannot": "Denna kartvy kan inte länkas till. Skapa en ny kartvy och försök igen."
+                "cannot": "Denna kartvy kan inte länkas till. Skapa en ny kartvy och försök igen.",
+                "addMarker": "Visa kartans mittmarkör",
+                "skipInfo": "Visa inte snabbguide"
             },
             "history": {
                 "reset": "Gå tillbaka till standardvyn för kartvyn.",

--- a/bundles/mapping/toolbar/resources/scss/toolbar.scss
+++ b/bundles/mapping/toolbar/resources/scss/toolbar.scss
@@ -19,15 +19,23 @@ div.toolrow {
     }
 
 }
-
-div.linkcontent {
-    word-wrap: break-word;
-    border-style: dashed;
-    border-width: 1px;
-    padding: 5px;
-    max-height: 200px;
-    overflow-y: auto;
+.link-wrapper {
+    .oskari-checkboxinput {
+        margin: 0px 6px 6px;
+    }
+    .link-content {
+        word-break: break-all;
+        border-style: dashed;
+        border-width: 1px;
+        padding: 5px;
+        max-height: 200px;
+        max-width: 600px;
+        overflow-y: auto;
+        margin-bottom: 12px;
+    }
 }
+
+
 
 div.tool.disabled {
     cursor: default;


### PR DESCRIPTION
Add check boxes for showMarker and showIntro params to maplink popup. Now user can select if guided tour and map focal marker are showed when maplink is opened (params are added or not to link). Also added copy to clipboard button, because that is what user want to do.

Guided tour is skipped if cookie is set or state showInfo is false.
Is there need to register guided tour even it's not showed at startup and only skip _startGuide()?
What if Oskari instance doesn't have guided tour bundle? Should we hide showInfo checkbox?

Skip guided tour requires: https://github.com/oskariorg/oskari-server/pull/287