### PR TITLE
Storybook poc

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,0 +1,10 @@
+import { configure } from '@storybook/react';
+
+function loadStories() {
+    // loads everything under bundles with filename ending .stories.js
+    // Note! doesn't work with .stories.js (needs prefix)
+    const req = require.context("../bundles", true, /\.stories\.js$/);
+    req.keys().forEach(filename => req(filename));
+}
+
+configure(loadStories, module);

--- a/bundles/admin/admin-layereditor/components/Button.jsx
+++ b/bundles/admin/admin-layereditor/components/Button.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Button from 'antd/lib/button';
+import AntButton from 'antd/lib/button';
 import 'antd/lib/button/style/css';
 
-export const ButtonComponent = (props) => {
+export const Button = (props) => {
     const {text, ...other} = props;
     return (
-        <Button {...other}>{text}</Button>
+        <AntButton {...other}>{text}</AntButton>
     );
 };
 
-ButtonComponent.propTypes = {
+Button.propTypes = {
     text: PropTypes.string
 };

--- a/bundles/admin/admin-layereditor/components/Button.stories.js
+++ b/bundles/admin/admin-layereditor/components/Button.stories.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Button } from './Button';
+
+const defaultProps = {
+  text: "My text"
+}
+storiesOf('Button', module)
+  .add('with text', () => (
+    <Button {... defaultProps} />
+  ))
+  .add('of type primary', () => {
+    const storyProps = {
+      ...defaultProps,
+      type: 'primary'
+    }
+    return (
+    <Button {... storyProps} />
+  )});   
+  

--- a/bundles/admin/admin-layereditor/components/Button.stories.js
+++ b/bundles/admin/admin-layereditor/components/Button.stories.js
@@ -3,18 +3,18 @@ import { storiesOf } from '@storybook/react';
 import { Button } from './Button';
 
 const defaultProps = {
-  text: "My text"
-}
+    text: 'My text'
+};
 storiesOf('Button', module)
-  .add('with text', () => (
-    <Button {... defaultProps} />
-  ))
-  .add('of type primary', () => {
-    const storyProps = {
-      ...defaultProps,
-      type: 'primary'
-    }
-    return (
-    <Button {... storyProps} />
-  )});   
-  
+    .add('with text', () => (
+        <Button {...defaultProps} />
+    ))
+    .add('of type primary', () => {
+        const storyProps = {
+            ...defaultProps,
+            type: 'primary'
+        };
+        return (
+            <Button {...storyProps} />
+        );
+    });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "eslint . --quiet",
     "build": "webpack --progress --mode production --env.appdef=devapp:applications/sample",
     "start": "webpack-dev-server --hot --env.appdef=devapp:applications/sample",
-    "sprite": "node webpack/sprite.js"
+    "sprite": "node webpack/sprite.js",
+    "storybook": "start-storybook"
   },
   "bugs": {
     "url": "https://github.com/oskariorg/oskari-docs/issues"
@@ -22,7 +23,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "antd": "3.15.0",
+    "antd": "3.11.2",
     "jsts": "2.0.0",
     "ol": "5.3.0",
     "ol-mapbox-style": "3.3.0",
@@ -34,6 +35,7 @@
     "@babel/polyfill": "7.0.0",
     "@babel/preset-env": "7.1.0",
     "@babel/preset-react": "7.0.0",
+    "@storybook/react": "^5.0.1",
     "babel-loader": "8.0.4",
     "babel-plugin-transform-remove-strict-mode": "0.0.2",
     "copy-webpack-plugin": "4.5.2",


### PR DESCRIPTION
- Rollback antd version so it works on NLS registry (need to update this later)
- Renames ButtonComponent to Button for convenience
- Add storybook support https://storybook.js.org/docs/guides/guide-react/

1) Do an npm install
2) npm run storybook
 -> starts a live server for React component preview without the need for oskari-server.
3) Create [something].stories.js files under oskari-frontend/bundles for your components.

