### PR TITLE
Fix publisher TOU handling

### DIFF
--- a/bundles/framework/publisher2/view/FlyoutStartView.js
+++ b/bundles/framework/publisher2/view/FlyoutStartView.js
@@ -261,7 +261,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.FlyoutStartView'
                     this.success(false);
                 },
                 success: function (resp) {
-                    me.hasAcceptedTou = resp;
+                    // response is "true" or "false" string
+                    me.hasAcceptedTou = ('true' === '' + resp);
                     me._updateContinueButton();
                 }
             });

--- a/bundles/framework/publisher2/view/FlyoutStartView.js
+++ b/bundles/framework/publisher2/view/FlyoutStartView.js
@@ -262,7 +262,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.FlyoutStartView'
                 },
                 success: function (resp) {
                     // response is "true" or "false" string
-                    me.hasAcceptedTou = ('true' === '' + resp);
+                    me.hasAcceptedTou = ('' + resp === 'true');
                     me._updateContinueButton();
                 }
             });


### PR DESCRIPTION
Successful response from the server was always read as user having accepted the terms of use ("false" string was treated as boolean true).