### PR TITLE
Refresh layer visibility on layer support changes

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerViewTabsHandler.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerViewTabsHandler.js
@@ -98,6 +98,19 @@ class UIStateHandler extends StateHandler {
                     this.getLayerListHandler().getFilterHandler().useStashedState();
                 }
             },
+            'MapLayerEvent': event => {
+                if (!['update', 'sticky', 'tool'].includes(event.getOperation())) {
+                    return;
+                }
+                const layerId = event.getLayerId();
+                if (layerId) {
+                    const { layers } = this.selectedLayersHandler.getState();
+                    if (!layers.find(layer => layer.getId() === layerId)) {
+                        return;
+                    }
+                }
+                updateSelectedLayers();
+            },
             'MapLayerVisibilityChangedEvent': event => this.selectedLayersHandler.updateVisibilityInfo(event),
             'AfterMapLayerRemoveEvent': updateSelectedLayers,
             'AfterMapLayerAddEvent': updateSelectedLayers,

--- a/bundles/mapping/mapmodule/service/map.state.js
+++ b/bundles/mapping/mapmodule/service/map.state.js
@@ -600,7 +600,23 @@ import { UnsupportedLayerReason } from '../domain/UnsupportedLayerReason';
          * @param {UnsupportedLayerReason} layerUnsupportedReason
          */
         addLayerSupportCheck: function (layerUnsupportedReason) {
+            if (typeof layerUnsupportedReason.getLayerCheckFunction !== 'function') {
+                return;
+            }
             this._layerSupportedChecks[layerUnsupportedReason.getId()] = layerUnsupportedReason.getLayerCheckFunction();
+            // notify change on unsupported layers
+            this.getLayers()
+                .map(layer => {
+                    const supported = layerUnsupportedReason.getLayerCheckFunction()(layer);
+                    if (supported instanceof UnsupportedLayerReason) {
+                        return layer;
+                    }
+                })
+                .filter(layer => typeof layer !== 'undefined')
+                .forEach(layer => {
+                    const evt = Oskari.eventBuilder('MapLayerEvent')(layer.getId(), 'update');
+                    this._sandbox.notifyAll(evt);
+                });
         }
     }, {
         /**

--- a/bundles/mapping/mapmodule/service/map.state.js
+++ b/bundles/mapping/mapmodule/service/map.state.js
@@ -604,19 +604,22 @@ import { UnsupportedLayerReason } from '../domain/UnsupportedLayerReason';
                 return;
             }
             this._layerSupportedChecks[layerUnsupportedReason.getId()] = layerUnsupportedReason.getLayerCheckFunction();
+
             // notify change on unsupported layers
-            this.getLayers()
+            const affectedLayers = this.getLayers()
                 .map(layer => {
                     const supported = layerUnsupportedReason.getLayerCheckFunction()(layer);
                     if (supported instanceof UnsupportedLayerReason) {
                         return layer;
                     }
                 })
-                .filter(layer => typeof layer !== 'undefined')
-                .forEach(layer => {
-                    const evt = Oskari.eventBuilder('MapLayerEvent')(layer.getId(), 'update');
-                    this._sandbox.notifyAll(evt);
-                });
+                .filter(layer => typeof layer !== 'undefined');
+
+            if (affectedLayers.length !== 0) {
+                const event = Oskari.eventBuilder('MapLayerEvent')(null, 'update');
+                this._sandbox.notifyAll(event);
+            }
+
         }
     }, {
         /**

--- a/bundles/mapping/mapmodule/service/map.state.js
+++ b/bundles/mapping/mapmodule/service/map.state.js
@@ -619,7 +619,6 @@ import { UnsupportedLayerReason } from '../domain/UnsupportedLayerReason';
                 const event = Oskari.eventBuilder('MapLayerEvent')(null, 'update');
                 this._sandbox.notifyAll(event);
             }
-
         }
     }, {
         /**


### PR DESCRIPTION
Fixes an issue where 3D layer was visible in layer selector when it was not supported (2D map).
Issue occurred when the layer was initially added to the map on page load.