### PR TITLE
Support optional params in Oskari.urls.getRoute()

### DIFF
--- a/src/oskari.es6.js
+++ b/src/oskari.es6.js
@@ -18,6 +18,32 @@ function getUrl (key) {
     return _urls[key];
 }
 
+function encodeParams(params) {
+    if (typeof params !== 'object') {
+        return '';
+    }
+    return Object.keys(params)
+        .map(k => encodeURIComponent(k) + '=' + encodeURIComponent(params[k]))
+        .join('&');
+    
+}
+
+function appendQueryToURL(url, query) {
+    if (typeof query === 'undefined' || query === '') {
+        return url;
+    }
+    if (url.indexOf('?') === -1) {
+        return `${url}?${query}`;
+    }
+    if (url.endsWith('?')) {
+        return url + query;
+    }
+    if (url.endsWith('&')) {
+        return url + query;
+    }
+    return `${url}&${query}`;
+}
+
 const Oskari = {
     VERSION: '1.54.0-dev',
     setMarkers (markers) {
@@ -80,11 +106,11 @@ const Oskari = {
              * @param  {String} route [description]
              * @return {String} url to use when making API calls
              */
-            getRoute: function (route) {
-                var url = getUrl('api') || '/action?';
+            getRoute: function (route, optionalParams) {
+                var url = appendQueryToURL(getUrl('api') || '/action?', encodeParams(optionalParams));
+
                 if (route) {
-                    // TODO: check if url ends with ? or &
-                    return url + 'action_route=' + route;
+                    return appendQueryToURL(url, 'action_route=' + route);
                 }
                 return url;
             }

--- a/src/oskari.es6.js
+++ b/src/oskari.es6.js
@@ -103,7 +103,8 @@ const Oskari = {
             },
             /**
              * Action route urls
-             * @param  {String} route [description]
+             * @param  {String} route optional route name. Returns base url if name is not given.
+             * @param  {Object} optionalParams optional object that will be encoded as querystring parameters for the URL.
              * @return {String} url to use when making API calls
              */
             getRoute: function (route, optionalParams) {

--- a/src/oskari.test.js
+++ b/src/oskari.test.js
@@ -1,0 +1,18 @@
+
+const Oskari = require('./oskari.es6').default;
+
+describe('Oskari', () => {
+    test('urls.getRoute()', () => {
+        Oskari.urls.set('api', 'random');
+        expect(Oskari.urls.getRoute('testing')).toEqual('random?action_route=testing');
+        expect(Oskari.urls.getRoute('testing', { test: 1})).toEqual('random?test=1&action_route=testing');
+        
+        Oskari.urls.set('api', 'random?');
+        expect(Oskari.urls.getRoute('testing')).toEqual('random?action_route=testing');
+        expect(Oskari.urls.getRoute('testing', { test: 1})).toEqual('random?test=1&action_route=testing');
+        
+        Oskari.urls.set('api', 'random?foo=bar');
+        expect(Oskari.urls.getRoute('testing')).toEqual('random?foo=bar&action_route=testing');
+        expect(Oskari.urls.getRoute('testing', { test: 1})).toEqual('random?foo=bar&test=1&action_route=testing');
+    });
+});


### PR DESCRIPTION
 Oskari.urls.getRoute() now accepts an optional second parameter for url-params that should be included in the url. Also added sanity checks for url instead of assuming it ends with ? or &