### PR TITLE
Default version from package.json instead of 'devapp' for builds

### DIFF
--- a/webpack/parseParams.js
+++ b/webpack/parseParams.js
@@ -2,7 +2,7 @@ const exampleCommand = `
 -----------------------------------------------------------
 Development (version defaults to "devapp"):
     npm start -- --env.appdef=applications/sample
-Production (version example 44.6):
+Production (version example 44.6 - defaults to package.json version):
     npm run build -- --env.appdef=44.6:applications/sample
 -----------------------------------------------------------
 `;
@@ -18,7 +18,7 @@ module.exports = function parseParams (env) {
         throw new Error('Format for "appdef" is "version:pathToAppsetupDirectory", eg.: ' + exampleCommand);
     }
 
-    const version = parts.length > 1 ? parts[0] : 'devapp';
+    const version = getVersion(parts);
     const pathParam = parts.length > 1 ? parts[1] : parts[0];
 
     const params = {
@@ -33,3 +33,16 @@ module.exports = function parseParams (env) {
 
     return params;
 };
+
+function getVersion (appdefParts) {
+    // After we upgrade webpack to latest we can use env: https://github.com/webpack/webpack-dev-server/pull/1929
+    // const isDevServer = !!process.env.WEBPACK_DEV_SERVER;
+    const isDevServer = !!process.argv.find(v => v.indexOf('webpack-dev-server') !== -1);
+    if (appdefParts.length > 1) {
+        return appdefParts[0];
+    } else if (!isDevServer) {
+        // version from package.json
+        return process.env.npm_package_version;
+    }
+    return 'devapp';
+}


### PR DESCRIPTION
Allows npm run build parameters for --env.appdef to be included in application specific package.json. Previously you couldn't because the version usually changes and it was part of the folder reference for apps. Now you can still give it as a parameter but it defaults to version in package.json for build and "devapp" for webpack-dev-server (npm start).

Which means you can usually just modify package.json and always use `npm run build` instead of `npm run build -- --env.appdef=THE_ONE_THING_THAT_CHANGES:applications`