### PR TITLE
Show indicator description on popup

### DIFF
--- a/bundles/framework/divmanazer/component/Popup.js
+++ b/bundles/framework/divmanazer/component/Popup.js
@@ -29,15 +29,14 @@ Oskari.clazz.define('Oskari.userinterface.component.Popup',
          */
         show: function (title, message, buttons) {
             this._closingInProgress = false;
-            var me = this,
-                contentDiv = this.dialog.find('div.content'),
-                actionDiv = this.dialog.find('div.actions'),
-                i,
-                contentHeight,
-                reasonableHeight,
-                focusedButton = -1,
-                screenWidth = window.innerWidth,
-                screenHeight = window.innerHeight;
+            var me = this;
+            var contentDiv = this.dialog.find('div.content');
+            var actionDiv = this.dialog.find('div.actions');
+            var i;
+            var focusedButton = -1;
+            var screenWidth = window.innerWidth;
+            var screenHeight = window.innerHeight;
+
             this.setTitle(title);
             this.setContent(message);
 
@@ -63,16 +62,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Popup',
                 buttons[focusedButton].focus();
             }
 
-            contentHeight = contentDiv.height();
-            reasonableHeight = jQuery(document).height() * 0.6;
-            if (contentHeight > reasonableHeight) {
-                contentDiv.height(reasonableHeight);
-                contentDiv.css('overflow-y', 'auto');
-            }
-
-            // center on screen
-            me.dialog.css('margin-left', -(this.dialog.width() / 2) + 'px');
-            me.dialog.css('margin-top', -(this.dialog.height() / 2) + 'px');
+            this._setReasonableHeight();
 
             // make popup to visible
             me.dialog.css('opacity', 1);
@@ -89,10 +79,35 @@ Oskari.clazz.define('Oskari.userinterface.component.Popup',
                 });
             }
 
+            this._centralize();
             this._bringMobilePopupToTop();
 
             me.__notifyListeners('show');
         },
+
+        /**
+         * @method _setReasonableHeight
+         * Restricts content height to be max 60% of the document's height.
+         */
+        _setReasonableHeight: function () {
+            const contentDiv = this.getJqueryContent();
+            const contentHeight = contentDiv.height();
+            const reasonableHeight = jQuery(document).height() * 0.6;
+            if (contentHeight > reasonableHeight) {
+                contentDiv.height(reasonableHeight);
+                contentDiv.css('overflow-y', 'auto');
+            }
+        },
+
+        /**
+         * @method _centralize
+         * Centers the dialog to it's top left corner location.
+         */
+        _centralize: function () {
+            this.dialog.css('margin-left', -(this.dialog.width() / 2) + 'px');
+            this.dialog.css('margin-top', -(this.dialog.height() / 2) + 'px');
+        },
+
         /**
          * @method _getMaxHeights
          * Calculates max heights for popup and content.
@@ -440,7 +455,7 @@ Oskari.clazz.define('Oskari.userinterface.component.Popup',
          * @param {HTML/DOM/jQueryObject}
          */
         setContent: function (content) {
-            var contentEl = this.dialog.find('div.content');
+            var contentEl = this.dialog.find('div.popup-body > div.content');
             contentEl.empty();
             contentEl.append(content);
         },
@@ -451,11 +466,11 @@ Oskari.clazz.define('Oskari.userinterface.component.Popup',
          * @return {String} dialog content
          */
         getContent: function () {
-            return this.dialog.find('div.content')[0].textContent;
+            return this.dialog.find('div.popup-body > div.content')[0].textContent;
         },
 
         getJqueryContent: function () {
-            return this.dialog.find('div.content');
+            return this.dialog.find('div.popup-body > div.content');
         },
 
         /**

--- a/bundles/statistics/statsgrid2016/components/IndicatorList.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorList.js
@@ -64,7 +64,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorList', function (servi
         content.find('.statsgrid-indicator-list').empty();
         // Get indicators and add them to content using template
         var indicators = me._getIndicators();
-        var metadataPopup = null;
         indicators.forEach(function (ind, id) {
             me.service.getUILabels(ind, function (labels) {
                 var indElem = jQuery(me.__templates.indicator({

--- a/bundles/statistics/statsgrid2016/components/IndicatorList.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorList.js
@@ -1,14 +1,24 @@
+import MetadataPopup from './MetadataPopup';
+
 Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorList', function (service) {
     this.loc = Oskari.getMsg.bind(null, 'StatsGrid');
     this.element = null;
     this.service = service;
+    this.metadataPopup = new MetadataPopup();
     this._removeAllBtn = Oskari.clazz.create('Oskari.userinterface.component.Button');
     this._wrapper = jQuery('<div class="statsgrid-indicator-list-wrapper"></div>');
     this._content = jQuery('<div class="statsgrid-indicator-list-content"><ol class="statsgrid-indicator-list"></ol></div>');
     this._bindToEvents();
 }, {
     __templates: {
-        indicator: _.template('<li><div>${name} <div class="indicator-list-remove icon-close" data-ind-hash="${indHash}"/></div></li>'),
+        indicator: _.template(
+            `<li>
+                <div>
+                    \${name}
+                    <div class="indicator-list-info icon-info"/>
+                    <div class="indicator-list-remove icon-close" data-ind-hash="\${indHash}"/>
+                </div>
+            </li>`),
         empty: _.template('<li>${emptyMsg}</li>')
     },
     /**
@@ -54,6 +64,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorList', function (servi
         content.find('.statsgrid-indicator-list').empty();
         // Get indicators and add them to content using template
         var indicators = me._getIndicators();
+        var metadataPopup = null;
         indicators.forEach(function (ind, id) {
             me.service.getUILabels(ind, function (labels) {
                 var indElem = jQuery(me.__templates.indicator({
@@ -64,6 +75,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorList', function (servi
                 // Add event listener for removing indicator
                 indElem.find('.icon-close').on('click', function () {
                     me.service.getStateService().removeIndicator(ind.datasource, ind.indicator, ind.selections, ind.series);
+                });
+                // Add event listener for showing indicator description
+                indElem.find('.icon-info').on('click', function () {
+                    me.metadataPopup.show(ind.datasource, ind.indicator);
                 });
             });
         });

--- a/bundles/statistics/statsgrid2016/components/MetadataPopup.js
+++ b/bundles/statistics/statsgrid2016/components/MetadataPopup.js
@@ -1,0 +1,119 @@
+const Popup = Oskari.clazz.get('Oskari.userinterface.component.Popup');
+
+export default class MetadataPopup extends Popup {
+    constructor () {
+        super();
+        this.loc = Oskari.getMsg.bind(null, 'StatsGrid');
+        this.service = Oskari.getSandbox().getService('Oskari.statistics.statsgrid.StatisticsService');
+        this._counter = 0;
+        this.datasource = null;
+        this.indicators = null;
+        this._accordions = [];
+
+        this.onClose(() => this._contentSizeChanged(false));
+    }
+
+    /**
+     * @override
+     * @method show
+    */
+    show (datasource, indicators) {
+        this._counter = 0;
+        this.datasource = datasource;
+        this.indicators = Array.isArray(indicators) ? indicators : indicators ? [indicators] : [];
+        this._accordions = [];
+        if (this.indicators.length === 0 || !this.datasource) {
+            return;
+        }
+        const createAccordion = this._createAccordion.bind(this);
+        this.indicators.forEach(ind => this.service.getIndicatorMetadata(this.datasource, ind, createAccordion));
+    }
+
+    /**
+     *  @method _count
+     * Increases processed indicator counter.
+     * Once all indicators have been processed, popup will open.
+    */
+    _count () {
+        this._counter++;
+        if (this._counter >= this.indicators.length) {
+            this._openPopup();
+        }
+    }
+
+    /**
+     * @method _createAccordion
+     * IndicatorMetadata callback function.
+     * Creates Accordion from metadata's title, description and source.
+     */
+    _createAccordion (err, metadata) {
+        if (err || !metadata) {
+            this._count();
+            return;
+        }
+        const header = Oskari.getLocalized(metadata.name);
+        const description = Oskari.getLocalized(metadata.description);
+        const datasource = Oskari.getLocalized(metadata.source);
+        if (!description && !datasource) {
+            this._count();
+            return;
+        }
+        let content = '';
+        if (description) {
+            content += description;
+        }
+        if (datasource) {
+            content += `<p>
+                            <b>${this.loc('panels.newSearch.datasourceTitle')}</b>
+                            <br>
+                            ${datasource}
+                        </p>`;
+        }
+        const accordion = Oskari.clazz.create('Oskari.userinterface.component.Accordion');
+        const panel = Oskari.clazz.create('Oskari.userinterface.component.AccordionPanel');
+        panel.setTitle(header);
+        panel.setContent(content);
+        accordion.addPanel(panel);
+        this._accordions.push(accordion);
+
+        panel.on('open', () => this._contentSizeChanged(true));
+        panel.on('close', () => this._contentSizeChanged(false));
+        this._count();
+    }
+
+    _openPopup () {
+        const container = jQuery('<div>');
+        if (this._accordions.length === 0) {
+            container.html(this.loc('metadataPopup.noMetadata', {indicators: this.indicators.length}));
+        } else {
+            const content = this.getJqueryContent();
+            if (!content.hasClass('indicator-metadata')) {
+                content.addClass('indicator-metadata');
+            };
+            this._accordions.forEach(accordion => accordion.insertTo(container));
+            // Open the last panel
+            this._accordions[this._accordions.length - 1].getPanels()[0].open();
+        }
+        const title = this.loc('metadataPopup.title', {indicators: this._accordions.length});
+        const okButton = Oskari.clazz.create('Oskari.userinterface.component.buttons.OkButton');
+        okButton.setHandler(() => this.close());
+        super.show(title, container, [okButton]);
+    }
+
+    /**
+     * @method _contentSizeChanged
+     * Handles content height changes and centers the dialog.
+     * @param {boolean} higher true, if the change makes the dialog higher
+     */
+    _contentSizeChanged (higher) {
+        if (higher) {
+            this._setReasonableHeight();
+        } else {
+            const contentDiv = this.getJqueryContent();
+            if (contentDiv.height() > contentDiv.children().height()) {
+                contentDiv.height('auto');
+            }
+        }
+        this._centralize();
+    };
+};

--- a/bundles/statistics/statsgrid2016/resources/locale/en.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/en.js
@@ -277,6 +277,11 @@ Oskari.registerLocalization({
             'removeAll': 'Remove all',
             'emptyMsg': 'No selected indicators'
         },
+        'metadataPopup': {
+            'open': 'Show indicator {indicators, plural, one {description} other {descriptions}}',
+            'title': 'Indicator {indicators, plural, one {description} other {descriptions}}',
+            'noMetadata': 'Service did not return {indicators, plural, one {description for the indicator} other {descriptions for the indicators}}'
+        },
         'sumo': {
             'placeholder': 'Select Here',
             'captionFormat': '{0} selected',

--- a/bundles/statistics/statsgrid2016/resources/locale/fi.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/fi.js
@@ -278,6 +278,11 @@ Oskari.registerLocalization({
             'removeAll': 'Poista kaikki',
             'emptyMsg': 'Ei valittuja indikaattoreita'
         },
+        'metadataPopup': {
+            'open': 'Näytä {indicators, plural, one {indikaattorin kuvaus} other {indikaattorien kuvaukset}}',
+            'title': '{indicators, plural, one {Indikaattorin kuvaus} other {Indikaattorien kuvaukset}}',
+            'noMetadata': 'Palvelusta ei saatu {indicators, plural, one {indikaattorin kuvausta} other {indikaattorien kuvauksia}}.'
+        },
         'sumo': {
             'placeholder': 'Valitse tästä',
             'captionFormat': '{0} valittu',

--- a/bundles/statistics/statsgrid2016/resources/locale/sv.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/sv.js
@@ -275,6 +275,11 @@ Oskari.registerLocalization({
             'removeAll': 'Ta bort alla',
             'emptyMsg': 'Inga valda indikatorer'
         },
+        'metadataPopup': {
+            'open': 'Visa {indicators, plural, one {indikator beskrivning} other {indikator beskrivningar}}',
+            'title': '{indicators, plural, one {Indikator beskrivning} other {Indikator beskrivningar}}',
+            'noMetadata': 'Tjänsten returnerade ingen beskrivning för {indicators, plural, one {indikatorn} other {indikatorer}}.'
+        },
         'sumo': {
             'placeholder': 'Välj här',
             'captionFormat': '{0} valda',

--- a/bundles/statistics/statsgrid2016/resources/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/resources/scss/style.scss
@@ -1198,7 +1198,26 @@ background-color: #888888;
  ol.statsgrid-indicator-list li:nth-child(2n) {
     background-color: #f3f3f3;
 }
-.indicator-list-remove {
+.indicator-list-remove, .indicator-list-info {
     cursor: pointer;
     float: right;
+    margin: 0 3px;
 }
+/* ********************************************
+ * Indicator metadata popup
+ * ********************************************/
+div.indicator-metadata {
+    border: solid #c0d0d0;
+    border-width: 1px 0;
+    div.accordion:first-child {
+        div.accordion_panel {
+            border-top: 0;
+        }
+    }
+    div.accordion_panel {
+        border-bottom: 0;
+        p {
+            margin-top: 10px;
+        }
+    }
+ }


### PR DESCRIPTION
Added popup for indicator description.
Added a text link indicator search for opening the popup.
Popup can also be opened by clicking info icons in the indicator list.