### PR TITLE
Disable tool event on layerselector to restore performance

### DIFF
--- a/bundles/framework/layerselector2/instance.js
+++ b/bundles/framework/layerselector2/instance.js
@@ -227,7 +227,8 @@ Oskari.clazz.define(
                     // refresh layer count
                     tile.refresh();
                 } else if (operation === 'tool') {
-                    this.layerChanged(layerId);
+                    // This will increase startup time in pti by ~300% 
+                    //this.layerChanged(layerId);
                 }
             },
 

--- a/bundles/framework/layerselector2/instance.js
+++ b/bundles/framework/layerselector2/instance.js
@@ -227,8 +227,8 @@ Oskari.clazz.define(
                     // refresh layer count
                     tile.refresh();
                 } else if (operation === 'tool') {
-                    // This will increase startup time in pti by ~300% 
-                    //this.layerChanged(layerId);
+                    // This will increase startup time in pti by ~300%
+                    // this.layerChanged(layerId);
                 }
             },
 


### PR DESCRIPTION
#803 added a feature where layerselector bundle listens to layer tools events. This crashes the performance  on startup when there's a lot of layers in the instance.

This fixes the issue. We'll have to find a better way of doing this in layerselector if it's needed.