### PR TITLE
no concurrent requests

### DIFF
--- a/bundles/statistics/statsgrid2016/view/SearchFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/SearchFlyout.js
@@ -351,7 +351,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
         }
 
         // Run the searches to see if we get data from the service.
-        const batchSize = 2;
+        const batchSize = 1;
         const batches = [];
         let batch;
         searchValues.forEach((search, index) => {


### PR DESCRIPTION
Set thematic map's stats search request batch limit to 1 to prevent concurrent requests.