### PR TITLE
Fix unresponsive features

### DIFF
--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/MvtLayerHandler/FeatureExposingMVTSource.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/MvtLayerHandler/FeatureExposingMVTSource.js
@@ -98,7 +98,7 @@ export class FeatureExposingMVTSource extends olSourceVectorTile {
                         return false;
                     }
                     const ftrExtent = feature instanceof olRenderFeature
-                        ? feature.getExtent() : feature.getGeometry().getExtent();
+                        ? this._getFixedFeatureExtent(tile, feature) : feature.getGeometry().getExtent();
                     return intersects(ftrExtent, extent);
                 });
                 if (!matching.length) {
@@ -106,5 +106,12 @@ export class FeatureExposingMVTSource extends olSourceVectorTile {
                 }
                 continuation(matching, tile);
             });
+    }
+
+    _getFixedFeatureExtent (tile, renderFeature) {
+        if (renderFeature.getExtent()[3] < tile.getExtent()[3]) {
+            renderFeature.extent_ = null;
+        }
+        return renderFeature.getExtent();
     }
 }

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/MvtLayerHandler/FeatureExposingMVTSource.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/MvtLayerHandler/FeatureExposingMVTSource.js
@@ -98,7 +98,7 @@ export class FeatureExposingMVTSource extends olSourceVectorTile {
                         return false;
                     }
                     const ftrExtent = feature instanceof olRenderFeature
-                        ? this._getFixedFeatureExtent(tile, feature) : feature.getGeometry().getExtent();
+                        ? this._getRenderFeatureExtent(feature, tile) : feature.getGeometry().getExtent();
                     return intersects(ftrExtent, extent);
                 });
                 if (!matching.length) {
@@ -108,8 +108,16 @@ export class FeatureExposingMVTSource extends olSourceVectorTile {
             });
     }
 
-    _getFixedFeatureExtent (tile, renderFeature) {
-        if (renderFeature.getExtent()[3] < tile.getExtent()[3]) {
+    /**
+     * @method _getRenderFeatureExtent
+     * RenderFeature's extent might be in tile coordinates instead of projected map coordinates.
+     * This helper method recalculates the feature's extent when it doesn't intersect with it's tile extent.
+     *
+     * @param {olRenderFeature} renderFeature
+     * @param {ol/VectorTile} tile
+     */
+    _getRenderFeatureExtent (renderFeature, tile) {
+        if (intersects(renderFeature.getExtent(), tile.getExtent())) {
             renderFeature.extent_ = null;
         }
         return renderFeature.getExtent();


### PR DESCRIPTION
Extent of the feature is calculated once extent is requested for the first time.
If extent was requested before transforming the feature to projected srs coordinates, extent would have the internal tile coordinates.
 
This forces update on `RenderFeature` extents when internal tile coordinates is used.