### PR TITLE
Optimizing hover performance

### DIFF
--- a/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
+++ b/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
@@ -30,6 +30,7 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
             this.layerTypeHandlers = {};
             this.defaultHandlers = {};
             this._registerEventHandlers();
+            this._handleHover = this._handleHover.bind(this);
         }
 
         /**
@@ -210,6 +211,32 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
         }
 
         /**
+         * Less accurate than _getTopmostFeatureAndLayer. Optimized for performance.
+         * @method _getHoveredFeatureAndLayer
+         *
+         * @param {Oskari.mapframework.event.common.MouseHoverEvent} event
+         * @return {Promise} Promise resolving to an object containing the topmost feature and it's layer on the mouse location.
+         * An empty object if features were not found.
+         */
+        async _getHoveredFeatureAndLayer (event) {
+            let feature, layer;
+            const pixel = [event.getPageX(), event.getPageY()];
+            const layers = this._map.getLayers().getArray()
+                .filter(layer => this._onlyRegisteredTypesFilter(layer) && layer.getVisible())
+                .reverse();
+
+            for (const lyr of layers) {
+                const features = await lyr.getFeatures(pixel);
+                if (features.length > 0) {
+                    layer = lyr;
+                    feature = features[0];
+                    break;
+                }
+            };
+            return { feature, layer };
+        }
+
+        /**
          * @method _getTooltipContent
          * @param {Array} contentOptions
          * @param {olFeature | olRenderFeature} feature
@@ -330,8 +357,10 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
             if (this._sandbox.getMap().isMoving()) {
                 return;
             }
-            let { feature, layer } = this._getTopmostFeatureAndLayer(event);
+            this._getHoveredFeatureAndLayer(event).then(this._handleHover);
+        }
 
+        _handleHover ({ feature, layer }) {
             // No feature hits for these layer types. Call hover handlers without feature or layer.
             Object.keys(this.layerTypeHandlers).forEach(layerType => {
                 const handler = this._getRegisteredHandler(layerType, SERVICE_HOVER);

--- a/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
+++ b/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
@@ -216,7 +216,6 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
          *
          * @param {Oskari.mapframework.event.common.MouseHoverEvent} event
          * @return {Promise} Promise resolving to an object containing the topmost feature and it's layer on the mouse location.
-         * An empty object if features were not found.
          */
         async _getHoveredFeatureAndLayer (event) {
             let feature, layer;


### PR DESCRIPTION
Updating map hover to use OL 6 `getFeatures` function for hover hit detection.
`getFeatures` has better performance, but is less accurate than previously used `forEachFeatureAtPixel`.