### PR TITLE
Remove assumption about guided tour

### DIFF
--- a/bundles/mapping/toolbar/default-buttons.js
+++ b/bundles/mapping/toolbar/default-buttons.js
@@ -234,15 +234,18 @@ Oskari.clazz.category(
                 linkContent.text(url);
             });
             options.append(addMarker.getElement());
-            var skipInfo = Oskari.clazz.create('Oskari.userinterface.component.CheckboxInput');
-            skipInfo.setTitle(loc.link.skipInfo);
-            skipInfo.setChecked(skipInfoBln);
-            skipInfo.setHandler(checked => {
-                skipInfoBln = checked;
-                url = this._updateUrl(baseUrl, addMarkerBln, skipInfoBln);
-                linkContent.text(url);
-            });
-            options.append(skipInfo.getElement());
+
+            if (Oskari.bundle('guidedtour')) {
+                var skipInfo = Oskari.clazz.create('Oskari.userinterface.component.CheckboxInput');
+                skipInfo.setTitle(loc.link.skipInfo);
+                skipInfo.setChecked(skipInfoBln);
+                skipInfo.setHandler(checked => {
+                    skipInfoBln = checked;
+                    url = this._updateUrl(baseUrl, addMarkerBln, skipInfoBln);
+                    linkContent.text(url);
+                });
+                options.append(skipInfo.getElement());
+            }
             content.append(options);
             // buttons
             closeBtn.addClass('primary');


### PR DESCRIPTION
Only show the guided tour selection on link tool if the bundle is part of the app.