### PR TITLE
Publisher default tool placing

### DIFF
--- a/bundles/framework/publisher2/view/PanelMapTools.js
+++ b/bundles/framework/publisher2/view/PanelMapTools.js
@@ -139,6 +139,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
                     tool.setEnabled(enabled);
                     if (enabled) {
                         ui.find('.extraOptions').show();
+                        me._setToolLocation(tool);
                     } else {
                         ui.find('.extraOptions').hide();
                     }
@@ -159,6 +160,30 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
             });
             me.panel = panel;
             return panel;
+        },
+        /**
+         * @private
+         * @method _setToolLocation
+         * Sets the tool's location according to users selection. (lefhanded/righthanded/userlayout)
+         */
+        _setToolLocation: function (tool) {
+            const layoutPanel = this.instance.publisher.panels.find(
+                panel => panel.getName && panel.getName() === 'Oskari.mapframework.bundle.publisher2.view.PanelToolLayout');
+            if (!layoutPanel || !tool[layoutPanel.activeToolLayout]) {
+                return;
+            }
+            if (!tool.config) {
+                tool.config = {};
+            }
+            if (!tool.config.location) {
+                tool.config.location = {};
+            }
+            const layout = layoutPanel.activeToolLayout;
+            tool.config.location.classes = tool[layout];
+            var plugin = tool.getPlugin();
+            if (plugin && plugin.setLocation) {
+                plugin.setLocation(tool.config.location.classes);
+            }
         },
         /**
          * Returns a hash containing ids of enabled plugins when restoring a published map.

--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -34,7 +34,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
         me.toolLayouts = ['lefthanded', 'righthanded', 'userlayout'];
         me.data = me.instance.publisher.data;
         me.activeToolLayout = me.instance.publisher.data && me.instance.publisher.data.metadata && me.instance.publisher.data.metadata.toolLayout
-            ? me.instance.publisher.data.metadata.toolLayout : 'lefthanded';
+            ? me.instance.publisher.data.metadata.toolLayout : 'userlayout';
         me.toolLayoutEditMode = false;
     }, {
         eventHandlers: {

--- a/bundles/mapping/maprotator/resources/scss/maprotator.scss
+++ b/bundles/mapping/maprotator/resources/scss/maprotator.scss
@@ -4,12 +4,6 @@ $iconShadow: 1px 1px 2px rgba(0,0,0,0.6);
 $darkIcon: url("../images/north_nobg_light.png");
 $lightIcon: url("../images/north_nobg_dark.png");
 
-div.mapplugins.left div.maprotator {
-  float: left;
-}
-div.mapplugins.right div.maprotator {
-  float: right;
-}
 div.mapplugin.maprotator {
     border-radius: 50%;
     width: 32px;


### PR DESCRIPTION
Fixes an issue where publisher tools would not respect the active tool layout. 
Now the tools check the layout setting when selected.
Default layout changed to "userlayout" meaning the tools get positioned to their default locations. 