### PR TITLE
Fix floating buttons on hierarchical admin

### DIFF
--- a/bundles/admin/admin-hierarchical-layerlist/resources/scss/style.scss
+++ b/bundles/admin/admin-hierarchical-layerlist/resources/scss/style.scss
@@ -82,6 +82,7 @@ $updateCapabilitiesIcon: url("../images/glyphicons-82-refresh.png");
 
             div.oskari-flyoutcontentcontainer {
                 max-height: 650px;
+                background-color: #fafafa;
             }
         }
     }
@@ -93,6 +94,7 @@ $updateCapabilitiesIcon: url("../images/glyphicons-82-refresh.png");
 
             div.oskari-flyoutcontentcontainer {
                 max-height: 700px;
+                background-color: #fafafa;
             }
         }
     }


### PR DESCRIPTION
This fix is not perfect. The border of the flyout is missing from the lower portion ~30px, but it looks better than without the background since now the the bottom half of buttons float outside the flyout. If the media queries are removed the flyout is a bit smaller, but the visuals are as they should. I guess the media queries have been added to make the flyout taller on smaller screens, but the difference is ~50px or so and introduces other problems on the layout.

Anyway, this change makes it look ok' ish on the browser sizes that hit the media queries by adding the same background on the element that is stretched out of the flyout container.