### PR TITLE
Fix thematic map search spinner positioning

### DIFF
--- a/bundles/statistics/statsgrid2016/view/SearchFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/SearchFlyout.js
@@ -66,21 +66,26 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
     getNewSearchElement: function () {
         var me = this;
         var container = jQuery('<div></div>');
-
         var selectionComponent = Oskari.clazz.create('Oskari.statistics.statsgrid.IndicatorSelection', me.instance, me.sandbox);
         container.append(selectionComponent.getPanelContent());
+
+        var buttonContainer = jQuery('<div id="statistics-search-flyout-button-container"></div>');
+        container.append(buttonContainer);
 
         var btn = Oskari.clazz.create('Oskari.userinterface.component.Button');
         btn.addClass('margintopLarge');
         btn.setPrimary(true);
         btn.setTitle(this.loc('panels.newSearch.addButtonTitle'));
         btn.setEnabled(false);
-        btn.insertTo(container);
+        btn.insertTo(buttonContainer);
 
         btn.setHandler(function (event) {
             event.stopPropagation();
-            me.setSpinnerVerticalPosition(event, selectionComponent.spinner);
-            me.setSpinner(selectionComponent.spinner);
+            const progressSpinner = Oskari.clazz.create('Oskari.userinterface.component.ProgressSpinner');
+            progressSpinner.insertTo(jQuery('#statistics-search-flyout-button-container'));
+            progressSpinner.opts.top = -100;
+            me.setSpinner(progressSpinner);
+            me.getSpinner().start();
             me.search(selectionComponent.getValues());
         });
         this.searchBtn = btn;
@@ -88,7 +93,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
         var clearBtn = Oskari.clazz.create('Oskari.userinterface.component.Button');
         clearBtn.addClass('margintopLarge');
         clearBtn.setTitle(this.loc('panels.newSearch.clearButtonTitle'));
-        clearBtn.insertTo(container);
+        clearBtn.insertTo(buttonContainer);
 
         clearBtn.setHandler(function (event) {
             event.stopPropagation();
@@ -515,17 +520,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
         }
         if (this.getSpinner()) {
             this.getSpinner().stop();
-            this.resetSpinnerVerticalPosition();
         }
-    },
-    setSpinnerVerticalPosition (event, spinner) {
-        spinner.opts.top = event.pageY - 100;
-        spinner.opts.position = 'absolute';
-    },
-    resetSpinnerVerticalPosition () {
-        const spinner = this.getSpinner();
-        spinner.opts.top = 'auto';
-        delete spinner.opts.position;
     }
 }, {
     extend: ['Oskari.userinterface.extension.ExtraFlyout']

--- a/bundles/statistics/statsgrid2016/view/SearchFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/SearchFlyout.js
@@ -69,7 +69,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
         var selectionComponent = Oskari.clazz.create('Oskari.statistics.statsgrid.IndicatorSelection', me.instance, me.sandbox);
         container.append(selectionComponent.getPanelContent());
 
-        var buttonContainer = jQuery('<div id="statistics-search-flyout-button-container"></div>');
+        var buttonContainer = jQuery('<div></div>');
         container.append(buttonContainer);
 
         var btn = Oskari.clazz.create('Oskari.userinterface.component.Button');
@@ -79,11 +79,12 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
         btn.setEnabled(false);
         btn.insertTo(buttonContainer);
 
+        const progressSpinner = Oskari.clazz.create('Oskari.userinterface.component.ProgressSpinner');
+        progressSpinner.insertTo(buttonContainer);
+        progressSpinner.opts.top = -100;
+
         btn.setHandler(function (event) {
             event.stopPropagation();
-            const progressSpinner = Oskari.clazz.create('Oskari.userinterface.component.ProgressSpinner');
-            progressSpinner.insertTo(jQuery('#statistics-search-flyout-button-container'));
-            progressSpinner.opts.top = -100;
             me.setSpinner(progressSpinner);
             me.getSpinner().start();
             me.search(selectionComponent.getValues());

--- a/bundles/statistics/statsgrid2016/view/SearchFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/SearchFlyout.js
@@ -79,6 +79,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
 
         btn.setHandler(function (event) {
             event.stopPropagation();
+            me.setSpinnerVerticalPosition(event, selectionComponent.spinner);
             me.setSpinner(selectionComponent.spinner);
             me.search(selectionComponent.getValues());
         });
@@ -514,7 +515,17 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
         }
         if (this.getSpinner()) {
             this.getSpinner().stop();
+            this.resetSpinnerVerticalPosition();
         }
+    },
+    setSpinnerVerticalPosition (event, spinner) {
+        spinner.opts.top = event.pageY - 100;
+        spinner.opts.position = 'absolute';
+    },
+    resetSpinnerVerticalPosition () {
+        const spinner = this.getSpinner();
+        spinner.opts.top = 'auto';
+        delete spinner.opts.position;
     }
 }, {
     extend: ['Oskari.userinterface.extension.ExtraFlyout']


### PR DESCRIPTION
Unfortunately first solution in commit a763a34 did not work when search button was pushed by pressing enter key instead of clicking button with mouse. When button was pressed with enter, needed y- coordinate containing location of button (issuer of event) was not included in event. For this reason solution in commit b58dcae is implemented which works in both mentioned cases. In proposed solution spinner is placed 100 pixels above buttons in Get content of data search. With data source and indicator selections, spinner should be located as near these selections (works as before).