### PR TITLE
Fix warning layout in map publishing domain validation

### DIFF
--- a/bundles/framework/publisher2/resources/scss/style.scss
+++ b/bundles/framework/publisher2/resources/scss/style.scss
@@ -318,11 +318,11 @@ div.publisher-color-picker-group-wrapper {
 
 div.domain-warning {
     color: black;
-    padding-top: 10px;
+    margin-top: 10px;
     div {
-        padding-left: 5px;
+        margin-right: 5px;
         float: left;
-        padding-bottom: 5px;
+        margin-bottom: 5px;
     }
 }
 


### PR DESCRIPTION
Changed padding to margin in styles to fix warning icon. Also changed 5 px space in div from left to right.