### PR TITLE
Fix bug in getAllLayerGroups method in 'Oskari.mapframework.service.M…

### DIFF
--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -696,7 +696,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
         /**
          * @method getAllLayerGroups
          * Returns an array of layer groups added to the service
-         * @param {String|Integer} id if defined return only wanted group
+         * @param {String|Integer} id if defined and not equal -1 return only wanted group
          * @return {Oskari.mapframework.domain.AbstractLayer[]}
          */
         getAllLayerGroups: function (id) {
@@ -727,7 +727,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                     layerGroups = group;
                 }
             }
-            return (id) ? layerGroups : this._layerGroups;
+            return (id && id !== -1) ? layerGroups : this._layerGroups;
         },
 
         /**


### PR DESCRIPTION
…apLayerService' causing hierarchical layerlist not being refreshed correctly on main group deleted

Related to: oskariorg/oskari-docs#104