### PR TITLE
Update indicator list on ActiveIndicatorChangedEvent

### DIFF
--- a/bundles/statistics/statsgrid2016/components/IndicatorList.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorList.js
@@ -30,6 +30,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorList', function (servi
         me.service.on('StatsGrid.IndicatorEvent', function (event) {
             me._updateIndicatorList();
         });
+        me.service.on('StatsGrid.ActiveIndicatorChangedEvent', function (event) {
+            me._updateIndicatorList();
+        });
     },
     /**
      * @method _getIndicators


### PR DESCRIPTION
Fixes state where indicator list has indicator(s) but the "No selected indicators" message is also shown