### PR TITLE
Fix maprotator positioning in publisher

### DIFF
--- a/bundles/mapping/maprotator/publisher/MapRotator.js
+++ b/bundles/mapping/maprotator/publisher/MapRotator.js
@@ -42,13 +42,14 @@ Oskari.clazz.define('Oskari.mapping.publisher.tool.MapRotator',
         init: function (data) {
             var me = this;
 
-            if (!data || !data.configuration[me.bundleName]) {
+            var bundleData = data && data.configuration[me.bundleName];
+            if (!bundleData) {
                 return;
             }
-            me.setEnabled(true);
-
-            var conf = data.configuration[me.bundleName].conf || {};
+            var conf = bundleData.conf || {};
+            me.setEnabled(conf.enabled);
             me.noUiIsCheckedInModifyMode = !!conf.noUI;
+            this.getMapRotatorInstance().setState(bundleData.state);
         },
         /**
          * Get values.
@@ -70,6 +71,7 @@ Oskari.clazz.define('Oskari.mapping.publisher.tool.MapRotator',
                 if (me.noUI) {
                     pluginConfig.noUI = me.noUI;
                 }
+                pluginConfig.enabled = me.state.enabled;
                 var json = {
                     configuration: {}
                 };

--- a/bundles/mapping/maprotator/resources/scss/maprotator.scss
+++ b/bundles/mapping/maprotator/resources/scss/maprotator.scss
@@ -4,6 +4,12 @@ $iconShadow: 1px 1px 2px rgba(0,0,0,0.6);
 $darkIcon: url("../images/north_nobg_light.png");
 $lightIcon: url("../images/north_nobg_dark.png");
 
+div.mapplugins.left div.maprotator {
+  float: left;
+}
+div.mapplugins.right div.maprotator {
+  float: right;
+}
 div.mapplugin.maprotator {
     border-radius: 50%;
     width: 32px;
@@ -28,7 +34,7 @@ div.mapplugin.maprotator {
       position: relative;
 
     }
-  
+
     /* default and rounded-dark theme */
     &.toolstyle-default, &.toolstyle-rounded-dark {
       background-color: $darkBgColor;


### PR DESCRIPTION
Fixes an issue where map rotator would get positioned under (like z-index under) other tools.