### PR TITLE
Publisher: unsupported projection

### DIFF
--- a/bundles/framework/publisher2/instance.js
+++ b/bundles/framework/publisher2/instance.js
@@ -275,20 +275,20 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
                 blnEnabled ? jQuery(this.getCustomTileRef()).addClass('activePublish') : jQuery(this.getCustomTileRef()).removeClass('activePublish');
             }
             if (blnEnabled) {
+                // FIXME: not like this! see removing...
+                me.sandbox.mapMode = 'mapPublishMode';
                 var stateRB = Oskari.requestBuilder('StateHandler.SetStateRequest');
                 this.getSandbox().request(this, stateRB(data.configuration));
                 if (data.uuid) {
                     this._showEditNotification();
                 }
 
-                me.getService().setNonPublisherLayers(deniedLayers || this.getLayersWithoutPublishRights());
+                me.getService().setNonPublisherLayers(deniedLayers || this.getNonPublisherLayers());
                 me.getService().removeLayers();
                 me.oskariLang = Oskari.getLang();
 
                 map.addClass('mapPublishMode');
                 map.addClass('published');
-                // FIXME: not like this! see removing...
-                me.sandbox.mapMode = 'mapPublishMode';
 
                 // hide flyout?
                 // TODO: move to default flyout/extension as "mode functionality"?
@@ -381,23 +381,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
             dialog.show(this.loc('edit.popup.published.error.title'), this.loc(errorKey));
             setTimeout(function () { dialog.fadeout(); }, 3000);
         },
-        /**
-         * @method hasPublishRight
-         * Checks if the layer can be published.
-         * @param
-         * {Oskari.mapframework.domain.WmsLayer/Oskari.mapframework.domain.WfsLayer/Oskari.mapframework.domain.VectorLayer}
-         * layer
-         *      layer to check
-         * @return {Boolean} true if the layer can be published
-         */
-        hasPublishRight: function (layer) {
-            // permission might be "no_publication_permission"
-            // or nothing at all
-            return (layer.getPermission('publish') === 'publication_permission_ok');
-        },
 
         /**
-         * @method getLayersWithoutPublishRights
+         * @method getNonPublisherLayers
          * Checks currently selected layers and returns a subset of the list
          * that has the layers that can't be published. If all selected
          * layers can be published, returns an empty list.
@@ -405,11 +391,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
          * {Oskari.mapframework.domain.WmsLayer[]/Oskari.mapframework.domain.WfsLayer[]/Oskari.mapframework.domain.VectorLayer[]/Mixed}
          * list of layers that can't be published.
          */
-        getLayersWithoutPublishRights: function () {
-            var me = this;
+        getNonPublisherLayers: function () {
             var selectedLayers = this.sandbox.getMap().getLayers();
-            var deniedLayers = selectedLayers.filter(function (layer) {
-                return !me.hasPublishRight(layer);
+            var service = this.getService();
+            var deniedLayers = selectedLayers.filter((layer) => {
+                return !service.hasPublishRight(layer) || !layer.isSupported(this.sandbox.getMap().getSrsName());
             });
             return deniedLayers;
         },

--- a/bundles/framework/publisher2/resources/locale/en.js
+++ b/bundles/framework/publisher2/resources/locale/en.js
@@ -227,8 +227,10 @@ Oskari.registerLocalization(
             "layerlist_title": "Publishable map layers open in map window:",
             "layerlist_empty": "No publishable map layers are open in the map window. Please check publishable map layers in the Selected Layers menu.",
             "layerlist_denied": "Unpublishable map layers open in map window:",
-            "denied_tooltip": "These map layers are not publishable in embedded maps. Data producers have not granted permissions for publishing. Please check publishable map layers in the Selected Layers menu.",
+            "denied_tooltip": "These map layers are not publishable in embedded maps. Data producers have not granted permissions for publishing or the current map projection is unsupported. Please check publishable map layers in the Selected Layers menu.",
             "myPlacesDisclaimer": "NOTE! If you are using this map layer in an embedded map, the map layer will be published.",
+            "noRights": "no permission",
+            "unsupportedProjection": "unsupported projection",
             "buttons": {
                 "continue": "Continue",
                 "continueAndAccept": "Accept and continue",

--- a/bundles/framework/publisher2/resources/locale/fi.js
+++ b/bundles/framework/publisher2/resources/locale/fi.js
@@ -227,8 +227,10 @@ Oskari.registerLocalization(
             "layerlist_title": "Avoinna olevat karttatasot, jotka ovat julkaistavissa",
             "layerlist_empty": "Avoinna olevat karttatasot eivät ole julkaistavissa. Tarkista Valitut tasot -valikosta, mitkä karttatasot ovat julkaistavissa.",
             "layerlist_denied": "Avoinna olevat karttatasot, jotka eivät ole julkaistavissa",
-            "denied_tooltip": "Karttatasot eivät ole julkaistavissa upotetussa kartassa. Tiedontuottaja ei ole antanut lupaa julkaista karttatasoa muissa verkkopalveluissa. Tarkista karttatason julkaisuoikeudet Valitut tasot -valikosta.",
+            "denied_tooltip": "Karttatasot eivät ole julkaistavissa upotetussa kartassa. Tiedontuottaja ei ole antanut lupaa julkaista karttatasoa muissa verkkopalveluissa tai tasoa ei voida näyttää tässä karttaprojektiossa. Tarkista karttatason julkaisuoikeudet Valitut tasot -valikosta.",
             "myPlacesDisclaimer": "HUOM! Jos käytät karttatasoa karttajulkaisussa, karttatasosta tulee julkinen.",
+            "noRights": "ei julkaisuoikeutta",
+            "unsupportedProjection": "väärä karttaprojektio",
             "buttons": {
                 "continue": "Jatka",
                 "continueAndAccept": "Hyväksy ehdot ja jatka",

--- a/bundles/framework/publisher2/resources/locale/sv.js
+++ b/bundles/framework/publisher2/resources/locale/sv.js
@@ -224,8 +224,10 @@ Oskari.registerLocalization(
             "layerlist_title": "Kartlager som kan inbäddas",
             "layerlist_empty": "Valda kartlager kan inte publiceras i en inbäddad karta. Kontrollera rätten att publicera i menyn \"Valda Kartlager\" innan du börjar skapa kartan.",
             "layerlist_denied": "Kartlagret kan inte publiceras i en inbäddad karta.",
-            "denied_tooltip": "Kartdataproducenterna har inte gett publiceringstillstånd till dessa material i andra webbtjänster. Kontrollera rätten att publicera i menyn \"Valda Kartlager\" innan du börjar skapa kartan.",
+            "denied_tooltip": "Kartdataproducenterna har inte gett publiceringstillstånd till dessa material i andra webbtjänster eller denna kartlager kan inte visas med den valda kartprojektionen. Kontrollera rätten att publicera i menyn \"Valda Kartlager\" innan du börjar skapa kartan.",
             "myPlacesDisclaimer": "Obs! Du publicerar ditt eget kartlager.",
+            "noRights": "inget tillstånd",
+            "unsupportedProjection": "ostödd kartprojektion",
             "buttons": {
                 "continue": "Fortsätt",
                 "continueAndAccept": "Godkänn användningsvillkor och fortsätt",

--- a/bundles/framework/publisher2/view/FlyoutStartView.js
+++ b/bundles/framework/publisher2/view/FlyoutStartView.js
@@ -116,7 +116,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.FlyoutStartView'
             var layers = [];
             var deniedLayers = [];
             me.instance.sandbox.findAllSelectedMapLayers().forEach(function (layer) {
-                if (!me.service.hasPublishRight(layer)) {
+                if (!me.service.hasPublishRight(layer) || !layer.isSupported(me.instance.sandbox.getMap().getSrsName())) {
                     deniedLayers.push(layer);
                 } else {
                     layers.push(layer);
@@ -174,14 +174,23 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.FlyoutStartView'
             var layerList = this.templateLayerList.clone();
             var listElement = layerList.find('ul');
             var listItemTemplate = this.templateListItem;
-            var usercontentDisclaimer = this.loc.myPlacesDisclaimer;
 
-            (list || []).forEach(function (layer) {
+            (list || []).forEach((layer) => {
                 var item = listItemTemplate.clone();
                 var txt = layer.getName();
+                var reasons = [];
                 // TODO: this covers myplaces layers - what about userlayers?
                 if (layer.isLayerOfType('MYPLACES')) {
-                    txt = txt + ' (' + usercontentDisclaimer + ')';
+                    reasons.push(this.loc.myPlacesDisclaimer);
+                }
+                if (!this.service.hasPublishRight(layer)) {
+                    reasons.push(this.loc.noRights);
+                }
+                if (!layer.isSupported(this.instance.sandbox.getMap().getSrsName())) {
+                    reasons.push(this.loc.unsupportedProjection);
+                }
+                if (reasons.length) {
+                    txt += ' (' + reasons.join(', ') + ')';
                 }
                 item.append(txt);
                 listElement.append(item);

--- a/bundles/framework/publisher2/view/PanelMapLayers.js
+++ b/bundles/framework/publisher2/view/PanelMapLayers.js
@@ -96,9 +96,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapLayers',
              * Updates the layerlist
              */
             AfterMapLayerAddEvent: function (event) {
-                if (!this.hasPublishRight(event._mapLayer)) {
-                    // TODO: ?
-                }
                 this.handleLayerSelectionChanged();
             },
 
@@ -722,20 +719,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapLayers',
                 requestName,
                 ['publishable', true]
             );
-        },
-        /**
-         * @method hasPublishRight
-         * Checks if the layer can be published.
-         * @param
-         * {Oskari.mapframework.domain.WmsLayer/Oskari.mapframework.domain.WfsLayer/Oskari.mapframework.domain.VectorLayer}
-         * layer
-         *      layer to check
-         * @return {Boolean} true if the layer can be published
-         */
-        hasPublishRight: function (layer) {
-            // permission might be "no_publication_permission"
-            // or nothing at all
-            return (layer.getPermission('publish') === 'publication_permission_ok');
         }
 
     }

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -2280,7 +2280,7 @@ Oskari.clazz.define(
                 layerFunctions = [],
                 sandbox = this.getSandbox();
 
-            if (!layer.isSupported(sandbox.getMap().getSrsName())) {
+            if (!layer.isSupported(sandbox.getMap().getSrsName()) && sandbox.mapMode !== 'mapPublishMode') {
                 this._mapLayerService.showUnsupportedPopup();
             }
 


### PR DESCRIPTION
Remove layers with unsupported projection when enterin publisher and restore when exiting.

Shows reason why layer is unsupported in Create Embedded Map flyout. Reason can be either "no permission" or "unsupported projection".