### PR TITLE
Handle complex properties and hide non-user data

### DIFF
--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/util/props.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/util/props.js
@@ -1,16 +1,32 @@
 export const WFS_ID_KEY = '_oid';
 export const WFS_FTR_ID_KEY = '__fid';
 
-const hiddenProps = new Set(['layer', 'geometry', WFS_ID_KEY]);
+const hiddenProps = new Set(['layer', 'geometry', 'bbox', WFS_ID_KEY]);
 
+function destructComplex (value) {
+    if (typeof value === 'undefined') {
+        return '';
+    }
+    return `${value}`;
+}
+
+function removeComplexPrefix (field) {
+    return field.startsWith('$') ? field.substring(1) : field;
+}
 function sortedFieldsFromProps (properties) {
-    const fields = Object.keys(properties).filter(key => !hiddenProps.has(key));
-    fields.sort();
+    const fields = Object.keys(properties).filter(key => !hiddenProps.has(removeComplexPrefix(key)));
+    fields.sort((a, b) => removeComplexPrefix(a).localeCompare(removeComplexPrefix(b)));
     return fields;
 }
 
 function propsArrayFrom (properties, fields) {
-    return [properties._oid].concat(fields.map(key => properties[key]));
+    return [properties._oid].concat(fields.map(key => {
+        const value = properties[key];
+        if (key.startsWith('$')) {
+            return destructComplex(value);
+        }
+        return value;
+    }));
 }
 
 export function propsAsArray (properties) {
@@ -23,10 +39,10 @@ export function getFieldsAndPropsArrays (propsList) {
         return { fields: [], properties: [] };
     }
 
-    const fields = sortedFieldsFromProps(propsList[0]);
-
+    let fields = sortedFieldsFromProps(propsList[0]);
     const properties = propsList.map(properties => propsArrayFrom(properties, fields));
 
+    fields = fields.map(removeComplexPrefix);
     fields.unshift('__fid');
 
     return { fields, properties };


### PR DESCRIPTION
Initial handling for complex properties. Complex property fields start with `$`.
Show the data as a string for now. Remove the $-sign from the field name.

Hides `bbox`-field.