### PR TITLE
Bugfixes to layer style saving

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerFormService.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerFormService.js
@@ -293,9 +293,7 @@ export class AdminLayerFormService {
         const styles = layer.styleJSON !== '' ? this.getMVTStylesWithSrcLayer(layer.styleJSON, layer.layerName) : undefined;
         const hoverStyle = layer.hoverJSON !== '' ? JSON.parse(layer.hoverJSON) : undefined;
         layer.options = { ...layer.options, ...{ styles: styles, hover: hoverStyle } };
-        if (layer.options) {
-            layer.options = JSON.stringify(layer.options);
-        }
+        layer.options = JSON.stringify(layer.options);
     }
 
     deleteLayer () {

--- a/bundles/admin/admin-layereditor/view/AdminLayerFormService.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerFormService.js
@@ -287,15 +287,9 @@ export class AdminLayerFormService {
         }
     }
     setLayerOptions (layer) {
-        if (layer.styleJSON !== '') {
-            const stylesWithSrcLayer = this.getMVTStylesWithSrcLayer(layer.styleJSON, layer.layerName);
-            layer.options = { ...layer.options, ...{ styles: stylesWithSrcLayer } };
-        }
-
-        if (layer.hoverJSON !== '') {
-            layer.options = { ...layer.options, ...{ hover: JSON.parse(layer.hoverJSON) } };
-        }
-
+        const styles = layer.styleJSON !== '' ? this.getMVTStylesWithSrcLayer(layer.styleJSON, layer.layerName) : undefined;
+        const hoverStyle = layer.hoverJSON !== '' ? JSON.parse(layer.hoverJSON) : undefined;
+        layer.options = { ...layer.options, ...{ styles: styles, hover: hoverStyle } };
         if (layer.options) {
             layer.options = JSON.stringify(layer.options);
         }

--- a/bundles/admin/admin-layereditor/view/AdminLayerFormService.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerFormService.js
@@ -281,7 +281,10 @@ export class AdminLayerFormService {
             return;
         }
         try {
-            JSON.parse(value);
+            const result = JSON.parse(value);
+            if (typeof result !== 'object') {
+                validationErrors.push({ key: msgKey, type: 'error' });
+            }
         } catch (error) {
             validationErrors.push({ key: msgKey, type: 'error' });
         }


### PR DESCRIPTION
- Fixed clearing of styles when user clears style fields in ui.
- Added type check to JSON parse result since noticed in testing that JSON.parse() call with input "abcd" throws error as expected but with input "1234" JSON.parse() does not trow error but instead returns numeric value 1234.