### PR TITLE
Remove dblclick workaround

### DIFF
--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -42,8 +42,6 @@ export class MapModule extends AbstractMapModule {
     _initImpl (sandbox, options, map) {
         // css references use olMap as selectors so we need to add it
         this.getMapEl().addClass('olMap');
-        // disables text-selection on map (fixes an issue in Chrome 69 where dblclick on map selects text and prevents dragging the map)
-        this.getMapEl().addClass('disable-select');
         return map;
     }
 

--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -472,10 +472,3 @@ select {
   overflow: auto;
   position: fixed !important;
 }
-
-.disable-select {
-  -webkit-user-select: none;  
-  -moz-user-select: none;    
-  -ms-user-select: none;      
-  user-select: none;
-}


### PR DESCRIPTION
Makes feature data info popup text selectable again.