### PR TITLE
Show region borders on point map

### DIFF
--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -55,7 +55,7 @@ hover: {
     // Apply hover style only on features having property "class" with value "building"
     filter: [
         {key: 'class', value: 'building'}
-    ]
+    ],
     featureStyle: {
         inherit: true,
         effect: 'darken',

--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -52,6 +52,10 @@ Options object
 Hover options describes how to visualize features on hover and what kind of tooltip should be shown.
 ```javascript
 hover: {
+    // Apply hover style only on features having property "class" with value "building"
+    filter: [
+        {key: 'class', value: 'building'}
+    ]
     featureStyle: {
         inherit: true,
         effect: 'darken',


### PR DESCRIPTION
Now shows region borders on thematic maps, when user has selected "points" as map style.
Also fixes an issue where points' drawing order was incorrect after changing active indicator.