### PR TITLE
Fix/workaround infobox from re-opening after close

### DIFF
--- a/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
+++ b/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
@@ -236,15 +236,16 @@ Oskari.clazz.define(
                 jQuery(popup.dialog).css('background-color', 'inherit');
             } else {
                 popupType = 'desktop';
+                popupElement.html(popupContentHtml);
                 popup = new olOverlay({
                     element: popupElement[0],
                     // start with null positioning
                     positioning: null,
+                    stopEvent: true,
                     offset: [offsetX, offsetY]
                 });
                 mapModule.getMap().addOverlay(popup);
                 popup.setPosition(lonlatArray);
-                jQuery(popup.getElement()).html(popupContentHtml);
                 setTimeout(me._panMapToShowPopup.bind(me, lonlatArray, positioning), 0);
 
                 jQuery(popup.div).css('overflow', 'visible');
@@ -470,9 +471,9 @@ Oskari.clazz.define(
         },
 
         _setClickEvent: function (id, popup, contentData, additionalTools, isMobilePopup) {
-            var me = this,
-                sandbox = this.getMapModule().getSandbox(),
-                popupElement;
+            const me = this;
+            const sandbox = this.getMapModule().getSandbox();
+            let popupElement;
 
             if (isMobilePopup) {
                 popupElement = popup.dialog[0];
@@ -481,13 +482,15 @@ Oskari.clazz.define(
             }
 
             popupElement.onclick = function (evt) {
-                var link = jQuery(evt.target || evt.srcElement);
+                const link = jQuery(evt.target || evt.srcElement);
 
                 if (link.hasClass('olPopupCloseBox')) { // Close button
                     me.close(id);
+                    evt.stopPropagation();
+                    return;
                 } else { // Action links
-                    var i = link.attr('contentdata'),
-                        text = link.attr('value');
+                    const i = link.attr('contentdata');
+                    let text = link.attr('value');
                     if (!text) {
                         text = link.html();
                     }
@@ -513,6 +516,7 @@ Oskari.clazz.define(
                 if (!link.is('a') || link.parents('.getinforesult_table').length) {
                     evt.stopPropagation();
                 }
+                return false;
             };
         },
 

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -148,10 +148,24 @@ export class MapModule extends AbstractMapModule {
             me.notifyStartMove();
         });
 
+        function wasInfoBoxClosed (event) {
+            const target = event.target || event.srcElement || {};
+            return target.id === 'oskari_getinforesult_headerCloseButton';
+        }
+
         map.on('singleclick', function (evt) {
             if (me.getDrawingMode()) {
                 return;
             }
+            if (wasInfoBoxClosed(evt.originalEvent)) {
+                // After OL 6 upgrade:
+                // - ol/MapBrowserEventHandler.emulateClick_ receives map click, dispatches it and schedules it to be triggered again after small delay
+                // - infobox/OpenlayersPopupPlugin receives the click in _setClickEvent() popupElement.onclick -> closes the popup so it's no longer on map
+                // - the delayed event from emulateClick_ triggers and detects that there is no overlay on the spot that was
+                //   clicked (since infobox was removed from that spot on the previous step) triggering a new MapClickedEvent and opening another infobox
+                return;
+            }
+
             var CtrlPressed = evt.originalEvent.ctrlKey;
             var lonlat = {
                 lon: evt.coordinate[0],

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -148,16 +148,20 @@ export class MapModule extends AbstractMapModule {
             me.notifyStartMove();
         });
 
-        function wasInfoBoxClosed (event) {
-            const target = event.target || event.srcElement || {};
-            return target.id === 'oskari_getinforesult_headerCloseButton';
+        function wasInfoBoxClicked (event) {
+            // - Chrome supports event.path.
+            // - Most others composedPath() https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath
+            // - Polyfilled for IE/Edge on src/polyfills.js
+            var path = event.path || (event.composedPath && event.composedPath()) || [];
+            const foundInfoBox = path.find(item => item.id === 'getinforesult');
+            return typeof foundInfoBox !== 'undefined';
         }
 
         map.on('singleclick', function (evt) {
             if (me.getDrawingMode()) {
                 return;
             }
-            if (wasInfoBoxClosed(evt.originalEvent)) {
+            if (wasInfoBoxClicked(evt.originalEvent)) {
                 // After OL 6 upgrade:
                 // - ol/MapBrowserEventHandler.emulateClick_ receives map click, dispatches it and schedules it to be triggered again after small delay
                 // - infobox/OpenlayersPopupPlugin receives the click in _setClickEvent() popupElement.onclick -> closes the popup so it's no longer on map

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -37,3 +37,25 @@ jQuery.fn.outerHTML = function (arg) {
 
     return this;
 };
+
+// FROM: https://stackoverflow.com/questions/39245488/event-path-undefined-with-firefox-and-vue-js?noredirect=1&lq=1
+// Event.composedPath
+// Possibly normalize to add window to Safari's chain, as it does not?
+(function (E, d, w) {
+    if (!E.composedPath) {
+        E.composedPath = function () {
+            if (this.path) {
+                return this.path;
+            }
+            var target = this.target;
+
+            this.path = [];
+            while (target.parentNode !== null) {
+                this.path.push(target);
+                target = target.parentNode;
+            }
+            this.path.push(d, w);
+            return this.path;
+        }
+    }
+})(Event.prototype, document, window);


### PR DESCRIPTION
Added a check on map.on('singleclick') to detect if click happened on an infobox overlay ("close" icon or a button etc inside infobox that would close it). Polyfill needs some testing.

Nothing done in OpenlayersPopupPlugin.ol.js really matters but it's mostly formatting to please ESLint rules.