### PR TITLE
Fixes duplicate indicator parameters and info text

### DIFF
--- a/bundles/statistics/statsgrid2016/components/IndicatorParameters.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorParameters.js
@@ -96,7 +96,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorParameters', function 
         var panelLoc = locale.panels.newSearch;
 
         var cont = jQuery(this.__templates.main());
-        this.parentElement.append(cont);
+        this.parentElement.html(cont);
         this.container = cont;
         var seriesSelection = null;
         var indicators = me.service.getStateService().getIndicators();

--- a/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
@@ -301,12 +301,13 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
             preselectSingleOption(indicSelect);
         });
         me._params.on('indicator.changed', function (enabled) {
-            dataLabelWithTooltips.find('.tooltip').hide();
             me.trigger('indicator.changed', enabled);
             if (enabled) {
                 indicDescriptionLink.show();
+                dataLabelWithTooltips.find('.tooltip').hide();
             } else {
                 indicDescriptionLink.hide();
+                dataLabelWithTooltips.find('.tooltip').show();
             }
         });
         me._params.on('indicator.parameter.changed', e => me.trigger('indicator.parameter.changed', e));


### PR DESCRIPTION
Fixes an issue where indicator parameters would appear twice after selecting all indicators and then clicking the time series checkbox.

Also fixes the parameter info text visibility.