### PR TITLE
Feature loading indicator fix

### DIFF
--- a/bundles/framework/featuredata2/instance.js
+++ b/bundles/framework/featuredata2/instance.js
@@ -246,6 +246,20 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
             me.sandbox.notifyAll(event);
         },
 
+        __refreshLoadingStatus: function () {
+            const status = {
+                loading: [],
+                error: []
+            };
+            Object.entries(this.__loadingStatus).forEach(([key, value]) => status[value].push(key));
+            if (status.loading.length === 0) {
+                // no layers in loading state
+                this.plugin.showLoadingIndicator(false);
+            }
+            // setup error indicator based on error statuses
+            this.plugin.showErrorIndicator(status.error.length > 0);
+        },
+
         /**
          * @property {Object} eventHandlers
          * @static
@@ -284,19 +298,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
                     this.plugins['Oskari.userinterface.Flyout'].showLoadingIndicator(event.getLayerId(), false);
                     this.plugins['Oskari.userinterface.Flyout'].showErrorIndicator(event.getLayerId(), true);
                 }
-                var status = {
-                    loading: [],
-                    error: []
-                };
-                _.each(this.__loadingStatus, function (value, key) {
-                    status[value].push(key);
-                });
-                if (status.loading.length === 0) {
-                    // no layers in loading state
-                    this.plugin.showLoadingIndicator(false);
-                }
-                // setup error indicator based on error statuses
-                this.plugin.showErrorIndicator(status.error.length > 0);
+                this.__refreshLoadingStatus();
             },
             'MapLayerEvent': function (event) {
                 if (event.getOperation() !== 'add') {
@@ -321,6 +323,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
                 if (event.getMapLayer().hasFeatureData()) {
                     this.plugin.refresh();
                     this.plugins['Oskari.userinterface.Flyout'].layerRemoved(event.getMapLayer());
+                    delete this.__loadingStatus['' + event.getMapLayer().getId()];
+                    this.__refreshLoadingStatus();
                 }
             },
 

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/AbstractLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/AbstractLayerHandler.ol.js
@@ -1,5 +1,10 @@
 import { getFieldsAndPropsArrays } from '../util/props';
 const FEATURE_DATA_UPDATE_THROTTLE = 1000;
+const LOADING_STATUS_VALUE = {
+    COMPLETE: 'complete',
+    LOADING: 'loading',
+    ERROR: 'error'
+};
 
 export class AbstractLayerHandler {
     constructor (layerPlugin) {
@@ -80,7 +85,7 @@ export class AbstractLayerHandler {
             this.plugin.setLayerLocales(layer);
         }
         if (layer.getActiveFeatures() && layer.getActiveFeatures().length) {
-            this.sendWFSStatusChangedEvent(layer.getId(), 'complete');
+            this.sendWFSStatusChangedEvent(layer.getId(), LOADING_STATUS_VALUE.COMPLETE);
         }
 
         this.plugin.notify('WFSPropertiesEvent', layer, layer.getLocales(), fields);
@@ -139,13 +144,13 @@ export class AbstractLayerHandler {
 
     _setStatusToLoadEvent (loadEvent, status) {
         switch (status) {
-        case 'loading':
+        case LOADING_STATUS_VALUE.LOADING:
             loadEvent.setStatus(loadEvent.status.loading);
             break;
-        case 'complete':
+        case LOADING_STATUS_VALUE.COMPLETE:
             loadEvent.setStatus(loadEvent.status.complete);
             break;
-        case 'error':
+        case LOADING_STATUS_VALUE.ERROR:
             loadEvent.setStatus(loadEvent.status.error);
             break;
         default:

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/AbstractLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/AbstractLayerHandler.ol.js
@@ -84,7 +84,7 @@ export class AbstractLayerHandler {
             layer.setFields(fields);
             this.plugin.setLayerLocales(layer);
         }
-        if (layer.getActiveFeatures() && layer.getActiveFeatures().length) {
+        if (layer.getActiveFeatures() && layer.getActiveFeatures().length > 0) {
             this.sendWFSStatusChangedEvent(layer.getId(), LOADING_STATUS_VALUE.COMPLETE);
         }
 

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/AbstractLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/AbstractLayerHandler.ol.js
@@ -79,6 +79,10 @@ export class AbstractLayerHandler {
             layer.setFields(fields);
             this.plugin.setLayerLocales(layer);
         }
+        if (layer.getActiveFeatures() && layer.getActiveFeatures().length) {
+            this.sendWFSStatusChangedEvent(layer.getId(), 'complete');
+        }
+
         this.plugin.notify('WFSPropertiesEvent', layer, layer.getLocales(), fields);
     }
     _getFeaturePropsInExtent (source, extent) {

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
@@ -99,7 +99,7 @@ export class VectorLayerHandler extends AbstractLayerHandler {
             if (olLayers !== undefined && olLayers.length > 0 && !olLayers[0].getVisible()) {
                 return;
             }
-            if (lastExtent && extentEquals(extent, lastExtent) && source.getFeatures().length !== 0) {
+            if (lastExtent && extentEquals(extent, lastExtent) && source.getFeatures().length > 0) {
                 return;
             }
             lastExtent = extent;

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
@@ -2,6 +2,7 @@
 import olSourceVector from 'ol/source/Vector';
 import olLayerVector from 'ol/layer/Vector';
 import olFormatGeoJSON from 'ol/format/GeoJSON';
+import { equals as extentEquals } from 'ol/extent';
 import { bbox as bboxStrategy } from 'ol/loadingstrategy';
 
 import { AbstractLayerHandler } from './AbstractLayerHandler.ol';
@@ -91,12 +92,17 @@ export class VectorLayerHandler extends AbstractLayerHandler {
      * @return {function} loader function for the layer
      */
     _getFeatureLoader (layer, source) {
+        let lastExtent = null;
         return (extent, resolution, projection) => {
             const olLayers = this.plugin.getOLMapLayers(layer.getId());
 
             if (olLayers !== undefined && olLayers.length > 0 && !olLayers[0].getVisible()) {
                 return;
             }
+            if (lastExtent && extentEquals(extent, lastExtent) && source.getFeatures().length !== 0) {
+                return;
+            }
+            lastExtent = extent;
 
             this.plugin.getMapModule().loadingState(layer.getId(), true);
             super.sendWFSStatusChangedEvent(layer.getId(), 'loading');


### PR DESCRIPTION
This fixes the issue where feature data button would not refresh its error state when moving the map in area where tiles had already been loaded.