### PR TITLE
Add null check for manual refresh event bulider

### DIFF
--- a/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
+++ b/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
@@ -158,8 +158,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
                 if (!me._flyoutOpen) {
                     if (me._mapStatusChanged) {
                         sandbox.postRequestByName('userinterface.UpdateExtensionRequest', [me._instance, 'detach']);
-                        var event = Oskari.eventBuilder('WFSRefreshManualLoadLayersEvent')();
-                        sandbox.notifyAll(event);
+                        var eventBuilder = Oskari.eventBuilder('WFSRefreshManualLoadLayersEvent');
+                        if (eventBuilder) {
+                            sandbox.notifyAll(event);
+                        }
                         me._mapStatusChanged = false;
                     } else {
                         sandbox.postRequestByName('userinterface.UpdateExtensionRequest', [me._instance, 'detach']);


### PR DESCRIPTION
Fixes an error that occurs when opening feature data table. This bug had no side effects other than the error log in console.