### PR TITLE
Require.js config for Webpack-build

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,8 @@ module.exports = {
     "OskariNavigation": false,
     "OskariPinchZoom": false,
     "Proj4js": false,
-    "turf": false
+    "turf": false,
+    "__webpack_public_path__": false
   },
   "parserOptions": {
     "ecmaVersion": 6,

--- a/bundles/admin/admin-hierarchical-layerlist/components/Layer.js
+++ b/bundles/admin/admin-hierarchical-layerlist/components/Layer.js
@@ -59,11 +59,11 @@ Oskari.clazz.define('Oskari.admin.hierarchical-layerlist.Layer', function (insta
         var requirementsConfig = {
             waitSeconds: 15,
             paths: {
-                '_bundle': '../../../Oskari/bundles/integration/admin-layerselector'
+                // reference to files under oskari-frontend/bundles/integration/admin-layerselector
+                // that Webpack build copies as assets
+                '_bundle': __webpack_public_path__ + 'assets/admin-layerselector'
             }
         };
-        // eslint-disable-next-line
-        requirementsConfig.paths._bundle = __webpack_public_path__ + 'assets/admin-layerselector';
         window.require.config(requirementsConfig);
     },
 

--- a/bundles/admin/admin-hierarchical-layerlist/components/Layer.js
+++ b/bundles/admin/admin-hierarchical-layerlist/components/Layer.js
@@ -62,6 +62,8 @@ Oskari.clazz.define('Oskari.admin.hierarchical-layerlist.Layer', function (insta
                 '_bundle': '../../../Oskari/bundles/integration/admin-layerselector'
             }
         };
+        // eslint-disable-next-line
+        requirementsConfig.paths._bundle = __webpack_public_path__ + 'assets/admin-layerselector';
         window.require.config(requirementsConfig);
     },
 


### PR DESCRIPTION
To make hierarchical layerselector admin compatible with Webpack build.