### PR TITLE
Printout use base image layer for preview 

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -2446,6 +2446,34 @@ Oskari.clazz.define(
             } else {
                 Oskari.on('bundle.start', handler);
             }
+        },
+        /**
+         * Get 1st visible image layer.
+         * fallback to first visible layer
+         * @returns {Layer} null|undefined if not found
+         */
+        getBaseLayer: function () {
+            const selectedLayers = Oskari.getSandbox().findAllSelectedMapLayers();
+
+            if (selectedLayers.length === 0) return null;
+
+            const layer = selectedLayers.find(l => {
+                const type = l.getLayerType();
+                return l.isVisible() && (type === 'wmts' || type === 'wms');
+            });
+            if (layer) return layer;
+            return selectedLayers.find(l => l.isVisible());
+        },
+        /**
+         * Get 1st visible ol image layer.
+         * fallback to first visible ol layer
+         * @returns {ol/layer/Layer} null if not found
+         */
+        getBaseOLMapLayer: function () {
+            const layer = this.getBaseLayer();
+            if (!layer) return null;
+            const olLayers = this.getOLMapLayers(layer.getId());
+            return olLayers && olLayers.length > 0 ? olLayers[0] : null;
         }
         /* --------------- /MAP LAYERS ------------------------ */
     }, {

--- a/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol.js
@@ -71,7 +71,7 @@ Oskari.clazz.define(
                 // Add index map control - remove old one
                 if (!me._indexMap || me._indexMap.getCollapsed()) {
                     // get/Set only base layer to index map
-                    var layer = me._getBaseLayer();
+                    var layer = me.getMapModule().getBaseOLMapLayer();
                     if (layer) {
                         if (typeof layer.createIndexMapLayer === 'function') {
                             // this is used for statslayer to create a copied layer as indexmap
@@ -151,28 +151,8 @@ Oskari.clazz.define(
                 // enable icon
                 this._bindIcon(icon);
             }
-        },
-        /**
-         * Get 1st visible image layer.
-         * fallback to first visible layer
-         * @returns {*}
-         * @private
-         */
-        _getBaseLayer: function () {
-            const selectedLayers = Oskari.getSandbox().findAllSelectedMapLayers();
-            if (selectedLayers.length === 0) return null;
-
-            let layer = selectedLayers.find(l => {
-                const type = l.getLayerType();
-                return l.isVisible() && (type === 'wmts' || type === 'wms');
-            });
-            if (!layer) {
-                layer = selectedLayers.find(l => l.isVisible());
-            }
-            if (!layer) return null;
-            const olLayers = this.getMapModule().getOLMapLayers(layer.getId());
-            return olLayers && olLayers.length > 0 ? olLayers[0] : null;
         }
+
     },
     {
         extend: ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],


### PR DESCRIPTION
Added _gatherSelectionsForPreview to create url for preview instead of using maplinkArgs. Removed unused sandbox.getMap().geojs. Left _stringifyGeoJson with null value if vectorlayer features are sent to print in the future.

Moved getBaseLayer from indexmap plugin to mapmodule.