### PR TITLE
Default to GeoJSON instead of MVT for WFS

### DIFF
--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
@@ -20,7 +20,7 @@ export class WfsVectorLayerPlugin extends AbstractMapLayerPlugin {
         this._config = config;
         this.__name = 'WfsVectorLayerPlugin';
         this._clazz = 'Oskari.wfs.WfsVectorLayerPlugin';
-        this.renderMode = config.renderMode;
+        this.renderMode = config.renderMode || RENDER_MODE_VECTOR;
         this.visualizationForm = null;
         this.oskariStyleSupport = true;
         this.layertype = 'wfs';

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
@@ -72,7 +72,11 @@ export class WfsVectorLayerPlugin extends AbstractMapLayerPlugin {
     _initImpl () {
         super._initImpl();
         const sandbox = this.getSandbox();
-        this.renderMode = this.renderMode || (this.getMapModule().getSupports3D() ? RENDER_MODE_VECTOR : RENDER_MODE_MVT);
+        if (this.getMapModule().getSupports3D() && this.renderMode !== RENDER_MODE_VECTOR) {
+            // 3D mapmodule doesn't support MVT
+            this._log.warn('Changing WFS render mode (3d only supports GeoJSON). Configuration was for: ' + this.renderMode);
+            this.renderMode = RENDER_MODE_VECTOR;
+        }
         this.reqEventHandler = new ReqEventHandler(sandbox);
         this.visualizationForm = new VisualizationForm();
         this.WFSLayerService = new WFSLayerService(sandbox);


### PR DESCRIPTION
Since MVT-mode has a hard limit for zoom-level (disregarding min/maxscale set by the admin) and users might have WFS-layers that can be viewed from further away in previous versions.