### PR TITLE
3D camera controls / Move up and down

### DIFF
--- a/bundles/mapping/camera-controls-3d/instance.js
+++ b/bundles/mapping/camera-controls-3d/instance.js
@@ -1,0 +1,63 @@
+/*
+Oskari.app.playBundle(
+{
+  bundlename : 'camera-controls-3d'
+});
+*/
+Oskari.clazz.define('Oskari.mapping.cameracontrols3d.CameraControls3dBundleInstance',
+    function () {
+        this._started = false;
+        this.plugin = null;
+        this._mapmodule = null;
+        this._sandbox = null;
+        this.state = undefined;
+    }, {
+        __name: 'camera-controls-3d',
+        /**
+        * @method getName
+        * @return {String} the name for the component
+        */
+        getName: function () {
+            return this.__name;
+        },
+        init: function () {},
+        setSandbox: function (sbx) {
+            this.sandbox = sbx;
+        },
+        getSandbox: function () {
+            return this.sandbox;
+        },
+        start: function (sandbox) {
+            if (this._started) {
+                return;
+            }
+            this._started = true;
+            sandbox = sandbox || Oskari.getSandbox();
+            this.setSandbox(sandbox);
+            this._mapmodule = sandbox.findRegisteredModuleInstance('MainMapModule');
+            this.createPlugin();
+            sandbox.register(this);
+        },
+        createPlugin: function () {
+            if (this.plugin) {
+                return;
+            }
+            var conf = this.conf || {};
+            var plugin = Oskari.clazz.create('Oskari.mapping.cameracontrols3d.CameraControls3dPlugin', conf);
+            this._mapmodule.registerPlugin(plugin);
+            this._mapmodule.startPlugin(plugin);
+            this.plugin = plugin;
+        },
+        stopPlugin: function () {
+            this._mapmodule.unregisterPlugin(this.plugin);
+            this._mapmodule.stopPlugin(this.plugin);
+            this.plugin = null;
+        },
+        stop: function () {
+            this.stopPlugin();
+            this.sandbox = null;
+            this.started = false;
+        }
+    }, {
+        protocol: ['Oskari.bundle.BundleInstance']
+    });

--- a/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
+++ b/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
@@ -6,8 +6,7 @@ import { CameraControls3d } from '../view/CameraControls3d';
 const className = 'Oskari.mapping.cameracontrols3d.CameraControls3dPlugin';
 
 Oskari.clazz.define(className,
-    function (config) {
-        this._config = config || {};
+    function () {
         this._clazz = className;
         this._defaultLocation = 'top right';
         this._toolOpen = false;
@@ -19,60 +18,19 @@ Oskari.clazz.define(className,
         getName: function () {
             return className;
         },
-        _createUI: function (mapInMobileMode) {
-            this._element = this._mountPoint.clone();
-
-            if (mapInMobileMode) {
-                //this._element.css({ 'float': 'left' });
-                this._element.css('display', 'inline');
-                this._addToMobileToolBar();
-            } else {
-                this._addToPluginContainer();
-            }
-            ReactDOM.render(
-                <LocaleContext.Provider value={this.loc}>
-                    <CameraControls3d mapInMobileMode={mapInMobileMode}/>
-                </LocaleContext.Provider>, this._element.get(0));
-        },
-        _addToMobileToolBar () {
-            const resetMapState = jQuery('.toolbar_mobileToolbar').find('.mobile-reset-map-state');
-            jQuery(this._element).insertAfter(resetMapState);
-        },
-        _addToPluginContainer () {
-            const panbuttons = jQuery('.mappluginsContent').find('.panbuttons');
-            jQuery(this._element).insertAfter(panbuttons);
-        },
         /**
          * @public @method changeToolStyle
-         * Changes the tool style of the plugin
+         * Changes the tool style of the plugin.
+         * Not implemented.
          *
          * @param {Object} style
          * @param {jQuery} div
          */
-        changeToolStyle: function (style, div) {
-            var me = this;
-            var el = div || me.getElement();
-
-            if (!el) {
-                return;
-            }
-
-            var styleClass = 'toolstyle-' + (style || 'default');
-
-            var classList = el.attr('class').split(/\s+/);
-            for (var c = 0; c < classList.length; c++) {
-                var className = classList[c];
-                if (className.indexOf('toolstyle-') > -1) {
-                    el.removeClass(className);
-                }
-            }
-            el.addClass(styleClass);
-        },
+        changeToolStyle: function (style, div) {},
         /**
          * Handle plugin UI and change it when desktop / mobile mode
          * @method  @public redrawUI
          * @param  {Boolean} mapInMobileMode is map in mobile mode
-         * @param {Boolean} forced application has started and ui should be rendered with assets that are available
          */
         redrawUI: function (mapInMobileMode) {
             if (this.getElement()) {
@@ -80,16 +38,12 @@ Oskari.clazz.define(className,
             }
             this._createUI(mapInMobileMode);
         },
-        teardownUI: function () {
-            // detach old element from screen
+        teardownUI: function (mapInMobileMode) {
             if (!this.getElement()) {
                 return;
             }
+            ReactDOM.unmountComponentAtNode(this.getElement().get(0));
             this.getElement().detach();
-            this.removeFromPluginContainer(this.getElement());
-        },
-        hasUi: function () {
-            return !this._config.noUI;
         },
         /**
          * Get jQuery element.
@@ -100,6 +54,29 @@ Oskari.clazz.define(className,
         },
         stopPlugin: function () {
             this.teardownUI();
+        },
+        _createUI: function (mapInMobileMode) {
+            this._element = this._mountPoint.clone();
+
+            if (mapInMobileMode) {
+                // In mobile mode set to same line as other controls
+                this._element.css('display', 'inline-block');
+                this._addToMobileToolBar();
+            } else {
+                this._addToPluginContainer();
+            }
+            ReactDOM.render(
+                <LocaleContext.Provider value={this.loc}>
+                    <CameraControls3d mapInMobileMode={mapInMobileMode}/>
+                </LocaleContext.Provider>, this._element.get(0));
+        },
+        _addToMobileToolBar () {
+            const resetMapStateControl = jQuery('.toolbar_mobileToolbar').find('.mobile-reset-map-state');
+            jQuery(this._element).insertAfter(resetMapStateControl);
+        },
+        _addToPluginContainer () {
+            const panButtonsControl = jQuery('.mappluginsContent').find('.panbuttons');
+            jQuery(this._element).insertAfter(panButtonsControl);
         }
     }, {
         'extend': ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],

--- a/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
+++ b/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { LocaleContext } from 'oskari-ui/util';
+import { CameraControls3d } from '../view/CameraControls3d';
+
+const className = 'Oskari.mapping.cameracontrols3d.CameraControls3dPlugin';
+
+Oskari.clazz.define(className,
+    function (config) {
+        this._config = config || {};
+        this._clazz = className;
+        this._defaultLocation = 'top right';
+        this._toolOpen = false;
+        this._index = 80;
+        this._log = Oskari.log(className);
+        this.loc = Oskari.getMsg.bind(null, 'CameraControls3d');
+        this._mountPoint = jQuery('<div class="mapplugin camera-controls-3d"><div></div></div>');
+    }, {
+        getName: function () {
+            return className;
+        },
+        _createUI: function (mapInMobileMode) {
+            this._element = this._mountPoint.clone();
+
+            if (mapInMobileMode) {
+                //this._element.css({ 'float': 'left' });
+                this._element.css('display', 'inline');
+                this._addToMobileToolBar();
+            } else {
+                this._addToPluginContainer();
+            }
+            ReactDOM.render(
+                <LocaleContext.Provider value={this.loc}>
+                    <CameraControls3d mapInMobileMode={mapInMobileMode}/>
+                </LocaleContext.Provider>, this._element.get(0));
+        },
+        _addToMobileToolBar () {
+            const resetMapState = jQuery('.toolbar_mobileToolbar').find('.mobile-reset-map-state');
+            jQuery(this._element).insertAfter(resetMapState);
+        },
+        _addToPluginContainer () {
+            const panbuttons = jQuery('.mappluginsContent').find('.panbuttons');
+            jQuery(this._element).insertAfter(panbuttons);
+        },
+        /**
+         * @public @method changeToolStyle
+         * Changes the tool style of the plugin
+         *
+         * @param {Object} style
+         * @param {jQuery} div
+         */
+        changeToolStyle: function (style, div) {
+            var me = this;
+            var el = div || me.getElement();
+
+            if (!el) {
+                return;
+            }
+
+            var styleClass = 'toolstyle-' + (style || 'default');
+
+            var classList = el.attr('class').split(/\s+/);
+            for (var c = 0; c < classList.length; c++) {
+                var className = classList[c];
+                if (className.indexOf('toolstyle-') > -1) {
+                    el.removeClass(className);
+                }
+            }
+            el.addClass(styleClass);
+        },
+        /**
+         * Handle plugin UI and change it when desktop / mobile mode
+         * @method  @public redrawUI
+         * @param  {Boolean} mapInMobileMode is map in mobile mode
+         * @param {Boolean} forced application has started and ui should be rendered with assets that are available
+         */
+        redrawUI: function (mapInMobileMode) {
+            if (this.getElement()) {
+                this.teardownUI();
+            }
+            this._createUI(mapInMobileMode);
+        },
+        teardownUI: function () {
+            // detach old element from screen
+            if (!this.getElement()) {
+                return;
+            }
+            this.getElement().detach();
+            this.removeFromPluginContainer(this.getElement());
+        },
+        hasUi: function () {
+            return !this._config.noUI;
+        },
+        /**
+         * Get jQuery element.
+         * @method @public getElement
+         */
+        getElement: function () {
+            return this._element;
+        },
+        stopPlugin: function () {
+            this.teardownUI();
+        }
+    }, {
+        'extend': ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],
+        /**
+         * @static @property {string[]} protocol array of superclasses
+         */
+        'protocol': [
+            'Oskari.mapframework.module.Module',
+            'Oskari.mapframework.ui.module.common.mapmodule.Plugin'
+        ]
+    });

--- a/bundles/mapping/camera-controls-3d/resources/locale/en.js
+++ b/bundles/mapping/camera-controls-3d/resources/locale/en.js
@@ -4,8 +4,8 @@ Oskari.registerLocalization(
         "key": "CameraControls3d",
         "value": {
             "tooltip": {
-                "up": "Move up",
-                "down": "Move down"
+                "up": "Move up in map",
+                "down": "Move down in map"
             }
         }
     }

--- a/bundles/mapping/camera-controls-3d/resources/locale/en.js
+++ b/bundles/mapping/camera-controls-3d/resources/locale/en.js
@@ -1,0 +1,13 @@
+Oskari.registerLocalization(
+    {
+        "lang": "en",
+        "key": "CameraControls3d",
+        "value": {
+            "tooltip": {
+                "up": "Move up",
+                "down": "Move down"
+            }
+        }
+    }
+);
+    

--- a/bundles/mapping/camera-controls-3d/resources/locale/fi.js
+++ b/bundles/mapping/camera-controls-3d/resources/locale/fi.js
@@ -4,8 +4,8 @@ Oskari.registerLocalization(
         "key": "CameraControls3d",
         "value": {
             "tooltip": {
-                "up": "Siirry ylös",
-                "down": "Siirry alas"
+                "up": "Siirry kartalla ylöspäin",
+                "down": "Siirry kartalla alaspäin "
             }
         }
     }

--- a/bundles/mapping/camera-controls-3d/resources/locale/fi.js
+++ b/bundles/mapping/camera-controls-3d/resources/locale/fi.js
@@ -1,0 +1,13 @@
+Oskari.registerLocalization(
+    {
+        "lang": "fi",
+        "key": "CameraControls3d",
+        "value": {
+            "tooltip": {
+                "up": "Siirry ylös",
+                "down": "Siirry alas"
+            }
+        }
+    }
+);
+    

--- a/bundles/mapping/camera-controls-3d/resources/locale/sv.js
+++ b/bundles/mapping/camera-controls-3d/resources/locale/sv.js
@@ -4,8 +4,8 @@ Oskari.registerLocalization(
         "key": "CameraControls3d",
         "value": {
             "tooltip": {
-                "up": "Flytta upp",
-                "down": "Flytta ner"
+                "up": "Flytta upp på kartan",
+                "down": "Flytta ner på kartan"
             }
         }
     }

--- a/bundles/mapping/camera-controls-3d/resources/locale/sv.js
+++ b/bundles/mapping/camera-controls-3d/resources/locale/sv.js
@@ -1,0 +1,13 @@
+Oskari.registerLocalization(
+    {
+        "lang": "sv",
+        "key": "CameraControls3d",
+        "value": {
+            "tooltip": {
+                "up": "Flytta upp",
+                "down": "Flytta ner"
+            }
+        }
+    }
+);
+    

--- a/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
+++ b/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
@@ -64,7 +64,6 @@ const MapControl = styled.div`
 `;
 
 const MobileContainer = styled.div`
-    float:left;
     margin-top: 5px;
     margin-right: 5px;
 `;

--- a/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
+++ b/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { withLocale } from 'oskari-ui/util';
+import { Icon } from 'oskari-ui';
+
+const upDownChangePercent = 10;
+const iconSize = '24px';
+const mobileIconSize = '32px';
+const iconShadow = '1px 1px 2px rgba(0,0,0,0.6)';
+const darkBgColor = 'rgba(20,20,20,0.8)';
+
+const UpSvg = ({ isMobile }) => (
+    <svg width={isMobile ? mobileIconSize : iconSize} height={isMobile ? mobileIconSize : iconSize} viewBox="0 0 24 24">
+        <g id="3D-upward" stroke="none" strokeWidth="1" fillRule="nonzero">
+            <path d="M12,3.93933983 L15.5303301,7.46966991 C15.8232233,7.76256313 15.8232233,8.23743687 15.5303301,8.53033009 C15.2640635,8.79659665 14.8473998,8.8208027 14.5537883,8.60294824 L14.4696699,8.53033009 L12.75,6.81033983 L12.75,13.25 L11.25,13.25 L11.25,6.81033983 L9.53033009,8.53033009 C9.26406352,8.79659665 8.84739984,8.8208027 8.55378835,8.60294824 L8.46966991,8.53033009 C8.20340335,8.26406352 8.1791973,7.84739984 8.39705176,7.55378835 L8.46966991,7.46966991 L12,3.93933983 Z" id="Combined-Shape" fill={'#ffffff'} fillRule="nonzero"></path>
+            <path d="M5.62209673,18.1021658 C9.74978057,15.6943503 13.9299778,15.6341549 18.0602873,17.9215797 L18.3779033,18.1021658 L19.0257374,18.4800691 L18.2699309,19.7757374 L17.6220967,19.3978342 C13.960243,17.2617528 10.3506039,17.2024172 6.69165094,19.2198274 L6.37790327,19.3978342 L5.73006909,19.7757374 L4.97426256,18.4800691 L5.62209673,18.1021658 Z" id="Path-2" fill={'#ffffff'} fillRule="nonzero"></path>
+        </g>
+    </svg>
+);
+UpSvg.propTypes = {
+    isMobile: PropTypes.bool.isRequired
+};
+
+const DownSvg = ({ isMobile }) => (
+    <svg width={isMobile ? mobileIconSize : iconSize} height={isMobile ? mobileIconSize : iconSize} viewBox="0 0 24 24">
+        <g id="3D-downward" stroke="none" strokeWidth="1" fillRule="nonzero">
+            <path d="M15,9 L12,12 L9,9 M12,10.5 L12,4.5" id="Combined-Shape" stroke={'#ffffff'} strokeWidth="1.5" strokeLinecap="round"></path>
+            <path d="M5.62209673,18.1021658 C9.74978057,15.6943503 13.9299778,15.6341549 18.0602873,17.9215797 L18.3779033,18.1021658 L19.0257374,18.4800691 L18.2699309,19.7757374 L17.6220967,19.3978342 C13.960243,17.2617528 10.3506039,17.2024172 6.69165094,19.2198274 L6.37790327,19.3978342 L5.73006909,19.7757374 L4.97426256,18.4800691 L5.62209673,18.1021658 Z" id="Path-2" fill={'#ffffff'} fillRule="nonzero"></path>
+        </g>
+    </svg>
+);
+DownSvg.propTypes = {
+    isMobile: PropTypes.bool.isRequired
+};
+
+const MapControlsContainer = styled.div`
+    margin-top: 10px;
+    display: flex;
+`;
+
+const MapControlContainer = styled.div`
+    border-radius: 50%;
+    width: 32px;
+    height: 32px;
+    cursor: pointer;
+    margin: 0 auto;
+    z-index: 15000;
+    margin-bottom: 5px;
+    box-shadow: ${iconShadow};
+    -moz-box-shadow: ${iconShadow};
+    -webkit-box-shadow: ${iconShadow};
+    -o-box-shadow: ${iconShadow};
+    background-color: ${darkBgColor};
+`;
+
+const MapControl = styled.div`
+    width: 32px;
+    height: 32px;
+    background-repeat: no-repeat;
+    margin: 0;
+    padding-top:3px;
+    text-align: center;
+`;
+
+const MobileContainer = styled.div`
+    float:left;
+    margin-top: 5px;
+    margin-right: 5px;
+`;
+
+const upDownClickHandler = (directionUp) => {
+    const mapmodule = Oskari.getSandbox().getStatefulComponents().mapfull.getMapModule();
+    const cam = mapmodule.getCamera();
+    if (directionUp) {
+        cam.location.altitude = cam.location.altitude * ((100 + upDownChangePercent) / 100);
+    } else {
+        cam.location.altitude = cam.location.altitude * ((100 - upDownChangePercent) / 100);
+    }
+    mapmodule.setCamera(cam);
+    Oskari.getSandbox().postRequestByName('MapMoveRequest');
+};
+
+const CameraControls3d = ({ mapInMobileMode, getMessage }) => {
+    const upControl = <Icon style={{ outline: 'none' }} component={() => <UpSvg isMobile={mapInMobileMode}/>} onClick={() => upDownClickHandler(true)} title = {getMessage('tooltip.up')}/>;
+    const downControl = <Icon style={{ outline: 'none' }} component={() => <DownSvg isMobile={mapInMobileMode}/>} onClick={() => upDownClickHandler(false)} title = {getMessage('tooltip.down')}/>;
+
+    let controls;
+
+    if (!mapInMobileMode) {
+        controls = <MapControlsContainer>
+            <MapControlContainer>
+                <MapControl>{upControl}</MapControl>
+            </MapControlContainer>
+            <MapControlContainer>
+                <MapControl>{downControl}</MapControl>
+            </MapControlContainer>
+        </MapControlsContainer>;
+    } else {
+        controls = <MobileContainer>
+            {upControl}
+            {downControl}
+        </MobileContainer>;
+    }
+    return (controls);
+};
+
+CameraControls3d.propTypes = {
+    mapInMobileMode: PropTypes.bool.isRequired,
+    getMessage: PropTypes.func.isRequired
+};
+
+const contextWrap = withLocale(CameraControls3d);
+export { contextWrap as CameraControls3d };

--- a/packages/mapping/camera-controls-3d/bundle.js
+++ b/packages/mapping/camera-controls-3d/bundle.js
@@ -1,0 +1,66 @@
+/**
+ * @class Oskari.mapping.cameracontrols3d.CameraControls3dBundle
+ *
+ * Definition for bundle. See source for details.
+ */
+Oskari.clazz.define("Oskari.mapping.cameracontrols3d.CameraControls3dBundle", function() {
+
+}, {
+	"create" : function() {
+		return Oskari.clazz.create("Oskari.mapping.cameracontrols3d.CameraControls3dBundleInstance");
+	}
+}, {
+
+	"protocol" : ["Oskari.bundle.Bundle", "Oskari.mapframework.bundle.extension.ExtensionBundle"],
+	"source" : {
+		"scripts" : [{
+			"type" : "text/javascript",
+			"src" : "../../../bundles/mapping/camera-controls-3d/instance.js"
+		}, {
+			"type" : "text/javascript",
+			"src" : "../../../bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js"
+		}],
+		"locales" : [{
+			"lang" : "fi",
+			"type" : "text/javascript",
+			"src" : "../../../bundles/mapping/camera-controls-3d/resources/locale/fi.js"
+		}, {
+			"lang" : "sv",
+			"type" : "text/javascript",
+			"src" : "../../../bundles/mapping/camera-controls-3d/resources/locale/sv.js"
+		}, {
+			"lang" : "en",
+			"type" : "text/javascript",
+			"src" : "../../../bundles/mapping/camera-controls-3d/resources/locale/en.js"
+		}]
+	},
+	"bundle" : {
+		"manifest" : {
+			"Bundle-Identifier" : "camera-controls-3d",
+			"Bundle-Name" : "camera-controls-3d",
+			"Bundle-Author" : [{
+				"Name" : "mm",
+				"Organisation" : "nls.fi",
+				"Temporal" : {
+					"Start" : "2019"
+				},
+				"Copyleft" : {
+					"License" : {
+						"License-Name" : "EUPL",
+						"License-Online-Resource" : "http://www.paikkatietoikkuna.fi/license"
+					}
+				}
+			}],
+			"Bundle-Version" : "1.0.0",
+			"Import-Namespace" : ["Oskari", "jquery"],
+			"Import-Bundle" : {}
+		}
+	},
+	/**
+	 * @static
+	 * @property dependencies
+	 */
+	"dependencies" : ["jquery"]
+});
+
+Oskari.bundle_manager.installBundleClass("camera-controls-3d", "Oskari.mapping.cameracontrols3d.CameraControls3dBundle");


### PR DESCRIPTION
Created new camera-controls-3d bundle which adds move up and move down controls to 3D views. When clicked, controls increase or decrease altitude of camera by 10 %. 