### PR TITLE
MyplacesLayer wms axisorder

### DIFF
--- a/bundles/mapping/mapmyplaces/plugin/MyPlacesLayerPlugin.ol.js
+++ b/bundles/mapping/mapmyplaces/plugin/MyPlacesLayerPlugin.ol.js
@@ -67,7 +67,9 @@ Oskari.clazz.define(
                     url: layer.getWmsUrl(),
                     params: {
                         'LAYERS': layer.getWmsName(),
-                        'FORMAT': 'image/png'
+                        'FORMAT': 'image/png',
+                        // Avoid AxisOrder issues by not using WMS 1.3.0
+                        'VERSION': '1.1.1'
                     },
                     crossOrigin: layer.getAttributes('crossOrigin')
                 }),


### PR DESCRIPTION
Use WMS 1.1.1 to avoid axis order issues with 'neu'-axis projection. 

The WMS 1.3.0 specification mandates that the axis ordering for geographic coordinate systems defined in the EPSG database be latitude/longitude, or y/x.
https://docs.geoserver.org/latest/en/user/services/wms/basics.html

Openlayers can reverse bbox coordinates if Projection.axisOrientation is 'neu' and wms version is 1.3.0 but Oskari proj4 definition for e.g. 3035 projection doesn't contain axis argument so OpenLayers is using default 'enu' for that.

