### PR TITLE
Remove height to get rid of unnecessary scrollbar

### DIFF
--- a/bundles/framework/search/resources/scss/style.scss
+++ b/bundles/framework/search/resources/scss/style.scss
@@ -36,10 +36,6 @@ div.search {
         margin-bottom: 8px;
     }
 
-    div.searchContainer {
-        height: 90%;
-    }
-
     div.resultList {
         height: 90%;
         overflow: auto;


### PR DESCRIPTION
Scrollbar appeared on the search flyout on 1.53.0 release.