### PR TITLE
Use smaller snap tolerance when drawing on desktop

### DIFF
--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
@@ -840,13 +840,19 @@ Oskari.clazz.define(
                     return geometry;
                 };
             }
-            var drawInteraction = new olInteractionDraw({
+            const opts = {
                 features: me._drawLayers[layerId].getSource().getFeaturesCollection(),
                 type: geometryType,
                 style: me._styles.draw,
                 geometryFunction: geometryFunction,
                 maxPoints: maxPoints
-            });
+            };
+
+            if (!Oskari.util.isMobile(true)) {
+                // use smaller snap tolerance on desktop
+                opts.snapTolerance = 3;
+            }
+            var drawInteraction = new olInteractionDraw(opts);
             // does this need to be registered here and/or for each functionalityId?
             me._draw[functionalityId] = drawInteraction;
 

--- a/src/util.js
+++ b/src/util.js
@@ -423,8 +423,11 @@ Oskari.util = (function () {
         return this.getColorBrightness(color) === 'light';
     };
 
-    util.isMobile = function () {
+    util.isMobile = function (ignoreSize) {
         var md = new MobileDetect(window.navigator.userAgent);
+        if (ignoreSize === true) {
+            return !!md.mobile();
+        }
         var mobileDefs = {
             width: 500,
             height: 400

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -867,6 +867,17 @@ describe('isMobile function', () => {
 
         expect(OskariMock.util.isMobile()).toEqual(true);
     });
+    test('returns false when screen size is small but device is desktop', () => {
+
+        expect.assertions(1);
+
+        document.body.innerHTML =
+            '<div id=\"mapdiv\" style=\"height: 300px;width: 300px;\">' +
+            'Dummy div content' +
+            '</div>';
+
+        expect(OskariMock.util.isMobile(true)).toEqual(false);
+    });
 
 });
 


### PR DESCRIPTION
Also modifies Oskari.util.isMobile(). Now you can pass true as param to ignore size of the map to know if the device is mobile or desktop.