### PR TITLE
Admin layer editor bundle stub

### DIFF
--- a/bundles/admin/admin-layereditor/instance.js
+++ b/bundles/admin/admin-layereditor/instance.js
@@ -1,0 +1,110 @@
+import LayerEditorFlyout from './view/Flyout';
+const BasicBundle = Oskari.clazz.get('Oskari.BasicBundle');
+
+Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
+    class AdminLayerEditor extends BasicBundle {
+        constructor () {
+            super();
+            this.loc = Oskari.getMsg.bind(null, 'admin-layereditor');
+            this.eventHandlers = {
+                'MapLayerEvent': (event) => {
+                    if (event.getOperation() !== 'add') {
+                        // only handle add layer
+                        return;
+                    }
+                    if (event.getLayerId()) {
+                        this._addTool(event.getLayerId());
+                    } else { // initial layer load
+                        this._setupLayerTools();
+                    }
+                }
+            };
+        }
+        _startImpl () {
+            this._setupLayerTools();
+        }
+
+        /**
+         * Fetches reference to the map layer service
+         * @return {Oskari.mapframework.service.MapLayerService}
+         */
+        _getLayerService () {
+            return this.sandbox.getService('Oskari.mapframework.service.MapLayerService');
+        }
+
+        /**
+         * Adds tools for all layers
+         */
+        _setupLayerTools () {
+            // add tools for feature data layers
+            const service = this._getLayerService();
+            const layers = service.getAllLayers();
+            layers.forEach(layer => {
+                this._addTool(layer, true);
+            });
+            // update all layers at once since we suppressed individual events
+            const event = Oskari.eventBuilder('MapLayerEvent')(null, 'tool');
+            this.sandbox.notifyAll(event);
+        }
+
+        /**
+         * Adds the layer edit tool for layer
+         * @method  @private _addTool
+         * @param  {String| Number} layerId layer to process
+         * @param  {Boolean} suppressEvent true to not send event about updated layer (optional)
+         */
+        _addTool (layer, suppressEvent) {
+            const service = this._getLayerService();
+            if (typeof layer !== 'object') {
+                // detect layerId and replace with the corresponding layerModel
+                layer = service.findMapLayer(layer);
+            }
+            if (!layer || layer.getLayerType() !== 'wfs' || layer.getVersion() !== '1.1.0') {
+                return;
+            }
+
+            // add feature data tool for layer
+            const tool = Oskari.clazz.create('Oskari.mapframework.domain.Tool');
+            tool.setName('layer-editor');
+            tool.setIconCls('icon-info-area');
+            tool.setTooltip(this.loc('editor-tool'));
+            tool.setTypes(['layerSelection']);
+
+            tool.setCallback(() => {
+                this._showEditor(layer.getId());
+            });
+
+            service.addToolForLayer(layer, tool, suppressEvent);
+        }
+        /**
+         * @private @method _showEditor
+         * Opens flyout with layer editor for given layerId
+         * @param {Number} layerId
+         */
+        _showEditor (layerId) {
+            const flyout = this._getFlyout();
+            flyout.setLayerId(layerId);
+            flyout.show();
+        }
+
+        /**
+         * @private @method _getFlyout
+         * Ensure flyout exists and return it
+         * @return {LayerEditorFlyout}
+         */
+        _getFlyout () {
+            if (!this.flyout) {
+                const xPosition = jQuery('#mapdiv').position().left;
+                const offset = 150;
+
+                this.flyout = new LayerEditorFlyout(this.loc('flyout-title'));
+                this.flyout.move(xPosition + offset, 15, true);
+                this.flyout.makeDraggable({
+                    handle: '.oskari-flyouttoolbar',
+                    scroll: false
+                });
+            }
+            return this.flyout;
+        }
+    }
+);

--- a/bundles/admin/admin-layereditor/instance.js
+++ b/bundles/admin/admin-layereditor/instance.js
@@ -68,7 +68,7 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
             tool.setName('layer-editor');
             tool.setIconCls('icon-info-area');
             tool.setTooltip(this.loc('editor-tool'));
-            tool.setTypes(['layerSelection']);
+            tool.setTypes(['layerList']);
 
             tool.setCallback(() => {
                 this._showEditor(layer.getId());

--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -1,0 +1,10 @@
+Oskari.registerLocalization(
+    {
+        "lang": "en",
+        "key": "admin-layereditor",
+        "value": {
+            "editor-tool": "Edit layer",
+            "flyout-title": "Layer administration"
+        }
+    }
+);

--- a/bundles/admin/admin-layereditor/view/Flyout.js
+++ b/bundles/admin/admin-layereditor/view/Flyout.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+const ExtraFlyout = Oskari.clazz.get('Oskari.userinterface.extension.ExtraFlyout');
+
+export default class LayerEditorFlyout extends ExtraFlyout {
+    constructor (title, options) {
+        super(title, options);
+        this.element = null;
+        this.layerId = null;
+        this.on('show', () => {
+            if (!this.getElement()) {
+                this.createUi();
+            }
+        });
+        this.on('hide', () => {
+            this.cleanUp();
+        });
+    }
+    setElement (el) {
+        this.element = el;
+    }
+    getElement () {
+        return this.element;
+    }
+    createUi () {
+        this.setElement(jQuery('<div></div>'));
+        this.addClass('admin-layereditor-flyout');
+        this.setContent(this.getElement());
+        this.update(this.layerId);
+    }
+    setLayerId (layerId) {
+        this.layerId = layerId;
+        this.update(layerId);
+    }
+    update (layerId) {
+        const el = this.getElement();
+        if (layerId === null || !el) {
+            return;
+        }
+        ReactDOM.render(<div>React content for layer id {layerId}</div>, el.get(0));
+    }
+    cleanUp () {
+        const el = this.getElement();
+        if (!el) {
+            return;
+        }
+        ReactDOM.unmountComponentAtNode(el.get(0));
+    }
+}

--- a/bundles/framework/hierarchical-layerlist/components/SelectedLayer.js
+++ b/bundles/framework/hierarchical-layerlist/components/SelectedLayer.js
@@ -382,10 +382,12 @@ Oskari.clazz.define('Oskari.framework.bundle.hierarchical-layerlist.SelectedLaye
     _addLayerTools: function () {
         var me = this;
 
-        me._layer.getTools().forEach(function (tool) {
-            me.addTool(tool.getName(), tool.getIconCls(), tool.getTooltip(), function (evt) {
-                tool.getCallback()();
+        me._layer.getTools()
+            .filter(tool => tool.getTypes().includes('selectedLayers'))
+            .forEach(function (tool) {
+                me.addTool(tool.getName(), tool.getIconCls(), tool.getTooltip(), function (evt) {
+                    tool.getCallback()();
+                });
             });
-        });
     }
 });

--- a/bundles/framework/layerselection2/Flyout.js
+++ b/bundles/framework/layerselection2/Flyout.js
@@ -790,6 +790,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselection2.Flyout',
 
             for (s = 0; s < laytools.length; s += 1) {
                 laytool = laytools[s];
+                if (!laytool.getTypes().includes('selectedLayers')) {
+                    continue;
+                }
                 if (laytool && me.blacklistedTools.indexOf(laytool.getName()) === -1) {
                     // Icon or text link
                     if (laytool.getIconCls() && me.toolsAsText.indexOf(laytool.getName()) === -1) {

--- a/bundles/framework/layerselector2/instance.js
+++ b/bundles/framework/layerselector2/instance.js
@@ -203,45 +203,37 @@ Oskari.clazz.define(
                         'Oskari.mapframework.service.MapLayerService'
                     ),
                     layerId = event.getLayerId(),
+                    operation = event.getOperation(),
                     layer;
 
-                if (event.getOperation() === 'update') {
+                if (layerId !== null && layerId !== undefined) {
                     layer = mapLayerService.findMapLayer(layerId);
+                }
+
+                if (operation === 'update') {
                     flyout.handleLayerModified(layer);
-                } else if (event.getOperation() === 'add') {
-                    layer = mapLayerService.findMapLayer(layerId);
+                } else if (operation === 'add') {
                     flyout.handleLayerAdded(layer);
                     flyout.updateFilters();
                     // refresh layer count
                     tile.refresh();
-                } else if (event.getOperation() === 'remove') {
+                } else if (operation === 'remove') {
                     flyout.handleLayerRemoved(layerId);
                     flyout.updateFilters();
                     // refresh layer count
                     tile.refresh();
-                } else if (event.getOperation() === 'sticky') {
-                    layer = mapLayerService.findMapLayer(layerId);
+                } else if (operation === 'sticky') {
                     flyout.handleLayerSticky(layer);
                     // refresh layer count
                     tile.refresh();
+                } else if (operation === 'tool') {
+                    this.layerChanged(layerId);
                 }
             },
 
             'BackendStatus.BackendStatusChangedEvent': function (event) {
-                var layerId = event.getLayerId(),
-                    flyout = this.plugins['Oskari.userinterface.Flyout'],
-                    mapLayerService = this.sandbox.getService(
-                        'Oskari.mapframework.service.MapLayerService'
-                    ),
-                    layer;
-
-                if (layerId === null || layerId === undefined) {
-                    // Massive update so just recreate the whole ui
-                    flyout.populateLayers();
-                } else {
-                    layer = mapLayerService.findMapLayer(layerId);
-                    flyout.handleLayerModified(layer);
-                }
+                var layerId = event.getLayerId();
+                this.layerChanged(layerId);
             },
 
             /**
@@ -264,6 +256,23 @@ Oskari.clazz.define(
                     plugin.deactivateAllFilters();
                     me.filteredLayerListOpenedByRequest = false;
                 }
+            }
+        },
+        /**
+         * @method layerChanged
+         * Update layer view by given ID, or update all if given null
+         * @param {Number} layerId
+         */
+        layerChanged: function (layerId) {
+            const flyout = this.plugins['Oskari.userinterface.Flyout'];
+            const mapLayerService = this.sandbox.getService('Oskari.mapframework.service.MapLayerService');
+
+            if (layerId === null || layerId === undefined) {
+                // Massive update so just recreate the whole ui
+                flyout.populateLayers();
+            } else {
+                let layer = mapLayerService.findMapLayer(layerId);
+                flyout.handleLayerModified(layer);
             }
         },
 

--- a/bundles/framework/layerselector2/resources/scss/style.scss
+++ b/bundles/framework/layerselector2/resources/scss/style.scss
@@ -33,6 +33,7 @@ div.layerselector2 {
         padding: 6px 10px 6px 40px;
         background-color: #ffffff;
         clear: both;
+        position: relative;
 
         /* Default line height is too high, make it so the text just fits */
         min-height: 14px;
@@ -40,6 +41,15 @@ div.layerselector2 {
 
         &:nth-child(even) {
             background-color: #f3f3f3;
+        }
+
+        div.custom-tools {
+            position: absolute;
+            left: 5px;    
+        }
+
+        div.custom-tools > div:hover {
+            cursor: pointer;
         }
 
         input {

--- a/bundles/framework/layerselector2/view/Layer.js
+++ b/bundles/framework/layerselector2/view/Layer.js
@@ -225,7 +225,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.view.Layer',
             /* add custom tools */
             const customToolsDiv = layerDiv.find('div.custom-tools');
             layer.getTools()
-                .filter(tool => tool.getTypes().includes('layerSelection'))
+                .filter(tool => tool.getTypes().includes('layerList'))
                 .forEach(tool => {
                     const toolContainer = jQuery('<div></div>');
                     toolContainer.addClass(tool.getIconCls());

--- a/bundles/framework/layerselector2/view/Layer.js
+++ b/bundles/framework/layerselector2/view/Layer.js
@@ -17,16 +17,18 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.view.Layer',
         this.backendStatus = 'UNKNOWN'; // see also 'backendstatus-ok'
         this.ui = this._createLayerContainer(layer);
     }, {
-        __template: '<div class="layer"><input type="checkbox" /> ' +
-                    '<div class="layer-tools">' +
-                    '   <div class="layer-not-supported icon-warning-light" title="" ></div>' +
-                    '   <div class="layer-backendstatus-icon backendstatus-unknown" title=""></div>' +
-                    '   <div class="layer-icon-secondary"></div>' +
-                    '   <div class="layer-icon"></div>' +
-                    '   <div class="layer-info"></div>' +
-                    '</div>' +
-                    '<div class="layer-title"></div>' +
-        '</div>',
+        __template: '<div class="layer">' +
+                        '<div class="custom-tools"></div>' +
+                        '<input type="checkbox" /> ' +
+                        '<div class="layer-tools">' +
+                        '   <div class="layer-not-supported icon-warning-light" title="" ></div>' +
+                        '   <div class="layer-backendstatus-icon backendstatus-unknown" title=""></div>' +
+                        '   <div class="layer-icon-secondary"></div>' +
+                        '   <div class="layer-icon"></div>' +
+                        '   <div class="layer-info"></div>' +
+                        '</div>' +
+                        '<div class="layer-title"></div>' +
+                    '</div>',
         /**
          * @method getId
          * @return {String} layer id
@@ -219,6 +221,24 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.view.Layer',
             if (layer.isSticky()) {
                 layerDiv.find('input').prop('disabled', true);
             }
+
+            /* add custom tools */
+            const customToolsDiv = layerDiv.find('div.custom-tools');
+            layer.getTools()
+                .filter(tool => tool.getTypes().includes('layerSelection'))
+                .forEach(tool => {
+                    const toolContainer = jQuery('<div></div>');
+                    toolContainer.addClass(tool.getIconCls());
+                    toolContainer.attr('title', tool.getTooltip());
+                    toolContainer.click(() => {
+                        const cb = tool.getCallback();
+                        if (cb) {
+                            cb();
+                        }
+                        return false;
+                    });
+                    customToolsDiv.append(toolContainer);
+                });
 
             /*
              * backend status

--- a/bundles/mapping/mapmodule/domain/tool.js
+++ b/bundles/mapping/mapmodule/domain/tool.js
@@ -16,6 +16,7 @@ Oskari.clazz.define('Oskari.mapframework.domain.Tool',
         this._tooltip = null;
         this._iconCls = null;
         this._callback = null;
+        this._types = ['selectedLayers'];
     }, {
 
         /**
@@ -110,5 +111,20 @@ Oskari.clazz.define('Oskari.mapframework.domain.Tool',
          */
         getCallback: function () {
             return this._callback;
+        },
+
+        setTypes: function (types) {
+            this._types = types;
+        },
+
+        addType: function (type) {
+            if (!type || this._types.includes(type)) {
+                return;
+            }
+            this._types.push(type);
+        },
+
+        getTypes: function () {
+            return this._types;
         }
     });

--- a/packages/admin/bundle/admin-layereditor/bundle.js
+++ b/packages/admin/bundle/admin-layereditor/bundle.js
@@ -1,0 +1,44 @@
+
+Oskari.clazz.define("Oskari.admin.admin-layereditor.bundle", function () {
+
+}, {
+        "create": function () {
+            return Oskari.clazz.create("Oskari.admin.admin-layereditor.instance");
+        },
+        "update": function (manager, bundle, bi, info) {
+
+        }
+    }, {
+
+        "protocol": ["Oskari.bundle.Bundle"],
+        "source": {
+
+            "scripts": [{
+                "src": "../../../../bundles/admin/admin-layereditor/instance.js"
+            }],
+            "locales": [{
+                "lang": "en",
+                "src": "../../../../bundles/admin/admin-layereditor/resources/locale/en.js"
+            }]
+        },
+        "bundle": {
+            "manifest": {
+                "Bundle-Identifier": "admin-layereditor",
+                "Bundle-Name": "admin-layereditor",
+                "Bundle-Author": [{
+                    "Name": "mmldev",
+                    "Organisation": "nls.fi",
+                    "Temporal": {
+                        "Start": "2019",
+                        "End": "?"
+                    },
+                    "Copyleft": {
+                        "License": {
+                            "License-Name": "EUPL"
+                        }
+                    }
+                }]
+            }
+        }
+    });
+Oskari.bundle_manager.installBundleClass("admin-layereditor", "Oskari.admin.admin-layereditor.bundle");


### PR DESCRIPTION
- Created new bundle "admin-layereditor". To use in your app:
  - Add bundle row to DB
  - In properties, add "admin-layereditor" into list `actionhandler.GetAppSetup.dynamic.bundles`
  - In properties, add the bundle to the role you want to have it shown to, typically `actionhandler.GetAppSetup.dynamic.bundle.admin-layereditor.roles = Administrator`
  - Add "admin-layereditor" into minifierAppSetup.json (or main.js), preferably as `lazy`.
- Changed `Oskari.mapframework.domain.Tool` to include concept of tool type that determines where the tool should be visible. Current implemented types: `selectedLayers` and `layerList`. 
  - Updated bundles `layerselection2` and `hierarchical-layerlist` only to show tools of type `selectedLayers`.
  - layerselector2 bundle shows tools of type `layerList` next to the layer selection checkbox. Clicking on the tool opens a flyout, which will house the actual layer editor form (separate PR).

Only layers of type WFS 1.1.0 will have the editor tool. This is just for demonstration purposes and will be changed to WFS 3.0.0 later.