### PR TITLE
Statsgrid search indicators mobile device fixes

### DIFF
--- a/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
@@ -78,7 +78,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
                 select.disableOptions(disabledIndicatorIDs);
             }
             if (select.getOptions().options.length > 0) {
-                me._enableIndicatorSelection();
+                select.setEnabled(true);
+            } else {
+                select.setEnabled(false);
             }
 
             if (result.complete) {
@@ -91,12 +93,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
                 }
             }
         });
-    },
-    _enableIndicatorSelection () {
-        const sumoSelectDiv = jQuery('.stats-ind-selector').find('.SumoSelect');
-        sumoSelectDiv.removeClass('disabled');
-        const select = sumoSelectDiv.find('.SumoUnder');
-        select.removeAttr('disabled');
     },
     setElement: function (el) {
         this.element = el;

--- a/bundles/statistics/statsgrid2016/components/SelectList.js
+++ b/bundles/statistics/statsgrid2016/components/SelectList.js
@@ -201,16 +201,19 @@ export class SelectList extends FormComponent {
      * @method selectFirstValue Select the first non-placeholder value
      */
     selectFirstValue () {
-        this._getSumoInstance().selectItem(0);
+        const val = this._element.find('option:enabled').first().val();
+        if (val) {
+            this.setValue(val);
+        }
     }
 
     /**
      * @method selectLastValue Select the last value
      */
     selectLastValue () {
-        const lastIndex = this._element.find('select').find('option:last-child').prop('index');
-        if (lastIndex || lastIndex === 0) {
-            this._getSumoInstance().selectItem(lastIndex);
+        const val = this._element.find('option:enabled').last().val();
+        if (val) {
+            this.setValue(val);
         }
     }
 

--- a/bundles/statistics/statsgrid2016/resources/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/resources/scss/style.scss
@@ -229,6 +229,7 @@ div.oskari-flyout {
                 }
                 // Placeholder styles for disabled select
                 [class='SumoSelect disabled'] {
+                    cursor: auto;
                     p {
                         background-color: #f5f5f5;
                     }


### PR DESCRIPTION
SumoSelect's selectItem() doesn't work with mobile devices native select (at least with multi select). Changed to use setValue(). Also _enableIndicatorSelection() didn't work with mobile devices, because them doesn't use same elements and attributes (classes, disabled). Changed to use SumoSelect's enable() and disable() (SelectList _setEnabledImpl).

Override SumoSelect's not-allowed cursor (shown only on dropdown's border and disabled button doesn't have not-allowed cursor).