### PR TITLE
Maprotator state

### DIFF
--- a/bundles/framework/printout/instance.js
+++ b/bundles/framework/printout/instance.js
@@ -399,6 +399,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.PrintoutBundleInstance'
                 this.printout.setEnabled(true);
                 this.printout.refresh(false);
                 this.printout.refresh(true);
+                // reset and disable map rotation
+                this.sandbox.postRequestByName('rotate.map', []);
+                this.sandbox.postRequestByName('DisableMapMouseMovementRequest', [['rotate']]);
             } else {
                 map.removeClass('mapPrintoutMode');
                 if (me.sandbox._mapMode === 'mapPrintoutMode') {
@@ -413,6 +416,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.PrintoutBundleInstance'
                 }
                 var builder = Oskari.requestBuilder('Toolbar.SelectToolButtonRequest');
                 this.sandbox.request(this, builder());
+                this.sandbox.postRequestByName('EnableMapMouseMovementRequest', [['rotate']]);
             }
             // resize map to fit screen with expanded/normal sidebar
             var reqBuilder = Oskari.requestBuilder('MapFull.MapSizeUpdateRequest');

--- a/bundles/mapping/mapmodule_ol3/request/MapMovementControlsRequestHandler.js
+++ b/bundles/mapping/mapmodule_ol3/request/MapMovementControlsRequestHandler.js
@@ -4,6 +4,7 @@ import olInteractionKeyboardPan from 'ol/interaction/KeyboardPan';
 import olInteractionKeyboardZoom from 'ol/interaction/KeyboardZoom';
 import olInteractionMouseWheelZoom from 'ol/interaction/MouseWheelZoom';
 import olInteractionDoubleClickZoom from 'ol/interaction/DoubleClickZoom';
+import olInteractionDragRotate from 'ol/interaction/DragRotate';
 
 /**
  * @class Oskari.mapframework.bundle.mapmodule.request.MapMovementInteractionsRequestHandler
@@ -80,11 +81,15 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.MapMovementCon
                         interactions.push(this.getMapModule().getInteractionInstance(olInteractionDoubleClickZoom));
                         interactions.push(this.getMapModule().getInteractionInstance(olInteractionDragZoom));
                     }
+                    if (request.getOptions('rotate')) {
+                        interactions.push(this.getMapModule().getInteractionInstance(olInteractionDragRotate));
+                    }
                 } else {
                     interactions.push(this.getMapModule().getInteractionInstance(olInteractionDragPan));
                     interactions.push(this.getMapModule().getInteractionInstance(olInteractionMouseWheelZoom));
                     interactions.push(this.getMapModule().getInteractionInstance(olInteractionDoubleClickZoom));
                     interactions.push(this.getMapModule().getInteractionInstance(olInteractionDragZoom));
+                    // DragRotate handled only when requested
                 }
                 interactions.forEach(function (interaction) {
                     if (interaction) {
@@ -101,11 +106,15 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.MapMovementCon
                         interactions.push(this.getMapModule().getInteractionInstance(olInteractionDoubleClickZoom));
                         interactions.push(this.getMapModule().getInteractionInstance(olInteractionDragZoom));
                     }
+                    if (request.getOptions('rotate')) {
+                        interactions.push(this.getMapModule().getInteractionInstance(olInteractionDragRotate));
+                    }
                 } else {
                     interactions.push(this.getMapModule().getInteractionInstance(olInteractionDragPan));
                     interactions.push(this.getMapModule().getInteractionInstance(olInteractionMouseWheelZoom));
                     interactions.push(this.getMapModule().getInteractionInstance(olInteractionDoubleClickZoom));
                     interactions.push(this.getMapModule().getInteractionInstance(olInteractionDragZoom));
+                    // DragRotate handled only when requested
                 }
                 interactions.forEach(function (interaction) {
                     if (interaction) {

--- a/bundles/mapping/maprotator/instance.js
+++ b/bundles/mapping/maprotator/instance.js
@@ -10,6 +10,7 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorBundleInstance',
         this.plugin = null;
         this._mapmodule = null;
         this._sandbox = null;
+        this.state = undefined;
     }, {
         __name: 'maprotator',
         /**
@@ -41,6 +42,9 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorBundleInstance',
             me.createPlugin();
             sandbox.register(me);
             sandbox.requestHandler('rotate.map', this);
+            sandbox.registerAsStateful(this.mediator.bundleId, this);
+
+            me.setState(this.state);
         },
         createPlugin: function () {
             if (this.plugin) {
@@ -60,9 +64,36 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorBundleInstance',
         stop: function () {
             this.stopPlugin();
             this.getSandbox().requestHandler('rotate.map', null);
+            this.sandbox.unregisterStateful(this.mediator.bundleId);
             this.sandbox = null;
             this.started = false;
+        },
+        setState: function (state) {
+            state = state || {};
+            let degrees = 0;
+            if (state.degrees) {
+                if (typeof state.degrees === 'string') {
+                    degrees = parseFloat(state.degrees);
+                } else {
+                    degrees = state.degrees;
+                }
+            }
+            this.plugin.setRotation(degrees);
+        },
+        getState: function () {
+            let state = {};
+            if (this.plugin) {
+                state.degrees = this.plugin.getRotation();
+            }
+            return state;
+        },
+        getStateParameters: function () {
+            let state = this.getState();
+            if (state.degrees) {
+                return 'rotate=' + Math.round(state.degrees);
+            }
+            return '';
         }
     }, {
-        protocol: ['Oskari.bundle.BundleInstance']
+        protocol: ['Oskari.bundle.BundleInstance', 'Oskari.userinterface.Stateful']
     });

--- a/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
+++ b/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
@@ -43,12 +43,12 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
 
             this._map.on('pointerdrag', function (e) {
                 degrees = me.getRotation();
-                me.rotateIcon(degrees);
                 if (degrees !== me.getDegrees()) {
+                    me.rotateIcon(degrees);
+                    me.setDegrees(degrees);
                     var event = eventBuilder(degrees);
                     me._sandbox.notifyAll(event);
                 }
-                me.setDegrees(degrees);
             });
         },
         setDegrees: function (degree) {
@@ -97,15 +97,14 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
             var rot = (typeof deg === 'number') ? deg / 57.3 : 0;
             // if deg is number use it for degrees otherwise use 0
             var degrees = (typeof deg === 'number') ? deg : 0;
-
             this.rotateIcon(degrees);
             this._map.getView().setRotation(rot);
             this.setDegrees(degrees);
         },
         getRotation: function () {
             var rot = this._map.getView().getRotation();
-            // radians to degrees
-            var deg = rot * 57.3;
+            // radians to degrees with one decimal
+            var deg = Math.round(rot * 573) / 10;
             return deg;
         },
         /**

--- a/bundles/mapping/maprotator/publisher/MapRotator.js
+++ b/bundles/mapping/maprotator/publisher/MapRotator.js
@@ -75,7 +75,7 @@ Oskari.clazz.define('Oskari.mapping.publisher.tool.MapRotator',
                 };
                 json.configuration[me.bundleName] = {
                     conf: pluginConfig,
-                    state: {}
+                    state: this.getMapRotatorInstance().getState()
                 };
                 return json;
             } else {


### PR DESCRIPTION
Register maprotator as stateful bundle and add state methods. If map is rotated, then rotate param is added to map view url (requires backend changes) and to published map's state.

Print map view doesn't support map rotation. When map printing is opened, map rotation is reset and DragRotate is disabled. Note that now map isn't re-rotated back when printing is closed.

https://github.com/oskariorg/oskari-server/pull/306