### PR TITLE
Coordinatetool add localization for EPSG:3857

### DIFF
--- a/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
+++ b/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
@@ -190,13 +190,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
                 popupTitle = loc('display.popup.title'),
                 popupContent = me._templates.popupContent.clone(),
                 crs = me.getMapModule().getProjection(),
-                crsDefaultText = loc('display.crs.default', { crs: crs }),
                 popupName = 'xytoolpopup',
                 popupLocation,
                 isMobile = Oskari.util.isMobile(),
                 mapmodule = me.getMapModule(),
                 popupService = me.getSandbox().getService('Oskari.userinterface.component.PopupService');
 
+            const crsText = loc('display.crs')[crs] || loc('display.crs.default', { crs: crs });
             me._popup = popupService.createPopup();
             var popupEl = me._popup.getJqueryContent().parent().parent();
 
@@ -299,7 +299,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
             }
 
             if (!me._getPreciseTransform) {
-                popupContent.find('.srs').html(crsDefaultText);
+                popupContent.find('.srs').html(crsText);
             }
 
             me._popup.createCloseIcon();

--- a/bundles/framework/coordinatetool/resources/locale/en.js
+++ b/bundles/framework/coordinatetool/resources/locale/en.js
@@ -9,6 +9,7 @@ Oskari.registerLocalization(
             "crs": {
                 "EPSG:3067": "ETRS89-TM35FIN coordinates",
                 "EPSG:3575": "North Pole LAEA Europe coordinates",
+                "EPSG:3857": "WGS 84 / Pseudo-Mercator coordinates",
                 "default": "{crs} coordinates"
             },
             "popup": {
@@ -85,7 +86,8 @@ Oskari.registerLocalization(
                     "EPSG:3386": "KKJ zone 0",
                     "EPSG:2391": "KKJ zone 1",
                     "EPSG:2392": "KKJ zone 2",
-                    "EPSG:2394": "KKJ zone 4"
+                    "EPSG:2394": "KKJ zone 4",
+                    "EPSG:3857": "WGS 84 / Pseudo-Mercator"
                 },
                 "emergencyCallLabel": "The coordinates recommended to be used in emergency calls are",
                 "emergencyCallLabelAnd": "and",

--- a/bundles/framework/coordinatetool/resources/locale/et.js
+++ b/bundles/framework/coordinatetool/resources/locale/et.js
@@ -9,6 +9,7 @@ Oskari.registerLocalization(
             "crs": {
                 "EPSG:3067": "ETRS89-TM35FIN coordinates",
                 "EPSG:3575": "North Pole LAEA Europe coordinates",
+                "EPSG:3857": "WGS 84 / Pseudo-Mercator coordinates",
                 "default": "{crs} coordinates"
             },
             "popup": {
@@ -85,7 +86,8 @@ Oskari.registerLocalization(
                     "EPSG:3386": "KKJ zone 0",
                     "EPSG:2391": "KKJ zone 1",
                     "EPSG:2392": "KKJ zone 2",
-                    "EPSG:2394": "KKJ zone 4"
+                    "EPSG:2394": "KKJ zone 4",
+                    "EPSG:3857": "WGS 84 / Pseudo-Mercator"
                 },
                 "emergencyCallLabel": "",
                 "emergencyCallLabelAnd": "",

--- a/bundles/framework/coordinatetool/resources/locale/fi.js
+++ b/bundles/framework/coordinatetool/resources/locale/fi.js
@@ -9,6 +9,7 @@ Oskari.registerLocalization(
             "crs": {
                 "EPSG:3067": "ETRS89-TM35FIN -koordinaatit",
                 "EPSG:3575": "North Pole LAEA Europe -koordinaatit",
+                "EPSG:3857": "WGS 84 / Pseudo-Mercator -koordinaatit",
                 "default": "{crs} -koordinaatit"
             },
             "popup": {
@@ -85,7 +86,8 @@ Oskari.registerLocalization(
                     "EPSG:3386": "KKJ kaista 0",
                     "EPSG:2391": "KKJ kaista 1",
                     "EPSG:2392": "KKJ kaista 2",
-                    "EPSG:2394": "KKJ kaista 4"
+                    "EPSG:2394": "KKJ kaista 4",
+                    "EPSG:3857": "WGS 84 / Pseudo-Mercator"
                 },
                 "emergencyCallLabel": "Hätäpuheluissa käytettäväksi suositellut koordinaatit ovat",
                 "emergencyCallLabelAnd": "ja",

--- a/bundles/framework/coordinatetool/resources/locale/fr.js
+++ b/bundles/framework/coordinatetool/resources/locale/fr.js
@@ -9,6 +9,7 @@ Oskari.registerLocalization(
             "crs": {
                 "EPSG:3067": "Coordonnées ETRS89-TM35FIN",
                 "EPSG:3575": "Coordonnées de la projection équivalente de Lambert de l'Europe centrée sur le pôle Nord",
+                "EPSG:3857": "Coordonnées WGS 84 / Pseudo-Mercator",
                 "default": "Coordonnées {crs}"
             },
             "popup": {
@@ -85,7 +86,8 @@ Oskari.registerLocalization(
                     "EPSG:3386": "Zone 0 KKJ",
                     "EPSG:2391": "Zone 1 KKJ",
                     "EPSG:2392": "Zone 2 KKJ",
-                    "EPSG:2394": "Zone 4 KKJ"
+                    "EPSG:2394": "Zone 4 KKJ",
+                    "EPSG:3857": "WGS 84 / Pseudo-Mercator"
                 },
                 "emergencyCallLabel": "Les coordonnées dont on recommande l'utilisation lors d'appels d'urgence sont",
                 "emergencyCallLabelAnd": "et",

--- a/bundles/framework/coordinatetool/resources/locale/is.js
+++ b/bundles/framework/coordinatetool/resources/locale/is.js
@@ -9,6 +9,7 @@ Oskari.registerLocalization(
             "crs": {
                 "EPSG:3067": "ETRS89-TM35FIN hnit",
                 "EPSG:3575": "Norðurpóll LAEA Evrópuhnit",
+                "EPSG:3857": "WGS 84 / Pseudo-Mercator hnit",
                 "default": "{crs} hnit"
             },
             "popup": {
@@ -85,7 +86,8 @@ Oskari.registerLocalization(
                     "EPSG:3386": "KKJ zone 0",
                     "EPSG:2391": "KKJ zone 1",
                     "EPSG:2392": "KKJ zone 2",
-                    "EPSG:2394": "KKJ zone 4"
+                    "EPSG:2394": "KKJ zone 4",
+                    "EPSG:3857": "WGS 84 / Pseudo-Mercator"
                 },
                 "emergencyCallLabel": "",
                 "emergencyCallLabelAnd": "",

--- a/bundles/framework/coordinatetool/resources/locale/nb.js
+++ b/bundles/framework/coordinatetool/resources/locale/nb.js
@@ -7,8 +7,9 @@ Oskari.registerLocalization(
         "desc": "",
         "display": {
             "crs": {
-                "EPSG:3067": "ETRS89-TM35FIN coordinates",
-                "EPSG:3575": "North Pole LAEA Europe coordinates",
+                "EPSG:3067": "ETRS89-TM35FIN koordinater",
+                "EPSG:3575": "North Pole LAEA Europe koordinater",
+                "EPSG:3857": "WGS 84 / Pseudo-Mercator koordinater",
                 "default": "{crs} koordinater"
             },
             "popup": {
@@ -85,7 +86,8 @@ Oskari.registerLocalization(
                     "EPSG:3386": "KKJ zone 0",
                     "EPSG:2391": "KKJ zone 1",
                     "EPSG:2392": "KKJ zone 2",
-                    "EPSG:2394": "KKJ zone 4"
+                    "EPSG:2394": "KKJ zone 4",
+                    "EPSG:3857": "WGS 84 / Pseudo-Mercator"
                 },
                 "emergencyCallLabel": "",
                 "emergencyCallLabelAnd": "",

--- a/bundles/framework/coordinatetool/resources/locale/nn.js
+++ b/bundles/framework/coordinatetool/resources/locale/nn.js
@@ -7,8 +7,9 @@ Oskari.registerLocalization(
         "desc": "",
         "display": {
             "crs": {
-                "EPSG:3067": "ETRS89-TM35FIN coordinates",
-                "EPSG:3575": "North Pole LAEA Europe coordinates",
+                "EPSG:3067": "ETRS89-TM35FIN koordinatar",
+                "EPSG:3575": "North Pole LAEA Europe koordinatar",
+                "EPSG:3857": "WGS 84 / Pseudo-Mercator koordinatar",
                 "default": "{crs} koordinatar"
             },
             "popup": {
@@ -85,7 +86,8 @@ Oskari.registerLocalization(
                     "EPSG:3386": "KKJ zone 0",
                     "EPSG:2391": "KKJ zone 1",
                     "EPSG:2392": "KKJ zone 2",
-                    "EPSG:2394": "KKJ zone 4"
+                    "EPSG:2394": "KKJ zone 4",
+                    "EPSG:3857": "WGS 84 / Pseudo-Mercator"
                 },
                 "emergencyCallLabel": "",
                 "emergencyCallLabelAnd": "",

--- a/bundles/framework/coordinatetool/resources/locale/ru.js
+++ b/bundles/framework/coordinatetool/resources/locale/ru.js
@@ -9,6 +9,7 @@ Oskari.registerLocalization(
             "crs": {
                 "EPSG:3067": "Координаты ETRS89-TM35FIN",
                 "EPSG:3575": "Координаты в азимутальной равновеликой проекции Ламберта Северного полюса (Европа)",
+                "EPSG:3857": "WGS 84 / Pseudo-Mercator координаты",
                 "default": "{crs} координаты"
             },
             "popup": {
@@ -85,7 +86,8 @@ Oskari.registerLocalization(
                     "EPSG:3386": "KKJ zone 0",
                     "EPSG:2391": "KKJ zone 1",
                     "EPSG:2392": "KKJ zone 2",
-                    "EPSG:2394": "KKJ zone 4"
+                    "EPSG:2394": "KKJ zone 4",
+                    "EPSG:3857": "WGS 84 / Pseudo-Mercator"
                 },
                 "emergencyCallLabel": "Координаты, рекомендуемые для использования при экстренных вызовах:",
                 "emergencyCallLabelAnd": "и",

--- a/bundles/framework/coordinatetool/resources/locale/sk.js
+++ b/bundles/framework/coordinatetool/resources/locale/sk.js
@@ -9,6 +9,7 @@ Oskari.registerLocalization(
             "crs": {
                 "EPSG:3067": "ETRS89-TM35FIN súradnice",
                 "EPSG:3575": "Severný pól LAEA Európske súradnice",
+                "EPSG:3857": "WGS 84 / Pseudo-Mercator súradnice",
                 "default": "{crs} súradnice"
             },
             "popup": {
@@ -85,7 +86,8 @@ Oskari.registerLocalization(
                     "EPSG:3386": "KKJ zóna 0",
                     "EPSG:2391": "KKJ zóna 1",
                     "EPSG:2392": "KKJ zóna 2",
-                    "EPSG:2394": "KKJ zóna 4"
+                    "EPSG:2394": "KKJ zóna 4",
+                    "EPSG:3857": "WGS 84 / Pseudo-Mercator"
                 },
                 "emergencyCallLabel": "",
                 "emergencyCallLabelAnd": "",

--- a/bundles/framework/coordinatetool/resources/locale/sv.js
+++ b/bundles/framework/coordinatetool/resources/locale/sv.js
@@ -9,6 +9,7 @@ Oskari.registerLocalization(
             "crs": {
                 "EPSG:3067": "ETRS89-TM35FIN koordinater",
                 "EPSG:3575": "North Pole LAEA Europe koordinater",
+                "EPSG:3857": "WGS 84 / Pseudo-Mercator koordinater",
                 "default": "{crs} koordinater"
             },
             "popup": {
@@ -85,7 +86,8 @@ Oskari.registerLocalization(
                     "EPSG:3386": "KKJ zon 0",
                     "EPSG:2391": "KKJ zon 1",
                     "EPSG:2392": "KKJ zon 2",
-                    "EPSG:2394": "KKJ zon 4"
+                    "EPSG:2394": "KKJ zon 4",
+                    "EPSG:3857": "WGS 84 / Pseudo-Mercator"
                 },
                 "emergencyCallLabel": "Koordinaterna som rekommenderas att användas i nödsamtal är",
                 "emergencyCallLabelAnd": "och",


### PR DESCRIPTION
Added "WGS 84 / Pseudo-Mercator" localization for EPSG:3857. epsg.io use this naming and I think it's official. Other possible names: Web Mercator, WGS 84 Web Mercator, WGS 84 Pseudo-Mercator.

In localization files there are also other localization for displaying crs but these are never used. Only default (like "EPSG:3857 coordinates") is used. I wondered that it should be used if transformation isn't enabled (shows map projection and no dropdown). This was changed in: https://github.com/oskariorg/oskari-frontend/pull/408. I think that wasn't wanted change. So restored checkt that use epsg specific display name if defined.