### PR TITLE
Locationmodule NaN coordinates fix

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -818,6 +818,7 @@ Oskari.clazz.define(
          * @param {Number} meters that must fit to viewport
          */
         zoomToFitMeters: function (meters) {
+            if (meters <= 0) return;
             var mapSize = this.getSize();
             var viewportPx = Math.min(mapSize.height, mapSize.width);
             var zoom = 0;

--- a/bundles/mapping/mapmodule/LocationModule.js
+++ b/bundles/mapping/mapmodule/LocationModule.js
@@ -9,6 +9,29 @@ let _locationWatch = null;
 function _addCoord (pos) {
     _locationCoords.push([pos.lon, pos.lat]);
 };
+function notifyError (cb, code) {
+    const error = errorCodes[code] || errorCodes[2];
+    if (typeof cb === 'function') {
+        cb(error);
+    }
+    const evt = Oskari.eventBuilder('UserLocationEvent');
+    // notify event without position to signal failure
+    sandbox.notifyAll(evt(null, null, null, error));
+};
+function notifyLonLat (cb, lonlat, accuracy) {
+    if (typeof cb === 'function') {
+        cb(lonlat.lon, lonlat.lat, accuracy);
+    }
+    const evt = Oskari.eventBuilder('UserLocationEvent');
+    sandbox.notifyAll(evt(lonlat.lon, lonlat.lat, accuracy));
+};
+function notifyPosition (cb, pos) {
+    if (typeof cb === 'function') {
+        cb(pos);
+    }
+    const evt = Oskari.eventBuilder('UserLocationEvent');
+    sandbox.notifyAll(evt(pos.lon, pos.lat, pos.accuracy));
+};
 
 // TODO: push pos to pathJson coords.
 // Now geojson is generated from coords array on update if it's added to map
@@ -30,7 +53,6 @@ function _updatePath (pos) {
  */
 export function getUserLocation (successCb, errorCB, options) {
     // normalize opts with defaults
-    const evtBuilder = Oskari.eventBuilder('UserLocationEvent');
     const mapmodule = sandbox.findRegisteredModuleInstance('MainMapModule');
     var opts = options || {};
     var navigatorOpts = {
@@ -47,39 +69,34 @@ export function getUserLocation (successCb, errorCB, options) {
     if (navigator.geolocation) {
         navigator.geolocation.getCurrentPosition(
             function (position) {
+                const { longitude, latitude, accuracy } = position.coords;
                 // transform coordinates from browser projection to current
                 var lonlat = mapmodule.transformCoordinates({
-                    lon: position.coords.longitude,
-                    lat: position.coords.latitude }, 'EPSG:4326');
-                sandbox.notifyAll(evtBuilder(lonlat.lon, lonlat.lat, position.coords.accuracy, null));
-                // notify callback
-                if (typeof successCb === 'function') {
-                    successCb(lonlat.lon, lonlat.lat, position.coords.accuracy);
+                    lon: longitude,
+                    lat: latitude }, 'EPSG:4326');
+                if (mapmodule.isValidLonLat(lonlat.lon, lonlat.lat)) {
+                    notifyLonLat(successCb, lonlat, accuracy);
+                } else {
+                    notifyError(errorCB);
                 }
             },
             function (errors) {
                 log.warn('Error getting user location', errors);
-                // notify event without position to signal failure
-                var error = errorCodes[errors.code] || errorCodes[2];
-                sandbox.notifyAll(evtBuilder(null, null, null, error));
-                if (typeof errorCB === 'function') {
-                    errorCB(error);
-                }
+                notifyError(errorCB, errors.code);
             }, navigatorOpts
         );
     } else {
         // browser doesn't support
-        sandbox.notifyAll(evtBuilder(null, null, null, errorCodes[2]));
+        notifyError(errorCB);
     }
 };
 export function watchUserLocation (successCb, errorCB, options) {
     // var me = this;
     // var sandbox = me.getSandbox();
-    const evtBuilder = Oskari.eventBuilder('UserLocationEvent');
     const mapmodule = sandbox.findRegisteredModuleInstance('MainMapModule');
     // var errorCodes = {1: 'denied', 2: 'unavailable', 3: 'timeout'};
     let opts = options || {};
-    let timestamp;
+    let prevTime;
     // default values
     let navigatorOpts = {
         maximumAge: 5000,
@@ -96,38 +113,34 @@ export function watchUserLocation (successCb, errorCB, options) {
         _locationWatch = navigator.geolocation.watchPosition(
             function (position) {
                 log.debug(position);
-                if (timestamp === position.timestamp) {
+                const { timestamp, coords } = position;
+                if (prevTime === timestamp) {
                     // some browsers sends first previous position and then changed position
                     // TODO: is this only location emulator feature, test how this works with mobile phones
                     return;
                 }
-                timestamp = position.timestamp;
+                prevTime = timestamp;
                 // transform coordinates from browser projection to current
                 var pos = mapmodule.transformCoordinates({
-                    lon: position.coords.longitude,
-                    lat: position.coords.latitude }, 'EPSG:4326');
-                pos.accuracy = position.coords.accuracy;
-                _addCoord(pos);
-                sandbox.notifyAll(evtBuilder(pos.lon, pos.lat, pos.accuracy, null));
-                // notify callback
-                if (typeof successCb === 'function') {
-                    successCb(pos);
+                    lon: coords.longitude,
+                    lat: coords.latitude }, 'EPSG:4326');
+                if (!mapmodule.isValidLonLat(pos.lon, pos.lat)) {
+                    notifyError(errorCB);
+                    return;
                 }
+
+                pos.accuracy = coords.accuracy;
+                _addCoord(pos);
+                notifyPosition(successCb, pos);
             },
             function (errors) {
                 log.warn('Error getting user location', errors);
-                // notify event without position to signal failure
-                var error = errorCodes[errors.code] || errorCodes[2];
-                sandbox.notifyAll(evtBuilder(null, null, null, error));
-                // me.stopUserLocationWatch();
-                if (typeof errorCB === 'function') {
-                    errorCB(error);
-                }
+                notifyError(errorCB, errors.code);
             }, navigatorOpts
         );
     } else {
         // browser doesn't support
-        sandbox.notifyAll(evtBuilder(null, null, null, errorCodes[2]));
+        notifyError(errorCB);
     }
 };
 export function getLocationCoords () {

--- a/bundles/mapping/mapmodule/LocationModule.js
+++ b/bundles/mapping/mapmodule/LocationModule.js
@@ -91,10 +91,7 @@ export function getUserLocation (successCb, errorCB, options) {
     }
 };
 export function watchUserLocation (successCb, errorCB, options) {
-    // var me = this;
-    // var sandbox = me.getSandbox();
     const mapmodule = sandbox.findRegisteredModuleInstance('MainMapModule');
-    // var errorCodes = {1: 'denied', 2: 'unavailable', 3: 'timeout'};
     let opts = options || {};
     let prevTime;
     // default values

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -538,11 +538,12 @@ export class MapModule extends AbstractMapModule {
      * @param {Boolean} suppressEnd true to NOT send an event about the map move
      *  (other components wont know that the map has moved, only use when chaining moves and
      *     wanting to notify at end of the chain for performance reasons or similar) (optional)
+     * @return {Boolean} success
      */
     centerMap (lonlat, zoom, suppressEnd) {
         lonlat = this.normalizeLonLat(lonlat);
         if (!this.isValidLonLat(lonlat.lon, lonlat.lat)) {
-            return;
+            return false;
         }
         this.getMap().getView().setCenter([lonlat.lon, lonlat.lat]);
         if (zoom === null || zoom === undefined) {
@@ -553,6 +554,7 @@ export class MapModule extends AbstractMapModule {
         if (suppressEnd !== true) {
             this.notifyMoveEnd();
         }
+        return true;
     }
     /**
      * Get maps current extent.

--- a/bundles/mapping/mapmodule/request/GetUserLocationRequestHandler.js
+++ b/bundles/mapping/mapmodule/request/GetUserLocationRequestHandler.js
@@ -18,8 +18,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.GetUserLocatio
             // move map to coordinates
             if (request.getCenterMap()) {
                 const zoom = opts.zoomLevel !== undefined ? opts.zoomLevel : 6;
-                mapmodule.centerMap({ lon: lon, lat: lat }, zoom);
-                if (opts.enableHighAccuracy === true && opts.zoomLevel === undefined) {
+                const success = mapmodule.centerMap({ lon: lon, lat: lat }, zoom);
+                if (success && opts.enableHighAccuracy === true && opts.zoomLevel === undefined) {
                     mapmodule.zoomToFitMeters(accuracy * 4);
                 }
             }

--- a/bundles/mapping/mapmodule/request/StartUserLocationTrackingRequestHandler.js
+++ b/bundles/mapping/mapmodule/request/StartUserLocationTrackingRequestHandler.js
@@ -20,20 +20,16 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.StartUserLocat
         this._clearLocationFromMap();
         clearLocationCoords();
         stopUserLocationWatch();
-
         var succesCb = function (pos) {
+            let mapMoved = false;
             // move map to coordinates
-            if (opts.centerMap === 'single' && !focused) {
+            if (opts.centerMap === 'update' || (opts.centerMap === 'single' && !focused)) {
+                mapMoved = mapmodule.centerMap(pos);
+            }
+            // zoom only once, skip if centerMap fails
+            if (!focused && mapMoved) {
                 focused = true;
-                mapmodule.centerMap(pos);
                 mapmodule.zoomToFitMeters(pos.accuracy * 4);
-            } else if (opts.centerMap === 'update') {
-                mapmodule.centerMap(pos);
-                // zoom only to first location
-                if (!focused) {
-                    focused = true;
-                    mapmodule.zoomToFitMeters(pos.accuracy * 4);
-                }
             }
             if (opts.addToMap === 'point') {
                 me._addLocationToMap(pos, false);


### PR DESCRIPTION
Firefox getCurrentPosition may return  success with NaN coordinates and 0 accuracy. GetUserLocationRequestHandler zooms map based on accuracy after map move if high accuracy is enabled and accuracy is received. Map was zoomed based on accuracy even map move fails. Added isValidLonLat check to coordinates. Also added mapmodule centerMap() to return success value to double check.

isValidLonLat check also prevents map to move outside bbox.