### PR TITLE
Styled-components library

### DIFF
--- a/bundles/admin/admin-layereditor/components/Button.stories.js
+++ b/bundles/admin/admin-layereditor/components/Button.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { Button } from './Button';
+import {StyledButton} from './StyledButton';
 
 const defaultProps = {
     text: 'My text'
@@ -17,4 +18,7 @@ storiesOf('Button', module)
         return (
             <Button {...storyProps} />
         );
+    })
+    .add('styled', () => {
+        return (<StyledButton {...defaultProps} />);
     });

--- a/bundles/admin/admin-layereditor/components/StyledButton.jsx
+++ b/bundles/admin/admin-layereditor/components/StyledButton.jsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+import {Button} from './Button';
+
+/** PoC for styled-components. Can be removed anytime */
+
+export const StyledButton = styled(Button)`
+    background-color: palevioletred;
+`;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "ol": "5.3.0",
     "ol-mapbox-style": "3.3.0",
     "react": "16.7.0",
-    "react-dom": "16.7.0"
+    "react-dom": "16.7.0",
+    "styled-components": "^4.1.3"
   },
   "devDependencies": {
     "@babel/core": "7.1.2",
@@ -37,6 +38,7 @@
     "@babel/preset-react": "7.0.0",
     "@storybook/react": "^5.0.1",
     "babel-loader": "8.0.4",
+    "babel-plugin-styled-components": "^1.10.0",
     "babel-plugin-transform-remove-strict-mode": "0.0.2",
     "copy-webpack-plugin": "4.5.2",
     "css-loader": "0.28.11",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,7 +63,7 @@ module.exports = (env, argv) => {
                                 ],
                                 require.resolve('@babel/preset-react') // Resolve path for use from external projects
                             ],
-                            plugins: [require.resolve('babel-plugin-transform-remove-strict-mode')] // Resolve path for use from external projects
+                            plugins: [require.resolve('babel-plugin-styled-components'), require.resolve('babel-plugin-transform-remove-strict-mode')] // Resolve path for use from external projects
                         }
                     }
                 },


### PR DESCRIPTION
Added support for [styled-components](https://www.styled-components.com) into webpack build.

Example component and demo using storybook.

**Coding conventions**
I suggest that, for consistency, we always use the _styled_ constructor when creating styled components:
```
import {Button} from './components/Button';

styled(Button)`color: red`; // creates styled React component
styled('div')`color: green`; // creates styled div-element
```

i.e. never use ```styled.div`color: blue`;```
