### PR TITLE
Fix webpack sprite generation

### DIFF
--- a/webpack/sprite.js
+++ b/webpack/sprite.js
@@ -49,12 +49,15 @@ function copyPngIcons (src, dest) {
     try {
         fs.copySync(src, dest, {
             // overwrite any existing file
-            clobber: true,
+            overwrite: true,
             // dereference symlinks
             dereference: true,
             // only include png files
-            filter: function (file) {
-                return file.endsWith('.png');
+            filter: function (path) {
+                if (fs.lstatSync(path).isDirectory()) {
+                    return true;
+                }
+                return path.endsWith('.png');
             }
         });
     } catch (e) {


### PR DESCRIPTION
Fixed an issue with webpack sprite generation where the source icons where filtered out.

The source directory itself is passed to the copySync filter function and as this didn't match the filter, the destination directory remained empty, which in turn ended the execution of the script in tears:
`sprite.write(spritePath, function (err) {
TypeError: Cannot read property 'write' of null`

Also replaced deprecated `clobber` parameter with `overwrite`.