### PR TITLE
Fix mapmodule.centerMap()

### DIFF
--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -615,7 +615,6 @@ export class MapModule extends AbstractMapModule {
      * @return {Boolean} success
      */
     centerMap (lonlat, zoom, suppressEnd, options) {
-        const { top, bottom, left, right } = zoom.value;
         const view = this.getMap().getView();
         const animation = options && options.animation ? options.animation : '';
         const duration = options && options.duration ? options.duration : 3000;
@@ -625,17 +624,20 @@ export class MapModule extends AbstractMapModule {
             return false;
         }
 
-        if (zoom && top && bottom && left && right) {
-            const zoomOut = top === bottom && left === right;
-            this.zoomToExtent(zoom, zoomOut, zoomOut);
-            view.setCenter(lonlat);
-            return true;
+        if (zoom === Number) {
+            // backwards compatibility
+            zoom = { type: 'zoom', value: zoom };
         }
         if (zoom === null || zoom === undefined) {
             zoom = { type: 'zoom', value: this.getMapZoom() };
-        }
-        if (zoom === Number) {
-            zoom = { type: 'zoom', value: zoom };
+        } else {
+            const { top, bottom, left, right } = zoom.value;
+            if (top && left && bottom && right) {
+                const zoomOut = top === bottom && left === right;
+                this.zoomToExtent(zoom, zoomOut, zoomOut);
+                view.setCenter(lonlat);
+                return true;
+            }
         }
 
         const zoomValue = zoom.type === 'scale' ? view.getZoomForResolution(zoom.value) : zoom.value;

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -624,20 +624,20 @@ export class MapModule extends AbstractMapModule {
             return false;
         }
 
-        if (zoom === Number) {
-            // backwards compatibility
-            zoom = { type: 'zoom', value: zoom };
-        }
         if (zoom === null || zoom === undefined) {
             zoom = { type: 'zoom', value: this.getMapZoom() };
         } else {
-            const { top, bottom, left, right } = zoom.value;
+            const { top, bottom, left, right } = zoom.value || zoom;
             if (top && left && bottom && right) {
                 const zoomOut = top === bottom && left === right;
                 this.zoomToExtent(zoom, zoomOut, zoomOut);
                 view.setCenter(lonlat);
                 return true;
             }
+        }
+        if (zoom === Number) {
+            // backwards compatibility
+            zoom = { type: 'zoom', value: zoom };
         }
 
         const zoomValue = zoom.type === 'scale' ? view.getZoomForResolution(zoom.value) : zoom.value;


### PR DESCRIPTION
Current code breaks when extent is not requested. If zoom is a number an error is printed out to developer console: "Cannot read property 'top' of undefined". This fixes the issue.