### PR TITLE
Use configurable property for highlighting features

### DIFF
--- a/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
@@ -23,8 +23,8 @@ class VectorTileLayerPlugin extends AbstractMapLayerPlugin {
         this.layertype = 'vectortile';
         this.hoverState = {
             layer: null,
-            propertyId: null,
-            feature: null
+            feature: null,
+            property: FTR_PROPERTY_ID
         };
     }
     /**
@@ -186,30 +186,26 @@ class VectorTileLayerPlugin extends AbstractMapLayerPlugin {
      * @param { olVectorTileLayer } layer
      */
     onMapHover (event, feature, layer) {
-        if (feature && layer) {
-            var hoverOptions = layer.get(LAYER_HOVER);
-            if (hoverOptions) {
-                const propertyId = feature.get(FTR_PROPERTY_ID);
-                if (this.hoverState.layer && this.hoverState.layer !== layer) {
-                    // clear highlight from previously highlighted layer.
-                    this.hoverState.propertyId = null;
-                    this.hoverState.feature = null;
-                    this.hoverState.layer.changed();
-                    this.hoverState.layer = null;
-                }
-                if (this.hoverState.feature !== feature && hoverOptions.featureStyle) {
-                    this.hoverState.propertyId = propertyId;
-                    this.hoverState.feature = feature;
-                    this.hoverState.layer = layer;
-                    this.hoverState.layer.changed();
-                }
+        const {feature: hoverFeature, layer: hoverLayer, property} = this.hoverState;
+        if (feature === hoverFeature) {
+            return;
+        }
+        if (feature && hoverFeature && feature.get(property) === hoverFeature.get(property)) {
+            return;
+        }
+        this.hoverState.feature = feature;
+        this.hoverState.layer = layer;
+        if (hoverLayer) {
+            const style = (hoverLayer.get(LAYER_HOVER) || {}).featureStyle;
+            if (style) {
+                hoverLayer.changed();
             }
-        } else if (this.hoverState.layer) {
-            // Remove feature highlighting
-            this.hoverState.propertyId = null;
-            this.hoverState.feature = null;
-            this.hoverState.layer.changed();
-            this.hoverState.layer = null;
+        }
+        if (layer && layer !== hoverLayer) {
+            const style = (layer.get(LAYER_HOVER) || {}).featureStyle;
+            if (style) {
+                layer.changed();
+            }
         }
     }
 

--- a/bundles/mapping/mapmodule/plugin/vectortilelayer/styleGenerator.js
+++ b/bundles/mapping/mapmodule/plugin/vectortilelayer/styleGenerator.js
@@ -1,17 +1,16 @@
 import olStyleStyle from 'ol/style/Style';
-import {FTR_PROPERTY_ID} from '../../domain/constants';
 
 const invisible = new olStyleStyle();
 
 const isHovered = (feature, hoverState) => {
-    if (hoverState && hoverState.feature) {
-        if (hoverState.propertyId) {
-            return hoverState.propertyId === feature.get(FTR_PROPERTY_ID);
-        } else {
-            return hoverState.feature === feature;
-        }
+    if (!hoverState) {
+        return false;
     }
-    return false;
+    const {feature: hoverFeature, property} = hoverState;
+    if (!hoverFeature || !property) {
+        return false;
+    }
+    return hoverFeature.get(property) === feature.get(property);
 };
 
 export default function styleGenerator (styleFactory, styleDef, hoverOptions, hoverState) {

--- a/bundles/mapping/mapwfs2/plugin/WfsMvtLayerPlugin.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsMvtLayerPlugin.js
@@ -15,6 +15,8 @@ Oskari.clazz.defineES('Oskari.wfsmvt.WfsMvtLayerPlugin',
             this._clazz = 'Oskari.wfsmvt.WfsMvtLayerPlugin';
             this._log = Oskari.log('WfsMvtLayerPlugin');
             this.layertype = 'wfs';
+            // mvt only support numeric IDs and WFS-layers often have other characters in ID as well
+            // fixes highlight on features spread to multiple tiles by using a generated _oid for "combining" features
             this.hoverState.property = '_oid';
         }
         _initImpl () {

--- a/bundles/mapping/mapwfs2/plugin/WfsMvtLayerPlugin.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsMvtLayerPlugin.js
@@ -15,6 +15,7 @@ Oskari.clazz.defineES('Oskari.wfsmvt.WfsMvtLayerPlugin',
             this._clazz = 'Oskari.wfsmvt.WfsMvtLayerPlugin';
             this._log = Oskari.log('WfsMvtLayerPlugin');
             this.layertype = 'wfs';
+            this.hoverState.property = '_oid';
         }
         _initImpl () {
             super._initImpl();


### PR DESCRIPTION
Sets _oid as hover property for WFS-MVT. Hover property can be set in VectorTileLayerPlugin's hover state.