### PR TITLE
Set props required in layer list

### DIFF
--- a/bundles/framework/layerlist/view/LayerCollapse.jsx
+++ b/bundles/framework/layerlist/view/LayerCollapse.jsx
@@ -50,11 +50,11 @@ export const LayerCollapse = ({ groups, openGroupTitles, filtered, selectedLayer
 };
 
 LayerCollapse.propTypes = {
-    groups: PropTypes.array,
-    openGroupTitles: PropTypes.array,
+    groups: PropTypes.array.isRequired,
+    openGroupTitles: PropTypes.array.isRequired,
     filtered: PropTypes.array,
-    selectedLayerIds: PropTypes.array,
-    mapSrs: PropTypes.string,
+    selectedLayerIds: PropTypes.array.isRequired,
+    mapSrs: PropTypes.string.isRequired,
     mutator: PropTypes.any.isRequired,
     locale: PropTypes.any.isRequired
 };

--- a/bundles/framework/layerlist/view/LayerCollapse.jsx
+++ b/bundles/framework/layerlist/view/LayerCollapse.jsx
@@ -27,7 +27,7 @@ const getNoResultsProps = locale => {
     return alertProps;
 };
 
-export const LayerCollapse = ({ locale, groups, openGroupTitles, filtered, mutator, selectedLayerIds }) => {
+export const LayerCollapse = ({ groups, openGroupTitles, filtered, selectedLayerIds, mapSrs, mutator, locale }) => {
     if (!Array.isArray(groups) || groups.length === 0 || (filtered && filtered.length === 0)) {
         return <StyledAlert {...getNoResultsProps(locale)}/>;
     }
@@ -39,13 +39,9 @@ export const LayerCollapse = ({ locale, groups, openGroupTitles, filtered, mutat
         <StyledCollapse bordered activeKey={openGroupTitles} onChange={keys => mutator.updateOpenGroupTitles(keys)}>
             {
                 panels.map(({group, showLayers}) => {
+                    const panelProps = {group, showLayers, selectedLayerIds, mapSrs, mutator, locale};
                     return (
-                        <LayerCollapsePanel key={group.getTitle()}
-                            mutator={mutator}
-                            locale={locale}
-                            group={group}
-                            showLayers={showLayers}
-                            selectedLayerIds={selectedLayerIds}/>
+                        <LayerCollapsePanel key={group.getTitle()} {...panelProps} />
                     );
                 })
             }
@@ -58,6 +54,7 @@ LayerCollapse.propTypes = {
     openGroupTitles: PropTypes.array,
     filtered: PropTypes.array,
     selectedLayerIds: PropTypes.array,
+    mapSrs: PropTypes.string,
     mutator: PropTypes.any.isRequired,
     locale: PropTypes.any.isRequired
 };

--- a/bundles/framework/layerlist/view/LayerCollapse/Layer.jsx
+++ b/bundles/framework/layerlist/view/LayerCollapse/Layer.jsx
@@ -50,9 +50,9 @@ export const Layer = ({model, even, selected, mapSrs, mutator, locale}) => {
 
 Layer.propTypes = {
     model: PropTypes.any.isRequired,
-    even: PropTypes.bool,
-    selected: PropTypes.bool,
-    mapSrs: PropTypes.string,
+    even: PropTypes.bool.isRequired,
+    selected: PropTypes.bool.isRequired,
+    mapSrs: PropTypes.string.isRequired,
     mutator: PropTypes.any.isRequired,
     locale: PropTypes.any.isRequired
 };

--- a/bundles/framework/layerlist/view/LayerCollapse/Layer/LayerTools.jsx
+++ b/bundles/framework/layerlist/view/LayerCollapse/Layer/LayerTools.jsx
@@ -137,7 +137,7 @@ export const LayerTools = ({model, mapSrs, mutator, locale}) => {
 
 LayerTools.propTypes = {
     model: PropTypes.any.isRequired,
-    mapSrs: PropTypes.string,
+    mapSrs: PropTypes.string.isRequired,
     mutator: PropTypes.any.isRequired,
     locale: PropTypes.any.isRequired
 };

--- a/bundles/framework/layerlist/view/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerCollapse/LayerCollapsePanel.jsx
@@ -19,21 +19,27 @@ const getBadgeText = (group, visibleLayerCount) => {
     return badgeText;
 };
 
-const renderItem = ({layer, ...rest}) => {
+const renderItem = ({model, even, selected, mapSrs, mutator, locale}) => {
+    const itemProps = {model, even, selected, mapSrs, mutator, locale};
     return (
         <StyledListItem>
-            <Layer key={layer.getId()} model={layer} {...rest} />
+            <Layer key={model.getId()} {...itemProps} />
         </StyledListItem>
     );
 };
 renderItem.propTypes = {
-    layer: PropTypes.any.isRequired
+    model: PropTypes.any,
+    even: PropTypes.bool,
+    selected: PropTypes.bool,
+    mapSrs: PropTypes.string,
+    mutator: PropTypes.any,
+    locale: PropTypes.any
 };
 
 export const LayerCollapsePanel = ({group, showLayers, selectedLayerIds, mapSrs, mutator, locale, ...propsNeededForPanel}) => {
     const items = showLayers.map((layer, index) => {
         const itemProps = {
-            layer,
+            model: layer,
             even: index % 2 === 0,
             selected: Array.isArray(selectedLayerIds) && selectedLayerIds.includes(layer.getId()),
             mapSrs,
@@ -57,8 +63,8 @@ export const LayerCollapsePanel = ({group, showLayers, selectedLayerIds, mapSrs,
 LayerCollapsePanel.propTypes = {
     group: PropTypes.any.isRequired,
     showLayers: PropTypes.array.isRequired,
-    selectedLayerIds: PropTypes.array,
-    mapSrs: PropTypes.string,
+    selectedLayerIds: PropTypes.array.isRequired,
+    mapSrs: PropTypes.string.isRequired,
     mutator: PropTypes.any.isRequired,
     locale: PropTypes.any.isRequired
 };

--- a/bundles/framework/layerlist/view/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerCollapse/LayerCollapsePanel.jsx
@@ -19,7 +19,7 @@ const getBadgeText = (group, visibleLayerCount) => {
     return badgeText;
 };
 
-const renderItem = ({model, even, selected, mapSrs, mutator, locale}) => {
+const renderLayer = ({model, even, selected, mapSrs, mutator, locale}) => {
     const itemProps = {model, even, selected, mapSrs, mutator, locale};
     return (
         <StyledListItem>
@@ -27,18 +27,18 @@ const renderItem = ({model, even, selected, mapSrs, mutator, locale}) => {
         </StyledListItem>
     );
 };
-renderItem.propTypes = {
+renderLayer.propTypes = {
     model: PropTypes.any,
-    even: PropTypes.bool,
-    selected: PropTypes.bool,
-    mapSrs: PropTypes.string,
+    even: PropTypes.any,
+    selected: PropTypes.any,
+    mapSrs: PropTypes.any,
     mutator: PropTypes.any,
     locale: PropTypes.any
 };
 
 export const LayerCollapsePanel = ({group, showLayers, selectedLayerIds, mapSrs, mutator, locale, ...propsNeededForPanel}) => {
-    const items = showLayers.map((layer, index) => {
-        const itemProps = {
+    const layerRows = showLayers.map((layer, index) => {
+        const layerProps = {
             model: layer,
             even: index % 2 === 0,
             selected: Array.isArray(selectedLayerIds) && selectedLayerIds.includes(layer.getId()),
@@ -46,7 +46,7 @@ export const LayerCollapsePanel = ({group, showLayers, selectedLayerIds, mapSrs,
             mutator,
             locale
         };
-        return itemProps;
+        return layerProps;
     });
     const visibleLayerCount = showLayers ? showLayers.length : 0;
     return (
@@ -55,7 +55,7 @@ export const LayerCollapsePanel = ({group, showLayers, selectedLayerIds, mapSrs,
             extra={
                 <Badge inversed={true} count={getBadgeText(group, visibleLayerCount)}/>
             }>
-            <List bordered={false} dataSource={items} renderItem={renderItem}/>
+            <List bordered={false} dataSource={layerRows} renderItem={renderLayer}/>
         </Panel>
     );
 };

--- a/bundles/framework/layerlist/view/LayerCollapse/StateHandler.js
+++ b/bundles/framework/layerlist/view/LayerCollapse/StateHandler.js
@@ -1,4 +1,4 @@
-const LAYER_TIMEOUT_MS = 360;
+const LAYER_TIMEOUT_MS = 400;
 
 export class StateHandler {
     constructor () {

--- a/bundles/framework/layerlist/view/LayerCollapse/StateHandler.js
+++ b/bundles/framework/layerlist/view/LayerCollapse/StateHandler.js
@@ -1,4 +1,4 @@
-const LAYER_TIMEOUT_MS = 300;
+const LAYER_TIMEOUT_MS = 360;
 
 export class StateHandler {
     constructor () {
@@ -52,7 +52,7 @@ export class StateHandler {
             groups: this.groups,
             filtered: this.filtered,
             openGroupTitles: this.openGroupTitles,
-            mapSrsName: this.map.getSrsName()
+            mapSrs: this.map.getSrsName()
         };
     }
     notify () {


### PR DESCRIPTION
Fixes passing `mapSrs` property.
Set all props required when there is no support for nullable value, to catch this kind of errors early.