### PR TITLE
Fix broken icon on admin-hierarchical-layerlist

### DIFF
--- a/bundles/admin/admin-hierarchical-layerlist/resources/scss/style.scss
+++ b/bundles/admin/admin-hierarchical-layerlist/resources/scss/style.scss
@@ -430,7 +430,10 @@ div.hierarchical-layerlist {
             .layer-tools {
                 .layer-tool {
                     &.edit-layer {
-                        background-image: $editIcon;
+                        /* Requires !important because Oskari icons.css has .edit-layer that otherwise overrides these with using !important */
+                        background-image: $editIcon !important;
+                        background-repeat: no-repeat !important;
+                        background-position: center center !important;
                     }
                 }
             }


### PR DESCRIPTION
Edit-layer icon was added to Oskari icons in 1.53.0 which broke the edit-layer icon on admin-hierarchical-layerlist. We need to force styling here as Oskari icons use !important. Proper fix would be trying to remove the !importants from Oskari icons.