### PR TITLE
Fix layer order after transition from/to publisher

### DIFF
--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -518,6 +518,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                 var event = Oskari.eventBuilder('Publisher2.ToolEnabledChangedEvent')(tool);
                 sb.notifyAll(event);
             });
+
+            // fix layer order after changing from/to publisher
+            setTimeout(() => {
+                sb.findRegisteredModuleInstance('MainMapModule').ensureLayerOrder();
+            }, 200);
         },
 
         /**

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -293,14 +293,10 @@ Oskari.clazz.define(
                 this._isInLayerToolsEditMode = event.isInMode();
             },
             AfterRearrangeSelectedMapLayerEvent: function (event) {
-                this.afterRearrangeSelectedMapLayerEvent();
+                this.ensureLayerOrder();
             },
             MapSizeChangedEvent: function (evt) {
                 this._handleMapSizeChanges({width: evt.getWidth(), height: evt.getHeight()});
-            },
-            UIChangeEvent: function (evt) {
-                // fix layer order after changing from/to publisher
-                setTimeout(() => this.afterRearrangeSelectedMapLayerEvent(), 200);
             },
             'Toolbar.ToolbarLoadedEvent': function () {
                 this.startLazyPlugins();
@@ -2308,13 +2304,13 @@ Oskari.clazz.define(
         },
 
         /**
-         * @method afterRearrangeSelectedMapLayerEvent
+         * @method ensureLayerOrder
          * @private
-         * Handles AfterRearrangeSelectedMapLayerEvent.
+         * Handles ensureLayerOrder.
          * Changes the layer order in Openlayers to match the selected layers list in
          * Oskari.
          */
-        afterRearrangeSelectedMapLayerEvent: function () {
+        ensureLayerOrder: function () {
             var me = this;
             var layers = this.getSandbox().findAllSelectedMapLayers();
             var layerIndex = 0;

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -293,10 +293,14 @@ Oskari.clazz.define(
                 this._isInLayerToolsEditMode = event.isInMode();
             },
             AfterRearrangeSelectedMapLayerEvent: function (event) {
-                this.afterRearrangeSelectedMapLayerEvent(event);
+                this.afterRearrangeSelectedMapLayerEvent();
             },
             MapSizeChangedEvent: function (evt) {
                 this._handleMapSizeChanges({width: evt.getWidth(), height: evt.getHeight()});
+            },
+            UIChangeEvent: function (evt) {
+                // fix layer order after changing from/to publisher
+                setTimeout(() => this.afterRearrangeSelectedMapLayerEvent(), 200);
             },
             'Toolbar.ToolbarLoadedEvent': function () {
                 this.startLazyPlugins();


### PR DESCRIPTION
Fixed timing dependant problem with restoring layer order after 200ms from `UIChangeEvent`.