### PR TITLE
Fix layerlist hiding layeradmin on tool click

### DIFF
--- a/bundles/admin/admin-layereditor/instance.js
+++ b/bundles/admin/admin-layereditor/instance.js
@@ -100,7 +100,11 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
             flyout.setDataProviders(this._getDataProviders());
             flyout.setMapLayerGroups(layerService.getAllLayerGroups());
             flyout.setLayer(layerService.findMapLayer(layerId));
-            flyout.show();
+            if (flyout.isVisible()) {
+                flyout.bringToTop();
+            } else {
+                flyout.show();
+            }
         }
 
         /**

--- a/bundles/framework/divmanazer/extension/ExtraFlyout.js
+++ b/bundles/framework/divmanazer/extension/ExtraFlyout.js
@@ -69,10 +69,10 @@ Oskari.clazz.define('Oskari.userinterface.extension.ExtraFlyout',
         show: function () {
             var me = this;
             if (me.isVisible()) {
+                me.bringToTop();
                 return;
             }
             me._popup.show();
-            me.bringToTop();
             me._visible = true;
             this.trigger('show');
         },

--- a/bundles/framework/divmanazer/extension/ExtraFlyout.js
+++ b/bundles/framework/divmanazer/extension/ExtraFlyout.js
@@ -69,10 +69,10 @@ Oskari.clazz.define('Oskari.userinterface.extension.ExtraFlyout',
         show: function () {
             var me = this;
             if (me.isVisible()) {
-                me.bringToTop();
                 return;
             }
             me._popup.show();
+            me.bringToTop();
             me._visible = true;
             this.trigger('show');
         },


### PR DESCRIPTION
Initially tried to fix this by using event.stopPropagation on tool click, but since we are on the React side of things, we can't stop native event bubbling. Native eventhandling is already done when React's SyntheticEvent handler receives the click. The correct fix for this situation would be rewriting the Flyout component, but since that's out of scope... here's a small workaround. Let them race for visibility!

React [docs](https://reactjs.org/docs/handling-events.html):
> When using React you should generally not need to call addEventListener to add listeners to a DOM element after it is created. Instead, just provide a listener when the element is initially rendered.
