### PR TITLE
Statistics fix classification rendering

### DIFF
--- a/bundles/statistics/statsgrid2016/components/classification/Classification.jsx
+++ b/bundles/statistics/statsgrid2016/components/classification/Classification.jsx
@@ -40,16 +40,21 @@ class Classification extends React.Component {
             <div className={containerClass}>
                 <Header active = {this.props.indicators.active} isEdit = {isEdit}
                     handleClick = {this.handleToggleClassification}
-                    indicators = {this.props.indicators.selected}/>
+                    indicators = {this.props.indicators.selected}
+                    mutator = {this.props.mutator}/>
                 <div className="classification-content-wrapper" style={this.getContentWrapperStyle()}>
                     {isEdit &&
                         <EditClassification classifications = {classifications}
                             indicators = {this.props.indicators}
-                            editEnabled = {pluginState.editEnabled}/>
+                            editEnabled = {pluginState.editEnabled}
+                            mutator = {this.props.mutator}
+                            indicatorData = {this.props.indicatorData}
+                            manualView = {this.props.manualView}/>
                     }
                     <Legend legendProps = {this.props.legendProps}
-                        indicatorData = {this.props.indicators.data}
-                        transparency = {classifications.values.transparency}/>
+                        indicatorData = {this.props.indicatorData}
+                        transparency = {classifications.values.transparency}
+                        mutator = {this.props.mutator}/>
                 </div>
             </div>
         );
@@ -57,13 +62,15 @@ class Classification extends React.Component {
 }
 
 Classification.propTypes = {
-    indicators: PropTypes.object,
-    classifications: PropTypes.object,
-    pluginState: PropTypes.object,
-    legendProps: PropTypes.object,
-    onRenderChange: PropTypes.func,
-    service: PropTypes.object,
-    loc: PropTypes.func
+    indicators: PropTypes.object.isRequired,
+    indicatorData: PropTypes.object.isRequired,
+    classifications: PropTypes.object.isRequired,
+    pluginState: PropTypes.object.isRequired,
+    legendProps: PropTypes.object.isRequired,
+    manualView: PropTypes.object,
+    onRenderChange: PropTypes.func.isRequired,
+    mutator: PropTypes.object.isRequired,
+    loc: PropTypes.func.isRequired
 };
 
 const cls = withContext(Classification);

--- a/bundles/statistics/statsgrid2016/components/classification/Header.jsx
+++ b/bundles/statistics/statsgrid2016/components/classification/Header.jsx
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 import { withContext } from 'oskari-ui/util';
 import './header.scss';
 
-const handleIndicatorChange = (service, value) => {
-    service.getStateService().setActiveIndicator(value);
+const handleIndicatorChange = (mutator, value) => {
+    mutator.setActiveIndicator(value);
 };
 
-const getTitleComponent = (indicators, active, service, title) => {
+const getTitleComponent = (indicators, active, mutator, title) => {
     if (indicators.length > 1) {
         return (
-            <select value={active.hash} onChange={evt => handleIndicatorChange(service, evt.target.value)}>
+            <select value={active.hash} onChange={evt => handleIndicatorChange(mutator, evt.target.value)}>
                 {indicators.map(opt => <option key={opt.id} value={opt.id}>{opt.title}</option>)}
             </select>
         );
@@ -21,7 +21,7 @@ const getTitleComponent = (indicators, active, service, title) => {
 };
 
 const Header = props => {
-    const { indicators, active, service } = props;
+    const { indicators, active, mutator } = props;
     const headerClass = indicators.length > 1 ? 'active-header multi-selected' : 'active-header single-selected';
     const { title } = indicators.find(indicator => active.hash === indicator.id) || { title: '' };
     let buttonClass = 'edit-button';
@@ -33,19 +33,19 @@ const Header = props => {
 
     return (
         <div className={headerClass} data-selected-indicator={title}>
-            {getTitleComponent(indicators, active, service, title)}
+            {getTitleComponent(indicators, active, mutator, title)}
             <div className={buttonClass} title={props.loc(buttonTooltip)} onMouseUp = {props.handleClick}/>
         </div>
     );
 };
 
 Header.propTypes = {
-    indicators: PropTypes.array,
-    active: PropTypes.object,
-    isEdit: PropTypes.bool,
-    handleClick: PropTypes.func,
-    service: PropTypes.object,
-    loc: PropTypes.func
+    indicators: PropTypes.array.isRequired,
+    active: PropTypes.object.isRequired,
+    isEdit: PropTypes.bool.isRequired,
+    handleClick: PropTypes.func.isRequired,
+    mutator: PropTypes.object.isRequired,
+    loc: PropTypes.func.isRequired
 };
 
 const contextWrapped = withContext(Header);

--- a/bundles/statistics/statsgrid2016/components/classification/Legend.jsx
+++ b/bundles/statistics/statsgrid2016/components/classification/Legend.jsx
@@ -4,7 +4,8 @@ import { withContext } from 'oskari-ui/util';
 import './legend.scss';
 
 const createLegendHTML = props => {
-    const { loc, legendProps, indicatorData } = props;
+    const { loc, legendProps } = props;
+    const indicatorData = props.indicatorData.data;
     const classification = legendProps.classification;
     const colors = legendProps.colors;
     const log = Oskari.log('Oskari.statistics.statsgrid.Classification');
@@ -58,10 +59,10 @@ const Legend = props => {
 };
 
 Legend.propTypes = {
-    indicatorData: PropTypes.object,
-    transparency: PropTypes.number,
-    legendProps: PropTypes.object,
-    loc: PropTypes.func
+    indicatorData: PropTypes.object.isRequired,
+    transparency: PropTypes.number.isRequired,
+    legendProps: PropTypes.object.isRequired,
+    loc: PropTypes.func.isRequired
 };
 
 const contextWrapped = withContext(Legend);

--- a/bundles/statistics/statsgrid2016/components/classification/editclassification/Color.jsx
+++ b/bundles/statistics/statsgrid2016/components/classification/editclassification/Color.jsx
@@ -4,14 +4,14 @@ import { withContext } from 'oskari-ui/util';
 import { ColorSelect } from './ColorSelect';
 import './color.scss';
 
-const handleReverseColors = (service, isReverse) => {
-    service.getStateService().updateActiveClassification('reverseColors', isReverse);
+const handleReverseColors = (mutator, isReverse) => {
+    mutator.updateClassification('reverseColors', isReverse);
 };
-const handleColorChange = (service, value) => {
-    service.getStateService().updateActiveClassification('name', value);
+const handleColorChange = (mutator, value) => {
+    mutator.updateClassification('name', value);
 };
 
-const Color = ({ colors, values, loc, service, disabled }) => {
+const Color = ({ colors, values, loc, mutator, disabled }) => {
     let label = loc('colorset.button');
     const isSimple = values.mapStyle !== 'choropleth';
     const opacity = values.transparency / 100 || 1;
@@ -23,12 +23,12 @@ const Color = ({ colors, values, loc, service, disabled }) => {
             <div className="select-label">{label}</div>
             <div className = "classification-colors value">
                 <ColorSelect colors = {colors} isSimple = {isSimple} value = {values.name} opacity = {opacity}
-                    disabled = {disabled} handleColorChange = {value => handleColorChange(service, value)}/>
+                    disabled = {disabled} handleColorChange = {value => handleColorChange(mutator, value)}/>
                 {!isSimple &&
                     <span className="flip-colors">
                         <input id="legend-flip-colors" type="checkbox"
                             checked = {values.reverseColors} disabled = {disabled}
-                            onChange = {evt => handleReverseColors(service, evt.target.checked)}/>
+                            onChange = {evt => handleReverseColors(mutator, evt.target.checked)}/>
                         <label htmlFor="legend-flip-colors">{loc('colorset.flipButton')}</label>
                     </span>
                 }
@@ -37,11 +37,11 @@ const Color = ({ colors, values, loc, service, disabled }) => {
     );
 };
 Color.propTypes = {
-    colors: PropTypes.array,
-    values: PropTypes.object,
-    disabled: PropTypes.bool,
-    service: PropTypes.object,
-    loc: PropTypes.func
+    colors: PropTypes.array.isRequired,
+    values: PropTypes.object.isRequired,
+    disabled: PropTypes.bool.isRequired,
+    mutator: PropTypes.object.isRequired,
+    loc: PropTypes.func.isRequired
 };
 
 const contextWrapped = withContext(Color);

--- a/bundles/statistics/statsgrid2016/components/classification/editclassification/ColorSelect.jsx
+++ b/bundles/statistics/statsgrid2016/components/classification/editclassification/ColorSelect.jsx
@@ -116,17 +116,16 @@ class ColorSelect extends React.Component {
 };
 
 ColorSelect.propTypes = {
-    colors: PropTypes.array,
+    colors: PropTypes.array.isRequired,
     value: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number
-    ]),
-    disabled: PropTypes.bool,
-    isSimple: PropTypes.bool,
-    opacity: PropTypes.number,
-    handleColorChange: PropTypes.func,
-    service: PropTypes.object,
-    loc: PropTypes.func
+    ]).isRequired,
+    disabled: PropTypes.bool.isRequired,
+    isSimple: PropTypes.bool.isRequired,
+    opacity: PropTypes.number.isRequired,
+    handleColorChange: PropTypes.func.isRequired,
+    loc: PropTypes.func.isRequired
 };
 
 const contextWrapped = withContext(ColorSelect);

--- a/bundles/statistics/statsgrid2016/components/classification/editclassification/EditClassification.jsx
+++ b/bundles/statistics/statsgrid2016/components/classification/editclassification/EditClassification.jsx
@@ -68,19 +68,19 @@ const getDisabledOptions = props => {
     return disabled;
 };
 
-const handleSelectChange = (service, properties, value) => {
+const handleSelectChange = (mutator, properties, value) => {
     if (properties.valueType === 'int') {
         value = parseInt(value);
     }
-    service.getStateService().updateActiveClassification(properties.id, value);
+    mutator.updateClassification(properties.id, value);
 };
 
-const handleCheckboxChange = (service, id, isSelected) => {
-    service.getStateService().updateActiveClassification(id, isSelected);
+const handleCheckboxChange = (mutator, id, isSelected) => {
+    mutator.updateClassification(id, isSelected);
 };
 
 const EditClassification = props => {
-    const { indicators, service, loc, editEnabled } = props;
+    const { indicators, mutator, loc, editEnabled, manualView, indicatorData } = props;
     const { methods, values, modes, colors, types, mapStyles } = props.classifications;
     const disabledOptions = getDisabledOptions(props);
     const disabled = !editEnabled;
@@ -88,8 +88,8 @@ const EditClassification = props => {
     return (
         <div className="classification-edit">
             <div className="classification-options">
-                <Select key="mapStyle" value = {values.mapStyle} disabled = {disabled}
-                    handleChange = {(properties, value) => handleSelectChange(service, properties, value)}
+                <Select value = {values.mapStyle} disabled = {disabled}
+                    handleChange = {(properties, value) => handleSelectChange(mutator, properties, value)}
                     options = {getLocalizedOptions(mapStyles, loc('classify.map'))}
                     properties = {{
                         id: 'mapStyle',
@@ -97,8 +97,8 @@ const EditClassification = props => {
                         label: loc('classify.map.mapStyle')
                     }}/>
 
-                <Select key="method" value = {values.method} disabled = {disabled}
-                    handleChange = {(properties, value) => handleSelectChange(service, properties, value)}
+                <Select value = {values.method} disabled = {disabled}
+                    handleChange = {(properties, value) => handleSelectChange(mutator, properties, value)}
                     options = {getLocalizedOptions(methods, loc('classify.methods'))}
                     properties = {{
                         id: 'method',
@@ -107,11 +107,12 @@ const EditClassification = props => {
                     }}/>
 
                 {values.method === 'manual' &&
-                    <ManualClassification key="modifyClassification" disabled = {disabled} indicators={indicators}/>
+                    <ManualClassification disabled = {disabled} manualView = {manualView}
+                        indicators={indicators} indicatorData = {indicatorData} mutator= {mutator}/>
                 }
 
-                <Select key="count" value = {values.count} disabled = {disabled}
-                    handleChange = {(properties, value) => handleSelectChange(service, properties, value)}
+                <Select value = {values.count} disabled = {disabled}
+                    handleChange = {(properties, value) => handleSelectChange(mutator, properties, value)}
                     options = {getValidCountRange(props.classifications)}
                     properties = {{
                         id: 'count',
@@ -120,8 +121,8 @@ const EditClassification = props => {
                         valueType: 'int'
                     }}/>
 
-                <Select key="mode" value = {values.mode} disabled = {disabled}
-                    handleChange = {(properties, value) => handleSelectChange(service, properties, value)}
+                <Select value = {values.mode} disabled = {disabled}
+                    handleChange = {(properties, value) => handleSelectChange(mutator, properties, value)}
                     options = {getLocalizedOptions(modes, loc('classify.modes'), disabledOptions.mode)}
                     properties = {{
                         id: 'mode',
@@ -130,21 +131,21 @@ const EditClassification = props => {
                     }}/>
 
                 {values.mapStyle !== 'choropleth' &&
-                    <Slider key="point-size" values = {values} disabled = {disabled}/>
+                    <Slider key="point-size" values = {values} disabled = {disabled} mutator = {mutator}/>
                 }
 
                 <Checkbox key="showValues" value = {values.showValues} disabled = {disabled}
-                    handleChange = {(id, isSelected) => handleCheckboxChange(service, id, isSelected)}
+                    handleChange = {(id, isSelected) => handleCheckboxChange(mutator, id, isSelected)}
                     properties = {{
                         id: 'showValues',
                         class: 'show-values',
                         label: loc('classify.map.showValues')
                     }}/>
 
-                <Color key="name" values = {values} disabled = {disabled} colors = {colors}/>
+                <Color values = {values} disabled = {disabled} colors = {colors} mutator = {mutator}/>
 
                 <Select key="transparency" value = {values.transparency} disabled = {disabled}
-                    handleChange = {(properties, value) => handleSelectChange(service, properties, value)}
+                    handleChange = {(properties, value) => handleSelectChange(mutator, properties, value)}
                     options = {getTransparencyOptions(values.transparency)}
                     properties = {{
                         id: 'transparency',
@@ -155,7 +156,7 @@ const EditClassification = props => {
 
                 {values.mapStyle !== 'points' &&
                     <Select key="type" value = {values.type} disabled = {disabled}
-                        handleChange = {(properties, value) => handleSelectChange(service, properties, value)}
+                        handleChange = {(properties, value) => handleSelectChange(mutator, properties, value)}
                         options = {getLocalizedOptions(types, loc('colorset'))}
                         properties = {{
                             id: 'type',
@@ -165,7 +166,7 @@ const EditClassification = props => {
                 }
 
                 <Select key="fractionDigits" value = {values.fractionDigits} disabled = {disabled}
-                    handleChange = {(properties, value) => handleSelectChange(service, properties, value)}
+                    handleChange = {(properties, value) => handleSelectChange(mutator, properties, value)}
                     options = {[0, 1, 2, 3, 4, 5]}
                     properties = {{
                         id: 'fractionDigits',
@@ -178,11 +179,13 @@ const EditClassification = props => {
     );
 };
 EditClassification.propTypes = {
-    indicators: PropTypes.object,
-    editEnabled: PropTypes.bool,
-    classifications: PropTypes.object,
-    service: PropTypes.object,
-    loc: PropTypes.func
+    indicators: PropTypes.object.isRequired,
+    indicatorData: PropTypes.object.isRequired,
+    editEnabled: PropTypes.bool.isRequired,
+    classifications: PropTypes.object.isRequired,
+    mutator: PropTypes.object.isRequired,
+    manualView: PropTypes.object,
+    loc: PropTypes.func.isRequired
 };
 
 const contextWrapped = withContext(EditClassification);

--- a/bundles/statistics/statsgrid2016/components/classification/editclassification/Select.jsx
+++ b/bundles/statistics/statsgrid2016/components/classification/editclassification/Select.jsx
@@ -23,11 +23,11 @@ const Select = ({ properties, options, value, disabled, handleChange }) => {
     );
 };
 Select.propTypes = {
-    properties: PropTypes.object,
-    options: PropTypes.array,
-    disabled: PropTypes.bool,
-    value: PropTypes.any,
-    handleChange: PropTypes.func
+    properties: PropTypes.object.isRequired,
+    options: PropTypes.array.isRequired,
+    disabled: PropTypes.bool.isRequired,
+    value: PropTypes.any.isRequired,
+    handleChange: PropTypes.func.isRequired
 };
 
 const contextWrapped = withContext(Select);

--- a/bundles/statistics/statsgrid2016/components/classification/editclassification/Slider.jsx
+++ b/bundles/statistics/statsgrid2016/components/classification/editclassification/Slider.jsx
@@ -35,7 +35,7 @@ class Slider extends React.Component {
                     min: ui.values[0],
                     max: ui.values[1]
                 };
-                this.props.service.getStateService().updateActiveClassificationObj(value);
+                this.props.mutator.updateClassificationObj(value);
             }
         });
     }
@@ -69,10 +69,10 @@ class Slider extends React.Component {
     }
 };
 Slider.propTypes = {
-    values: PropTypes.object,
-    disabled: PropTypes.bool,
-    service: PropTypes.object,
-    loc: PropTypes.func
+    values: PropTypes.object.isRequired,
+    disabled: PropTypes.bool.isRequired,
+    mutator: PropTypes.object.isRequired,
+    loc: PropTypes.func.isRequired
 };
 const cls = withContext(Slider);
 export { cls as Slider };

--- a/bundles/statistics/statsgrid2016/components/manualClassification/ManualClassification.jsx
+++ b/bundles/statistics/statsgrid2016/components/manualClassification/ManualClassification.jsx
@@ -1,28 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withContext } from 'oskari-ui/util';
-import { ManualClassificationView } from './View';
-
 // TODO: change to use general oskari react button and pass props.handleClick = handleManualClassification
 
-const update = (stateService, bounds) => {
-    stateService.updateActiveClassification('manualBounds', bounds);
-};
-
-const handleManualClassification = ({ service, indicators }) => {
-    const { series, state, classification, color } = service.getAllServices();
-    const ind = indicators.active;
-    const view = new ManualClassificationView(classification, color, ind.classification);
-
-    if (ind.series && indicators.serieStats && indicators.serieStats.serie) {
+const handleManualClassification = ({ indicators, mutator, manualView, indicatorData }) => {
+    const view = manualView.view;
+    if (indicators.active.series && indicators.serieStats && indicators.serieStats.serie) {
         view.setData(indicators.serieStats.serie);
-    } else if (indicators.data) {
-        view.setData(indicators.data);
+    } else if (indicatorData.data) {
+        view.setData(indicatorData.data);
     } else {
-        return; // failed to get serie or data -> don't open
+        // failed to get serie or data -> don't open
     }
-    series.setAnimating(false);
-    view.openEditor(bounds => update(state, bounds));
+    manualView.setAnimating(false);
+    view.openEditor(bounds => mutator.updateClassification('manualBounds', bounds));
 };
 
 const ManualClassification = props => {
@@ -38,10 +29,12 @@ const ManualClassification = props => {
 };
 
 ManualClassification.propTypes = {
-    disabled: PropTypes.bool,
-    service: PropTypes.object,
-    indicators: PropTypes.object,
-    loc: PropTypes.func
+    disabled: PropTypes.bool.isRequired,
+    mutator: PropTypes.object.isRequired,
+    indicators: PropTypes.object.isRequired,
+    manualView: PropTypes.object.isRequired,
+    indicatorData: PropTypes.object.isRequired,
+    loc: PropTypes.func.isRequired
 };
 const contextWrapped = withContext(ManualClassification);
 export { contextWrapped as ManualClassification };

--- a/bundles/statistics/statsgrid2016/service/StateService.js
+++ b/bundles/statistics/statsgrid2016/service/StateService.js
@@ -87,6 +87,40 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
             this.classificationPluginState[key] = value;
             this.trigger('ClassificationPluginChanged', { key: key, value: value });
         },
+        updateClassificationTransparency: function (transparency) {
+            const indicator = this.getActiveIndicator();
+            if (indicator) {
+                indicator.classification.transparency = transparency;
+            }
+        },
+
+        getClassificationMutator: function () {
+            return {
+                setActiveIndicator: hash => this.setActiveIndicator(hash),
+                updateClassification: (key, value) => {
+                    const indicator = this.getActiveIndicator();
+                    if (indicator) {
+                        indicator.classification[key] = value;
+                        var eventBuilder = Oskari.eventBuilder('StatsGrid.ClassificationChangedEvent');
+                        if (eventBuilder) {
+                            this.sandbox.notifyAll(eventBuilder(indicator.classification));
+                        }
+                    }
+                },
+                updateClassificationObj: obj => {
+                    const indicator = this.getActiveIndicator();
+                    if (indicator) {
+                        Object.keys(obj).forEach(key => {
+                            indicator.classification[key] = obj[key];
+                        });
+                        const eventBuilder = Oskari.eventBuilder('StatsGrid.ClassificationChangedEvent');
+                        if (eventBuilder) {
+                            this.sandbox.notifyAll(eventBuilder(indicator.classification));
+                        }
+                    }
+                }
+            };
+        },
         /**
          * Resets the current state and sends events about the changes.
          * Removes all selected indicators, selected region and regionset is set to undefined
@@ -158,34 +192,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
          */
         getRegion: function () {
             return this.activeRegion;
-        },
-        updateActiveClassification: function (key, value) {
-            const indicator = this.getActiveIndicator();
-            if (indicator) {
-                indicator.classification[key] = value;
-                var eventBuilder = Oskari.eventBuilder('StatsGrid.ClassificationChangedEvent');
-                if (eventBuilder) {
-                    this.sandbox.notifyAll(eventBuilder(indicator.classification));
-                }
-            }
-        },
-        updateActiveClassificationObj: function (valueObj) {
-            const indicator = this.getActiveIndicator();
-            if (indicator) {
-                Object.keys(valueObj).forEach(key => {
-                    indicator.classification[key] = valueObj[key];
-                });
-                const eventBuilder = Oskari.eventBuilder('StatsGrid.ClassificationChangedEvent');
-                if (eventBuilder) {
-                    this.sandbox.notifyAll(eventBuilder(indicator.classification));
-                }
-            }
-        },
-        updateClassificationTransparency: function (transparency) {
-            const indicator = this.getActiveIndicator();
-            if (indicator) {
-                indicator.classification.transparency = transparency;
-            }
         },
 
         /**

--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -84,11 +84,11 @@
         },
         getAllServices: function () {
             return {
-                series: this.series,
-                state: this.state,
-                classification: this.classification,
-                color: this.colors,
-                error: this.error
+                seriesService: this.series,
+                stateService: this.state,
+                classificationService: this.classification,
+                colorService: this.colors,
+                errorService: this.error
             };
         },
         addDatasource: function (ds) {


### PR DESCRIPTION
Indicator data wasn't always received from backend when components were rendered. Added status for indicatorData. Plugin doesn't render components if data is pending.

Removed service from general context and added mutator to props. Also had to add manualView to props because service isn't passed to manualClassification component.

Now classification plugin gathers props and keeps indicatorData status. This is not good solution, but other plugins depends also on same services and events. Should be refactored when other statistics functionalities are implemented with React.