### PR TITLE
RPC client version check

### DIFF
--- a/bundles/framework/rpc/instance.js
+++ b/bundles/framework/rpc/instance.js
@@ -32,7 +32,8 @@ Oskari.clazz.define(
             if (!clientVer) {
                 return false;
             }
-            return clientVer.indexOf('2.0.') === 0;
+            const [major, minor, patch] = clientVer.split('.').map(p => parseInt(p));
+            return major === 2 && minor <= 1 && patch >= 0;
         },
         /**
          * @public @method start


### PR DESCRIPTION
Major version must be 2.
Minor version 0 and 1 supported. (to support upcoming 2.1.0)
Patch version can be any whole number.