### PR TITLE
Handle missing layer name localizations

### DIFF
--- a/bundles/mapping/mapmodule/domain/AbstractLayer.js
+++ b/bundles/mapping/mapmodule/domain/AbstractLayer.js
@@ -287,6 +287,10 @@ Oskari.clazz.define(
                 if (!value) {
                     value = this._name[Oskari.getDefaultLanguage()];
                 }
+                if (!value) {
+                    lang = Object.keys(this._name).find(key => this._name[key]);
+                    value = this._name[lang];
+                }
                 return value;
             }
             return this._name;

--- a/bundles/statistics/statsgrid2016/instance.js
+++ b/bundles/statistics/statsgrid2016/instance.js
@@ -35,9 +35,9 @@ Oskari.clazz.define(
         afterStart: function (sandbox) {
             var me = this;
             var mapModule = sandbox.findRegisteredModuleInstance('MainMapModule');
+            var locale = Oskari.getMsg.bind(null, 'StatsGrid');
             // create the StatisticsService for handling ajax calls and common functionality.
-            // FIXME: panels.newSearch.selectionValues should come from server response instead of passing it here (it's datasource specific)
-            var statsService = Oskari.clazz.create('Oskari.statistics.statsgrid.StatisticsService', sandbox, this.getLocalization().panels.newSearch.selectionValues);
+            var statsService = Oskari.clazz.create('Oskari.statistics.statsgrid.StatisticsService', sandbox, locale);
             sandbox.registerService(statsService);
             me.statsService = statsService;
 

--- a/bundles/statistics/statsgrid2016/resources/locale/en.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/en.js
@@ -170,6 +170,9 @@ Oskari.registerLocalization({
             'myIndicatorDatasource': 'Datasource is empty.',
             'cannotDisplayAsSeries': 'Indicator cannot be inspected as a series.'
         },
+        'missing': {
+            'regionsetName': 'Unknown'
+        },
         'datacharts': {
             'flyout': 'Searched data',
             'barchart': 'Bar chart',

--- a/bundles/statistics/statsgrid2016/resources/locale/fi.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/fi.js
@@ -171,6 +171,9 @@ Oskari.registerLocalization({
             'myIndicatorDatasource': 'Tietolähde on tyhjä.',
             'cannotDisplayAsSeries': 'Indikaattoria ei voida tarkastella sarjana'
         },
+        'missing': {
+            'regionsetName': 'Tuntematon'
+        },
         'datacharts': {
             'flyout': 'Haettu aineisto',
             'barchart': 'Pylväskuvio',

--- a/bundles/statistics/statsgrid2016/resources/locale/sv.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/sv.js
@@ -167,6 +167,9 @@ Oskari.registerLocalization({
             'myIndicatorDatasource': 'Datakällan är tom.',
             'cannotDisplayAsSeries': 'Indikatorn kan inte inspekteras som en serie.'
         },
+        'missing': {
+            'regionsetName': 'Okänd'
+        },
         'datacharts': {
             'flyout': 'Sökta datamängden',
             'barchart': 'Stapeldiagram',

--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -15,6 +15,7 @@
         this.colors = Oskari.clazz.create('Oskari.statistics.statsgrid.ColorService');
         this.classification = Oskari.clazz.create('Oskari.statistics.statsgrid.ClassificationService', this.colors);
         this.error = Oskari.clazz.create('Oskari.statistics.statsgrid.ErrorService', sandbox);
+        this.missingRegionsetNamesCount = 0;
 
         // pushed from instance
         this.datasources = [];
@@ -105,7 +106,7 @@
         },
         getUILabels: function (indicator, callback) {
             var me = this;
-            var locale = this.locale;
+            var selectionValues = this.locale('panels.newSearch.selectionValues');
             if (typeof callback !== 'function') {
                 // log error message
                 return;
@@ -138,7 +139,7 @@
                                 name = value.id || value;
                                 // try finding localization for the param
                                 // FIXME: get rid of this -> have server give ui labels
-                                name = (locale[selector.id] && locale[selector.id][name]) ? locale[selector.id][name] : name;
+                                name = (selectionValues[selector.id] && selectionValues[selector.id][name]) ? selectionValues[selector.id][name] : name;
                             }
                             uiLabels.push({
                                 selector: selector.id,
@@ -200,6 +201,9 @@
                     me.addRegionset(item);
                 });
                 return;
+            }
+            if (!regionset.name) {
+                regionset.name = `${this.locale('missing.regionsetName')} ${++this.missingRegionsetNamesCount}`;
             }
             if (regionset.id && regionset.name) {
                 this.regionsets.push(regionset);


### PR DESCRIPTION
Fixes an issue where layer name would be empty when localized layer name was missing in both, requested and default languages. Now uses any available translation instead.

If a statsgrid regionset's names are missing, shows the regionset as "Unknown"