### PR TITLE
Hide duplicate overlays

### DIFF
--- a/bundles/framework/myplaces3/view/PlaceForm.js
+++ b/bundles/framework/myplaces3/view/PlaceForm.js
@@ -281,6 +281,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.view.PlaceForm',
          */
         _getOnScreenForm: function () {
             // unbind live so
-            return jQuery('div.myplacesform');
+            return jQuery('div.myplacesform').filter(':visible');
         }
     });

--- a/bundles/mapping/mapmodule/mapmodule.olcs.js
+++ b/bundles/mapping/mapmodule/mapmodule.olcs.js
@@ -94,7 +94,7 @@ class MapModuleOlCesium extends MapModuleOl {
 
         this._initTerrainProvider();
         this._setupMapEvents(map);
-        this._fixDuplicateOverlays();
+        this._fixDuplicateOverlays(true);
 
         var updateReadyStatus = function () {
             scene.postRender.removeEventListener(updateReadyStatus);


### PR DESCRIPTION
Olcs creates a duplicates `ol/Overlay` for 3D view but won't hide the original overlay. That caused a new marker not to be added on map. When saving the plugin tried to read the values from the original overlay and not the one with actual values.

Now fixed. 

Having duplicate overlays can still cause issues since there is id's in the duplicated elements.  `Oskari.mapframework.bundle.infobox.plugin.mapmodule.OpenlayersPopupPlugin` needs some refactoring.