### PR TITLE
Add warning for unsupported layers

### DIFF
--- a/bundles/admin/admin-layereditor/components/Icon.jsx
+++ b/bundles/admin/admin-layereditor/components/Icon.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import { Icon as AntIcon } from 'antd';
+import 'antd/es/icon/style/index.js';
+
+export const Icon = props => <AntIcon {...props} />;

--- a/bundles/admin/admin-layereditor/components/Tooltip.jsx
+++ b/bundles/admin/admin-layereditor/components/Tooltip.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import { Tooltip as AntTooltip } from 'antd';
+import 'antd/es/tooltip/style/index.js';
+
+export const Tooltip = (props) => <AntTooltip {...props} />;

--- a/bundles/admin/admin-layereditor/components/WarningIcon.jsx
+++ b/bundles/admin/admin-layereditor/components/WarningIcon.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Icon, Tooltip } from 'oskari-ui';
+
+const type = 'warning';
+const theme = 'twoTone';
+const color = '#FFBF00';
+
+export const WarningIcon = (props) => {
+    return (
+        props.tooltip
+            ? <Tooltip title={props.tooltip}>
+                <Icon type={type} theme={theme} twoToneColor={color} {...props}/>
+            </Tooltip>
+            : <Icon type={type} theme={theme} twoToneColor={color} {...props}/>
+    );
+};
+
+WarningIcon.propTypes = {
+    tooltip: PropTypes.string
+};

--- a/bundles/admin/admin-layereditor/components/WarningIcon.test.jsx
+++ b/bundles/admin/admin-layereditor/components/WarningIcon.test.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { WarningIcon, Tooltip } from 'oskari-ui';
+
+describe('<WarningIcon/> ', () => {
+    test('renders tooltip component when tooltip prop is passed', () => {
+        expect.assertions(1);
+        const tooltip = 'test value';
+        const wrapper = mount(<WarningIcon tooltip={tooltip}/>);
+        expect(wrapper.find(Tooltip).length).toEqual(1);
+    });
+
+    test('does not render tooltip component when tooltip prop is omitted', () => {
+        expect.assertions(1);
+        const wrapper = mount(<WarningIcon/>);
+        expect(wrapper.find(Tooltip).length).toEqual(0);
+    });
+});

--- a/bundles/framework/layerlist/view/LayerCollapse/Layer/LayerTools.jsx
+++ b/bundles/framework/layerlist/view/LayerCollapse/Layer/LayerTools.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { LAYER_TYPE } from '../constants';
+import { WarningIcon } from 'oskari-ui';
 
 const getIconDiv = float => styled('div')`
     float: ${float};
@@ -125,9 +126,9 @@ export const LayerTools = ({ model, mapSrs, mutator, locale }) => {
         <Tools className="layer-tools">
             {
                 !model.isSupportedSrs(mapSrs) &&
-                <RightFloatingIcon
-                    className="layer-not-supported icon-warning-light"
-                    title={locale.tooltip['unsupported-srs']} />
+                <LeftFloatingIcon>
+                    <WarningIcon tooltip={locale.tooltip['unsupported-srs']}/>
+                </LeftFloatingIcon>
             }
             <BackendStatus {...backendStatusProps} onClick={() => mutator.showLayerBackendStatus(model.getId())}/>
             <SecondaryIcon {...secondaryIconProps}/>

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -16,3 +16,6 @@ export { Tabs, TabPane } from '../../bundles/admin/admin-layereditor/components/
 export { TextAreaInput } from '../../bundles/admin/admin-layereditor/components/TextAreaInput';
 export { TextInput } from '../../bundles/admin/admin-layereditor/components/TextInput';
 export { UrlInput } from '../../bundles/admin/admin-layereditor/components/UrlInput';
+export { Icon } from '../../bundles/admin/admin-layereditor/components/Icon';
+export { WarningIcon } from '../../bundles/admin/admin-layereditor/components/WarningIcon';
+export { Tooltip } from '../../bundles/admin/admin-layereditor/components/Tooltip';


### PR DESCRIPTION
Created icon, warning icon and tooltip components to oskari-ui and changed layerlist to use created  warning icon. Check is layer supported is not changed since according to testing this seems to work properly.