### PR TITLE
Fix publisher tool

### DIFF
--- a/bundles/framework/timeseries/publisher/TimeseriesTool.js
+++ b/bundles/framework/timeseries/publisher/TimeseriesTool.js
@@ -95,7 +95,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesTool',
         * @returns {Boolean} is tool disabled
         */
         isDisabled: function (data) {
-            return typeof this._getTimeseriesService().getActiveTimeseries() === 'undefined';
+            const service = this._getTimeseriesService();
+            return typeof service === 'undefined' || typeof service.getActiveTimeseries() === 'undefined';
         },
         /**
         * Get values.


### PR DESCRIPTION
Fixes an issue where publisher breaks if timeseries code is included in frontend code (main.js) but the bundle is not started as part of the app (GetAppSetup).