### PR TITLE
Fix zooming bug and set resolution constrain on

### DIFF
--- a/bundles/framework/myplaces3/MyPlacesTab.js
+++ b/bundles/framework/myplaces3/MyPlacesTab.js
@@ -142,7 +142,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.MyPlacesTab',
             var mapModule = this.instance.getSandbox().findRegisteredModuleInstance('MainMapModule');
             var center = mapModule.getCentroidFromGeoJSON(geometry);
             var bounds = mapModule.getBoundsFromGeoJSON(geometry);
-            var mapmoveRequest = Oskari.requestBuilder('MapMoveRequest')(center.x, center.y, bounds);
+            var mapmoveRequest = Oskari.requestBuilder('MapMoveRequest')(center.lon, center.lat, bounds);
             this.instance.sandbox.request(this.instance, mapmoveRequest);
             // add the myplaces layer to map
             var layerId = 'myplaces_' + categoryId;

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -83,7 +83,8 @@ export class MapModule extends AbstractMapModule {
             // still these need to be set to prevent errors
             center: [0, 0],
             zoom: 0,
-            resolutions: this.getResolutionArray()
+            resolutions: this.getResolutionArray(),
+            constrainResolution: true
         };
 
         const worldProjections = ['EPSG:3857', 'EPSG:4326'];
@@ -549,7 +550,7 @@ export class MapModule extends AbstractMapModule {
      */
     zoomToExtent (bounds, suppressStart, suppressEnd) {
         var extent = this.__boundsToArray(bounds);
-        this.getMap().getView().fit(extent, this.getMap().getSize());
+        this.getMap().getView().fit(extent);
         this.updateDomain();
         // send note about map change
         if (suppressStart !== true) {
@@ -688,7 +689,11 @@ export class MapModule extends AbstractMapModule {
             const { top, bottom, left, right } = zoom.value || zoom;
             if (top && left && bottom && right) {
                 const zoomOut = top === bottom && left === right;
-                this.zoomToExtent(zoom, zoomOut, zoomOut);
+                const suppressEvent = zoomOut;
+                this.zoomToExtent({ top, bottom, left, right }, suppressEvent, suppressEvent);
+                if (zoomOut) {
+                    this.zoomToScale(2000);
+                }
                 view.setCenter([lonlat.lon, lonlat.lat]);
                 return true;
             }

--- a/bundles/mapping/mapmodule/mapmodule.olcs.js
+++ b/bundles/mapping/mapmodule/mapmodule.olcs.js
@@ -467,6 +467,9 @@ class MapModuleOlCesium extends MapModuleOl {
      */
     centerMap (lonlat, zoom, suppressEnd, options) {
         lonlat = this.normalizeLonLat(lonlat);
+        if (!this.isValidLonLat(lonlat.lon, lonlat.lat)) {
+            return false;
+        }
         const location = olProj.transform([lonlat.lon, lonlat.lat], this.getProjection(), 'EPSG:4326');
         const cameraHeight = this.adjustZoom(zoom);
         const duration = options && options.duration ? options.duration : 3000;
@@ -478,7 +481,11 @@ class MapModuleOlCesium extends MapModuleOl {
         const { top, bottom, left, right } = zoom.value || zoom;
         if (zoom && top && bottom && left && right) {
             const zoomOut = top === bottom && left === right;
-            this.zoomToExtent(zoom, zoomOut, zoomOut);
+            const suppressEvent = zoomOut;
+            this.zoomToExtent({ top, bottom, left, right }, suppressEvent, suppressEvent);
+            if (zoomOut) {
+                this.zoomToScale(2000);
+            }
             this.getMap().getView().setCenter([lonlat.lon, lonlat.lat]);
             return true;
         }


### PR DESCRIPTION
Fix logic when zooming to a point. (zoom out a bit)
Set `constrainResolution` on map view. (OL 6 change) - zooms to closest resolution after interaction. 