### PR TITLE
Clear map

### DIFF
--- a/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
+++ b/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
@@ -19,6 +19,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
         const regionset = state.getRegionset();
 
         if (!ind || !regionset) {
+            me._clearRegions();
             return;
         }
         me._updateLayerProperties();


### PR DESCRIPTION
Remove region features when there is no indicators or region set selected.
Fixes an issue where region features would stay on the map when user removed all indicators.