### PR TITLE
Handle failed loading for vector features

### DIFF
--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
@@ -229,7 +229,11 @@ export class VectorLayerHandler extends AbstractLayerHandler {
                     this.updateLayerProperties(layer, source);
                     updateLoadingStatus(LOADING_STATUS_VALUE.COMPLETE);
                 },
-                error: () => updateLoadingStatus(LOADING_STATUS_VALUE.ERROR)
+                error: () => {
+                    updateLoadingStatus(LOADING_STATUS_VALUE.ERROR);
+                    // mark failed loading so OL retries it later if map moves
+                    source.removeLoadedExtent(extent);
+                }
             });
         };
     }


### PR DESCRIPTION
Vector features are loaded with "tile strategy" with custom loader. Currently "tiles" with vector features that have have failed to load from the server are not retried later when the map moves etc and the user has to refresh the page to see the features. This _should_ fix the issue by telling OpenLayers that the loading failed.