### PR TITLE
Admin options for wfs render mode 

### DIFF
--- a/bundles/integration/admin-layerselector/resources/locale/en.js
+++ b/bundles/integration/admin-layerselector/resources/locale/en.js
@@ -93,6 +93,12 @@ Oskari.registerLocalization(
             "editWfs": "Edit WFS",
             "options": "Options JSON",
             "apiKey": "Api key",
+            "renderMode": {
+                "title": "Collection Type",
+                "mvt": "Lots of small objects",
+                "vector": "Big objects",
+                "info": "Viewing of small objects has been optimized but it restricts the minimum scale"
+            },
             "mvtAttributions": "Attributions",
             "mvtAttributionsDesc": "JSON \n[{\n  \"label\": \"© MyOrganization\",\n  \"link\": \"https://linktomycopyrights\"\n}]",
             "mvtTileGrid": "Tile grid",

--- a/bundles/integration/admin-layerselector/resources/locale/fi.js
+++ b/bundles/integration/admin-layerselector/resources/locale/fi.js
@@ -93,6 +93,12 @@ Oskari.registerLocalization(
             "editWfs": "Muokkaa WFS-tietoja",
             "options": "Options JSON",
             "apiKey": "Api key",
+            "renderMode": {
+                "title": "Sisällön tyyppi",
+                "mvt": "Paljon pieniä kohteita",
+                "vector": "Suuria kohteita",
+                "info": "Pienten kohteiden esittämistä on optimoitu, mutta se rajoittaa tarkastelualueen kokoa."
+            },
             "mvtAttributions": "Lähdeviitteet",
             "mvtAttributionsDesc": "JSON \n[{\n  \"label\": \"© MyOrganization\",\n  \"link\": \"https://linktomycopyrights\"\n}]",
             "mvtTileGrid": "Tiilimatriisi",

--- a/bundles/integration/admin-layerselector/resources/locale/sv.js
+++ b/bundles/integration/admin-layerselector/resources/locale/sv.js
@@ -93,6 +93,12 @@ Oskari.registerLocalization(
             "editWfs": "Editera WFS",
             "options": "Options JSON",
             "apiKey": "Api key",
+            "renderMode": {
+                "title": "Innehållstyp",
+                "mvt": "Massor av små objekt",
+                "vector": "Stora objekt",
+                "info": "Visning av små objekt har optimerats men det begränsar minsta skala"
+            },
             "mvtAttributions": "Tillskrivningar",
             "mvtAttributionsDesc": "JSON \n[{\n  \"label\": \"© MyOrganization\",\n  \"link\": \"https://linktomycopyrights\"\n}]",
             "mvtTileGrid": "Rutmatris",

--- a/bundles/integration/admin-layerselector/templates/layer/wfslayerSettingsTemplateFooter.html
+++ b/bundles/integration/admin-layerselector/templates/layer/wfslayerSettingsTemplateFooter.html
@@ -5,6 +5,28 @@
     var wfsPlugin = mapModule.getLayerPlugins(model.getLayerType());
 %>
 <div class="add-layer-record" <% if (!wfsPlugin.oskariStyleSupport) { %>style="display: none"<% } %>>
+    <% 
+        var renderMode = model.getOptions() && model.getOptions().renderMode;
+        var renderModeLoc = instance.getLocalization('admin').renderMode;
+    %>
+    <div class="add-layer-label-area">
+        <label for="add-layer-jobtype" class="add-layer-label" title="<%= renderModeLoc.title %>"><%= renderModeLoc.title %></label>
+        <div class="layer-render-mode icon-info" title="<%= renderModeLoc.info %>"></div>
+    </div>
+    <div class="add-layer-input-area">
+        <div class="input-controls">
+            <label><%= renderModeLoc.mvt %><input type="radio" name="renderMode" <% if (renderMode === 'mvt' ) { %>checked<% } %>
+                    class="add-class-input layer-options-renderMode" value="mvt" />
+            </label>
+        </div>
+        <div class="input-controls">
+            <label><%= renderModeLoc.vector %><input type="radio" name="renderMode" <% if (renderMode === 'vector' ) { %>checked<% } %>
+                    class="add-class-input layer-options-renderMode" value="vector" />
+            </label>
+        </div>
+    </div>
+</div>
+<div class="add-layer-record" <% if (!wfsPlugin.oskariStyleSupport) { %>style="display: none"<% } %>>
     <%
         var styles = model.getMVTStylesWithoutSrcLayer();
         styles = styles ? JSON.stringify(styles) : '';

--- a/bundles/integration/admin-layerselector/views/adminLayerSettingsView.js
+++ b/bundles/integration/admin-layerselector/views/adminLayerSettingsView.js
@@ -1027,6 +1027,7 @@ function (
                 attributions: parseOptionQuietly('.add-layer-input.layer-options-attributions'),
                 tileGrid: parseOptionQuietly('.add-layer-input.layer-options-tileGrid'),
                 hover: parseOptionQuietly('.add-layer-input.layer-options-hover'),
+                renderMode: parseOptionQuietly('.layer-options-renderMode:checked', true),
                 apiKey: parseOptionQuietly('.add-layer-input.layer-options-apikey', true)
             };
             if (parseErrors.length > 0) {


### PR DESCRIPTION
Admin can select between `mvt` and `vector` render modes.