### PR TITLE
Wfs mvt performance optimization

### DIFF
--- a/bundles/framework/featuredata2/Flyout.js
+++ b/bundles/framework/featuredata2/Flyout.js
@@ -132,6 +132,10 @@ Oskari.clazz.define(
 
         },
 
+        isActive: function () {
+            return !!this.active;
+        },
+
         /**
          * @method setState
          * @param {Object} state

--- a/bundles/framework/featuredata2/instance.js
+++ b/bundles/framework/featuredata2/instance.js
@@ -343,8 +343,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
              */
             'WFSPropertiesEvent': function (event) {
                 // update grid information [don't update the grid if not active]
-                var layer = event.getLayer();
-                this.plugins['Oskari.userinterface.Flyout'].updateData(layer);
+                const flyout = this.plugins['Oskari.userinterface.Flyout'];
+                if (flyout.isActive()) {
+                    this.plugins['Oskari.userinterface.Flyout'].updateData(event.getLayer());
+                }
             },
 
             /**
@@ -353,8 +355,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
              */
             'WFSFeatureEvent': function (event) {
                 // update grid information [don't update the grid if not active]
-                var layer = event.getLayer();
-                this.plugins['Oskari.userinterface.Flyout'].updateData(layer);
+                const flyout = this.plugins['Oskari.userinterface.Flyout'];
+                if (flyout.isActive()) {
+                    this.plugins['Oskari.userinterface.Flyout'].updateData(event.getLayer());
+                }
             },
 
             /**

--- a/bundles/mapping/mapwfs2/plugin/WfsMvtLayerPlugin.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsMvtLayerPlugin.js
@@ -119,7 +119,6 @@ Oskari.clazz.defineES('Oskari.wfsmvt.WfsMvtLayerPlugin',
                 this.setLayerLocales(layer);
             }
             this.reqEventHandler.notify('WFSPropertiesEvent', layer, layer.getLocales(), fields);
-            this.reqEventHandler.notify('WFSFeatureEvent', layer, properties.length ? properties[properties.length - 1] : []);
         }
         /**
          * @method setLayerLocales


### PR DESCRIPTION
* Only update data on featuredata flyout when the flyout is visible.
* Trigger only WFSPropertiesEvent to avoid duplicate functionality.