### PR TITLE
Fix region highlighting

### DIFF
--- a/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
+++ b/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
@@ -428,9 +428,13 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
         const searchOptions = {id: regionId};
         me.sb.postRequestByName('MapModulePlugin.AddFeaturesToMapRequest', [searchOptions, requestOptions]);
 
-        delete requestOptions.prio;
-        searchOptions.id = 'border' + regionId;
-        me.sb.postRequestByName('MapModulePlugin.AddFeaturesToMapRequest', [searchOptions, requestOptions]);
+        if (classification.mapStyle && classification.mapStyle === 'points') {
+            const borderRequestOptions = {...requestOptions};
+            const borderSearchOptions = {...searchOptions};
+            delete borderRequestOptions.prio;
+            borderSearchOptions.id = 'border' + regionId;
+            me.sb.postRequestByName('MapModulePlugin.AddFeaturesToMapRequest', [borderSearchOptions, borderRequestOptions]);
+        }
     },
     /**
      * Listen to events that require re-rendering the UI


### PR DESCRIPTION
Fixes region highlighting issue on thematic map that occurred when user selected a region.
Only region's borders were highlighted on point map style.
On choropleth map style, region was not highlighted at all.