### PR TITLE
Allow links to work in infobox

### DIFF
--- a/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
+++ b/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
@@ -516,7 +516,6 @@ Oskari.clazz.define(
                 if (!link.is('a') || link.parents('.getinforesult_table').length) {
                     evt.stopPropagation();
                 }
-                return false;
             };
         },
 


### PR DESCRIPTION
My "formatting changes" broke links in infobox on #1068. This fixes the issue.