### PR TITLE
Fix layer filtering on hierarchical layerselector

### DIFF
--- a/bundles/framework/hierarchical-layerlist/Flyout.js
+++ b/bundles/framework/hierarchical-layerlist/Flyout.js
@@ -171,7 +171,8 @@ Oskari.clazz.define('Oskari.framework.bundle.hierarchical-layerlist.Flyout',
             var layersCopy = layers.slice(0);
             var notLoadedBackend = {};
 
-            // TODO: is this needed anymore? Now that groups are coming with the layers...
+            // layers that come in mapfull.config only have a dummy group with no name until layers have been
+            // loaded by the layerselector -  remove such groups from the result
             layersCopy.forEach(function (layer) {
                 var group = layer.getGroups()[0];
                 if (group && isNaN(group.id) && !me.mapLayerService.getAllLayerGroups(group.name)) {

--- a/bundles/framework/hierarchical-layerlist/Flyout.js
+++ b/bundles/framework/hierarchical-layerlist/Flyout.js
@@ -162,8 +162,8 @@ Oskari.clazz.define('Oskari.framework.bundle.hierarchical-layerlist.Flyout',
          * @private
          */
         _getLayerGroups: function (groupingMethod) {
-            var me = this,
-                groupList = [];
+            var me = this;
+            var groupList = [];
 
             var allGroups = (me._currentFilter) ? me.mapLayerService.getFilteredLayerGroups(me._currentFilter) : me.mapLayerService.getAllLayerGroups();
 
@@ -171,6 +171,7 @@ Oskari.clazz.define('Oskari.framework.bundle.hierarchical-layerlist.Flyout',
             var layersCopy = layers.slice(0);
             var notLoadedBackend = {};
 
+            // TODO: is this needed anymore? Now that groups are coming with the layers...
             layersCopy.forEach(function (layer) {
                 var group = layer.getGroups()[0];
                 if (group && isNaN(group.id) && !me.mapLayerService.getAllLayerGroups(group.name)) {

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -870,9 +870,9 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
             var allLayerGroups = me.getAllLayerGroups();
             var filteredLayers = me.getFilteredLayers(filterId);
 
-            var hasFilteredLayer = function (groupLayer) {
+            var hasFilteredLayer = function (layerId) {
                 var layers = filteredLayers.filter(function (l) {
-                    return groupLayer.getId() === l.getId();
+                    return layerId === l.getId();
                 });
                 return layers.length > 0;
             };
@@ -882,12 +882,14 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
 
                 groups.forEach(function (group) {
                     var filteredLayers = [];
-                    var filteredLayerModels = [];
 
-                    group.getLayers().forEach(function (mapLayer) {
-                        if (hasFilteredLayer(mapLayer)) {
-                            filteredLayers.push(mapLayer.getId());
-                            filteredLayerModels.push(mapLayer);
+                    group.getLayerIdList().forEach(function (mapLayerId) {
+                        if (hasFilteredLayer(mapLayerId)) {
+                            let layer = me.findMapLayer(mapLayerId);
+                            filteredLayers.push({
+                                id: layer.getId(),
+                                orderNumber: layer.getOrderNumber()
+                            });
                         }
                     });
 
@@ -900,7 +902,6 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                         groups: getRecursiveFilteredGroups(group.getGroups())
                     };
                     var groupModel = Oskari.clazz.create('Oskari.mapframework.domain.MaplayerGroup', json);
-                    groupModel.setLayers(filteredLayerModels);
                     filteredGroups.push(groupModel);
                 });
 


### PR DESCRIPTION
Previously caused JS-error as groups don't have getLayers() function.