### PR TITLE
Update thematic map selections

### DIFF
--- a/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
@@ -77,6 +77,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
             if (hasRegionSetRestriction) {
                 select.disableOptions(disabledIndicatorIDs);
             }
+            if (select.getOptions().options.length > 0) {
+                me._enableIndicatorSelection();
+            }
 
             if (result.complete) {
                 me.spinner.stop();
@@ -88,6 +91,12 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
                 }
             }
         });
+    },
+    _enableIndicatorSelection () {
+        const sumoSelectDiv = jQuery('.stats-ind-selector').find('.SumoSelect');
+        sumoSelectDiv.removeClass('disabled');
+        const select = sumoSelectDiv.find('.SumoUnder');
+        select.removeAttr('disabled');
     },
     setElement: function (el) {
         this.element = el;
@@ -167,7 +176,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
         me.spinner.insertTo(indicatorSelector);
         var indicOptions = {
             placeholder: panelLoc.selectIndicatorPlaceholder,
-            multi: true
+            multi: true,
+            disabled: true
         };
         var indicSelect = new SelectList();
         var indicDropdown = indicSelect.create(null, indicOptions);

--- a/bundles/statistics/statsgrid2016/components/SelectList.js
+++ b/bundles/statistics/statsgrid2016/components/SelectList.js
@@ -161,6 +161,9 @@ export class SelectList extends FormComponent {
         if (options.multi) {
             select.prop('multiple', true);
         }
+        if (options.disabled) {
+            select.prop('disabled', true);
+        }
         // Initialize SumoSelect
         select.SumoSelect(options);
         // Sumo selects the first value by default. Reset to placeholder.

--- a/bundles/statistics/statsgrid2016/resources/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/resources/scss/style.scss
@@ -214,6 +214,30 @@ div.oskari-flyout {
             /* TODO: limits the description from blowing up the flyout, but this needs to be handled in some other way */
             max-width : 450px;
 
+            .oskari-select {
+                // Placeholder styles not depended on enabled/disabled state
+                .SumoSelect {
+                    .placeholder {
+                        font-style: normal;
+                    }
+                }
+                // Placeholder styles for enabled select
+                [class='SumoSelect'] {
+                    .placeholder {
+                        color: #595959;
+                    }
+                }
+                // Placeholder styles for disabled select
+                [class='SumoSelect disabled'] {
+                    p {
+                        background-color: #f5f5f5;
+                    }
+                    .placeholder {
+                        color: #979797;
+                    }
+                }
+            }
+
             div.selection {
                 padding-top: 0;
                 padding-bottom: 6px;


### PR DESCRIPTION
This PR contains changes to initialize indicator selection as disabled. Once some indicators are fetched and populated to list, indicator selection is enabled. Also styling is done to make more visual contrast between enabled and disabled fields.