### PR TITLE
Prevent GFI requests for layers that don't need it

### DIFF
--- a/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
@@ -60,12 +60,12 @@ Oskari.clazz.define(
         },
 
         _ignoreUserLayers: function () {
-            this.config = this.config || {};
-            const ignoredLayerTypes = new Set(this.config.ignoredLayerTypes || []);
+            this._config = this._config || {};
+            const ignoredLayerTypes = new Set(this._config.ignoredLayerTypes || []);
             ignoredLayerTypes.add('WFS');
             ignoredLayerTypes.add('MYPLACES');
             ignoredLayerTypes.add('USERLAYER');
-            this.config.ignoredLayerTypes = Array.from(ignoredLayerTypes);
+            this._config.ignoredLayerTypes = Array.from(ignoredLayerTypes);
         },
 
         _destroyControlElement: function () {


### PR DESCRIPTION
Prevent GFI requests for being sent to layers that have the data in browser already.