### PR TITLE
Rename Panel as CollapsePanel, use oskari-ui alias

### DIFF
--- a/bundles/admin/admin-layereditor/view/LayerWizard/LayerCapabilitiesListing.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard/LayerCapabilitiesListing.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {List, ListItem} from '../../components/List';
+import { List, ListItem } from 'oskari-ui';
 
 export class LayerCapabilitiesListing extends React.Component {
     getItem (item) {

--- a/bundles/admin/admin-layereditor/view/LayerWizard/LayerTypeSelection.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard/LayerTypeSelection.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Button } from '../../components/Button';
+import { Button } from 'oskari-ui';
 
 const StyledButton = styled(Button)`
     margin: 10px;

--- a/bundles/framework/layerlist/view/LayerCollapse.jsx
+++ b/bundles/framework/layerlist/view/LayerCollapse.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Collapse } from '../../../admin/admin-layereditor/components/Collapse';
-import { Alert } from '../../../admin/admin-layereditor/components/Alert';
+import { Alert, Collapse } from 'oskari-ui';
 import { LayerCollapsePanel } from './LayerCollapse/LayerCollapsePanel';
 import styled from 'styled-components';
 

--- a/bundles/framework/layerlist/view/LayerCollapse/Layer.jsx
+++ b/bundles/framework/layerlist/view/LayerCollapse/Layer.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Switch } from '../../../../admin/admin-layereditor/components/Switch';
+import { Switch } from 'oskari-ui';
 import { LayerTools } from './Layer/LayerTools';
 
 const LayerDiv = styled('div')`

--- a/bundles/framework/layerlist/view/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerCollapse/LayerCollapsePanel.jsx
@@ -1,10 +1,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { List, ListItem } from '../../../../admin/admin-layereditor/components/List';
+import { Badge, CollapsePanel, List, ListItem } from 'oskari-ui';
 import { Layer } from './Layer';
-import { Panel } from '../../../../admin/admin-layereditor/components/Collapse';
-import { Badge } from '../../../../admin/admin-layereditor/components/Badge';
 import styled from 'styled-components';
 
 const StyledListItem = styled(ListItem)`
@@ -50,13 +48,13 @@ export const LayerCollapsePanel = ({group, showLayers, selectedLayerIds, mapSrs,
     });
     const visibleLayerCount = showLayers ? showLayers.length : 0;
     return (
-        <Panel {...propsNeededForPanel}
+        <CollapsePanel {...propsNeededForPanel}
             header={group.getTitle()}
             extra={
                 <Badge inversed={true} count={getBadgeText(group, visibleLayerCount)}/>
             }>
             <List bordered={false} dataSource={layerRows} renderItem={renderLayer}/>
-        </Panel>
+        </CollapsePanel>
     );
 };
 

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -2,7 +2,7 @@ export { Alert } from '../../bundles/admin/admin-layereditor/components/Alert';
 export { Badge } from '../../bundles/admin/admin-layereditor/components/Badge';
 export { Button } from '../../bundles/admin/admin-layereditor/components/Button';
 export { Checkbox } from '../../bundles/admin/admin-layereditor/components/Checkbox';
-export { Collapse, Panel } from '../../bundles/admin/admin-layereditor/components/Collapse';
+export { Collapse, Panel as CollapsePanel } from '../../bundles/admin/admin-layereditor/components/Collapse';
 export { Confirm } from '../../bundles/admin/admin-layereditor/components/Confirm';
 export { List, ListItem } from '../../bundles/admin/admin-layereditor/components/List';
 export { NumberInput } from '../../bundles/admin/admin-layereditor/components/NumberInput';


### PR DESCRIPTION
Renaming potentially ambiguous component "Panel".
Updating references to ui components.