### PR TITLE
Improve feature request api documents

### DIFF
--- a/api/mapping/mapmodule/request/addfeaturestomaprequest.md
+++ b/api/mapping/mapmodule/request/addfeaturestomaprequest.md
@@ -11,7 +11,7 @@ Allows user to add features to map.
 
 Adds vector features to the map or updates existing features.
 
-The request takes two parameters. The first describes the features. When updating existing features on map, the first parameter is an object containing feature attributes that are used for feature matching. The second parameter is for options which are the same in both cases.
+The request takes two parameters. The first describes the features. When updating existing features on map, the first parameter is an object containing feature attributes that are used for feature matching. The second parameter options.
 
 #### Adding features to map
 
@@ -77,6 +77,8 @@ var updateFeatureWithProperty = {
   ]
 };
 ```
+
+Updating supports only `prio` and `featureStyle` options.
 
 #### Options
 The second parameter is options.

--- a/api/mapping/mapmodule/request/addfeaturestomaprequest.md
+++ b/api/mapping/mapmodule/request/addfeaturestomaprequest.md
@@ -9,7 +9,13 @@ Allows user to add features to map.
 
 ## Description
 
-Vector features can be added on the map. The request must contain the geometries of the features. The geometry must be provided either as a WKT-string or a GeoJSON - object. Request creates a new feature layer if any layer with given layer id doesn't exist. Optionally, also additional layer control options such as features' style can be provided in a JSON-object. Recommendable practice is to prepare a layer with [VectorLayerRequest](/api/requests/#unreleased/mapping/mapmodule/request/vectorlayerrequest.md) before adding features.
+Adds vector features to the map or updates the features. The request takes two parameters. The first describes the features and second is for options. When updating existing features on map, the first parameter is an object containing feature attributes that are used for feature matching.
+
+Options are same on both cases.
+
+### Adding features to map
+
+The geometry must be provided either as a WKT-string or a GeoJSON - object. Request creates a new feature layer if any layer with given layer id doesn't exist. Optionally, also additional layer control options such as features' style can be provided in a JSON-object. Recommendable practice is to prepare a layer with [VectorLayerRequest](/api/requests/#unreleased/mapping/mapmodule/request/vectorlayerrequest.md) before adding features.
 
 WKT
 ```javascript
@@ -51,7 +57,17 @@ var geojsonObject = {
 };
 ```
 
-Options object
+### Updating existing features on map
+
+The first parameter is an object containing feature attributes that are used for feature matching.
+
+```javascript
+var updateFeature = {'test_property':2};
+```
+
+### Options
+Second parameter is options.
+
 ```javascript
 {
   layerId: 'MY_VECTOR_LAYER',
@@ -60,7 +76,9 @@ Options object
   centerTo: true,
   clearPrevious: true,
   cursor: 'zoom-in',
-  prio: 1
+  prio: 1,
+  featureStyle: {},
+  optionalStyles: []
 }
 ```
 <ul>
@@ -78,13 +96,14 @@ Options object
         <b>cursor</b> - Mouse cursor when cursor is over the feature.
     </li><li>
         <b>prio</b> - Feature prio. The lowest number is the must important feature (top on the layer). The highest number is the least important.
+    </li><li>
+        <b>featureStyle</b> - A Oskari style object. Defines a generic style used for all the features.
+    </li><li>
+        <b>optionalStyles</b> - Array of Oskari styles for geojson features. Style is used, if filtering values matches to feature properties.
     </li>
 <ul>
 
-Geometry can also feature properties object. This will identify feature what you want to update. This is usefull for example highlight feature.
-```javascript
-var updateFeature = {'test_property':2};
-```
+See [Oskari JSON style](/documentation/examples/oskari-style) for style object definitions.
 
 ## Examples
 

--- a/api/mapping/mapmodule/request/addfeaturestomaprequest.md
+++ b/api/mapping/mapmodule/request/addfeaturestomaprequest.md
@@ -13,7 +13,7 @@ Adds vector features to the map or updates existing features.
 
 The request takes two parameters. The first describes the features. When updating existing features on map, the first parameter is an object containing feature attributes that are used for feature matching. The second parameter is for options which are the same in both cases.
 
-### Adding features to map
+#### Adding features to map
 
 The first parameter, geometry must be provided either as a WKT-string or a GeoJSON - object. Request creates a new feature layer if any layer with given layer id doesn't exist. Optionally, also additional layer control options such as features' style can be provided in a JSON-object. 
 
@@ -59,7 +59,7 @@ var geojsonObject = {
 };
 ```
 
-### Updating existing features on map
+#### Updating existing features on map
 
 The first parameter is an object containing feature attributes that are used for feature matching.
 
@@ -67,22 +67,8 @@ The first parameter is an object containing feature attributes that are used for
 var updateFeatureWithAttributes = {'test_property':2};
 ```
 
-### Options
+#### Options
 The second parameter is options.
-
-```javascript
-{
-  layerId: 'MY_VECTOR_LAYER',
-  animationDuration: 500,
-  attributes: {},
-  centerTo: true,
-  clearPrevious: true,
-  cursor: 'zoom-in',
-  prio: 1,
-  featureStyle: {},
-  optionalStyles: []
-}
-```
 
 |Key|Type|Description|
 |---:|:---:|:---|
@@ -94,13 +80,13 @@ The second parameter is options.
 | cursor | string | Mouse cursor when cursor is over the feature.|
 | prio | number | Feature prio. The lowest number is the must important feature (top on the layer). The highest number is the least important.|
 | featureStyle | object | Defines a generic style used for all the features.|
-| optionalStyles | object | Array of Oskari styles for geojson features. Style is used, if filtering values matches to feature properties.|
+| optionalStyles | array | Array of Oskari styles for geojson features. Style is used, if filtering values matches to feature properties.|
 
 See [Oskari JSON style](/documentation/examples/oskari-style) for style object definitions.
 
 ## Examples
 
-Usage example (GeoJSON)
+Add feature using GeoJSON
 
 ```javascript
 // Define the features as GeoJSON
@@ -147,7 +133,7 @@ var options = {
 Oskari.getSandbox().postRequestByName(rn, [geojsonObject, layerOptions]);
 ```
 
-Usage example (WKT)
+Add feature using WKT
 
 ```javascript
 // Define a wkt-geometry
@@ -169,8 +155,7 @@ var options = {
 Oskari.getSandbox().postRequestByName(rn, [WKT, layerOptions]);
 ```
 
-
-Usage example - Update specific feature.
+Update specific feature
 
 ```javascript
 // First add feature, feature format can be an WKT or GeoJSON

--- a/api/mapping/mapmodule/request/addfeaturestomaprequest.md
+++ b/api/mapping/mapmodule/request/addfeaturestomaprequest.md
@@ -72,8 +72,8 @@ The property value can also be an object of properties that will be added to mat
 ```javascript
 var updateFeatureWithProperty = {
   'test_property': [
-    { 'value': 1, 'newly_added_property': 10 },
-    { 'value': 2, 'new_added_property': 20 },
+    { 'value': 1, 'properties': { 'newly_added_property': 10 }},
+    { 'value': 2, 'properties': { 'newly_added_property': 20 }},
   ]
 };
 ```

--- a/api/mapping/mapmodule/request/addfeaturestomaprequest.md
+++ b/api/mapping/mapmodule/request/addfeaturestomaprequest.md
@@ -83,27 +83,18 @@ The second parameter is options.
   optionalStyles: []
 }
 ```
-<ul>
-    <li>
-        <b>layerId</b> - Layer's id to specify which layer you want to add features (if the layer does not exist one will be created).
-    </li><li>
-        <b>animationDuration</b> - On update requests it's possible to animate fill color change. Specify animation duration in ms.
-    </li><li>
-        <b>attributes</b> - Feature's attributes, especially handy when the geometry is a WKT-string.
-    </li><li>
-        <b>clearPrevious</b> - when true, the previous features will be cleared
-    </li><li>
-        <b>centerTo</b> - Whether to zoom to the added features.
-    </li><li>
-        <b>cursor</b> - Mouse cursor when cursor is over the feature.
-    </li><li>
-        <b>prio</b> - Feature prio. The lowest number is the must important feature (top on the layer). The highest number is the least important.
-    </li><li>
-        <b>featureStyle</b> - A Oskari style object. Defines a generic style used for all the features.
-    </li><li>
-        <b>optionalStyles</b> - Array of Oskari styles for geojson features. Style is used, if filtering values matches to feature properties.
-    </li>
-<ul>
+
+|Key|Description|
+|---:|---|
+|layerId|Layer's id to specify which layer you want to add features (if the layer does not exist one will be created).|
+|animationDuration|On update requests it's possible to animate fill color change. Specify animation duration in ms.|
+|attributes|Feature's attributes, especially handy when the geometry is a WKT-string.|
+|clearPrevious|when true, the previous features will be cleared|
+|centerTo|Whether to zoom to the added features.|
+|cursor|Mouse cursor when cursor is over the feature.|
+|prio|Feature prio. The lowest number is the must important feature (top on the layer). The highest number is the least important.|
+|featureStyle|A Oskari style object. Defines a generic style used for all the features.|
+|optionalStyles|Array of Oskari styles for geojson features. Style is used, if filtering values matches to feature properties.|
 
 See [Oskari JSON style](/documentation/examples/oskari-style) for style object definitions.
 

--- a/api/mapping/mapmodule/request/addfeaturestomaprequest.md
+++ b/api/mapping/mapmodule/request/addfeaturestomaprequest.md
@@ -9,13 +9,15 @@ Allows user to add features to map.
 
 ## Description
 
-Adds vector features to the map or updates the features. The request takes two parameters. The first describes the features and second is for options. When updating existing features on map, the first parameter is an object containing feature attributes that are used for feature matching.
+Adds vector features to the map or updates existing features.
 
-Options are same on both cases.
+The request takes two parameters. The first describes the features. When updating existing features on map, the first parameter is an object containing feature attributes that are used for feature matching. The second parameter is for options which are the same in both cases.
 
 ### Adding features to map
 
-The geometry must be provided either as a WKT-string or a GeoJSON - object. Request creates a new feature layer if any layer with given layer id doesn't exist. Optionally, also additional layer control options such as features' style can be provided in a JSON-object. Recommendable practice is to prepare a layer with [VectorLayerRequest](/api/requests/#unreleased/mapping/mapmodule/request/vectorlayerrequest.md) before adding features.
+The first parameter, geometry must be provided either as a WKT-string or a GeoJSON - object. Request creates a new feature layer if any layer with given layer id doesn't exist. Optionally, also additional layer control options such as features' style can be provided in a JSON-object. 
+
+Recommendable practice is to prepare a layer with [VectorLayerRequest](/api/requests/#unreleased/mapping/mapmodule/request/vectorlayerrequest.md) before adding features.
 
 WKT
 ```javascript
@@ -62,11 +64,11 @@ var geojsonObject = {
 The first parameter is an object containing feature attributes that are used for feature matching.
 
 ```javascript
-var updateFeature = {'test_property':2};
+var updateFeatureWithAttributes = {'test_property':2};
 ```
 
 ### Options
-Second parameter is options.
+The second parameter is options.
 
 ```javascript
 {

--- a/api/mapping/mapmodule/request/addfeaturestomaprequest.md
+++ b/api/mapping/mapmodule/request/addfeaturestomaprequest.md
@@ -84,17 +84,17 @@ The second parameter is options.
 }
 ```
 
-|Key|Description|
-|---:|---|
-|layerId|Layer's id to specify which layer you want to add features (if the layer does not exist one will be created).|
-|animationDuration|On update requests it's possible to animate fill color change. Specify animation duration in ms.|
-|attributes|Feature's attributes, especially handy when the geometry is a WKT-string.|
-|clearPrevious|when true, the previous features will be cleared|
-|centerTo|Whether to zoom to the added features.|
-|cursor|Mouse cursor when cursor is over the feature.|
-|prio|Feature prio. The lowest number is the must important feature (top on the layer). The highest number is the least important.|
-|featureStyle|A Oskari style object. Defines a generic style used for all the features.|
-|optionalStyles|Array of Oskari styles for geojson features. Style is used, if filtering values matches to feature properties.|
+|Key|Type|Description|
+|---|---|---|
+| layerId | string | Layer's id to specify which layer you want to add features (if the layer does not exist one will be created).|
+| animationDuration | number | On update requests it's possible to animate fill color change. Specify animation duration in ms.|
+| attributes | object | Feature's attributes, especially handy when the geometry is a WKT-string.|
+| clearPrevious | boolean | when true, the previous features will be cleared|
+| centerTo | boolean | Whether to zoom to the added features.|
+| cursor | string | Mouse cursor when cursor is over the feature.|
+| prio | number | Feature prio. The lowest number is the must important feature (top on the layer). The highest number is the least important.|
+| featureStyle | Oskari style object | Defines a generic style used for all the features.|
+| optionalStyles | object | Array of Oskari styles for geojson features. Style is used, if filtering values matches to feature properties.|
 
 See [Oskari JSON style](/documentation/examples/oskari-style) for style object definitions.
 

--- a/api/mapping/mapmodule/request/addfeaturestomaprequest.md
+++ b/api/mapping/mapmodule/request/addfeaturestomaprequest.md
@@ -78,7 +78,7 @@ var updateFeatureWithProperty = {
 };
 ```
 
-Updating supports only `prio` and `featureStyle` options.
+Updating supports `layerId`, `prio` and `featureStyle` options.
 
 #### Options
 The second parameter is options.

--- a/api/mapping/mapmodule/request/addfeaturestomaprequest.md
+++ b/api/mapping/mapmodule/request/addfeaturestomaprequest.md
@@ -85,7 +85,7 @@ The second parameter is options.
 ```
 
 |Key|Type|Description|
-|---|---|---|
+|---:|:---:|:---|
 | layerId | string | Layer's id to specify which layer you want to add features (if the layer does not exist one will be created).|
 | animationDuration | number | On update requests it's possible to animate fill color change. Specify animation duration in ms.|
 | attributes | object | Feature's attributes, especially handy when the geometry is a WKT-string.|
@@ -93,7 +93,7 @@ The second parameter is options.
 | centerTo | boolean | Whether to zoom to the added features.|
 | cursor | string | Mouse cursor when cursor is over the feature.|
 | prio | number | Feature prio. The lowest number is the must important feature (top on the layer). The highest number is the least important.|
-| featureStyle | Oskari style object | Defines a generic style used for all the features.|
+| featureStyle | object | Defines a generic style used for all the features.|
 | optionalStyles | object | Array of Oskari styles for geojson features. Style is used, if filtering values matches to feature properties.|
 
 See [Oskari JSON style](/documentation/examples/oskari-style) for style object definitions.

--- a/api/mapping/mapmodule/request/addfeaturestomaprequest.md
+++ b/api/mapping/mapmodule/request/addfeaturestomaprequest.md
@@ -130,7 +130,7 @@ var options = {
   centerTo: true
 };
 
-Oskari.getSandbox().postRequestByName(rn, [geojsonObject, layerOptions]);
+Oskari.getSandbox().postRequestByName(rn, [geojsonObject, options]);
 ```
 
 Add feature using WKT
@@ -152,7 +152,7 @@ var options = {
   attributes
 };
 
-Oskari.getSandbox().postRequestByName(rn, [WKT, layerOptions]);
+Oskari.getSandbox().postRequestByName(rn, [WKT, options]);
 ```
 
 Update specific feature
@@ -188,7 +188,6 @@ var featureStyle = {
 
 // Define wanted feature attributes
 var updatedFeatureAttributes = {'test_property':1};
-var params = [updatedFeatureAttributes, options];
 
 var options = {
     featureStyle: featureStyle,
@@ -198,7 +197,7 @@ var options = {
 
 Oskari.getSandbox().postRequestByName(
     'MapModulePlugin.AddFeaturesToMapRequest',
-    params
+     [updatedFeatureAttributes, options]
 );
 ```
 

--- a/api/mapping/mapmodule/request/addfeaturestomaprequest.md
+++ b/api/mapping/mapmodule/request/addfeaturestomaprequest.md
@@ -61,10 +61,21 @@ var geojsonObject = {
 
 #### Updating existing features on map
 
-The first parameter is an object containing feature attributes that are used for feature matching.
+The first parameter is an object containing a feature property that is used for feature matching. The value can be an array or a single value.
 
 ```javascript
-var updateFeatureWithAttributes = {'test_property':2};
+var updateFeatureWithProperty = {'test_property': [1,2]};
+```
+
+The property value can also be an object of properties that will be added to matching features.
+
+```javascript
+var updateFeatureWithProperty = {
+  'test_property': [
+    { 'value': 1, 'newly_added_property': 10 },
+    { 'value': 2, 'new_added_property': 20 },
+  ]
+};
 ```
 
 #### Options

--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -19,7 +19,7 @@ The request takes one parameter, options.
 | layerInspireName | string | Layer Inspire name (theme) when adding layer to visible (see showLayer). | `'Inspire theme name'` |
 | layerOrganizationName | string | Layer organization name when adding layer to visible (see showLayer). | `'Organization name'` |
 | showLayer | boolean | Adds layer to layer selector as a selected map layer. | `true` |
-| opacity | number | Opacity value, 0-100 | `80` |
+| opacity | number | 0-100 | `80` |
 | layerName | string | Name | `'Layer name'` |
 | layerDescription | string | Description | `'Description text'` | 
 | layerPermissions | object | Permissions | `{ publish: 'publication_permission_ok' }` |

--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -22,7 +22,7 @@ The request takes one parameter, options.
 | opacity | number | Opacity value, 0-100 |
 | layerName | string | Name |
 | layerDescription | string | Description |
-| layerPermissions | object | Permissions { publish: 'publication_permission_ok' }` |
+| layerPermissions | object | Permissions `{ publish: 'publication_permission_ok' }` |
 | minScale | number | Feature min scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. |
 | maxScale | number | Feature max scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. |
 | hover | object | See Hover Settings section below |

--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -9,9 +9,49 @@ Adds a new feature layer to map or updates an existing layer.
 
 ## Description
 
-Prepares a layer for later use.
+Prepares a layer for later use or updates an existing layer. 
 
-Options object
+The request takes one parameter, options.
+
+|Key|Type|Description|
+|---:|:---:|:---|---|
+| layerId | string | In case you want to add layer with specified id (if the layer does not exist one will be created). Needed, if at a later point you need to be able to remove features on only that specific layer or update the layer's properties. |
+| layerInspireName | string | Layer Inspire name (theme) when adding layer to visible (see showLayer). |
+| layerOrganizationName | string | Layer organization name when adding layer to visible (see showLayer). |
+| showLayer | boolean | Adds layer to layer selector as a selected map layer. |
+| opacity | number | Opacity value, 0-100 |
+| layerName | string | Name |
+| layerDescription | string | Description |
+| layerPermissions | object | Permissions ```{ publish: 'publication_permission_ok' }``` |
+| minScale | number | Feature min scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. |
+| maxScale | number | Feature max scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. |
+| hover | object | Describes how to visualize features on mouse hover and what kind of tooltip should be shown. Note that features are not hovered while drawing is active (DrawTools).
+Hover has two optional keys `featureStyle` and `content`.
+See [Oskari JSON style](/documentation/examples/oskari-style) for style object definitions. 
+
+Content should be content of tooltip as an array. Each object creates a row to the tooltip.
+Each row object has `key` or `keyProperty` and `valueProperty`.
+`key` is a label and will be rendered as is.
+`valueProperty` and `keyProperty` will be fetched from the feature's properties.
+
+```javascript
+"hover": {
+    "featureStyle":  {...},
+    "content": [
+        { "key": "Feature Data" },
+        { "key": 'Feature ID', "valueProperty": "id" },
+        { "keyProperty": "type", "valueProperty": "name" }
+    ]
+}
+```
+Exampe above would create a tooltip like
+
+Feature Data
+Feature ID: 23098523243
+Road: Main Street
+|
+
+Example object
 ```javascript
 {
     layerId: 'MY_VECTOR_LAYER',
@@ -26,34 +66,39 @@ Options object
     },
     minScale: 1451336,
     maxScale: 1,
-    hover: {}
+    hover: {
+        'content': [
+            { 'key': 'Feature ID', 'valueProperty': 'id' }
+        ]
+    }
 }
 ```
-<ul>
-    <li>
-        <b>layerId</b> - In case you want to add layer with specified id (if the layer does not exist one will be created). Needed, if at a later point you need to be able to remove features on only that specific layer or update the layer's properties.
-    </li><li>
-        <b>layerInspireName</b> - Layer Inspire name when adding layer to visible (see showLayer).
-    </li><li>
-        <b>layerOrganizationName</b> - Layer organization name when adding layer to visible (see showLayer).
-    </li><li>
-        <b>showLayer</b> - Adds layer to layer selector as a selected map layer.
-    </li><li>
-        <b>opacity</b> - Layer opacity.
-    </li><li>
-        <b>layerName</b> - Layer name. If already added layer then update layer name.
-    </li><li>
-        <b>layerDescription</b> - Layer description. If already added layer then update layer description.
-    </li><li>
-        <b>layerPermissions</b> - Layer permissions.
-    </li><li>
-        <b>minScale</b> - Feature min scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features.
-    </li><li>
-        <b>maxScale</b> - Feature max scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features.
-    </li><li>
-        <b>hover</b> - Layer hover options. Oskari style with hover options. Describes how to visualize features on hover and what kind of tooltip should be shown. Note that features are not hovered while drawing is active (DrawTools). See [Oskari JSON style](/documentation/examples/oskari-style) for style object definitions.
-    </li>
-</ul>
+
+#### Hover settings
+
+Hover describes how to visualize features on mouse hover and what kind of tooltip should be shown.
+Hover has two optional keys `featureStyle` and `content`.
+
+Content should be content of tooltip as an array. Each object creates a row to the tooltip.
+Each row object has `key` or `keyProperty` and `valueProperty`.
+`key` is a label and will be rendered as is.
+`valueProperty` and `keyProperty` will be fetched from the feature's properties.
+
+```javascript
+"hover": {
+    "featureStyle":  {...},
+    "content": [
+        { "key": "Feature Data" },
+        { "key": 'Feature ID', "valueProperty": "id" },
+        { "keyProperty": "type", "valueProperty": "name" }
+    ]
+}
+```
+Exampe above would create a tooltip like
+
+Feature Data
+Feature ID: 23098523243
+Road: Main Street
 
 ## Examples
 ### Adding a new layer example
@@ -84,7 +129,11 @@ Define layerId which matches layer's id which should be updated. Add properties 
 const newOptions = {
     layerId: 'MY_VECTOR_LAYER', // existing id
     opacity: 100,
-    hover: {}
+    hover: {
+        'content': [
+            { 'key': 'Feature ID', 'valueProperty': 'id' }
+        ]
+    }
 };
 Oskari.getSandbox().postRequestByName('VectorLayerRequest', [newOptions]); 
 ```

--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -64,7 +64,7 @@ Road: Main Street
 Only prepares a layer for later use. To add features to this layer see [AddFeaturesToMapRequest](/api/requests/#unreleased/mapping/mapmodule/request/addfeaturestomaprequest.md).
 
 ```javascript
-const options = {
+var options = {
     layerId: 'MY_VECTOR_LAYER',
     layerInspireName: 'Inspire theme name',
     layerOrganizationName: 'Organization name',
@@ -76,7 +76,13 @@ const options = {
         'publish': 'publication_permission_ok'
     },
     maxScale: 1,
-    minScale: 1451336
+    minScale: 1451336,
+    hover: {
+        'featureStyle':  {
+            'inherit': true,
+            'effect': 'darken'
+        }
+    }
 };
 Oskari.getSandbox().postRequestByName('VectorLayerRequest', [options]); 
 
@@ -85,12 +91,16 @@ Oskari.getSandbox().postRequestByName('VectorLayerRequest', [options]);
 Define layerId which matches layer's id which should be updated. Add properties which should be updated. Note that if id doesn't match any existing layer, a new layer will be created.
 
 ```javascript
-const newOptions = {
+var newOptions = {
     layerId: 'MY_VECTOR_LAYER', // existing id
     opacity: 100,
     hover: {
+        'featureStyle':  {
+            'inherit': true,
+            'effect': 'darken'
+        },
         'content': [
-            { 'key': 'Feature ID', 'valueProperty': 'id' }
+            { 'key': 'Feature ID', 'valueProperty': 'test_property' }
         ]
     }
 };

--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -14,7 +14,7 @@ Prepares a layer for later use or updates an existing layer.
 The request takes one parameter, options.
 
 |Key|Type|Description|Example value|
-|---:|:---:|:---|---|
+|---:|:---:|:---|:---:|
 | layerId | string | In case you want to add layer with specified id (if the layer does not exist one will be created). Needed, if at a later point you need to be able to remove features on only that specific layer or update the layer's properties. | `'MY_VECTOR_LAYER'` |
 | layerInspireName | string | Layer Inspire name (theme) when adding layer to visible (see showLayer). | `'Inspire theme name'` |
 | layerOrganizationName | string | Layer organization name when adding layer to visible (see showLayer). | `'Organization name'` |
@@ -25,7 +25,7 @@ The request takes one parameter, options.
 | layerPermissions | object | Permissions | `{ publish: 'publication_permission_ok' }` |
 | minScale | number | Feature min scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. | `1451336` |
 | maxScale | number | Feature max scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. | `1` |
-| hover | Describes how to visualize features on hover and what kind of tooltip should be shown. | See Hover Settings section below |
+| hover | object | Describes how to visualize features on hover and what kind of tooltip should be shown. | See Hover Settings section below |
 
 ### Hover Settings
 
@@ -48,11 +48,12 @@ Each row object has `key` or `keyProperty` and `valueProperty`.
     ]
 }
 ```
-Exampe above would create a tooltip like
-
+Exampe above would create a tooltip like:
+```
 Feature Data
 Feature ID: 23098523243
 Road: Main Street
+```
 
 ## Examples
 ### Adding a new layer example

--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -25,40 +25,11 @@ The request takes one parameter, options.
 | layerPermissions | object | Permissions | `{ publish: 'publication_permission_ok' }` |
 | minScale | number | Feature min scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. | `1451336` |
 | maxScale | number | Feature max scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. | `1` |
-| hover | object | See Hover Settings section below | ```
-{
-    'content': [
-        { 'key': 'Feature ID', 'valueProperty': 'id' }
-    ]
-}
-```|
-
-Example object
-```javascript
-{
-    layerId: 'MY_VECTOR_LAYER',
-    layerInspireName: 'Inspire theme name',
-    layerOrganizationName: 'Organization name',
-    showLayer: true,
-    opacity: 80,
-    layerName: 'Layer name',
-    layerDescription: 'Description text',
-    layerPermissions: {
-        'publish': 'publication_permission_ok'
-    },
-    minScale: 1451336,
-    maxScale: 1,
-    hover: {
-        'content': [
-            { 'key': 'Feature ID', 'valueProperty': 'id' }
-        ]
-    }
-}
-```
+| hover | Describes how to visualize features on hover and what kind of tooltip should be shown. | See Hover Settings section below |
 
 ### Hover Settings
 
-Hover describes how to visualize features on mouse hover and what kind of tooltip should be shown. Note that features are not hovered while drawing is active (DrawTools). 
+Note that features are not hovered while drawing is active (DrawTools). 
 
 Hover has two optional keys `featureStyle` and `content`. See [Oskari JSON style](/documentation/examples/oskari-style) for `featureStyle` definition.
 

--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -13,19 +13,25 @@ Prepares a layer for later use or updates an existing layer.
 
 The request takes one parameter, options.
 
-|Key|Type|Description|
-|---:|:---:|:---|
-| layerId | string | In case you want to add layer with specified id (if the layer does not exist one will be created). Needed, if at a later point you need to be able to remove features on only that specific layer or update the layer's properties. |
-| layerInspireName | string | Layer Inspire name (theme) when adding layer to visible (see showLayer). |
-| layerOrganizationName | string | Layer organization name when adding layer to visible (see showLayer). |
-| showLayer | boolean | Adds layer to layer selector as a selected map layer. |
-| opacity | number | Opacity value, 0-100 |
-| layerName | string | Name |
-| layerDescription | string | Description |
-| layerPermissions | object | Permissions `{ publish: 'publication_permission_ok' }` |
-| minScale | number | Feature min scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. |
-| maxScale | number | Feature max scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. |
-| hover | object | See Hover Settings section below |
+|Key|Type|Description|Example value|
+|---:|:---:|:---|---|
+| layerId | string | In case you want to add layer with specified id (if the layer does not exist one will be created). Needed, if at a later point you need to be able to remove features on only that specific layer or update the layer's properties. | `'MY_VECTOR_LAYER'` |
+| layerInspireName | string | Layer Inspire name (theme) when adding layer to visible (see showLayer). | `'Inspire theme name'` |
+| layerOrganizationName | string | Layer organization name when adding layer to visible (see showLayer). | `'Organization name'` |
+| showLayer | boolean | Adds layer to layer selector as a selected map layer. | `true` |
+| opacity | number | Opacity value, 0-100 | `80` |
+| layerName | string | Name | `'Layer name'` |
+| layerDescription | string | Description | `'Description text'` | 
+| layerPermissions | object | Permissions | `{ publish: 'publication_permission_ok' }` |
+| minScale | number | Feature min scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. | `1451336` |
+| maxScale | number | Feature max scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. | `1` |
+| hover | object | See Hover Settings section below | ```
+{
+    'content': [
+        { 'key': 'Feature ID', 'valueProperty': 'id' }
+    ]
+}
+```|
 
 Example object
 ```javascript

--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -25,7 +25,7 @@ The request takes one parameter, options.
 | layerPermissions | object | Permissions | `{ publish: 'publication_permission_ok' }` |
 | minScale | number | Feature min scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. | `1451336` |
 | maxScale | number | Feature max scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. | `1` |
-| hover | object | Describes how to visualize features on hover and what kind of tooltip should be shown. | See Hover Settings section below |
+| hover | object | Describes how to visualize features on hover and what kind of tooltip should be shown. | See Hover Settings below |
 
 ### Hover Settings
 

--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -14,7 +14,7 @@ Prepares a layer for later use or updates an existing layer.
 The request takes one parameter, options.
 
 |Key|Type|Description|
-|---:|:---:|:---|---|
+|---:|:---:|:---|
 | layerId | string | In case you want to add layer with specified id (if the layer does not exist one will be created). Needed, if at a later point you need to be able to remove features on only that specific layer or update the layer's properties. |
 | layerInspireName | string | Layer Inspire name (theme) when adding layer to visible (see showLayer). |
 | layerOrganizationName | string | Layer organization name when adding layer to visible (see showLayer). |
@@ -22,7 +22,7 @@ The request takes one parameter, options.
 | opacity | number | Opacity value, 0-100 |
 | layerName | string | Name |
 | layerDescription | string | Description |
-| layerPermissions | object | Permissions |
+| layerPermissions | object | Permissions { publish: 'publication_permission_ok' }` |
 | minScale | number | Feature min scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. |
 | maxScale | number | Feature max scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. |
 | hover | object | See Hover Settings section below |

--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -26,8 +26,6 @@ Options object
     },
     minScale: 1451336,
     maxScale: 1,
-    featureStyle: {},
-    optionalStyles: [],  
     hover: {}
 }
 ```
@@ -53,17 +51,9 @@ Options object
     </li><li>
         <b>maxScale</b> - Feature max scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features.
     </li><li>
-        <b>featureStyle</b> - A Oskari style object.
-    </li><li>
-        <b>optionalStyles</b> - Array of Oskari styles for geojson features. Style is used, if filtering values matches to feature properties.
-    </li><li>
-        <b>hover</b> - Layer hover options. Oskari style with hover options.
+        <b>hover</b> - Layer hover options. Oskari style with hover options. Describes how to visualize features on hover and what kind of tooltip should be shown. Note that features are not hovered while drawing is active (DrawTools). See [Oskari JSON style](/documentation/examples/oskari-style) for style object definitions.
     </li>
 </ul>
-
-FeatureStyle property defines a generic style used for all the features. With optionalStyles property you can specify style for certain features only. Hover options describes how to visualize features on hover and what kind of tooltip should be shown. Note that features isn't hovered while drawing is active (DrawTools).
-
-See [Oskari JSON style](/documentation/examples/oskari-style) for style object definitions.
 
 ## Examples
 ### Adding a new layer example
@@ -94,15 +84,10 @@ Define layerId which matches layer's id which should be updated. Add properties 
 const newOptions = {
     layerId: 'MY_VECTOR_LAYER', // existing id
     opacity: 100,
-    featureStyle: {},
-    optionalStyles: [],
     hover: {}
 };
 Oskari.getSandbox().postRequestByName('VectorLayerRequest', [newOptions]); 
 ```
-FeatureStyle property defines a generic style used for all the features. With optionalStyles property you can specify style for certain features only. The constructor is the same for both of these styles but in optionalStyle you also need to specify the feature it is used for.
-
-See [Oskari JSON style](/documentation/examples/oskari-style) for style object definitions.
 
 ## Related api
 

--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -38,9 +38,13 @@ Each row object has `key` or `keyProperty` and `valueProperty`.
 `key` is a label and will be rendered as is.
 `valueProperty` and `keyProperty` will be fetched from the feature's properties.
 
+For example:
 ```javascript
-'hover': {
-    'featureStyle':  {...},
+{
+    'featureStyle':  {
+        'inherit': true,
+        'effect': 'darken'
+    },
     'content': [
         { 'key': 'Feature Data' },
         { 'key': 'Feature ID', 'valueProperty': 'id' },
@@ -48,7 +52,7 @@ Each row object has `key` or `keyProperty` and `valueProperty`.
     ]
 }
 ```
-Exampe above would create a tooltip like:
+The features would be darker on mouse hover and they would have a tooltip like:
 ```
 Feature Data
 Feature ID: 23098523243

--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -22,7 +22,7 @@ The request takes one parameter, options.
 | opacity | number | Opacity value, 0-100 |
 | layerName | string | Name |
 | layerDescription | string | Description |
-| layerPermissions | object | Permissions ```{ publish: 'publication_permission_ok' }``` |
+| layerPermissions | object | Permissions `{ publish: 'publication_permission_ok' }` |
 | minScale | number | Feature min scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. |
 | maxScale | number | Feature max scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. |
 | hover | object | See Hover Settings section below |

--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -25,31 +25,7 @@ The request takes one parameter, options.
 | layerPermissions | object | Permissions ```{ publish: 'publication_permission_ok' }``` |
 | minScale | number | Feature min scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. |
 | maxScale | number | Feature max scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. |
-| hover | object | Describes how to visualize features on mouse hover and what kind of tooltip should be shown. Note that features are not hovered while drawing is active (DrawTools).
-Hover has two optional keys `featureStyle` and `content`.
-See [Oskari JSON style](/documentation/examples/oskari-style) for style object definitions. 
-
-Content should be content of tooltip as an array. Each object creates a row to the tooltip.
-Each row object has `key` or `keyProperty` and `valueProperty`.
-`key` is a label and will be rendered as is.
-`valueProperty` and `keyProperty` will be fetched from the feature's properties.
-
-```javascript
-"hover": {
-    "featureStyle":  {...},
-    "content": [
-        { "key": "Feature Data" },
-        { "key": 'Feature ID', "valueProperty": "id" },
-        { "keyProperty": "type", "valueProperty": "name" }
-    ]
-}
-```
-Exampe above would create a tooltip like
-
-Feature Data
-Feature ID: 23098523243
-Road: Main Street
-|
+| hover | object | See Hover Settings section below |
 
 Example object
 ```javascript
@@ -74,10 +50,11 @@ Example object
 }
 ```
 
-#### Hover settings
+### Hover Settings
 
-Hover describes how to visualize features on mouse hover and what kind of tooltip should be shown.
-Hover has two optional keys `featureStyle` and `content`.
+Hover describes how to visualize features on mouse hover and what kind of tooltip should be shown. Note that features are not hovered while drawing is active (DrawTools). 
+
+Hover has two optional keys `featureStyle` and `content`. See [Oskari JSON style](/documentation/examples/oskari-style) for `featureStyle` definition.
 
 Content should be content of tooltip as an array. Each object creates a row to the tooltip.
 Each row object has `key` or `keyProperty` and `valueProperty`.
@@ -85,12 +62,12 @@ Each row object has `key` or `keyProperty` and `valueProperty`.
 `valueProperty` and `keyProperty` will be fetched from the feature's properties.
 
 ```javascript
-"hover": {
-    "featureStyle":  {...},
-    "content": [
-        { "key": "Feature Data" },
-        { "key": 'Feature ID', "valueProperty": "id" },
-        { "keyProperty": "type", "valueProperty": "name" }
+'hover': {
+    'featureStyle':  {...},
+    'content': [
+        { 'key': 'Feature Data' },
+        { 'key': 'Feature ID', 'valueProperty': 'id' },
+        { 'keyProperty': 'type', 'valueProperty': 'name' }
     ]
 }
 ```

--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -22,7 +22,7 @@ The request takes one parameter, options.
 | opacity | number | Opacity value, 0-100 |
 | layerName | string | Name |
 | layerDescription | string | Description |
-| layerPermissions | object | Permissions `{ publish: 'publication_permission_ok' }` |
+| layerPermissions | object | Permissions |
 | minScale | number | Feature min scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. |
 | maxScale | number | Feature max scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. |
 | hover | object | See Hover Settings section below |

--- a/api/mapping/mapmodule/vectorlayerplugin.md
+++ b/api/mapping/mapmodule/vectorlayerplugin.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-''Provides functionality to draw vector layers on the map.''
+ Provides functionality to draw vector layers on the map.
 
 ## Bundle configuration
 


### PR DESCRIPTION
Fixed an error stating that style would be set using `VectorlayerRequest` when style is actually set using `MapModulePlugin.AddFeaturesToMapRequest`.

Improved request readability and modified examples.