### PR TITLE
Import mapmodule before bundles that refer to classes it provides

### DIFF
--- a/applications/sample/servlet/main.js
+++ b/applications/sample/servlet/main.js
@@ -1,11 +1,11 @@
+import 'oskari-loader!../../../packages/framework/bundle/mapfull/bundle.js';
+import 'oskari-loader!../../../packages/framework/bundle/oskariui/bundle.js';
+import 'oskari-loader!../../../packages/mapping/ol3/mapmodule/bundle.js';
 import 'oskari-loader!../../../packages/mapping/ol3/mapmyplaces/bundle.js';
 import 'oskari-loader!../../../packages/mapping/ol3/maparcgis/bundle.js';
-import 'oskari-loader!../../../packages/mapping/ol3/mapmodule/bundle.js';
-import 'oskari-loader!../../../packages/framework/bundle/oskariui/bundle.js';
 import 'oskari-loader!../../../packages/mapping/ol3/mapwfs2/bundle.js';
 import 'oskari-loader!../../../packages/mapping/ol3/mapuserlayers/bundle.js';
 import 'oskari-loader!../../../packages/framework/bundle/ui-components/bundle.js';
-import 'oskari-loader!../../../packages/framework/bundle/mapfull/bundle.js';
 import 'oskari-loader!../../../packages/mapping/ol3/mapwmts/bundle.js';
 
 import 'oskari-loader!../../../packages/framework/bundle/divmanazer/bundle.js';

--- a/applications/sample/servlet_published_ol3/main.js
+++ b/applications/sample/servlet_published_ol3/main.js
@@ -1,32 +1,20 @@
+import 'oskari-loader!../../../packages/framework/bundle/mapfull/bundle.js';
+import 'oskari-loader!../../../packages/framework/bundle/oskariui/bundle.js';
+import 'oskari-loader!../../../packages/mapping/ol3/mapmodule/bundle.js';
 import 'oskari-loader!../../../packages/mapping/ol3/mapwmts/bundle.js';
 import 'oskari-loader!../../../packages/mapping/ol3/mapwfs2/bundle.js';
 import 'oskari-loader!../../../packages/mapping/ol3/mapuserlayers/bundle.js';
 import 'oskari-loader!../../../packages/mapping/ol3/maparcgis/bundle.js';
-import 'oskari-loader!../../../packages/mapping/ol3/mapmodule/bundle.js';
-import 'oskari-loader!../../../packages/framework/bundle/mapfull/bundle.js';
-import 'oskari-loader!../../../packages/framework/bundle/oskariui/bundle.js';
 import 'oskari-loader!../../../packages/framework/bundle/ui-components/bundle.js';
-
 import 'oskari-loader!../../../packages/framework/bundle/divmanazer/bundle.js';
-
 import 'oskari-loader!../../../packages/mapping/ol3/infobox/bundle.js';
-
 import 'oskari-loader!../../../packages/framework/bundle/coordinatetool/bundle.js';
-
 import 'oskari-lazy-loader?statsgrid!../../../packages/statistics/statsgrid/bundle.js';
-
 import 'oskari-loader!../../../packages/mapping/ol3/toolbar/bundle.js';
-
 import 'oskari-loader!../../../packages/framework/bundle/publishedstatehandler/bundle.js';
-
 import 'oskari-loader!../../../packages/framework/featuredata2/bundle.js';
-
 import 'oskari-loader!../../../packages/mapping/ol3/drawtools/bundle.js';
-
 import 'oskari-lazy-loader?routingService!../../../packages/framework/bundle/routingService/bundle.js';
-
 import 'oskari-lazy-loader?maprotator!../../../packages/mapping/ol3/maprotator/bundle.js';
-
 import 'oskari-loader!../../../packages/framework/bundle/rpc/bundle.js';
-
 import './css/overwritten.css';


### PR DESCRIPTION
Fixes an error when opening an embedded map published from the sample app (class_system.js:48 Uncaught Error: No class registered with name: Oskari.mapframework.domain.Style)