### PR TITLE
Wfs feature clustering

### DIFF
--- a/bundles/integration/admin-layerselector/resources/locale/en.js
+++ b/bundles/integration/admin-layerselector/resources/locale/en.js
@@ -99,6 +99,7 @@ Oskari.registerLocalization(
                 "vector": "Big objects",
                 "info": "Viewing of small objects has been optimized. This restricts the scale on which the objects are viewed."
             },
+            "clusteringDistance": "Point distance in cluster",
             "mvtAttributions": "Attributions",
             "mvtAttributionsDesc": "JSON \n[{\n  \"label\": \"© MyOrganization\",\n  \"link\": \"https://linktomycopyrights\"\n}]",
             "mvtTileGrid": "Tile grid",

--- a/bundles/integration/admin-layerselector/resources/locale/fi.js
+++ b/bundles/integration/admin-layerselector/resources/locale/fi.js
@@ -99,6 +99,7 @@ Oskari.registerLocalization(
                 "vector": "Suuria kohteita",
                 "info": "Pienten kohteiden esittämistä on optimoitu. Tämä rajoittaa mittakaavatasoja, joilla kohteet näytetään."
             },
+            "clusteringDistance": "Pisteiden etäisyys klusteroidessa",
             "mvtAttributions": "Lähdeviitteet",
             "mvtAttributionsDesc": "JSON \n[{\n  \"label\": \"© MyOrganization\",\n  \"link\": \"https://linktomycopyrights\"\n}]",
             "mvtTileGrid": "Tiilimatriisi",

--- a/bundles/integration/admin-layerselector/resources/locale/sv.js
+++ b/bundles/integration/admin-layerselector/resources/locale/sv.js
@@ -99,6 +99,7 @@ Oskari.registerLocalization(
                 "vector": "Stora objekt",
                 "info": "Visning av små objekt har optimerats. Detta begränsar skalanivåerna på vilka objekten visas."
             },
+            "clusteringDistance": "Punktavstånd i kluster",
             "mvtAttributions": "Tillskrivningar",
             "mvtAttributionsDesc": "JSON \n[{\n  \"label\": \"© MyOrganization\",\n  \"link\": \"https://linktomycopyrights\"\n}]",
             "mvtTileGrid": "Rutmatris",

--- a/bundles/integration/admin-layerselector/templates/layer/wfslayerSettingsTemplateFooter.html
+++ b/bundles/integration/admin-layerselector/templates/layer/wfslayerSettingsTemplateFooter.html
@@ -46,7 +46,7 @@
     </div>
 </div>
 <div class="add-layer-record" <% if (!supportsWFS3) { %>style="display: none"<% } %>>
-    <% var clusteringDist = (_.isEmpty(model.getOptions()) || _.isEmpty(model.getOptions().clusteringDistance)) ? '' : JSON.stringify(model.getOptions().clusteringDistance); %>
+    <% var clusteringDist = (_.isEmpty(model.getOptions()) || !model.getOptions().clusteringDistance) ? '' : model.getOptions().clusteringDistance; %>
     <div class="add-layer-label-area">
         <label class="add-layer-label" title="<%= instance.getLocalization('admin').clusteringDistance %>"><%= instance.getLocalization('admin').clusteringDistance %></label>
     </div>

--- a/bundles/integration/admin-layerselector/templates/layer/wfslayerSettingsTemplateFooter.html
+++ b/bundles/integration/admin-layerselector/templates/layer/wfslayerSettingsTemplateFooter.html
@@ -45,6 +45,15 @@
             placeholder="<%- instance.getLocalization('admin').mvtHoverDesc %>"><%=hover%></textarea>
     </div>
 </div>
+<div class="add-layer-record" <% if (!supportsWFS3) { %>style="display: none"<% } %>>
+    <% var clusteringDist = (_.isEmpty(model.getOptions()) || _.isEmpty(model.getOptions().clusteringDistance)) ? '' : JSON.stringify(model.getOptions().clusteringDistance); %>
+    <div class="add-layer-label-area">
+        <label class="add-layer-label" title="<%= instance.getLocalization('admin').clusteringDistance %>"><%= instance.getLocalization('admin').clusteringDistance %></label>
+    </div>
+    <div class="add-layer-input-area">
+        <input type="text" class="add-layer-input small layer-options-clustering-distance" value="<%= clusteringDist %>" />&nbsp;px
+    </div>
+</div>
 <% if (!supportsWFS3) { %>
 <div class="add-layer-record">
     <div class="add-layer-label-area">

--- a/bundles/integration/admin-layerselector/views/adminLayerSettingsView.js
+++ b/bundles/integration/admin-layerselector/views/adminLayerSettingsView.js
@@ -1031,7 +1031,8 @@ function (
                 tileGrid: parseOptionQuietly('.add-layer-input.layer-options-tileGrid'),
                 hover: parseOptionQuietly('.add-layer-input.layer-options-hover'),
                 renderMode: parseOptionQuietly('.layer-options-renderMode:checked', true),
-                apiKey: parseOptionQuietly('.add-layer-input.layer-options-apikey', true)
+                apiKey: parseOptionQuietly('.add-layer-input.layer-options-apikey', true),
+                clusteringDistance: parseOptionQuietly('.add-layer-input.layer-options-clustering-distance')
             };
             if (parseErrors.length > 0) {
                 options.errors = parseErrors;

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -191,6 +191,14 @@ export class MapModule extends AbstractMapModule {
     _getFeaturesAtPixelImpl (x, y) {
         const hits = [];
         this.getMap().forEachFeatureAtPixel([x, y], (feature, layer) => {
+            // Cluster source check
+            if (feature && feature.get('features')) {
+                if (feature.get('features').length > 1) {
+                    return;
+                }
+                // Single feature in cluster
+                feature = feature.get('features')[0];
+            }
             const hit = {
                 featureProperties: feature.getProperties(),
                 layerId: layer.get(LAYER_ID)

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -190,20 +190,19 @@ export class MapModule extends AbstractMapModule {
      */
     _getFeaturesAtPixelImpl (x, y) {
         const hits = [];
-        this.getMap().forEachFeatureAtPixel([x, y], (feature, layer) => {
-            // Cluster source check
-            if (feature && feature.get('features')) {
-                if (feature.get('features').length > 1) {
-                    return;
-                }
-                // Single feature in cluster
-                feature = feature.get('features')[0];
-            }
-            const hit = {
-                featureProperties: feature.getProperties(),
+        const addHit = (ftr, layer) => {
+            hits.push({
+                featureProperties: ftr.getProperties(),
                 layerId: layer.get(LAYER_ID)
-            };
-            hits.push(hit);
+            });
+        };
+        this.getMap().forEachFeatureAtPixel([x, y], (feature, layer) => {
+            // Cluster source
+            if (feature && feature.get('features')) {
+                feature.get('features').forEach(cur => addHit(cur, layer));
+                return;
+            }
+            addHit(feature, layer);
         });
         return hits;
     }

--- a/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
+++ b/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
@@ -330,7 +330,7 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
             if (this._sandbox.getMap().isMoving()) {
                 return;
             }
-            const { feature, layer } = this._getTopmostFeatureAndLayer(event);
+            let { feature, layer } = this._getTopmostFeatureAndLayer(event);
 
             // No feature hits for these layer types. Call hover handlers without feature or layer.
             Object.keys(this.layerTypeHandlers).forEach(layerType => {
@@ -342,6 +342,14 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
             });
 
             if (feature && layer) {
+                if (feature && feature.get('features')) {
+                    // Cluster source
+                    if (feature.get('features').length > 1) {
+                        return;
+                    }
+                    // Single feature
+                    feature = feature.get('features')[0];
+                }    
                 const layerType = layer.get(LAYER_TYPE);
                 const hoverOptions = layer.get(LAYER_HOVER);
                 const contentOptions = hoverOptions ? hoverOptions.content : null;
@@ -388,6 +396,14 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
             me._map.forEachFeatureAtPixel([event.getMouseX(), event.getMouseY()], (feature, layer) => {
                 if (!layer) {
                     return;
+                }
+                if (feature.get('features')) {
+                    // Cluster source
+                    if (feature.get('features').length > 1) {
+                        return;
+                    }
+                    // Single feature
+                    feature = feature.get('features')[0];
                 }
                 const layerType = layer.get(LAYER_TYPE);
                 const isRegisteredLayerType = layerType && me.layerTypeHandlers[layerType];

--- a/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
+++ b/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
@@ -349,7 +349,7 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
                     }
                     // Single feature
                     feature = feature.get('features')[0];
-                }    
+                }
                 const layerType = layer.get(LAYER_TYPE);
                 const hoverOptions = layer.get(LAYER_HOVER);
                 const contentOptions = hoverOptions ? hoverOptions.content : null;

--- a/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
+++ b/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
@@ -3,10 +3,11 @@
  * JSON-parsing for myplaces layer
  */
 Oskari.clazz.define('Oskari.mapframework.bundle.mapmyplaces.domain.MyPlacesLayerModelBuilder',
-    function (sandbox) {
+    function (sandbox, clusteringDistance) {
         this.localization = Oskari.getLocalization('MapMyPlaces');
         this.sandbox = sandbox;
         this.wfsBuilder = Oskari.clazz.create('Oskari.mapframework.bundle.mapwfs2.domain.WfsLayerModelBuilder', sandbox);
+        this.clusteringDistance = clusteringDistance;
     }, {
         /**
          * parses any additional fields to model
@@ -27,6 +28,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmyplaces.domain.MyPlacesLayer
             this.wfsBuilder.parseLayerData(layer, mapLayerJson, maplayerService);
             this.wfsBuilder.setDefaultRenderMode(layer, 'vector');
 
+            if (this.clusteringDistance && this.clusteringDistance > 0) {
+                layer.setClusteringDistance(this.clusteringDistance);
+            }
             if (mapLayerJson.fields) {
                 layer.setFields(mapLayerJson.fields);
             }

--- a/bundles/mapping/mapmyplaces/plugin/MyPlacesLayerPlugin.ol.js
+++ b/bundles/mapping/mapmyplaces/plugin/MyPlacesLayerPlugin.ol.js
@@ -14,7 +14,8 @@ Oskari.clazz.define(
      *
      *
      */
-    function () {
+    function (config) {
+        this._config = config;
     }, {
         _clazz: 'Oskari.mapframework.bundle.mapmyplaces.plugin.MyPlacesLayerPlugin',
         __name: 'MyPlacesLayerPlugin',
@@ -30,8 +31,9 @@ Oskari.clazz.define(
          */
         _initImpl: function () {
             const layerClass = 'Oskari.mapframework.bundle.mapmyplaces.domain.MyPlacesLayer';
+            const { clusteringDistance } = this._config;
             const modelBuilderClass = 'Oskari.mapframework.bundle.mapmyplaces.domain.MyPlacesLayerModelBuilder';
-            const layerModelBuilder = Oskari.clazz.create(modelBuilderClass, this.getSandbox());
+            const layerModelBuilder = Oskari.clazz.create(modelBuilderClass, this.getSandbox(), clusteringDistance);
 
             const wfsPlugin = this.getMapModule().getLayerPlugins('wfs');
             if (typeof wfsPlugin.registerLayerType === 'function') {

--- a/bundles/mapping/mapuserlayers/domain/UserLayerModelBuilder.js
+++ b/bundles/mapping/mapuserlayers/domain/UserLayerModelBuilder.js
@@ -4,13 +4,14 @@
  */
 Oskari.clazz.define(
     'Oskari.mapframework.bundle.myplacesimport.domain.UserLayerModelBuilder',
-    function (sandbox) {
+    function (sandbox, clusteringDistance) {
         this.sandbox = sandbox;
         this.localization = Oskari.getLocalization('MyPlacesImport');
         this.wfsBuilder = Oskari.clazz.create(
             'Oskari.mapframework.bundle.mapwfs2.domain.WfsLayerModelBuilder',
             sandbox
         );
+        this.clusteringDistance = clusteringDistance;
     }, {
         /**
          * Parses any additional fields to model
@@ -24,6 +25,9 @@ Oskari.clazz.define(
             // call parent parseLayerData
             this.wfsBuilder.parseLayerData(layer, mapLayerJson, maplayerService);
             // set layer specific data
+            if (this.clusteringDistance && this.clusteringDistance > 0) {
+                layer.setClusteringDistance(this.clusteringDistance);
+            }
             layer.setOrganizationName(loclayer.organization);
             layer.setGroups([{
                 id: 'USERLAYER',

--- a/bundles/mapping/mapuserlayers/plugin/UserLayersLayerPlugin.ol.js
+++ b/bundles/mapping/mapuserlayers/plugin/UserLayersLayerPlugin.ol.js
@@ -29,8 +29,9 @@ Oskari.clazz.define(
          */
         _initImpl: function () {
             const layerClass = 'Oskari.mapframework.bundle.myplacesimport.domain.UserLayer';
+            const { clusteringDistance } = this._config;
             const modelBuilderClass = 'Oskari.mapframework.bundle.myplacesimport.domain.UserLayerModelBuilder';
-            const layerModelBuilder = Oskari.clazz.create(modelBuilderClass, this.getSandbox());
+            const layerModelBuilder = Oskari.clazz.create(modelBuilderClass, this.getSandbox(), clusteringDistance);
 
             const wfsPlugin = this.getMapModule().getLayerPlugins('wfs');
             if (typeof wfsPlugin.registerLayerType === 'function') {

--- a/bundles/mapping/mapuserlayers/plugin/UserLayersLayerPlugin.ol.js
+++ b/bundles/mapping/mapuserlayers/plugin/UserLayersLayerPlugin.ol.js
@@ -12,7 +12,8 @@ Oskari.clazz.define(
      *
      *
      */
-    function () {
+    function (config) {
+        this._config = config;
         this._log = Oskari.log(this.getName());
     }, {
         __name: 'UserLayersLayerPlugin',

--- a/bundles/mapping/mapwfs2/domain/WFSLayer.js
+++ b/bundles/mapping/mapwfs2/domain/WFSLayer.js
@@ -294,6 +294,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapwfs2.domain.WFSLayer',
             return this._options.clusteringDistance;
         },
         /**
+         * To setup clustering. Sets the minimum distance between features before clustering kicks in.
+         *  @method setClusteringDistance
+         *  @return {Number} Distance between features in pixels
+         */
+        setClusteringDistance (distance) {
+            this._options.clusteringDistance = distance;
+        },
+        /**
          * @method isSupportedSrs
          * Wfs layer is always supported
          */

--- a/bundles/mapping/mapwfs2/domain/WFSLayer.js
+++ b/bundles/mapping/mapwfs2/domain/WFSLayer.js
@@ -286,6 +286,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapwfs2.domain.WFSLayer',
             }
         },
         /**
+         * To get distance between features when clustering kicks in.
+         *  @method getClusteringDistance
+         *  @return {Number} Distance between features in pixels
+         */
+        getClusteringDistance () {
+            return this._options.clusteringDistance;
+        },
+        /**
          * @method isSupportedSrs
          * Wfs layer is always supported
          */

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
@@ -277,12 +277,14 @@ export class WfsVectorLayerPlugin extends AbstractMapLayerPlugin {
         if (!olLayers || olLayers.length === 0) {
             return;
         }
-        const lyr = olLayers[0];
-        lyr.setStyle(this.getCurrentStyleFunction(layer));
-        if (this.renderMode === RENDER_MODE_VECTOR && this.getMapModule().getSupports3D()) {
-            // Trigger features changed to synchronize 3D view
-            lyr.getSource().getFeatures().forEach(ftr => ftr.changed());
-        }
+        const style = this.getCurrentStyleFunction(layer);
+        olLayers.forEach(lyr => {
+            lyr.setStyle(style);
+            if (this.renderMode === RENDER_MODE_VECTOR && this.getMapModule().getSupports3D()) {
+                // Trigger features changed to synchronize 3D view
+                lyr.getSource().getFeatures().forEach(ftr => ftr.changed());
+            }
+        });
     }
     /**
      * @method updateLayerProperties

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
@@ -160,16 +160,21 @@ export class WfsVectorLayerPlugin extends AbstractMapLayerPlugin {
         }
         const handler = renderMode === RENDER_MODE_MVT ? this.mvtLayerHandler : this.vectorLayerHandler;
         this.layerHandlersByLayerId[layer.getId()] = handler;
-        const added = handler.addMapLayerToMap(layer, keepLayerOnTop, isBaseMap);
+        let added = handler.addMapLayerToMap(layer, keepLayerOnTop, isBaseMap);
         if (!added) {
             return;
         }
+        if (!Array.isArray(added)) {
+            added = [added];
+        }
         // Set oskari properties for vector feature service functionalities.
-        const silent = true;
-        added.set(LAYER_ID, layer.getId(), silent);
-        added.set(LAYER_TYPE, layer.getLayerType(), silent);
-        added.set(LAYER_HOVER, layer.getHoverOptions(), silent);
-        added.setStyle(this.getCurrentStyleFunction(layer, handler));
+        added.forEach(lyr => {
+            const silent = true;
+            lyr.set(LAYER_ID, layer.getId(), silent);
+            lyr.set(LAYER_TYPE, layer.getLayerType(), silent);
+            lyr.set(LAYER_HOVER, layer.getHoverOptions(), silent);
+            lyr.setStyle(this.getCurrentStyleFunction(layer, handler));
+        });
     }
     /**
      * @method refreshLayersOfType

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
@@ -1,17 +1,15 @@
 /* eslint-disable new-cap */
-import olSourceVector from 'ol/source/Vector';
-import olLayerVector from 'ol/layer/Vector';
+import { Cluster as olCluster, Vector as olSourceVector, TileDebug as olSourceTileDebug } from 'ol/source';
+import { Vector as olLayerVector, Tile as olLayerTile } from 'ol/layer';
 import olFormatGeoJSON from 'ol/format/GeoJSON';
 import { tile as tileStrategyFactory } from 'ol/loadingstrategy';
 import { createXYZ } from 'ol/tilegrid';
 
 import { AbstractLayerHandler, LOADING_STATUS_VALUE } from './AbstractLayerHandler.ol';
-import { applyOpacity } from '../util/style';
+import { applyOpacity, clusterStyleFunc } from '../util/style';
 import { WFS_ID_KEY } from '../util/props';
 import { RequestCounter } from './RequestCounter';
 
-import olLayerTile from 'ol/layer/Tile';
-import olSourceTileDebug from 'ol/source/TileDebug';
 import olPoint from 'ol/geom/Point';
 import olLineString from 'ol/geom/LineString';
 import olLinearRing from 'ol/geom/LinearRing';
@@ -20,6 +18,8 @@ import olMultiPoint from 'ol/geom/MultiPoint';
 import olMultiLineString from 'ol/geom/MultiLineString';
 import olMultiPolygon from 'ol/geom/MultiPolygon';
 import olGeometryCollection from 'ol/geom/GeometryCollection';
+
+import { getCenter as getOlExtentCenter } from 'ol/extent';
 
 import GeoJSONReader from 'jsts/org/locationtech/jts/io/GeoJSONReader';
 import OL3Parser from 'jsts/org/locationtech/jts/io/OL3Parser';
@@ -51,7 +51,23 @@ export class VectorLayerHandler extends AbstractLayerHandler {
         return handlers;
     }
     getStyleFunction (layer, styleFunction, selectedIds) {
+        const clustering = typeof layer.getClusteringDistance() !== 'undefined';
         return (feature, resolution) => {
+            // Cluster layer feature
+            if (feature.get('features')) {
+                if (feature.get('features').length > 1) {
+                    return clusterStyleFunc(feature);
+                } else {
+                    // Only single point in cluster. Use it in styling.
+                    feature = feature.get('features')[0];
+                }
+            } else if (clustering) {
+                // Vector layer feature, hide points
+                const geomType = feature.getGeometry().getType();
+                if (geomType === 'Point' || geomType === 'MultiPoint') {
+                    return null;
+                }
+            }
             const isSelected = selectedIds.has(feature.get(WFS_ID_KEY));
             const style = styleFunction(feature, resolution, isSelected);
             if (!this.plugin.getMapModule().getSupports3D()) {
@@ -68,7 +84,12 @@ export class VectorLayerHandler extends AbstractLayerHandler {
         const geomFilter = reader.read(geometry);
         const envelope = geomFilter.getEnvelopeInternal();
         const extentFilter = [envelope.getMinX(), envelope.getMinY(), envelope.getMaxX(), envelope.getMaxY()];
-        layer.getSource().forEachFeatureInExtent(extentFilter, ftr => {
+        let source = layer.getSource();
+        if (source instanceof olCluster) {
+            // Get wrapped vector source
+            source = source.getSource();
+        }
+        source.forEachFeatureInExtent(extentFilter, ftr => {
             const geom = olParser.read(ftr.getGeometry());
             if (RelateOp.relate(geomFilter, geom).isIntersects()) {
                 featuresById.set(ftr.get(WFS_ID_KEY), ftr.getProperties());
@@ -84,15 +105,50 @@ export class VectorLayerHandler extends AbstractLayerHandler {
             opacity,
             visible: layer.isVisible(),
             renderMode: 'hybrid',
-            source
+            source: source
         });
-        this.applyZoomBounds(layer, vectorLayer);
-        this.plugin.getMapModule().addLayer(vectorLayer, !keepLayerOnTop);
-        this.plugin.setOLMapLayers(layer.getId(), vectorLayer);
+        const olLayers = [vectorLayer];
+
+        // TEMP TEST
+        layer._options.clusteringDistance = 20;
+
+        // Setup clustering
+        if (layer.getClusteringDistance()) {
+            const clusterSource = new olCluster({
+                distance: layer.getClusteringDistance(),
+                source,
+                geometryFunction: feature => {
+                    const geom = feature.getGeometry();
+                    if (geom instanceof olPoint) {
+                        return geom;
+                    }
+                    if (geom instanceof olMultiPoint) {
+                        const center = getOlExtentCenter(geom.getExtent());
+                        return new olPoint(center);
+                    }
+                    return null;
+                }
+            });
+            const clusterLayer = new olLayerVector({
+                opacity,
+                visible: layer.isVisible(),
+                source: clusterSource
+            });
+            vectorLayer.on('change:opacity', () => clusterLayer.setOpacity(vectorLayer.getOpacity()));
+
+            olLayers.push(clusterLayer);
+        }
+
+        olLayers.forEach(olLayer => {
+            this.applyZoomBounds(layer, olLayer);
+            this.plugin.getMapModule().addLayer(olLayer, !keepLayerOnTop);
+        });
+
+        this.plugin.setOLMapLayers(layer.getId(), olLayers);
         if (this.plugin.getMapModule().getSupports3D()) {
             this._loadFeaturesForLayer(layer);
         }
-        return vectorLayer;
+        return olLayers;
     }
     refreshLayer (layer) {
         if (!layer) {
@@ -121,7 +177,7 @@ export class VectorLayerHandler extends AbstractLayerHandler {
         });
         const strategy = tileStrategyFactory(tileGrid);
         this.loadingStrategies['' + layer.getId()] = strategy;
-        const source = new olSourceVector({
+        let source = new olSourceVector({
             format: new olFormatGeoJSON(),
             url: Oskari.urls.getRoute('GetWFSFeatures'),
             projection: projection,

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/util/style.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/util/style.js
@@ -1,3 +1,6 @@
+/* eslint-disable new-cap */
+import { Style as olStyle, Circle as olCircleStyle, Stroke as olStroke, Fill as olFill, Text as olText } from 'ol/style';
+
 const defaults = {
     style: {
         fill: {
@@ -219,4 +222,33 @@ export const styleGenerator = (styleFactory, layer, hoverHandler) => {
         });
     }
     return getStyleFunction(styles, hoverHandler);
+};
+
+// Style for cluster circles
+const clusterStyleCache = {};
+export const clusterStyleFunc = feature => {
+    const size = feature.get('features').length;
+    let style = clusterStyleCache[size];
+    if (!style) {
+        style = new olStyle({
+            image: new olCircleStyle({
+                radius: size > 9 ? 14 : 12,
+                stroke: new olStroke({
+                    color: '#fff'
+                }),
+                fill: new olFill({
+                    color: '#3399CC'
+                })
+            }),
+            text: new olText({
+                text: size.toString(),
+                font: 'bold 14px sans-sherif',
+                fill: new olFill({
+                    color: '#fff'
+                })
+            })
+        });
+        clusterStyleCache[size] = style;
+    }
+    return style;
 };

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/util/style.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/util/style.js
@@ -226,9 +226,10 @@ export const styleGenerator = (styleFactory, layer, hoverHandler) => {
 
 // Style for cluster circles
 const clusterStyleCache = {};
-export const clusterStyleFunc = feature => {
+export const clusterStyleFunc = (feature, isSelected) => {
     const size = feature.get('features').length;
-    let style = clusterStyleCache[size];
+    const cacheKey = [`${size} ${isSelected}`];
+    let style = clusterStyleCache[cacheKey];
     if (!style) {
         style = new olStyle({
             image: new olCircleStyle({
@@ -237,7 +238,7 @@ export const clusterStyleFunc = feature => {
                     color: '#fff'
                 }),
                 fill: new olFill({
-                    color: '#3399CC'
+                    color: isSelected ? '#005d90' : '#3399CC'
                 })
             }),
             text: new olText({
@@ -248,7 +249,8 @@ export const clusterStyleFunc = feature => {
                 })
             })
         });
-        clusterStyleCache[size] = style;
+        clusterStyleCache[cacheKey] = style;
     }
     return style;
 };
+export const hiddenStyle = new olStyle({ visibility: 'hidden' });

--- a/bundles/mapping/mapwfs2/service/WFSLayerService.js
+++ b/bundles/mapping/mapwfs2/service/WFSLayerService.js
@@ -140,28 +140,29 @@ Oskari.clazz.define(
          * Handles status of selected features
          */
         setWFSFeaturesSelections: function (layerId, featureIds, makeNewSelection) {
-            var me = this,
-                existingFeatureSelections;
+            var me = this;
 
             if (makeNewSelection) {
                 _.remove(me.WFSFeatureSelections, { 'layerId': layerId });
                 me.WFSFeatureSelections.push({ 'layerId': layerId, 'featureIds': featureIds });
             } else {
-                existingFeatureSelections = _.pluck(_.where(me.WFSFeatureSelections, { 'layerId': layerId }), 'featureIds');
+                const existingFeatureSelections = _.pluck(_.where(me.WFSFeatureSelections, { 'layerId': layerId }), 'featureIds');
                 // no existing selections -> add all
                 if (!existingFeatureSelections || existingFeatureSelections.length === 0) {
                     existingFeatureSelections.push(featureIds);
                 } else {
-                    // existing selections found -> just add the features that weren't previously selected
-                    _.each(featureIds, function (featureId) {
-                        // add the features that weren't previously selected
-                        if (existingFeatureSelections[0].indexOf(featureId) < 0) {
-                            existingFeatureSelections[0].push(featureId);
-                        // remove the features that were previously selected
-                        } else {
-                            _.pull(existingFeatureSelections[0], featureId);
-                        }
-                    });
+                    // Either add all featureIds or remove all feature Ids from selection. Don't mix.
+                    const selectionArray = existingFeatureSelections[0];
+                    const someSelected = selectionArray.some(selected => featureIds.includes(selected));
+                    if (someSelected) {
+                        featureIds.forEach(id => {
+                            if (selectionArray.includes(id)) {
+                                selectionArray.splice(selectionArray.indexOf(id), 1);
+                            }
+                        });
+                        return;
+                    }
+                    featureIds.forEach(id => selectionArray.push(id));
                 }
                 // clear old selection
                 _.remove(me.WFSFeatureSelections, { 'layerId': layerId });


### PR DESCRIPTION
Client side clustering for geojson wfs layers.
Supports mixed layers (lines, polygons, points...) but only points are clustered.

Cluster configuring is done in the layer options. Setting `{ clusteringDistance: 20 }` on layer options will create clusters with 20 px buffering area.

`MyPlacesLayerPlugin` and `UserLayersLayerPlugin` can also take `clusteringDistance` in their plugin configurations.