### PR TITLE
Set user layers ignored in gfi when using wfs vector plugin

### DIFF
--- a/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
@@ -52,6 +52,20 @@ Oskari.clazz.define(
          */
         _initImpl: function () {
             Oskari.log('GetInfoPlugin').debug('init');
+            const wfsPlugin = this.getMapModule().getLayerPlugins('wfs');
+            if (wfsPlugin && !!wfsPlugin.isRenderModeSupported) {
+                // Using wfs vector plugin
+                this._ignoreUserLayers();
+            }
+        },
+
+        _ignoreUserLayers: function () {
+            this.config = this.config || {};
+            const ignoredLayerTypes = new Set(this.config.ignoredLayerTypes || []);
+            ignoredLayerTypes.add('WFS');
+            ignoredLayerTypes.add('MYPLACES');
+            ignoredLayerTypes.add('USERLAYER');
+            this.config.ignoredLayerTypes = Array.from(ignoredLayerTypes);
         },
 
         _destroyControlElement: function () {
@@ -206,9 +220,11 @@ Oskari.clazz.define(
          * @return {Boolean} true if layer's type is ignored
          */
         _isIgnoredLayerType: function (layer) {
-            return _.any((this._config || {}).ignoredLayerTypes, function (type) {
-                return layer.isLayerOfType(type);
-            });
+            const ignored = (this._config || {}).ignoredLayerTypes;
+            if (!Array.isArray(ignored)) {
+                return false;
+            }
+            return ignored.some(type => layer.isLayerOfType(type));
         },
 
         /**


### PR DESCRIPTION
Fixes viewing duplicate GFI data when using the new WFS vector layer plugin.