### PR TITLE
Statistics minor bug fixes

### DIFF
--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -90,8 +90,8 @@ Oskari.clazz.define(
          * @method  @private _createConfiguredLayers Create configured layers an their styles
          */
         _createConfiguredLayers: function () {
-            var me = this,
-                conf = me.getConfig();
+            var me = this;
+            var conf = me.getConfig();
             if (conf.layers) {
                 for (var i = 0; i < conf.layers.length; i++) {
                     var layer = conf.layers[i];
@@ -152,8 +152,8 @@ Oskari.clazz.define(
          * @param {Oskari.mapframework.event.common.AfterChangeMapLayerOpacityEvent} event
          */
         _afterChangeMapLayerOpacityEvent: function (event) {
-            var me = this,
-                layer = event.getMapLayer();
+            var me = this;
+            var layer = event.getMapLayer();
 
             if (!layer.isLayerOfType('VECTOR')) {
                 return;
@@ -303,13 +303,13 @@ Oskari.clazz.define(
          * Removes all/selected features from map.
          *
          * @param {String} identifier the feature attribute identifier
-         * @param {String} value the feature identifier value
+         * @param {String/Array} value the feature identifier value or values in array
          * @param {ol/layer/Vector} layer object OR {String} layerId
          */
         removeFeaturesFromMap: function (identifier, value, layer) {
-            var me = this,
-                olLayer,
-                layerId;
+            var me = this;
+            var olLayer;
+            var layerId;
             if (layer && layer !== null) {
                 if (layer instanceof olLayerVector) {
                     layerId = layer.get(LAYER_ID);
@@ -329,8 +329,7 @@ Oskari.clazz.define(
                 }
                 // remove all features from the given layer
                 else {
-                    this._removeFeaturesByAttribute(olLayer);
-                    delete this._features[layerId];
+                    this._removeAllFeatures(olLayer);
                 }
             }
             // Removes all features from all layers if layer is not specified
@@ -338,58 +337,78 @@ Oskari.clazz.define(
                 for (layerId in me._olLayers) {
                     if (me._olLayers.hasOwnProperty(layerId)) {
                         olLayer = me._olLayers[layerId];
-                        this._removeFeaturesByAttribute(olLayer);
-                        delete this._features[layerId];
+                        this._removeAllFeatures(olLayer);
                     }
                 }
             }
         },
-        _removeFeaturesByAttribute: function (olLayer, identifier, value) {
-            var me = this,
-                source = olLayer.getSource(),
-                featuresToRemove = [];
-
-            // add all features if identifier and value are missing or
-            // if given -> features that have
-            source.forEachFeature(function (feature) {
-                if ((!identifier && !value) ||
-                    feature.get(identifier) === value) {
-                    featuresToRemove.push(feature);
-                }
+        _removeAllFeatures: function (olLayer) {
+            const source = olLayer.getSource();
+            const formatter = this._supportedFormats.GeoJSON;
+            const removeEvent = Oskari.eventBuilder('FeatureEvent')().setOpRemove();
+            const layerId = olLayer.get(LAYER_ID);
+            source.forEachFeature(f => {
+                const geojson = formatter.writeFeaturesObject([f]);
+                removeEvent.addFeature(f.getId(), geojson, layerId);
             });
+            source.clear();
+            // remove from "cache"
+            delete this._features[layerId];
+            delete this._styleCache[layerId];
+            if (removeEvent.hasFeatures()) {
+                this.getSandbox().notifyAll(removeEvent);
+            }
+        },
+        _removeFeaturesByAttribute: function (olLayer, identifier, value) {
+            const source = olLayer.getSource();
+            const featuresToRemove = [];
+            const formatter = this._supportedFormats.GeoJSON;
+            const removeEvent = Oskari.eventBuilder('FeatureEvent')().setOpRemove();
+            const layerId = olLayer.get(LAYER_ID);
 
+            if (Array.isArray(value)) {
+                source.forEachFeature(f => {
+                    if (value.includes(f.get(identifier))) {
+                        featuresToRemove.push(f);
+                    }
+                });
+            } else {
+                source.forEachFeature(f => {
+                    if (f.get(identifier) === value) {
+                        featuresToRemove.push(f);
+                    }
+                });
+            }
             // If there is no features to remove then return
             if (featuresToRemove.length === 0) {
                 return;
             }
-
             // notify other components of removal
-            var formatter = this._supportedFormats.GeoJSON;
-            var sandbox = this.getSandbox();
-            var removeEvent = Oskari.eventBuilder('FeatureEvent')().setOpRemove();
-
-            featuresToRemove.forEach(function (feature) {
-                source.removeFeature(feature);
+            featuresToRemove.forEach(f => {
+                source.removeFeature(f);
+                // add to event
+                const geojson = formatter.writeFeaturesObject([f]);
+                removeEvent.addFeature(f.getId(), geojson, layerId);
                 // remove from "cache"
-                me._removeFromCache(olLayer.get(LAYER_ID), feature);
-
-                var geojson = formatter.writeFeaturesObject([feature]);
-                removeEvent.addFeature(feature.getId(), geojson, olLayer.get(LAYER_ID));
+                this._removeFromCache(layerId, f);
             });
-            sandbox.notifyAll(removeEvent);
+            this.getSandbox().notifyAll(removeEvent);
         },
+
         _removeFromCache: function (layerId, feature) {
             var storedFeatures = this._features[layerId];
-            for (var i = 0; i < storedFeatures.length; i++) {
-                var featuresInDataset = storedFeatures[i].data;
-                for (var j = 0; j < featuresInDataset.length; j++) {
-                    if (feature === featuresInDataset[j]) {
-                        featuresInDataset.splice(j, 1);
+            if (storedFeatures) {
+                for (var i = 0; i < storedFeatures.length; i++) {
+                    var featuresInDataset = storedFeatures[i].data;
+                    for (var j = 0; j < featuresInDataset.length; j++) {
+                        if (feature === featuresInDataset[j]) {
+                            featuresInDataset.splice(j, 1);
+                        }
                     }
-                }
-                if (!featuresInDataset.length) {
-                    // remove block if empty
-                    storedFeatures.splice(i, 1);
+                    if (!featuresInDataset.length) {
+                        // remove block if empty
+                        storedFeatures.splice(i, 1);
+                    }
                 }
             }
             if (this._styleCache[layerId]) {
@@ -844,8 +863,8 @@ Oskari.clazz.define(
          * Create request handlers.
          */
         _createRequestHandlers: function () {
-            var me = this,
-                sandbox = me.getSandbox();
+            var me = this;
+            var sandbox = me.getSandbox();
             return {
                 'MapModulePlugin.AddFeaturesToMapRequest': Oskari.clazz.create(
                     'Oskari.mapframework.bundle.mapmodule.request.AddFeaturesToMapRequestHandler',
@@ -924,8 +943,8 @@ Oskari.clazz.define(
          *
          */
         rearrangeFeatures: function () {
-            var me = this,
-                layers = me.layers;
+            var me = this;
+            var layers = me.layers;
             for (var key in layers) {
                 if (layers[key].features.length > 0) {
                     var layer = layers[key];
@@ -1100,9 +1119,9 @@ Oskari.clazz.define(
          * @param {Object} options
          */
         zoomToFeatures: function (layer, options) {
-            var me = this,
-                layers = me.getLayerIds(layer),
-                features = me.getFeaturesMatchingQuery(layers, options);
+            var me = this;
+            var layers = me.getLayerIds(layer);
+            var features = me.getFeaturesMatchingQuery(layers, options);
             if (!_.isEmpty(features)) {
                 var vector = new olSourceVector({
                     features: features
@@ -1122,10 +1141,10 @@ Oskari.clazz.define(
          */
         getBufferedExtent: function (extent, percentage) {
             var line = new olGeom.LineString([
-                    [extent[0], extent[1]],
-                    [extent[2], extent[3]]
-                ]),
-                buffer = line.getLength() * percentage / 100;
+                [extent[0], extent[1]],
+                [extent[2], extent[3]]
+            ]);
+            var buffer = line.getLength() * percentage / 100;
             if (buffer === 0) {
                 return extent;
             }
@@ -1142,8 +1161,8 @@ Oskari.clazz.define(
          * @param {Array} features
          */
         sendZoomFeatureEvent: function (features) {
-            var me = this,
-                featureEvent = Oskari.eventBuilder('FeatureEvent')().setOpZoom();
+            var me = this;
+            var featureEvent = Oskari.eventBuilder('FeatureEvent')().setOpZoom();
             if (!_.isEmpty(features)) {
                 var formatter = me._supportedFormats.GeoJSON;
                 _.each(features, function (feature) {
@@ -1159,8 +1178,8 @@ Oskari.clazz.define(
          * @param {Array} features
          */
         sendErrorFeatureEvent: function (msg) {
-            var me = this,
-                featureEvent = Oskari.eventBuilder('FeatureEvent')().setOpError(msg);
+            var me = this;
+            var featureEvent = Oskari.eventBuilder('FeatureEvent')().setOpError(msg);
             me._sandbox.notifyAll(featureEvent);
         },
         /**
@@ -1170,8 +1189,8 @@ Oskari.clazz.define(
          * @param {Object} featureQuery and object like { "id" : [123, "myvalue"] }
          */
         getFeaturesMatchingQuery: function (layers, featureQuery) {
-            var me = this,
-                features = [];
+            var me = this;
+            var features = [];
             _.each(layers, function (layerId) {
                 if (!me._olLayers[layerId]) {
                     // invalid layerId
@@ -1208,8 +1227,8 @@ Oskari.clazz.define(
          * @return {Array} layres
          */
         getLayerIds: function (layerIds) {
-            var me = this,
-                layers = [];
+            var me = this;
+            var layers = [];
             if (_.isEmpty(layerIds)) {
                 _.each(me._olLayers, function (key, value) {
                     layers.push(value);

--- a/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
+++ b/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
@@ -178,12 +178,20 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
 
         // Remove regions missing value
         if (handledRegions.length !== regions.length) {
-            const regionsWithoutValue = regions.filter(r => !handledRegions.includes(r.id)).map(r => r.id);
+            const regionsWithoutValue = [];
+            me._regionsAdded = [];
+            regions.forEach(r => {
+                const id = r.id;
+                if (handledRegions.includes(id)) {
+                    me._regionsAdded.push(id);
+                } else {
+                    regionsWithoutValue.push(id);
+                }
+            });
             const borders = regionsWithoutValue.map(id => 'border' + id);
             const removes = regionsWithoutValue.concat(borders);
-            if (regionsWithoutValue.length > 0) {
-                sandbox.postRequestByName('MapModulePlugin.RemoveFeaturesFromMapRequest', ['id', removes, me.LAYER_ID]);
-            }
+
+            sandbox.postRequestByName('MapModulePlugin.RemoveFeaturesFromMapRequest', ['id', removes, me.LAYER_ID]);
         }
         addFeaturesRequestParams.forEach(params => {
             sandbox.postRequestByName('MapModulePlugin.AddFeaturesToMapRequest', params);

--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -498,9 +498,6 @@
             if (!ind) {
                 return;
             }
-            if (!ind.classification) {
-                ind.classification = this.state.getClassificationOpts(indicatorHash);
-            }
             if (typeof ind.classification.fractionDigits !== 'number') {
                 var allInts = Object.keys(data).every(function (key) {
                     return data[key] % 1 === 0;

--- a/bundles/statistics/statsgrid2016/view/SearchFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/SearchFlyout.js
@@ -255,8 +255,12 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
         if (!selections) {
             return indSearchValues;
         }
+
         Object.keys(selections).forEach(selectionKey => {
             const selector = metadata.selectors.find(selector => selector.id === selectionKey);
+            const checkNotAllowed = value =>
+                !selector.allowedValues.includes(value) && !selector.allowedValues.find(obj => obj.id === value);
+
             if (!selector) {
                 // Remove unsupported selectors silently
                 delete selections[selectionKey];
@@ -267,15 +271,14 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
 
             if (!Array.isArray(value)) {
                 // Single option
-                if (!selector.allowedValues.includes(value)) {
+                if (checkNotAllowed(value)) {
                     indSearchValues.error = { notAllowed: selectionKey };
                 }
                 return;
             }
             // Multiselect or series
             // Filter out unsupported search param values
-            const notAllowed = value.filter(cur =>
-                !selector.allowedValues.includes(cur) && !selector.allowedValues.find(obj => obj.id === cur));
+            const notAllowed = value.filter(checkNotAllowed);
 
             // Set multiselect status for search
             indSearchValues.multiselectStatus = { selector: selectionKey, invalid: notAllowed, requested: [...value] };


### PR DESCRIPTION
Fix guest user's own indicator search. Use checkNotAllowed to check also object values.

If changed indicator doesn't have values for every existing regions, then old values are shown for these regions. RemoveFeaturesFromMapRequest contains array of values. Added array check and update addedRegions. Also refactored by adding _removeAllFeatures which decreases looping. VectorLayerPlugin contains also lintfixes (autofix on save was enabled) sorry for that.

Indicator with series doesn't have all classification values which breaks some functionality. init indicator's classification when it's added instead of in _setInitialFractions. Don't add fractionDigits and manualBounds from latestClassification.

