### PR TITLE
Fix exception handling on regionviewer

### DIFF
--- a/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
+++ b/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
@@ -32,6 +32,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
         service.getIndicatorData(datasource, indicator, selections, series, regionset, function (err, data) {
             if (err) {
                 Oskari.log('RegionsetViewer').warn('Error getting indicator data', datasource, indicator, selections, regionset);
+                me._clearRegions();
                 return;
             }
             const classificationOpts = state.getClassificationOpts(ind.hash);
@@ -39,6 +40,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
             const classified = service.getClassificationService().getClassification(data, classificationOpts, groupStats);
             if (!classified) {
                 Oskari.log('RegionsetViewer').warn('Error getting classification', data, classified);
+                me._clearRegions();
                 return;
             }
             if (me._lastRenderCache.classification &&


### PR DESCRIPTION
Clear region features from map when indicator has not enough data to create classification