### PR TITLE
Convenience fix for devserver

### DIFF
--- a/webpack/generateEntries.js
+++ b/webpack/generateEntries.js
@@ -36,7 +36,7 @@ module.exports = function generateEntries (appsetupPaths, isProd, context) {
             { from: 'resources/icons.png', to: appName, context }
         ];
         if (!isProd) {
-            copyDef.push({ from: 'empty.js', to: path.join(appName, 'oskari.min.css'), context }); // empty CSS to keep browser happy in dev mode
+            copyDef.push({ from: 'webpack/empty.js', to: path.join(appName, 'oskari.min.css'), context }); // empty CSS to keep browser happy in dev mode
         }
         entries[appName] = [
             path.resolve(context, './webpack/polyfill.js'),


### PR DESCRIPTION
Empty.js was removed in #712 but turns out Webpack build was using it. So restoring it and moving it to webpack-dir.