### PR TITLE
Ol6 tuning

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -53,7 +53,13 @@ Oskari.clazz.define(
         me._options = {
             resolutions: [2000, 1000, 500, 200, 100, 50, 20, 10, 4, 2, 1, 0.5, 0.25],
             srsName: 'EPSG:3067',
-            units: 'm'
+            units: 'm',
+            maxExtent: {
+                left: 0,
+                bottom: 0,
+                right: 10000000,
+                top: 10000000
+            }
         };
         if (options) {
             for (var key in options) {
@@ -75,12 +81,7 @@ Oskari.clazz.define(
         me._mapScales = [];
 
         // props: left,bottom,right, top
-        me._maxExtent = me._options.maxExtent || {
-            left: 0,
-            bottom: 0,
-            right: 10000000,
-            top: 10000000
-        };
+        me._maxExtent = me._options.maxExtent;
 
         me._sandbox = null;
 

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -75,7 +75,7 @@ export class MapModule extends AbstractMapModule {
         var projection = olProj.get(me.getProjection());
         projection.setExtent(this.__boundsToArray(this.getMaxExtent()));
 
-        map.setView(new olView({
+        const viewOpts = {
             extent: projection.getExtent(),
             projection: projection,
             // actual startup location is set with MapMoveRequest later on
@@ -83,7 +83,15 @@ export class MapModule extends AbstractMapModule {
             center: [0, 0],
             zoom: 0,
             resolutions: this.getResolutionArray()
-        }));
+        };
+
+        const worldProjections = ['EPSG:3857', 'EPSG:4326'];
+        if (!worldProjections.includes(me.getProjection())) {
+            // constraint center to extent allowing viewport to extend beyond extent for "local" projections
+            viewOpts.constrainOnlyCenter = true;
+        }
+
+        map.setView(new olView(viewOpts));
 
         me._setupMapEvents(map);
         return map;


### PR DESCRIPTION
Workaround for https://github.com/openlayers/openlayers/blob/master/changelog/upgrade-notes.md#the-view-extent-option-now-applies-to-the-whole-viewport. EPSG:3857 and 4326 projections are now limited to extent on viewport but other projections work as before (viewport can show outside extent but center can't go beyond extent). 

(Note: constrainCenterOnly mentioned in ol 6 upgrade notes is actually constrainOnlyCenter https://openlayers.org/en/latest/apidoc/module-ol_View-View.html)