### PR TITLE
Fix preselect single option

### DIFF
--- a/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
@@ -282,7 +282,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
                 if (state.options.length - state.disabled.length === 1) {
                     var enabled = state.options.not(':disabled');
                     select.setValue(enabled.val());
-                    select.element.trigger('change');
                 }
             };
             preselectSingleOption(dsSelect);


### PR DESCRIPTION
Fixes an issue where clicking "OK" on the region set filter would not close the dropdown.
Issue occurs when there is only one matching data source or indicator.

Removed invalid line of code.
Setting value for the SelectList already handles triggering change on the select element.