### PR TITLE
Divmanazer popup modal draggable fix

### DIFF
--- a/bundles/framework/divmanazer/component/FilterDialog.js
+++ b/bundles/framework/divmanazer/component/FilterDialog.js
@@ -869,12 +869,10 @@ Oskari.clazz.define('Oskari.userinterface.component.FilterDialog',
                 popupTitle = (this.loc.error && this.loc.error.title) ? this.loc.error.title : '',
                 popupContent = '<h4>' + loc.title + '</h4>',
                 i;
-
             for (i = 0; i < errors.length; ++i) {
                 popupContent += '<p>' + loc[errors[i]] + '</p>';
             }
-
-            popup.show(popupTitle, popupContent, [closeButton]);
+            popup.showFromModal(this.popup.getElement(), popupTitle, popupContent, [closeButton]);
         },
 
         /**


### PR DESCRIPTION
Keep z-index over overlay while dragging.

Add showFromModal to open new popup from modal popup. Change wfs filter error message to use showFromModal.

Remove popup opened from modal from draggable stack.