### PR TITLE
Reject empty indicators

### DIFF
--- a/bundles/framework/divmanazer/component/Button.js
+++ b/bundles/framework/divmanazer/component/Button.js
@@ -78,6 +78,16 @@ Oskari.clazz.define('Oskari.userinterface.component.Button',
                 Oskari.getSandbox().printWarn('Oskari.userinterface.component.Button.setId: No UI');
             }
         },
+
+        /**
+         * @method isEnabled
+         * @override FormComponent.isEnabled
+         * @return is the button enabled or not
+         */
+        isEnabled: function () {
+            return !this._element.disabled;
+        },
+
         /**
          * @method setEnabled
          * Enables/Disables the button

--- a/bundles/statistics/statsgrid2016/resources/locale/en.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/en.js
@@ -168,7 +168,8 @@ Oskari.registerLocalization({
             'myIndicatorYearInput': 'Year field cannot be empty.',
             'myIndicatorRegionselect': 'Regionselect cannot be empty.',
             'myIndicatorDatasource': 'Datasource is empty.',
-            'cannotDisplayAsSeries': 'Indicator cannot be inspected as a series.'
+            'cannotDisplayAsSeries': 'Indicator cannot be inspected as a series.',
+            'noDataForIndicators': 'Service did not return data for {indicators, plural, one {the indicator} other {indicators}}'
         },
         'missing': {
             'regionsetName': 'Unknown'

--- a/bundles/statistics/statsgrid2016/resources/locale/fi.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/fi.js
@@ -169,7 +169,8 @@ Oskari.registerLocalization({
             'myIndicatorYearInput': 'Vuosi kenttä ei voi olla tyhjä.',
             'myIndicatorRegionselect': 'Aluejako ei voi olla tyhjä.',
             'myIndicatorDatasource': 'Tietolähde on tyhjä.',
-            'cannotDisplayAsSeries': 'Indikaattoria ei voida tarkastella sarjana'
+            'cannotDisplayAsSeries': 'Indikaattoria ei voida tarkastella sarjana',
+            'noDataForIndicators': 'Palvelusta ei saatu tietoja {indicators, plural, one {indikaattorille} other {indikaattoreille}}'
         },
         'missing': {
             'regionsetName': 'Tuntematon'

--- a/bundles/statistics/statsgrid2016/resources/locale/sv.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/sv.js
@@ -165,7 +165,8 @@ Oskari.registerLocalization({
             'myIndicatorYearInput': 'Årsfält kan inte vara tom.',
             'myIndicatorRegionselect': 'Områdesindelning kan inte vara tom.',
             'myIndicatorDatasource': 'Datakällan är tom.',
-            'cannotDisplayAsSeries': 'Indikatorn kan inte inspekteras som en serie.'
+            'cannotDisplayAsSeries': 'Indikatorn kan inte inspekteras som en serie.',
+            'noDataForIndicators': 'Tjänsten returnerade ingen data för {indicators, plural, one {indikatorn} other {indikatorer}}'
         },
         'missing': {
             'regionsetName': 'Okänd'

--- a/bundles/statistics/statsgrid2016/service/ErrorService.js
+++ b/bundles/statistics/statsgrid2016/service/ErrorService.js
@@ -20,11 +20,11 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ErrorService',
         getName: function () {
             return this.__name;
         },
-        show: function (title, message, fadeoutTime = 5000) {
+        show: function (title, message) {
             var me = this;
             me.close();
             me.popup.show(title, message);
-            me.popup.fadeout(fadeoutTime);
+            me.popup.fadeout(5000);
         },
         close: function () {
             var me = this;

--- a/bundles/statistics/statsgrid2016/service/ErrorService.js
+++ b/bundles/statistics/statsgrid2016/service/ErrorService.js
@@ -20,11 +20,11 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ErrorService',
         getName: function () {
             return this.__name;
         },
-        show: function (title, message) {
+        show: function (title, message, fadeoutTime = 5000) {
             var me = this;
             me.close();
             me.popup.show(title, message);
-            me.popup.fadeout(5000);
+            me.popup.fadeout(fadeoutTime);
         },
         close: function () {
             var me = this;

--- a/bundles/statistics/statsgrid2016/view/SearchFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/SearchFlyout.js
@@ -4,6 +4,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
     this.element = null;
     this.sandbox = this.instance.getSandbox();
     this.service = this.sandbox.getService('Oskari.statistics.statsgrid.StatisticsService');
+    this.searchBtn;
     var me = this;
     this.on('show', function () {
         if (!me.getElement()) {
@@ -69,9 +70,11 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
         btn.insertTo(container);
 
         btn.setHandler(function (event) {
+            btn.setEnabled(false);
             event.stopPropagation();
             me.search(selectionComponent.getValues());
         });
+        this.searchBtn = btn;
 
         var clearBtn = Oskari.clazz.create('Oskari.userinterface.component.Button');
         clearBtn.addClass('margintopLarge');
@@ -294,6 +297,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
                 ));
                 this._showSearchErrorMessages(errors, multiselectStatusMap);
                 this._addIndicators(successfullSearches);
+                this.searchBtn.setEnabled(true);
             }
         };
         const searchSuccessfull = search => {

--- a/bundles/statistics/statsgrid2016/view/SearchFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/SearchFlyout.js
@@ -130,12 +130,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
      * (f.ex.Selected year out of range)
      *
      * @param {Object} commonSearchValues User's selected values from the search form
-     * @param {function} handleSearchValuesCb callback for continuing the search with refined search selections.
-     * The callback will receive an object with keys "searchValues", "errors" and "multiselectStatusMap"
      */
-    _handleMultipleIndicatorsSearch: function (commonSearchValues, handleSearchValuesCb) {
+    _handleMultipleIndicatorsSearch: function (commonSearchValues) {
         const indicators = Array.isArray(commonSearchValues.indicator) ? commonSearchValues.indicator : [commonSearchValues.indicator];
-        if (indicators.length === 0) {
+        if (!commonSearchValues.indicator || indicators.length === 0) {
             return;
         }
         const refinedSearchValues = [];

--- a/bundles/statistics/statsgrid2016/view/SearchFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/SearchFlyout.js
@@ -118,8 +118,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
             return;
         }
         this.service.getStateService().setRegionset(commonSearchValues.regionset);
-        this.searchPending = true;
-        this.updateSearchButtonEnabled();
         this._handleMultipleIndicatorsSearch(commonSearchValues);
     },
 
@@ -137,10 +135,15 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
      */
     _handleMultipleIndicatorsSearch: function (commonSearchValues, handleSearchValuesCb) {
         const indicators = Array.isArray(commonSearchValues.indicator) ? commonSearchValues.indicator : [commonSearchValues.indicator];
-        if )=
+        if (indicators.length === 0) {
+            return;
+        }
         const refinedSearchValues = [];
         const errorMap = new Map();
         const multiselectStatusMap = new Map();
+
+        this.searchPending = true;
+        this.updateSearchButtonEnabled();
 
         // Overrides selection key and value from provided search values.
         const getSearchWithModifiedParam = (values, paramKey, paramValue) => {


### PR DESCRIPTION
Performs sanity checks for indicator search. Only requests indicators with valid search conditions.
Alert user when service did not return data for an indicator.