### PR TITLE
Publisher tool for timeseries-bundle

### DIFF
--- a/bundles/framework/timeseries/publisher/TimeseriesTool.js
+++ b/bundles/framework/timeseries/publisher/TimeseriesTool.js
@@ -37,8 +37,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesTool',
             if (this.isDisabled()) {
                 this.controlConfig.showControl = false;
             }
-            // Apply configuration
-            this.setEnabled(this.controlConfig.showControl);
+            if (this.isDisplayed()) {
+                // Apply configuration
+                this.setEnabled(this.controlConfig.showControl);
+            }
         },
         _getTimeseriesService: function () {
             if (!this.service) {
@@ -97,6 +99,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesTool',
         isDisabled: function (data) {
             const service = this._getTimeseriesService();
             return typeof service === 'undefined' || typeof service.getActiveTimeseries() === 'undefined';
+        },
+        /**
+         * Don't show the tool if this code is loaded BUT the timeseries bundle is not started as part of the appsetup
+         */
+        isDisplayed: function () {
+            return typeof this._getTimeseriesService() !== 'undefined';
         },
         /**
         * Get values.


### PR DESCRIPTION
PR #1057 didn't completely fix the timeseries publisher tool problem (timeseries part of oskari.min.js but not started as part of appsetup). This does.