### PR TITLE
MouseHoverEvent add isDrawing

### DIFF
--- a/api/mapping/mapmodule/event/MouseHoverEvent.md
+++ b/api/mapping/mapmodule/event/MouseHoverEvent.md
@@ -1,0 +1,58 @@
+# MouseHoverEvent
+
+Notifies user about the pointer moves.
+
+## Description
+
+Event is used to nofify user about the pointer moves. Event includes information about the pointer coordinates and if moving is paused and if drawing is active. Note that on touch devices this is triggered when the map is panned, so is not the same as mouse move.
+
+## Parameters
+
+(* means the parameter is required)
+
+<table class="table">
+<tr>
+  <th> Name</th><th> Type</th><th> Description</th><th> Default value</th>
+</tr>
+<tr>
+  <td> \* lon </td><td> Number </td><td> longitude on pointer location </td><td> </td>
+</tr>
+<tr>
+  <td> \* lat </td><td> Number </td><td> latitude on pointer location </td><td> </td>
+</tr>
+<tr>
+  <td> \* isPaused </td><td> Boolean </td><td> True if move is paused </td><td> </td>
+</tr>
+<tr>
+  <td> \* pageX </td><td> Number </td><td> viewport pointer position x </td><td> </td>
+</tr>
+<tr>
+  <td> \* pageY </td><td> Number </td><td> viewport pointer position y </td><td> </td>
+</tr>
+<tr>
+  <td> \* isDrawing </td><td> Boolean </td><td> True while drawing (DrawTools) </td><td> </td>
+</tr>
+</table>
+
+## Event methods
+
+### getName()
+Returns event name
+
+### getLon()
+Returns longitude on mouse location
+
+### getLat()
+Returns latitude on mouse location
+
+### isPaused()
+Returns True if move is paused (no move in 1000 ms).
+
+### getPageX()
+Returns viewport mouse position x
+
+### getPageY()
+Returns viewport mouse position y
+
+### isDrawing()
+Returns true while DrawTools drawing is active. Drawing is activated by StartDrawingRequest (e.g. measure tool, add or modify MyPlaces or feature selection tool).

--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -49,7 +49,7 @@ Options object
     </li>
 </ul>
 
-Hover options describes how to visualize features on hover and what kind of tooltip should be shown.
+Hover options describes how to visualize features on hover and what kind of tooltip should be shown. Note that features isn't hovered while drawing is active (DrawTools).
 ```javascript
 hover: {
     featureStyle: {

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -134,7 +134,8 @@ export default class MapModule extends AbstractMapModule {
                     evt.coordinate[1],
                     true,
                     evt.pixel[0],
-                    evt.pixel[1]
+                    evt.pixel[1],
+                    me.getDrawingMode()
                 );
                 sandbox.notifyAll(hoverEvent);
             }, 1000);
@@ -143,7 +144,8 @@ export default class MapModule extends AbstractMapModule {
                 evt.coordinate[1],
                 false,
                 evt.pixel[0],
-                evt.pixel[1]);
+                evt.pixel[1],
+                me.getDrawingMode());
             sandbox.notifyAll(hoverEvent);
         });
     }

--- a/bundles/mapping/mapmodule/event/MouseHoverEvent.js
+++ b/bundles/mapping/mapmodule/event/MouseHoverEvent.js
@@ -19,9 +19,11 @@ Oskari.clazz.define('Oskari.mapframework.event.common.MouseHoverEvent',
      *            pageX mouse location x
      * @param {Number}
      *            pageY mouse location y
+     * @param {Boolean}
+     *            isDrawing true when drawtools is active
      */
 
-    function (lon, lat, isPaused, pageX, pageY) {
+    function (lon, lat, isPaused, pageX, pageY, isDrawing) {
         this._creator = null;
 
         this._lon = lon;
@@ -33,6 +35,8 @@ Oskari.clazz.define('Oskari.mapframework.event.common.MouseHoverEvent',
         this._pageX = pageX;
 
         this._pageY = pageY;
+
+        this._isDrawing = isDrawing;
     }, {
         /** @static @property __name event name */
         __name: 'MouseHoverEvent',
@@ -67,12 +71,13 @@ Oskari.clazz.define('Oskari.mapframework.event.common.MouseHoverEvent',
          * @param {Number}
          *            lat latitude on mouse location
          */
-        set: function (lon, lat, isPaused, pageX, pageY) {
+        set: function (lon, lat, isPaused, pageX, pageY, isDrawing) {
             this._lon = lon;
             this._lat = lat;
             this._paused = isPaused;
             this._pageX = pageX;
             this._pageY = pageY;
+            this._isDrawing = isDrawing;
         },
 
         isPaused: function () {
@@ -84,6 +89,9 @@ Oskari.clazz.define('Oskari.mapframework.event.common.MouseHoverEvent',
         },
         getPageY: function () {
             return this._pageY;
+        },
+        isDrawing: function () {
+            return this._isDrawing;
         }
     }, {
         /**

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
@@ -513,7 +513,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
                     },
                     stroke: {
                         color: '#ffffff',
-                        width: 1
+                        width: 3
                     }
                 }
             };

--- a/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
+++ b/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
@@ -311,6 +311,10 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
          * @param {Oskari.mapframework.event.common.MouseHoverEvent} event
          */
         _onMapHover (event) {
+            // don't hover while drawing
+            if (event.isDrawing()) {
+                return;
+            }
             const { feature, layer } = this._getTopmostFeatureAndLayer(event);
 
             // No feature hits for these layer types. Call hover handlers without feature or layer.


### PR DESCRIPTION
Add isDrawing to MouseHoverEvent and don't hover vectorlayer while drawing. If it's fine to add isDrawing to event, then API documentation should be updated.

MarkersPlugin: change marker's text stroke width to 3