### PR TITLE
Doubleline removal from visu form

### DIFF
--- a/applications/sample/servlet/icons.css
+++ b/applications/sample/servlet/icons.css
@@ -238,14 +238,6 @@
     background-position: -586px 0px !important;
 }
 
-.icon-double-line {
-    width: 28px;
-    height: 28px;
-    background-image: url('icons.png') !important;
-    background-repeat: no-repeat !important;
-    background-position: -614px 0px !important;
-}
-
 .icon-drag-corner {
     width: 23px;
     height: 23px;

--- a/applications/sample/servlet_published_ol3/icons.css
+++ b/applications/sample/servlet_published_ol3/icons.css
@@ -222,14 +222,6 @@
     background-position: -546px 0px !important;
 }
 
-.icon-double-line {
-    width: 28px;
-    height: 28px;
-    background-image: url('icons.png') !important;
-    background-repeat: no-repeat !important;
-    background-position: -574px 0px !important;
-}
-
 .icon-drag-corner {
     width: 23px;
     height: 23px;

--- a/bundles/framework/divmanazer/component/VisualizationForm.js
+++ b/bundles/framework/divmanazer/component/VisualizationForm.js
@@ -20,8 +20,8 @@ Oskari.clazz.define(
         this._loc = this._getLocalization('DivManazer');
         this.lineCapMap = ['butt', 'round'];
         this.lineCornerMap = ['mitre', 'round', 'bevel'];
-        this.lineStyleMap = ['', '5 2', 'D'];
-        this._oskariLineStyleMap = ['solid', 'dash', 'solid'];
+        this.lineStyleMap = ['', '5 2'];
+        this._oskariLineStyleMap = ['solid', 'dash'];
         this.dialog = null;
 
         var defaultOptions = {

--- a/bundles/framework/divmanazer/component/visualization-form/AreaForm.js
+++ b/bundles/framework/divmanazer/component/visualization-form/AreaForm.js
@@ -28,8 +28,7 @@ Oskari.clazz.define(
 
         this.styleButtonNames = [
             'icon-line-basic',
-            'icon-line-dashed',
-            'icon-double-line'
+            'icon-line-dashed'
         ];
         this.cornerButtonNames = [
             'icon-corner-sharp',

--- a/bundles/framework/divmanazer/component/visualization-form/LineForm.js
+++ b/bundles/framework/divmanazer/component/visualization-form/LineForm.js
@@ -24,7 +24,7 @@ Oskari.clazz.define(
             color: '#' + this.defaultValues.color
         };
 
-        this.styleButtonNames = ['icon-line-basic', 'icon-line-dashed', 'icon-double-line'];
+        this.styleButtonNames = ['icon-line-basic', 'icon-line-dashed'];
         this.capButtonNames = ['icon-line-flat_cap', 'icon-line-round_cap'];
         this.cornerButtonNames = ['icon-corner-sharp', 'icon-corner-round'];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6368,7 +6368,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6389,12 +6390,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6409,17 +6412,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6536,7 +6542,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6548,6 +6555,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6562,6 +6570,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6569,12 +6578,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6593,6 +6604,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6673,7 +6685,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6685,6 +6698,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6770,7 +6784,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6806,6 +6821,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6825,6 +6841,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6868,12 +6885,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/resources/icons.css
+++ b/resources/icons.css
@@ -238,14 +238,6 @@
     background-position: -582px 0px !important;
 }
 
-.icon-double-line {
-    width: 28px;
-    height: 28px;
-    background-image: url('icons.png') !important;
-    background-repeat: no-repeat !important;
-    background-position: -610px 0px !important;
-}
-
 .icon-drag-corner {
     width: 23px;
     height: 23px;


### PR DESCRIPTION
Removed possibility to select double line style for Line and Area in visualization form. Also removed related CSS- class and  backend <---> frontend style mapping for double line as obsolete.