### PR TITLE
Fix issue where tool click changes flyout order

### DIFF
--- a/bundles/framework/hierarchical-layerlist/components/SelectedLayer.js
+++ b/bundles/framework/hierarchical-layerlist/components/SelectedLayer.js
@@ -127,6 +127,7 @@ Oskari.clazz.define('Oskari.framework.bundle.hierarchical-layerlist.SelectedLaye
         if (typeof handler === 'function') {
             tool.off('click');
             tool.on('click', function (evt) {
+                evt.stopPropagation();
                 handler(evt);
             });
         }


### PR DESCRIPTION
If click is propagated to flyout it tries to raise itself to be on top of other flyouts. That is problematic if another flyout is opened from the tool (the opened flyout is taken to the background).