### PR TITLE
Statistics classification scroll

### DIFF
--- a/bundles/statistics/statsgrid2016/components/classification/Classification.jsx
+++ b/bundles/statistics/statsgrid2016/components/classification/Classification.jsx
@@ -23,7 +23,7 @@ class Classification extends React.Component {
     getContentWrapperStyle () {
         const docHeight = document.documentElement.offsetHeight;
         return {
-            maxHeight: docHeight - 35 + 'px', // header + border
+            maxHeight: docHeight - 50 + 'px', // header + border,
             overflowY: 'auto'
         };
     }

--- a/bundles/statistics/statsgrid2016/components/classification/legend.scss
+++ b/bundles/statistics/statsgrid2016/components/classification/legend.scss
@@ -2,6 +2,7 @@
 
     .active-legend {
         height: 100%;
+        margin-bottom: 5px;
     }
 
     /* overrides for geostats CSS */


### PR DESCRIPTION
Add margin to legend because to prevent scroll bar.