### PR TITLE
Patch jQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "antd": "3.15.2",
-    "jquery": "3.4.0",
+    "jquery": "3.4.1",
     "jsts": "2.0.3",
     "lodash": "4.17.11",
     "ol": "5.3.1",


### PR DESCRIPTION
Fixes an issue with "save view" functionality where focusing the name field the second time resulted in `shift is not a function` error in dev console. 

https://blog.jquery.com/2019/05/01/jquery-3-4-1-triggering-focus-events-in-ie-and-finding-root-elements-in-ios-10/ -> These changes caused a regression that sometimes resulted in an enigmatic error being thrown in the form of "saved.shift is not a function". This is now fixed.
