### PR TITLE
Fix filtering via button and search text

### DIFF
--- a/bundles/framework/layerlist/view/LayerCollapse/StateHandler.js
+++ b/bundles/framework/layerlist/view/LayerCollapse/StateHandler.js
@@ -25,10 +25,11 @@ export class StateHandler {
         return 'LayerCollapseStateHandler';
     }
     updateStateWithProps ({ groups, selectedLayerIds, filterKeyword }) {
+        const groupsChanged = groups && groups !== this.groups;
         this.groups = groups || this.groups;
         this.mutatedGroups = null;
         this.selectedLayerIds = selectedLayerIds || this.selectedLayerIds;
-        if (!this._filterStateChanged(filterKeyword)) {
+        if (!groupsChanged && !this._filterStateChanged(filterKeyword)) {
             this.notify();
             return;
         }

--- a/bundles/framework/layerlist/view/LayersTab.jsx
+++ b/bundles/framework/layerlist/view/LayersTab.jsx
@@ -179,12 +179,6 @@ Oskari.clazz.define(
             );
             me.layerListMountPoint = jQuery(me.templates.layerListMountPoint);
             me.tabPanel.getContainer().append(me.layerListMountPoint);
-
-            me.tabPanel.setSelectionHandler(selected => {
-                if (selected) {
-                    me._render();
-                }
-            });
         },
 
         _addLayerWizardBtn: function () {
@@ -314,7 +308,6 @@ Oskari.clazz.define(
         showLayerGroups: function (groups) {
             this.layerGroups = groups;
             this.filterLayers(this.filterField.getValue());
-            this._render();
         },
 
         /**


### PR DESCRIPTION
Fixes an issue where user would first filter layers using search text and then change active filter button.
Also skip duplicate render pass.