### PR TITLE
Prevent ol keyboard panning on input field

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Filter/Search.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Filter/Search.jsx
@@ -3,6 +3,11 @@ import { TextInput, Icon } from 'oskari-ui';
 import { Mutator } from 'oskari-ui/util';
 import PropTypes from 'prop-types';
 
+const handleChange = (event, mutator) => {
+    event.stopPropagation();
+    mutator.setSearchText(event.currentTarget.value);
+};
+
 export const Search = React.forwardRef(({ searchText, locale, mutator }, ref) => {
     return <TextInput
         ref={ref}
@@ -10,7 +15,7 @@ export const Search = React.forwardRef(({ searchText, locale, mutator }, ref) =>
         allowClear
         placeholder={locale.filter.search.placeholder}
         prefix={<Icon type="search"/>}
-        onChange={event => mutator.setSearchText(event.currentTarget.value)}/>;
+        onChange={event => handleChange(event, mutator)}/>;
 });
 Search.displayName = 'Search';
 Search.propTypes = {

--- a/bundles/framework/layerselection2/Flyout.js
+++ b/bundles/framework/layerselection2/Flyout.js
@@ -341,10 +341,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselection2.Flyout',
 
             if (input) {
                 input.val(layer.getOpacity());
-                input.on('change paste keyup', function () {
+                input.on('change paste keyup', function (e) {
                     // sliderEl.slider('value', jQuery(this).val());
                     me._layerOpacityChanged(layer, jQuery(this).val());
                 });
+                input.on('keydown', e => e.stopPropagation());
             }
 
             return slider;

--- a/bundles/framework/layerselection2/Flyout.js
+++ b/bundles/framework/layerselection2/Flyout.js
@@ -345,7 +345,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselection2.Flyout',
                     // sliderEl.slider('value', jQuery(this).val());
                     me._layerOpacityChanged(layer, jQuery(this).val());
                 });
-                input.on('keydown', e => e.stopPropagation());
             }
 
             return slider;

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -2,6 +2,7 @@
 import * as olExtent from 'ol/extent';
 import { defaults as olInteractionDefaults } from 'ol/interaction';
 import KeyboardPan from 'ol/interaction/KeyboardPan';
+import KeyboardZoom from 'ol/interaction/KeyboardZoom';
 import { noModifierKeys, targetNotEditable } from 'ol/events/condition';
 import Collection from 'ol/Collection';
 import olFormatWKT from 'ol/format/WKT';
@@ -106,7 +107,7 @@ export class MapModule extends AbstractMapModule {
             altShiftDragRotate: false,
             pinchRotate: false
         };
-        const keyboardPanOptions = {
+        const keyboardInteractionOptions = {
             condition: mapBrowserEvent => {
                 if (!noModifierKeys(mapBrowserEvent) || !targetNotEditable(mapBrowserEvent)) {
                     return false;
@@ -121,7 +122,10 @@ export class MapModule extends AbstractMapModule {
         const interactions = olInteractionDefaults(interactionOptions).getArray()
             .map(interaction => {
                 if (interaction instanceof KeyboardPan) {
-                    return new KeyboardPan(keyboardPanOptions);
+                    return new KeyboardPan(keyboardInteractionOptions);
+                }
+                if (interaction instanceof KeyboardZoom) {
+                    return new KeyboardZoom(keyboardInteractionOptions);
                 }
                 return interaction;
             });


### PR DESCRIPTION
Interaction behavior has changed in OL 6.
Key events in input fields bubble causing `KeyboardPan` actions.

Experimented on ol/Map `keyboardEventTarget` property without luck.

Perhaps `condition` in `KeyboardPan` options would be worth checking.
https://openlayers.org/en/latest/apidoc/module-ol_interaction_KeyboardPan-KeyboardPan.html
https://openlayers.org/en/latest/apidoc/module-ol_events_condition.html#.targetNotEditable

Stopping propagation works on dom elements, but doubtly in React.

This doesn't seem to be sufficient check for our case.
https://github.com/openlayers/openlayers/blob/v6.1.1/src/ol/events/condition.js#L210
Created an issue to Openlayers in case this is a bug. https://github.com/openlayers/openlayers/issues/10270

Created a fix to mapmodule using custom `condition` function for keyboard interactions.