### PR TITLE
Statsmap always in publisher

### DIFF
--- a/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
@@ -11,7 +11,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractStatsPluginTool'
     },
     /**
      * @method isDisplayed Is displayed.
-     * @returns {Boolean} true, if data contains statsdrid conf and state has indicators
+     * @returns {Boolean} true, if stats layer is on the map or data contains statsdrid conf
      */
     isDisplayed: function (data) {
         if (this._getStatsLayer()) {

--- a/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
@@ -8,6 +8,16 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractStatsPluginTool'
     */
     _getStatsLayer: function () {
         return Oskari.getSandbox().findAllSelectedMapLayers().find(lyr => lyr.getId() === 'STATS_LAYER');
+    },
+    /**
+     * @method isDisplayed Is displayed.
+     * @returns {Boolean} true, if data contains statsdrid conf and state has indicators
+     */
+    isDisplayed: function (data) {
+        if (this._getStatsLayer()) {
+            return true;
+        }
+        return Oskari.util.keyExists(data, 'configuration.statsgrid.conf');
     }
 }, {
     'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool']

--- a/bundles/statistics/statsgrid2016/publisher/ClassificationToggleTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/ClassificationToggleTool.js
@@ -40,13 +40,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationToggleTool
             stats.togglePlugin.removeTool(this.id);
         }
     },
-    isDisplayed: function (data) {
-        var hasStatsLayerOnMap = this._getStatsLayer() !== null;
-        if (hasStatsLayerOnMap) {
-            return true;
-        }
-        return Oskari.util.keyExists(data, 'configuration.statsgrid.conf');
-    },
     getValues: function () {
         var me = this;
         var statsGridState = me.__sandbox.getStatefulComponents().statsgrid.getState();

--- a/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
@@ -47,27 +47,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationTool', fun
         this.state.enabled = enabled;
         this.getPlugin().enableClassification(enabled);
     },
-    isDisplayed: function (data) {
-        var hasStatsLayerOnMap = this._getStatsLayer() !== null;
-        if (hasStatsLayerOnMap) {
-            // If there's a statslayer on the map show the tool for statistics functionality
-            // relevant when creating a new published map
-            return true;
-        }
-        // If there isn't one, the user hasn't visited the functionality on this session
-        // Check if the user is editing a map with statslayer
-        var configExists = Oskari.util.keyExists(data, 'configuration.statsgrid.conf');
-        if (!configExists) {
-            return false;
-        }
-        if (!Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid')) {
-            Oskari.log('Oskari.mapframework.publisher.tool.ClassificationTool')
-                .warn("Published map had config, but current appsetup doesn't include StatsGrid! " +
-                  'The thematic map functionality will be removed if user saves the map!!');
-            return false;
-        }
-        return true;
-    },
     getValues: function () {
         var me = this;
         var statsGridState = me.__sandbox.getStatefulComponents().statsgrid.getState();

--- a/bundles/statistics/statsgrid2016/publisher/DiagramTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/DiagramTool.js
@@ -40,23 +40,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.DiagramTool', function (
             stats.togglePlugin.removeTool(this.id);
         }
     },
-    isDisplayed: function (data) {
-        var hasStatsLayerOnMap = this._getStatsLayer() !== null;
-        if (hasStatsLayerOnMap) {
-            return true;
-        }
-        var configExists = Oskari.util.keyExists(data, 'configuration.statsgrid.conf');
-        if (!configExists) {
-            return false;
-        }
-        if (!Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid')) {
-            Oskari.log('Oskari.mapframework.publisher.tool.DiagramTool')
-                .warn("Published map had config, but current appsetup doesn't include StatsGrid! " +
-                  'The thematic map functionality will be removed if user saves the map!!');
-            return false;
-        }
-        return true;
-    },
     getValues: function () {
         var me = this;
         var statsGridState = me.__sandbox.getStatefulComponents().statsgrid.getState();

--- a/bundles/statistics/statsgrid2016/publisher/OpacityTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/OpacityTool.js
@@ -43,23 +43,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.OpacityTool', function (
             stats.classificationPlugin.makeTransparent(false);
         }
     },
-    isDisplayed: function (data) {
-        var hasStatsLayerOnMap = this._getStatsLayer() !== null;
-        if (hasStatsLayerOnMap) {
-            return true;
-        }
-        var configExists = Oskari.util.keyExists(data, 'configuration.statsgrid.conf');
-        if (!configExists) {
-            return false;
-        }
-        if (!Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid')) {
-            Oskari.log('Oskari.mapframework.publisher.tool.DiagramTool')
-                .warn("Published map had config, but current appsetup doesn't include StatsGrid! " +
-                  'The thematic map functionality will be removed if user saves the map!!');
-            return false;
-        }
-        return true;
-    },
     getValues: function () {
         var me = this;
         var statsGridState = me.__sandbox.getStatefulComponents().statsgrid.getState();

--- a/bundles/statistics/statsgrid2016/publisher/StatsTableTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/StatsTableTool.js
@@ -63,34 +63,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.StatsTableTool', functio
             stats.togglePlugin.removeTool(this.id);
         }
     },
-    /**
-    * Is displayed.
-    * @method isDisplayed
-    * @public
-    *
-    * @returns {Boolean} is tool displayed
-    */
-    isDisplayed: function (data) {
-        var hasStatsLayerOnMap = this._getStatsLayer() !== null;
-        if (hasStatsLayerOnMap) {
-            // If there's a statslayer on the map show the tool for statistics functionality
-            // relevant when creating a new published map
-            return true;
-        }
-        // If there isn't one, the user hasn't visited the functionality on this session
-        // Check if the user is editing a map with statslayer
-        var configExists = Oskari.util.keyExists(data, 'configuration.statsgrid.conf');
-        if (!configExists) {
-            return false;
-        }
-        if (!Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid')) {
-            Oskari.log('Oskari.mapframework.publisher.tool.ClassificationTool')
-                .warn("Published map had config, but current appsetup doesn't include StatsGrid! " +
-                  'The thematic map functionality will be removed if user saves the map!!');
-            return false;
-        }
-        return true;
-    },
     getValues: function () {
         var me = this;
         var statsGridState = me.__sandbox.getStatefulComponents().statsgrid.getState();


### PR DESCRIPTION
Fixes an issue where thematic map tools were always visible in the publisher. Even when there was no thematic layers added on the map.