### PR TITLE
First version of 3D camera controls

### DIFF
--- a/bundles/mapping/camera-controls-3d/instance.js
+++ b/bundles/mapping/camera-controls-3d/instance.js
@@ -1,63 +1,46 @@
-/*
-Oskari.app.playBundle(
-{
-  bundlename : 'camera-controls-3d'
-});
-*/
-Oskari.clazz.define('Oskari.mapping.cameracontrols3d.CameraControls3dBundleInstance',
-    function () {
-        this._started = false;
-        this.plugin = null;
-        this._mapmodule = null;
-        this._sandbox = null;
-        this.state = undefined;
-    }, {
-        __name: 'camera-controls-3d',
-        /**
-        * @method getName
-        * @return {String} the name for the component
-        */
-        getName: function () {
-            return this.__name;
-        },
-        init: function () {},
-        setSandbox: function (sbx) {
-            this.sandbox = sbx;
-        },
-        getSandbox: function () {
-            return this.sandbox;
-        },
-        start: function (sandbox) {
+const BasicBundle = Oskari.clazz.get('Oskari.BasicBundle');
+
+Oskari.clazz.defineES('Oskari.mapping.cameracontrols3d.instance',
+    class CameraControls3dBundleInstance extends BasicBundle {
+        constructor () {
+            super();
+            this._started = false;
+            this.plugin = null;
+            this._mapmodule = null;
+            this._sandbox = null;
+            this.state = undefined;
+            this.name = 'camera-controls-3d';
+        }
+        getName () {
+            return this.name;
+        }
+        start (sandbox) {
             if (this._started) {
                 return;
             }
-            this._started = true;
-            sandbox = sandbox || Oskari.getSandbox();
-            this.setSandbox(sandbox);
+            this.sandbox = sandbox || Oskari.getSandbox();
             this._mapmodule = sandbox.findRegisteredModuleInstance('MainMapModule');
             this.createPlugin();
-            sandbox.register(this);
-        },
-        createPlugin: function () {
+            this.sandbox.register(this);
+            this._started = true;
+        }
+        createPlugin () {
             if (this.plugin) {
                 return;
             }
-            var conf = this.conf || {};
-            var plugin = Oskari.clazz.create('Oskari.mapping.cameracontrols3d.CameraControls3dPlugin', conf);
-            this._mapmodule.registerPlugin(plugin);
-            this._mapmodule.startPlugin(plugin);
-            this.plugin = plugin;
-        },
-        stopPlugin: function () {
+            this.plugin = Oskari.clazz.create('Oskari.mapping.cameracontrols3d.CameraControls3dPlugin');
+            this._mapmodule.registerPlugin(this.plugin);
+            this._mapmodule.startPlugin(this.plugin);
+        }
+        stopPlugin () {
             this._mapmodule.unregisterPlugin(this.plugin);
             this._mapmodule.stopPlugin(this.plugin);
             this.plugin = null;
-        },
-        stop: function () {
+        }
+        stop () {
             this.stopPlugin();
             this.sandbox = null;
             this.started = false;
         }
-    }, {
-        protocol: ['Oskari.bundle.BundleInstance']
-    });
+    }
+);

--- a/bundles/mapping/camera-controls-3d/instance.js
+++ b/bundles/mapping/camera-controls-3d/instance.js
@@ -1,0 +1,63 @@
+/*
+Oskari.app.playBundle(
+{
+  bundlename : 'camera-controls-3d'
+});
+*/
+Oskari.clazz.define('Oskari.mapping.cameracontrols3d.CameraControls3dBundleInstance',
+    function () {
+        this._started = false;
+        this.plugin = null;
+        this._mapmodule = null;
+        this._sandbox = null;
+        this.state = undefined;
+    }, {
+        __name: 'camera-controls-3d',
+        /**
+        * @method getName
+        * @return {String} the name for the component
+        */
+        getName: function () {
+            return this.__name;
+        },
+        init: function () {},
+        setSandbox: function (sbx) {
+            this.sandbox = sbx;
+        },
+        getSandbox: function () {
+            return this.sandbox;
+        },
+        start: function (sandbox) {
+            if (this._started) {
+                return;
+            }
+            this._started = true;
+            sandbox = sandbox || Oskari.getSandbox();
+            this.setSandbox(sandbox);
+            this._mapmodule = sandbox.findRegisteredModuleInstance('MainMapModule');
+            this.createPlugin();
+            sandbox.register(this);
+        },
+        createPlugin: function () {
+            if (this.plugin) {
+                return;
+            }
+            var conf = this.conf || {};
+            var plugin = Oskari.clazz.create('Oskari.mapping.cameracontrols3d.CameraControls3dPlugin', conf);
+            this._mapmodule.registerPlugin(plugin);
+            this._mapmodule.startPlugin(plugin);
+            this.plugin = plugin;
+        },
+        stopPlugin: function () {
+            this._mapmodule.unregisterPlugin(this.plugin);
+            this._mapmodule.stopPlugin(this.plugin);
+            this.plugin = null;
+        },
+        stop: function () {
+            this.stopPlugin();
+            this.sandbox = null;
+            this.started = false;
+        }
+    }, {
+        protocol: ['Oskari.bundle.BundleInstance']
+    });

--- a/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
+++ b/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
@@ -15,6 +15,8 @@ Oskari.clazz.define(className,
         this._log = Oskari.log(shortName);
         this.loc = Oskari.getMsg.bind(null, 'CameraControls3d');
         this._mountPoint = jQuery('<div class="mapplugin camera-controls-3d"><div></div></div>');
+        // plugin index 25. Insert after panbuttons.
+        this._index = 25;
     }, {
         getName: function () {
             return shortName;
@@ -69,20 +71,27 @@ Oskari.clazz.define(className,
                 this._element.css('display', 'inline-block');
                 this._addToMobileToolBar();
             } else {
-                this._addToPluginContainer();
+                this.addToPluginContainer(this._element);
             }
             ReactDOM.render(
                 <LocaleContext.Provider value={this.loc}>
                     <CameraControls3d mapInMobileMode={mapInMobileMode}/>
                 </LocaleContext.Provider>, this._element.get(0));
         },
+        /**
+         * @public @method getIndex
+         * Returns the plugin's preferred position in the container
+         *
+         *
+         * @return {Number} Plugin's preferred position in container
+         */
+        getIndex: function () {
+            // i.e. position
+            return this._index;
+        },
         _addToMobileToolBar () {
             const resetMapStateControl = jQuery('.toolbar_mobileToolbar').find('.mobile-reset-map-state');
             jQuery(this._element).insertAfter(resetMapStateControl);
-        },
-        _addToPluginContainer () {
-            const panButtonsControl = jQuery('.mappluginsContent').find('.panbuttons');
-            jQuery(this._element).insertAfter(panButtonsControl);
         }
     }, {
         'extend': ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],

--- a/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
+++ b/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
@@ -6,8 +6,7 @@ import { CameraControls3d } from '../view/CameraControls3d';
 const className = 'Oskari.mapping.cameracontrols3d.CameraControls3dPlugin';
 
 Oskari.clazz.define(className,
-    function (config) {
-        this._config = config || {};
+    function () {
         this._clazz = className;
         this._defaultLocation = 'top right';
         this._toolOpen = false;
@@ -19,60 +18,19 @@ Oskari.clazz.define(className,
         getName: function () {
             return className;
         },
-        _createUI: function (mapInMobileMode) {
-            this._element = this._mountPoint.clone();
-
-            if (mapInMobileMode) {
-                //this._element.css({ 'float': 'left' });
-                this._element.css('display', 'inline');
-                this._addToMobileToolBar();
-            } else {
-                this._addToPluginContainer();
-            }
-            ReactDOM.render(
-                <LocaleContext.Provider value={this.loc}>
-                    <CameraControls3d mapInMobileMode={mapInMobileMode}/>
-                </LocaleContext.Provider>, this._element.get(0));
-        },
-        _addToMobileToolBar () {
-            const resetMapState = jQuery('.toolbar_mobileToolbar').find('.mobile-reset-map-state');
-            jQuery(this._element).insertAfter(resetMapState);
-        },
-        _addToPluginContainer () {
-            const panbuttons = jQuery('.mappluginsContent').find('.panbuttons');
-            jQuery(this._element).insertAfter(panbuttons);
-        },
         /**
          * @public @method changeToolStyle
-         * Changes the tool style of the plugin
+         * Changes the tool style of the plugin.
+         * Not implemented.
          *
          * @param {Object} style
          * @param {jQuery} div
          */
-        changeToolStyle: function (style, div) {
-            var me = this;
-            var el = div || me.getElement();
-
-            if (!el) {
-                return;
-            }
-
-            var styleClass = 'toolstyle-' + (style || 'default');
-
-            var classList = el.attr('class').split(/\s+/);
-            for (var c = 0; c < classList.length; c++) {
-                var className = classList[c];
-                if (className.indexOf('toolstyle-') > -1) {
-                    el.removeClass(className);
-                }
-            }
-            el.addClass(styleClass);
-        },
+        changeToolStyle: function (style, div) {},
         /**
          * Handle plugin UI and change it when desktop / mobile mode
          * @method  @public redrawUI
          * @param  {Boolean} mapInMobileMode is map in mobile mode
-         * @param {Boolean} forced application has started and ui should be rendered with assets that are available
          */
         redrawUI: function (mapInMobileMode) {
             if (this.getElement()) {
@@ -80,16 +38,12 @@ Oskari.clazz.define(className,
             }
             this._createUI(mapInMobileMode);
         },
-        teardownUI: function () {
-            // detach old element from screen
+        teardownUI: function (mapInMobileMode) {
             if (!this.getElement()) {
                 return;
             }
+            ReactDOM.unmountComponentAtNode(this.getElement().get(0));
             this.getElement().detach();
-            this.removeFromPluginContainer(this.getElement());
-        },
-        hasUi: function () {
-            return !this._config.noUI;
         },
         /**
          * Get jQuery element.
@@ -100,6 +54,29 @@ Oskari.clazz.define(className,
         },
         stopPlugin: function () {
             this.teardownUI();
+        },
+        _createUI: function (mapInMobileMode) {
+            this._element = this._mountPoint.clone();
+
+            if (mapInMobileMode) {
+                // In mobile mode set to same line as other controls
+                this._element.css('display', 'inline-block');
+                this._addToMobileToolBar();
+            } else {
+                this._addToPluginContainer();
+            }
+            ReactDOM.render(
+                <LocaleContext.Provider value={this.loc}>
+                    <CameraControls3d mapInMobileMode={mapInMobileMode}/>
+                </LocaleContext.Provider>, this._element.get(0));
+        },
+        _addToMobileToolBar () {
+            const resetMapStateControl = jQuery('.toolbar_mobileToolbar').find('.mobile-reset-map-state');
+            jQuery(this._element).insertAfter(resetMapStateControl);
+        },
+        _addToPluginContainer () {
+            const panButtonsControl = jQuery('.mappluginsContent').find('.panbuttons');
+            jQuery(this._element).insertAfter(panButtonsControl);
         }
     }, {
         'extend': ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],

--- a/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
+++ b/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
@@ -4,6 +4,7 @@ import { LocaleContext } from 'oskari-ui/util';
 import { CameraControls3d } from '../view/CameraControls3d';
 
 const className = 'Oskari.mapping.cameracontrols3d.CameraControls3dPlugin';
+const shortName = 'CameraControls3dPlugin';
 
 Oskari.clazz.define(className,
     function () {
@@ -11,12 +12,19 @@ Oskari.clazz.define(className,
         this._defaultLocation = 'top right';
         this._toolOpen = false;
         this._index = 80;
-        this._log = Oskari.log(className);
+        this._log = Oskari.log(shortName);
         this.loc = Oskari.getMsg.bind(null, 'CameraControls3d');
         this._mountPoint = jQuery('<div class="mapplugin camera-controls-3d"><div></div></div>');
     }, {
         getName: function () {
-            return className;
+            return shortName;
+        },
+        /**
+         * @method resetState
+         * Resets the state in the plugin
+         */
+        resetState: function () {
+            this.redrawUI(Oskari.util.isMobile());
         },
         /**
          * @public @method changeToolStyle
@@ -33,12 +41,10 @@ Oskari.clazz.define(className,
          * @param  {Boolean} mapInMobileMode is map in mobile mode
          */
         redrawUI: function (mapInMobileMode) {
-            if (this.getElement()) {
-                this.teardownUI();
-            }
+            this.teardownUI();
             this._createUI(mapInMobileMode);
         },
-        teardownUI: function (mapInMobileMode) {
+        teardownUI: function () {
             if (!this.getElement()) {
                 return;
             }

--- a/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
+++ b/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { LocaleContext } from 'oskari-ui/util';
+import { CameraControls3d } from '../view/CameraControls3d';
+
+const className = 'Oskari.mapping.cameracontrols3d.CameraControls3dPlugin';
+
+Oskari.clazz.define(className,
+    function (config) {
+        this._config = config || {};
+        this._clazz = className;
+        this._defaultLocation = 'top right';
+        this._toolOpen = false;
+        this._index = 80;
+        this._log = Oskari.log(className);
+        this.loc = Oskari.getMsg.bind(null, 'CameraControls3d');
+        this._mountPoint = jQuery('<div class="mapplugin camera-controls-3d"><div></div></div>');
+    }, {
+        getName: function () {
+            return className;
+        },
+        _createUI: function (mapInMobileMode) {
+            this._element = this._mountPoint.clone();
+
+            if (mapInMobileMode) {
+                //this._element.css({ 'float': 'left' });
+                this._element.css('display', 'inline');
+                this._addToMobileToolBar();
+            } else {
+                this._addToPluginContainer();
+            }
+            ReactDOM.render(
+                <LocaleContext.Provider value={this.loc}>
+                    <CameraControls3d mapInMobileMode={mapInMobileMode}/>
+                </LocaleContext.Provider>, this._element.get(0));
+        },
+        _addToMobileToolBar () {
+            const resetMapState = jQuery('.toolbar_mobileToolbar').find('.mobile-reset-map-state');
+            jQuery(this._element).insertAfter(resetMapState);
+        },
+        _addToPluginContainer () {
+            const panbuttons = jQuery('.mappluginsContent').find('.panbuttons');
+            jQuery(this._element).insertAfter(panbuttons);
+        },
+        /**
+         * @public @method changeToolStyle
+         * Changes the tool style of the plugin
+         *
+         * @param {Object} style
+         * @param {jQuery} div
+         */
+        changeToolStyle: function (style, div) {
+            var me = this;
+            var el = div || me.getElement();
+
+            if (!el) {
+                return;
+            }
+
+            var styleClass = 'toolstyle-' + (style || 'default');
+
+            var classList = el.attr('class').split(/\s+/);
+            for (var c = 0; c < classList.length; c++) {
+                var className = classList[c];
+                if (className.indexOf('toolstyle-') > -1) {
+                    el.removeClass(className);
+                }
+            }
+            el.addClass(styleClass);
+        },
+        /**
+         * Handle plugin UI and change it when desktop / mobile mode
+         * @method  @public redrawUI
+         * @param  {Boolean} mapInMobileMode is map in mobile mode
+         * @param {Boolean} forced application has started and ui should be rendered with assets that are available
+         */
+        redrawUI: function (mapInMobileMode) {
+            if (this.getElement()) {
+                this.teardownUI();
+            }
+            this._createUI(mapInMobileMode);
+        },
+        teardownUI: function () {
+            // detach old element from screen
+            if (!this.getElement()) {
+                return;
+            }
+            this.getElement().detach();
+            this.removeFromPluginContainer(this.getElement());
+        },
+        hasUi: function () {
+            return !this._config.noUI;
+        },
+        /**
+         * Get jQuery element.
+         * @method @public getElement
+         */
+        getElement: function () {
+            return this._element;
+        },
+        stopPlugin: function () {
+            this.teardownUI();
+        }
+    }, {
+        'extend': ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],
+        /**
+         * @static @property {string[]} protocol array of superclasses
+         */
+        'protocol': [
+            'Oskari.mapframework.module.Module',
+            'Oskari.mapframework.ui.module.common.mapmodule.Plugin'
+        ]
+    });

--- a/bundles/mapping/camera-controls-3d/resources/locale/en.js
+++ b/bundles/mapping/camera-controls-3d/resources/locale/en.js
@@ -4,8 +4,8 @@ Oskari.registerLocalization(
         "key": "CameraControls3d",
         "value": {
             "tooltip": {
-                "up": "Move up",
-                "down": "Move down"
+                "up": "Move up in map",
+                "down": "Move down in map"
             }
         }
     }

--- a/bundles/mapping/camera-controls-3d/resources/locale/en.js
+++ b/bundles/mapping/camera-controls-3d/resources/locale/en.js
@@ -1,0 +1,13 @@
+Oskari.registerLocalization(
+    {
+        "lang": "en",
+        "key": "CameraControls3d",
+        "value": {
+            "tooltip": {
+                "up": "Move up",
+                "down": "Move down"
+            }
+        }
+    }
+);
+    

--- a/bundles/mapping/camera-controls-3d/resources/locale/en.js
+++ b/bundles/mapping/camera-controls-3d/resources/locale/en.js
@@ -5,7 +5,9 @@ Oskari.registerLocalization(
         "value": {
             "tooltip": {
                 "up": "Move up in map",
-                "down": "Move down in map"
+                "down": "Move down in map",
+                "move": "Move map",
+                "rotate": "Rotate map"
             }
         }
     }

--- a/bundles/mapping/camera-controls-3d/resources/locale/fi.js
+++ b/bundles/mapping/camera-controls-3d/resources/locale/fi.js
@@ -4,8 +4,8 @@ Oskari.registerLocalization(
         "key": "CameraControls3d",
         "value": {
             "tooltip": {
-                "up": "Siirry ylös",
-                "down": "Siirry alas"
+                "up": "Siirry kartalla ylöspäin",
+                "down": "Siirry kartalla alaspäin "
             }
         }
     }

--- a/bundles/mapping/camera-controls-3d/resources/locale/fi.js
+++ b/bundles/mapping/camera-controls-3d/resources/locale/fi.js
@@ -5,7 +5,10 @@ Oskari.registerLocalization(
         "value": {
             "tooltip": {
                 "up": "Siirry kartalla ylöspäin",
-                "down": "Siirry kartalla alaspäin "
+                "down": "Siirry kartalla alaspäin ",
+                "move": "Liikuta karttaa",
+                "rotate": "Kierrä karttaa"
+
             }
         }
     }

--- a/bundles/mapping/camera-controls-3d/resources/locale/fi.js
+++ b/bundles/mapping/camera-controls-3d/resources/locale/fi.js
@@ -1,0 +1,13 @@
+Oskari.registerLocalization(
+    {
+        "lang": "fi",
+        "key": "CameraControls3d",
+        "value": {
+            "tooltip": {
+                "up": "Siirry ylös",
+                "down": "Siirry alas"
+            }
+        }
+    }
+);
+    

--- a/bundles/mapping/camera-controls-3d/resources/locale/sv.js
+++ b/bundles/mapping/camera-controls-3d/resources/locale/sv.js
@@ -4,8 +4,8 @@ Oskari.registerLocalization(
         "key": "CameraControls3d",
         "value": {
             "tooltip": {
-                "up": "Flytta upp",
-                "down": "Flytta ner"
+                "up": "Flytta upp på kartan",
+                "down": "Flytta ner på kartan"
             }
         }
     }

--- a/bundles/mapping/camera-controls-3d/resources/locale/sv.js
+++ b/bundles/mapping/camera-controls-3d/resources/locale/sv.js
@@ -5,7 +5,9 @@ Oskari.registerLocalization(
         "value": {
             "tooltip": {
                 "up": "Flytta upp på kartan",
-                "down": "Flytta ner på kartan"
+                "down": "Flytta ner på kartan",
+                "move": "flytta karta",
+                "rotate": "rotera kartan"
             }
         }
     }

--- a/bundles/mapping/camera-controls-3d/resources/locale/sv.js
+++ b/bundles/mapping/camera-controls-3d/resources/locale/sv.js
@@ -1,0 +1,13 @@
+Oskari.registerLocalization(
+    {
+        "lang": "sv",
+        "key": "CameraControls3d",
+        "value": {
+            "tooltip": {
+                "up": "Flytta upp",
+                "down": "Flytta ner"
+            }
+        }
+    }
+);
+    

--- a/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
+++ b/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
@@ -1,42 +1,24 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { withLocale } from 'oskari-ui/util';
-import { Icon } from 'oskari-ui';
+import { MoveMapIcon, RotateMapIcon, UpIcon, DownIcon } from './CameraControls3d/CameraControl3dIcons';
 
 const upDownChangePercent = 10;
-const iconSize = '24px';
-const mobileIconSize = '32px';
 const iconShadow = '1px 1px 2px rgba(0,0,0,0.6)';
 const darkBgColor = 'rgba(20,20,20,0.8)';
-
-const UpSvg = ({ isMobile }) => (
-    <svg width={isMobile ? mobileIconSize : iconSize} height={isMobile ? mobileIconSize : iconSize} viewBox="0 0 24 24">
-        <g id="3D-upward" stroke="none" strokeWidth="1" fillRule="nonzero">
-            <path d="M12,3.93933983 L15.5303301,7.46966991 C15.8232233,7.76256313 15.8232233,8.23743687 15.5303301,8.53033009 C15.2640635,8.79659665 14.8473998,8.8208027 14.5537883,8.60294824 L14.4696699,8.53033009 L12.75,6.81033983 L12.75,13.25 L11.25,13.25 L11.25,6.81033983 L9.53033009,8.53033009 C9.26406352,8.79659665 8.84739984,8.8208027 8.55378835,8.60294824 L8.46966991,8.53033009 C8.20340335,8.26406352 8.1791973,7.84739984 8.39705176,7.55378835 L8.46966991,7.46966991 L12,3.93933983 Z" id="Combined-Shape" fill={'#ffffff'} fillRule="nonzero"></path>
-            <path d="M5.62209673,18.1021658 C9.74978057,15.6943503 13.9299778,15.6341549 18.0602873,17.9215797 L18.3779033,18.1021658 L19.0257374,18.4800691 L18.2699309,19.7757374 L17.6220967,19.3978342 C13.960243,17.2617528 10.3506039,17.2024172 6.69165094,19.2198274 L6.37790327,19.3978342 L5.73006909,19.7757374 L4.97426256,18.4800691 L5.62209673,18.1021658 Z" id="Path-2" fill={'#ffffff'} fillRule="nonzero"></path>
-        </g>
-    </svg>
-);
-UpSvg.propTypes = {
-    isMobile: PropTypes.bool.isRequired
-};
-
-const DownSvg = ({ isMobile }) => (
-    <svg width={isMobile ? mobileIconSize : iconSize} height={isMobile ? mobileIconSize : iconSize} viewBox="0 0 24 24">
-        <g id="3D-downward" stroke="none" strokeWidth="1" fillRule="nonzero">
-            <path d="M15,9 L12,12 L9,9 M12,10.5 L12,4.5" id="Combined-Shape" stroke={'#ffffff'} strokeWidth="1.5" strokeLinecap="round"></path>
-            <path d="M5.62209673,18.1021658 C9.74978057,15.6943503 13.9299778,15.6341549 18.0602873,17.9215797 L18.3779033,18.1021658 L19.0257374,18.4800691 L18.2699309,19.7757374 L17.6220967,19.3978342 C13.960243,17.2617528 10.3506039,17.2024172 6.69165094,19.2198274 L6.37790327,19.3978342 L5.73006909,19.7757374 L4.97426256,18.4800691 L5.62209673,18.1021658 Z" id="Path-2" fill={'#ffffff'} fillRule="nonzero"></path>
-        </g>
-    </svg>
-);
-DownSvg.propTypes = {
-    isMobile: PropTypes.bool.isRequired
-};
+// TODO: Change secondary color reference later when global way available
+const secondaryColor = '#006ce8';
+const mapMoveMethodMove = 'move';
+const mapMoveMethodRotate = 'rotate';
 
 const MapControlsContainer = styled.div`
     margin-top: 10px;
+    margin-left: 5px;
     display: flex;
+    flex-wrap: wrap;
+    width: 80px;
+    align-items: center;
 `;
 
 const MapControlContainer = styled.div`
@@ -44,14 +26,14 @@ const MapControlContainer = styled.div`
     width: 32px;
     height: 32px;
     cursor: pointer;
-    margin: 0 auto;
     z-index: 15000;
     margin-bottom: 5px;
+    margin-left: 5px;
     box-shadow: ${iconShadow};
     -moz-box-shadow: ${iconShadow};
     -webkit-box-shadow: ${iconShadow};
     -o-box-shadow: ${iconShadow};
-    background-color: ${darkBgColor};
+    background-color: ${props => props.controlIsActive && !props.isMobile ? secondaryColor : darkBgColor};
 `;
 
 const MapControl = styled.div`
@@ -62,10 +44,14 @@ const MapControl = styled.div`
     padding-top:3px;
     text-align: center;
 `;
-
 const MobileContainer = styled.div`
     margin-top: 5px;
     margin-right: 5px;
+`;
+
+const Break = styled.div`
+    flex-basis: 100%;
+    height: 0;
 `;
 
 const upDownClickHandler = (directionUp) => {
@@ -80,14 +66,42 @@ const upDownClickHandler = (directionUp) => {
     Oskari.getSandbox().postRequestByName('MapMoveRequest');
 };
 
+const moveMapClickHandler = () => {
+    console.log('TODO: implemetation');
+};
+const rotateMapClickHandler = () => {
+    console.log('TODO: implemetation');
+};
+
 const CameraControls3d = ({ mapInMobileMode, getMessage }) => {
-    const upControl = <Icon style={{ outline: 'none' }} component={() => <UpSvg isMobile={mapInMobileMode}/>} onClick={() => upDownClickHandler(true)} title = {getMessage('tooltip.up')}/>;
-    const downControl = <Icon style={{ outline: 'none' }} component={() => <DownSvg isMobile={mapInMobileMode}/>} onClick={() => upDownClickHandler(false)} title = {getMessage('tooltip.down')}/>;
+    const [activeMapMoveMethod, setActiveMapMoveMethod] = useState(mapMoveMethodMove);
+
+    const moveMapControl = <MoveMapIcon mapInMobileMode={mapInMobileMode} clickHandler={() => {
+        setActiveMapMoveMethod(mapMoveMethodMove);
+        moveMapClickHandler();
+    }} title={getMessage('tooltip.move')} controlIsActive = {activeMapMoveMethod === mapMoveMethodMove}/>;
+
+    const rotateMapControl = <RotateMapIcon mapInMobileMode={mapInMobileMode} clickHandler={() => {
+        setActiveMapMoveMethod(mapMoveMethodRotate);
+        rotateMapClickHandler();
+    }} title={getMessage('tooltip.rotate')} controlIsActive = {activeMapMoveMethod === mapMoveMethodRotate}/>;
+
+    const upControl = <UpIcon mapInMobileMode={mapInMobileMode}
+        clickHandler={() => upDownClickHandler(true)} title={getMessage('tooltip.up')}/>;
+    const downControl = <DownIcon mapInMobileMode={mapInMobileMode}
+        clickHandler={() => upDownClickHandler(false)} title={getMessage('tooltip.down')}/>;
 
     let controls;
 
     if (!mapInMobileMode) {
         controls = <MapControlsContainer>
+            <MapControlContainer isMobile={mapInMobileMode} controlIsActive = {activeMapMoveMethod === mapMoveMethodMove}>
+                <MapControl>{moveMapControl}</MapControl>
+            </MapControlContainer>
+            <MapControlContainer isMobile={mapInMobileMode} controlIsActive = {activeMapMoveMethod === mapMoveMethodRotate}>
+                <MapControl>{rotateMapControl}</MapControl>
+            </MapControlContainer>
+            <Break/>
             <MapControlContainer>
                 <MapControl>{upControl}</MapControl>
             </MapControlContainer>
@@ -97,6 +111,8 @@ const CameraControls3d = ({ mapInMobileMode, getMessage }) => {
         </MapControlsContainer>;
     } else {
         controls = <MobileContainer>
+            {moveMapControl}
+            {rotateMapControl}
             {upControl}
             {downControl}
         </MobileContainer>;

--- a/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
+++ b/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
@@ -64,7 +64,6 @@ const MapControl = styled.div`
 `;
 
 const MobileContainer = styled.div`
-    float:left;
     margin-top: 5px;
     margin-right: 5px;
 `;

--- a/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
+++ b/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
@@ -30,12 +30,9 @@ const MapControlContainer = styled.div`
     margin-bottom: 5px;
     margin-left: 5px;
     box-shadow: ${iconShadow};
-    -moz-box-shadow: ${iconShadow};
-    -webkit-box-shadow: ${iconShadow};
-    -o-box-shadow: ${iconShadow};
     background-color: ${props => props.controlIsActive && !props.isMobile ? secondaryColor : darkBgColor};
     opacity: ${props => props.disabled ? 0.3 : 1.0};
-    pointer-events: ${props => props.disabled ? 'none': 'auto'};
+    pointer-events: ${props => props.disabled ? 'none' : 'auto'};
 `;
 
 const MapControl = styled.div`

--- a/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
+++ b/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
@@ -100,33 +100,29 @@ const CameraControls3d = ({ mapInMobileMode, getMessage }) => {
     const downControl = <DownIcon mapInMobileMode={mapInMobileMode}
         clickHandler={() => upDownClickHandler(false)} title={mapInMobileMode ? '' : getMessage('tooltip.down')}/>;
 
-    let controls;
-
-    if (!mapInMobileMode) {
-        controls = <MapControlsContainer>
-            <MapControlContainer isMobile={mapInMobileMode} controlIsActive = {activeMapMoveMethod === mapMoveMethodMove}>
-                <MapControl>{moveMapControl}</MapControl>
-            </MapControlContainer>
-            <MapControlContainer isMobile={mapInMobileMode} controlIsActive = {activeMapMoveMethod === mapMoveMethodRotate}>
-                <MapControl>{rotateMapControl}</MapControl>
-            </MapControlContainer>
-            <Break/>
-            <MapControlContainer disabled = {activeMapMoveMethod === mapMoveMethodRotate}>
-                <MapControl>{upControl}</MapControl>
-            </MapControlContainer>
-            <MapControlContainer disabled = {activeMapMoveMethod === mapMoveMethodRotate}>
-                <MapControl>{downControl}</MapControl>
-            </MapControlContainer>
-        </MapControlsContainer>;
-    } else {
-        controls = <MobileContainer>
+    if (mapInMobileMode) {
+        return (<MobileContainer>
             {moveMapControl}
             {rotateMapControl}
             {upControl}
             {downControl}
-        </MobileContainer>;
+        </MobileContainer>);
     }
-    return (controls);
+    return (<MapControlsContainer>
+        <MapControlContainer isMobile={mapInMobileMode} controlIsActive = {activeMapMoveMethod === mapMoveMethodMove}>
+            <MapControl>{moveMapControl}</MapControl>
+        </MapControlContainer>
+        <MapControlContainer isMobile={mapInMobileMode} controlIsActive = {activeMapMoveMethod === mapMoveMethodRotate}>
+            <MapControl>{rotateMapControl}</MapControl>
+        </MapControlContainer>
+        <Break/>
+        <MapControlContainer disabled = {activeMapMoveMethod === mapMoveMethodRotate}>
+            <MapControl>{upControl}</MapControl>
+        </MapControlContainer>
+        <MapControlContainer disabled = {activeMapMoveMethod === mapMoveMethodRotate}>
+            <MapControl>{downControl}</MapControl>
+        </MapControlContainer>
+    </MapControlsContainer>);
 };
 
 CameraControls3d.propTypes = {

--- a/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
+++ b/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
@@ -66,11 +66,31 @@ const upDownClickHandler = (directionUp) => {
     Oskari.getSandbox().postRequestByName('MapMoveRequest');
 };
 
-const moveMapClickHandler = () => {
-    console.log('TODO: implemetation');
+const getCamera = () => {
+    const mapmodule = Oskari.getSandbox().getStatefulComponents().mapfull.getMapModule();
+    return mapmodule.getCesiumScene().camera;
 };
-const rotateMapClickHandler = () => {
-    console.log('TODO: implemetation');
+
+const refreshCamera = (camera) => {
+    // TODO: Better way to reftresh camera than saying look where u are looking right now?
+    camera.lookAt(camera.position, new Cesium.HeadingPitchRange(camera.heading, camera.pitch, camera.roll));
+};
+
+const setCameraToMoveMode = (activeMapMoveMethod) => {
+    if (activeMapMoveMethod === mapMoveMethodMove) {
+        return;
+    }
+    const camera = getCamera();
+    camera.constrainedAxis = undefined;
+    refreshCamera(camera);
+};
+const setCameraToRotateMode = (activeMapMoveMethod) => {
+    if (activeMapMoveMethod === mapMoveMethodRotate) {
+        return;
+    }
+    const camera = getCamera();
+    camera.constrainedAxis = Cesium.Cartesian3.UNIT_Z;
+    refreshCamera(camera);
 };
 
 const CameraControls3d = ({ mapInMobileMode, getMessage }) => {
@@ -78,12 +98,12 @@ const CameraControls3d = ({ mapInMobileMode, getMessage }) => {
 
     const moveMapControl = <MoveMapIcon mapInMobileMode={mapInMobileMode} clickHandler={() => {
         setActiveMapMoveMethod(mapMoveMethodMove);
-        moveMapClickHandler();
+        setCameraToMoveMode(activeMapMoveMethod);
     }} title={getMessage('tooltip.move')} controlIsActive = {activeMapMoveMethod === mapMoveMethodMove}/>;
 
     const rotateMapControl = <RotateMapIcon mapInMobileMode={mapInMobileMode} clickHandler={() => {
         setActiveMapMoveMethod(mapMoveMethodRotate);
-        rotateMapClickHandler();
+        setCameraToRotateMode(activeMapMoveMethod);
     }} title={getMessage('tooltip.rotate')} controlIsActive = {activeMapMoveMethod === mapMoveMethodRotate}/>;
 
     const upControl = <UpIcon mapInMobileMode={mapInMobileMode}

--- a/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
+++ b/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
@@ -54,8 +54,12 @@ const Break = styled.div`
     height: 0;
 `;
 
+const getMapModule = () => {
+    return Oskari.getSandbox().getStatefulComponents().mapfull.getMapModule();
+};
+
 const upDownClickHandler = (directionUp) => {
-    const mapmodule = Oskari.getSandbox().getStatefulComponents().mapfull.getMapModule();
+    const mapmodule = getMapModule();
     const cam = mapmodule.getCamera();
     if (directionUp) {
         cam.location.altitude = cam.location.altitude * ((100 + upDownChangePercent) / 100);
@@ -66,31 +70,17 @@ const upDownClickHandler = (directionUp) => {
     Oskari.getSandbox().postRequestByName('MapMoveRequest');
 };
 
-const getCamera = () => {
-    const mapmodule = Oskari.getSandbox().getStatefulComponents().mapfull.getMapModule();
-    return mapmodule.getCesiumScene().camera;
-};
-
-const refreshCamera = (camera) => {
-    // TODO: Better way to reftresh camera than saying look where u are looking right now?
-    camera.lookAt(camera.position, new Cesium.HeadingPitchRange(camera.heading, camera.pitch, camera.roll));
-};
-
 const setCameraToMoveMode = (activeMapMoveMethod) => {
     if (activeMapMoveMethod === mapMoveMethodMove) {
         return;
     }
-    const camera = getCamera();
-    camera.constrainedAxis = undefined;
-    refreshCamera(camera);
+    getMapModule().setCameraToMoveMode();
 };
 const setCameraToRotateMode = (activeMapMoveMethod) => {
     if (activeMapMoveMethod === mapMoveMethodRotate) {
         return;
     }
-    const camera = getCamera();
-    camera.constrainedAxis = Cesium.Cartesian3.UNIT_Z;
-    refreshCamera(camera);
+    getMapModule().setCameraToRotateMode();
 };
 
 const CameraControls3d = ({ mapInMobileMode, getMessage }) => {
@@ -99,17 +89,17 @@ const CameraControls3d = ({ mapInMobileMode, getMessage }) => {
     const moveMapControl = <MoveMapIcon mapInMobileMode={mapInMobileMode} clickHandler={() => {
         setActiveMapMoveMethod(mapMoveMethodMove);
         setCameraToMoveMode(activeMapMoveMethod);
-    }} title={getMessage('tooltip.move')} controlIsActive = {activeMapMoveMethod === mapMoveMethodMove}/>;
+    }} title={mapInMobileMode ? '' : getMessage('tooltip.move')} controlIsActive = {activeMapMoveMethod === mapMoveMethodMove}/>;
 
     const rotateMapControl = <RotateMapIcon mapInMobileMode={mapInMobileMode} clickHandler={() => {
         setActiveMapMoveMethod(mapMoveMethodRotate);
         setCameraToRotateMode(activeMapMoveMethod);
-    }} title={getMessage('tooltip.rotate')} controlIsActive = {activeMapMoveMethod === mapMoveMethodRotate}/>;
+    }} title={ mapInMobileMode ? '' : getMessage('tooltip.rotate')} controlIsActive = {activeMapMoveMethod === mapMoveMethodRotate}/>;
 
     const upControl = <UpIcon mapInMobileMode={mapInMobileMode}
-        clickHandler={() => upDownClickHandler(true)} title={getMessage('tooltip.up')}/>;
+        clickHandler={() => upDownClickHandler(true)} title={mapInMobileMode ? '' : getMessage('tooltip.up')}/>;
     const downControl = <DownIcon mapInMobileMode={mapInMobileMode}
-        clickHandler={() => upDownClickHandler(false)} title={getMessage('tooltip.down')}/>;
+        clickHandler={() => upDownClickHandler(false)} title={mapInMobileMode ? '' : getMessage('tooltip.down')}/>;
 
     let controls;
 

--- a/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
+++ b/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
@@ -34,6 +34,8 @@ const MapControlContainer = styled.div`
     -webkit-box-shadow: ${iconShadow};
     -o-box-shadow: ${iconShadow};
     background-color: ${props => props.controlIsActive && !props.isMobile ? secondaryColor : darkBgColor};
+    opacity: ${props => props.disabled ? 0.3 : 1.0};
+    pointer-events: ${props => props.disabled ? 'none': 'auto'};
 `;
 
 const MapControl = styled.div`
@@ -88,12 +90,12 @@ const CameraControls3d = ({ mapInMobileMode, getMessage }) => {
 
     const moveMapControl = <MoveMapIcon mapInMobileMode={mapInMobileMode} clickHandler={() => {
         setActiveMapMoveMethod(mapMoveMethodMove);
-        setCameraToMoveMode(activeMapMoveMethod);
+        setCameraToMoveMode();
     }} title={mapInMobileMode ? '' : getMessage('tooltip.move')} controlIsActive = {activeMapMoveMethod === mapMoveMethodMove}/>;
 
     const rotateMapControl = <RotateMapIcon mapInMobileMode={mapInMobileMode} clickHandler={() => {
         setActiveMapMoveMethod(mapMoveMethodRotate);
-        setCameraToRotateMode(activeMapMoveMethod);
+        setCameraToRotateMode();
     }} title={ mapInMobileMode ? '' : getMessage('tooltip.rotate')} controlIsActive = {activeMapMoveMethod === mapMoveMethodRotate}/>;
 
     const upControl = <UpIcon mapInMobileMode={mapInMobileMode}
@@ -112,10 +114,10 @@ const CameraControls3d = ({ mapInMobileMode, getMessage }) => {
                 <MapControl>{rotateMapControl}</MapControl>
             </MapControlContainer>
             <Break/>
-            <MapControlContainer>
+            <MapControlContainer disabled = {activeMapMoveMethod === mapMoveMethodRotate}>
                 <MapControl>{upControl}</MapControl>
             </MapControlContainer>
-            <MapControlContainer>
+            <MapControlContainer disabled = {activeMapMoveMethod === mapMoveMethodRotate}>
                 <MapControl>{downControl}</MapControl>
             </MapControlContainer>
         </MapControlsContainer>;

--- a/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
+++ b/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { withLocale } from 'oskari-ui/util';
+import { Icon } from 'oskari-ui';
+
+const upDownChangePercent = 10;
+const iconSize = '24px';
+const mobileIconSize = '32px';
+const iconShadow = '1px 1px 2px rgba(0,0,0,0.6)';
+const darkBgColor = 'rgba(20,20,20,0.8)';
+
+const UpSvg = ({ isMobile }) => (
+    <svg width={isMobile ? mobileIconSize : iconSize} height={isMobile ? mobileIconSize : iconSize} viewBox="0 0 24 24">
+        <g id="3D-upward" stroke="none" strokeWidth="1" fillRule="nonzero">
+            <path d="M12,3.93933983 L15.5303301,7.46966991 C15.8232233,7.76256313 15.8232233,8.23743687 15.5303301,8.53033009 C15.2640635,8.79659665 14.8473998,8.8208027 14.5537883,8.60294824 L14.4696699,8.53033009 L12.75,6.81033983 L12.75,13.25 L11.25,13.25 L11.25,6.81033983 L9.53033009,8.53033009 C9.26406352,8.79659665 8.84739984,8.8208027 8.55378835,8.60294824 L8.46966991,8.53033009 C8.20340335,8.26406352 8.1791973,7.84739984 8.39705176,7.55378835 L8.46966991,7.46966991 L12,3.93933983 Z" id="Combined-Shape" fill={'#ffffff'} fillRule="nonzero"></path>
+            <path d="M5.62209673,18.1021658 C9.74978057,15.6943503 13.9299778,15.6341549 18.0602873,17.9215797 L18.3779033,18.1021658 L19.0257374,18.4800691 L18.2699309,19.7757374 L17.6220967,19.3978342 C13.960243,17.2617528 10.3506039,17.2024172 6.69165094,19.2198274 L6.37790327,19.3978342 L5.73006909,19.7757374 L4.97426256,18.4800691 L5.62209673,18.1021658 Z" id="Path-2" fill={'#ffffff'} fillRule="nonzero"></path>
+        </g>
+    </svg>
+);
+UpSvg.propTypes = {
+    isMobile: PropTypes.bool.isRequired
+};
+
+const DownSvg = ({ isMobile }) => (
+    <svg width={isMobile ? mobileIconSize : iconSize} height={isMobile ? mobileIconSize : iconSize} viewBox="0 0 24 24">
+        <g id="3D-downward" stroke="none" strokeWidth="1" fillRule="nonzero">
+            <path d="M15,9 L12,12 L9,9 M12,10.5 L12,4.5" id="Combined-Shape" stroke={'#ffffff'} strokeWidth="1.5" strokeLinecap="round"></path>
+            <path d="M5.62209673,18.1021658 C9.74978057,15.6943503 13.9299778,15.6341549 18.0602873,17.9215797 L18.3779033,18.1021658 L19.0257374,18.4800691 L18.2699309,19.7757374 L17.6220967,19.3978342 C13.960243,17.2617528 10.3506039,17.2024172 6.69165094,19.2198274 L6.37790327,19.3978342 L5.73006909,19.7757374 L4.97426256,18.4800691 L5.62209673,18.1021658 Z" id="Path-2" fill={'#ffffff'} fillRule="nonzero"></path>
+        </g>
+    </svg>
+);
+DownSvg.propTypes = {
+    isMobile: PropTypes.bool.isRequired
+};
+
+const MapControlsContainer = styled.div`
+    margin-top: 10px;
+    display: flex;
+`;
+
+const MapControlContainer = styled.div`
+    border-radius: 50%;
+    width: 32px;
+    height: 32px;
+    cursor: pointer;
+    margin: 0 auto;
+    z-index: 15000;
+    margin-bottom: 5px;
+    box-shadow: ${iconShadow};
+    -moz-box-shadow: ${iconShadow};
+    -webkit-box-shadow: ${iconShadow};
+    -o-box-shadow: ${iconShadow};
+    background-color: ${darkBgColor};
+`;
+
+const MapControl = styled.div`
+    width: 32px;
+    height: 32px;
+    background-repeat: no-repeat;
+    margin: 0;
+    padding-top:3px;
+    text-align: center;
+`;
+
+const MobileContainer = styled.div`
+    float:left;
+    margin-top: 5px;
+    margin-right: 5px;
+`;
+
+const upDownClickHandler = (directionUp) => {
+    const mapmodule = Oskari.getSandbox().getStatefulComponents().mapfull.getMapModule();
+    const cam = mapmodule.getCamera();
+    if (directionUp) {
+        cam.location.altitude = cam.location.altitude * ((100 + upDownChangePercent) / 100);
+    } else {
+        cam.location.altitude = cam.location.altitude * ((100 - upDownChangePercent) / 100);
+    }
+    mapmodule.setCamera(cam);
+    Oskari.getSandbox().postRequestByName('MapMoveRequest');
+};
+
+const CameraControls3d = ({ mapInMobileMode, getMessage }) => {
+    const upControl = <Icon style={{ outline: 'none' }} component={() => <UpSvg isMobile={mapInMobileMode}/>} onClick={() => upDownClickHandler(true)} title = {getMessage('tooltip.up')}/>;
+    const downControl = <Icon style={{ outline: 'none' }} component={() => <DownSvg isMobile={mapInMobileMode}/>} onClick={() => upDownClickHandler(false)} title = {getMessage('tooltip.down')}/>;
+
+    let controls;
+
+    if (!mapInMobileMode) {
+        controls = <MapControlsContainer>
+            <MapControlContainer>
+                <MapControl>{upControl}</MapControl>
+            </MapControlContainer>
+            <MapControlContainer>
+                <MapControl>{downControl}</MapControl>
+            </MapControlContainer>
+        </MapControlsContainer>;
+    } else {
+        controls = <MobileContainer>
+            {upControl}
+            {downControl}
+        </MobileContainer>;
+    }
+    return (controls);
+};
+
+CameraControls3d.propTypes = {
+    mapInMobileMode: PropTypes.bool.isRequired,
+    getMessage: PropTypes.func.isRequired
+};
+
+const contextWrap = withLocale(CameraControls3d);
+export { contextWrap as CameraControls3d };

--- a/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
+++ b/bundles/mapping/camera-controls-3d/view/CameraControls3d.jsx
@@ -87,12 +87,12 @@ const CameraControls3d = ({ mapInMobileMode, getMessage }) => {
 
     const moveMapControl = <MoveMapIcon mapInMobileMode={mapInMobileMode} clickHandler={() => {
         setActiveMapMoveMethod(mapMoveMethodMove);
-        setCameraToMoveMode();
+        setCameraToMoveMode(activeMapMoveMethod);
     }} title={mapInMobileMode ? '' : getMessage('tooltip.move')} controlIsActive = {activeMapMoveMethod === mapMoveMethodMove}/>;
 
     const rotateMapControl = <RotateMapIcon mapInMobileMode={mapInMobileMode} clickHandler={() => {
         setActiveMapMoveMethod(mapMoveMethodRotate);
-        setCameraToRotateMode();
+        setCameraToRotateMode(activeMapMoveMethod);
     }} title={ mapInMobileMode ? '' : getMessage('tooltip.rotate')} controlIsActive = {activeMapMoveMethod === mapMoveMethodRotate}/>;
 
     const upControl = <UpIcon mapInMobileMode={mapInMobileMode}

--- a/bundles/mapping/camera-controls-3d/view/CameraControls3d/CameraControl3dIcons.jsx
+++ b/bundles/mapping/camera-controls-3d/view/CameraControls3d/CameraControl3dIcons.jsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Icon } from 'oskari-ui';
+
+const iconSize = '24px';
+const mobileIconSize = '32px';
+const svgFill = '#ffffff';
+const iconStyle = { outline: 'none' };
+// TODO: Change secondary color reference later when global way available
+const secondaryColor = '#006ce8';
+
+const UpSvg = ({ isMobile }) => (
+    <svg width={isMobile ? mobileIconSize : iconSize} height={isMobile ? mobileIconSize : iconSize} viewBox="0 0 24 24">
+        <g id="3D-upward" stroke="none" strokeWidth="1" fillRule="nonzero">
+            <path d="M12,3.93933983 L15.5303301,7.46966991 C15.8232233,7.76256313 15.8232233,8.23743687 15.5303301,8.53033009 C15.2640635,8.79659665 14.8473998,8.8208027 14.5537883,8.60294824 L14.4696699,8.53033009 L12.75,6.81033983 L12.75,13.25 L11.25,13.25 L11.25,6.81033983 L9.53033009,8.53033009 C9.26406352,8.79659665 8.84739984,8.8208027 8.55378835,8.60294824 L8.46966991,8.53033009 C8.20340335,8.26406352 8.1791973,7.84739984 8.39705176,7.55378835 L8.46966991,7.46966991 L12,3.93933983 Z" id="Combined-Shape" fill={svgFill} fillRule="nonzero"></path>
+            <path d="M5.62209673,18.1021658 C9.74978057,15.6943503 13.9299778,15.6341549 18.0602873,17.9215797 L18.3779033,18.1021658 L19.0257374,18.4800691 L18.2699309,19.7757374 L17.6220967,19.3978342 C13.960243,17.2617528 10.3506039,17.2024172 6.69165094,19.2198274 L6.37790327,19.3978342 L5.73006909,19.7757374 L4.97426256,18.4800691 L5.62209673,18.1021658 Z" id="Path-2" fill={svgFill} fillRule="nonzero"></path>
+        </g>
+    </svg>
+);
+UpSvg.propTypes = {
+    isMobile: PropTypes.bool.isRequired
+};
+
+const DownSvg = ({ isMobile }) => (
+    <svg width={isMobile ? mobileIconSize : iconSize} height={isMobile ? mobileIconSize : iconSize} viewBox="0 0 24 24">
+        <g id="3D-downward" stroke="none" strokeWidth="1" fillRule="nonzero">
+            <path d="M15,9 L12,12 L9,9 M12,10.5 L12,4.5" id="Combined-Shape" stroke={svgFill} strokeWidth="1.5" strokeLinecap="round"></path>
+            <path d="M5.62209673,18.1021658 C9.74978057,15.6943503 13.9299778,15.6341549 18.0602873,17.9215797 L18.3779033,18.1021658 L19.0257374,18.4800691 L18.2699309,19.7757374 L17.6220967,19.3978342 C13.960243,17.2617528 10.3506039,17.2024172 6.69165094,19.2198274 L6.37790327,19.3978342 L5.73006909,19.7757374 L4.97426256,18.4800691 L5.62209673,18.1021658 Z" id="Path-2" fill={svgFill} fillRule="nonzero"></path>
+        </g>
+    </svg>
+);
+DownSvg.propTypes = {
+    isMobile: PropTypes.bool.isRequired
+};
+
+const MoveMapSvg = ({ isMobile, controlIsActive }) => (
+    <svg width={isMobile ? mobileIconSize : iconSize} height={isMobile ? mobileIconSize : iconSize} viewBox="0 0 24 24">
+        <g id="move" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+            <path d="M12.1803973,3.0525387 C12.1955584,3.06390955 12.2090265,3.07737757 12.2203973,3.0925387 L14.3120066,5.88135105 C14.3782807,5.96971661 14.3603721,6.09507688 14.2720066,6.16135105 C14.2373873,6.18731548 14.1952806,6.20135105 14.1520066,6.20135105 L12.89,6.201 L12.89,11.109 L17.798,11.109 L17.798649,9.84799342 C17.798649,9.73753647 17.888192,9.64799342 17.998649,9.64799342 C18.041923,9.64799342 18.0840297,9.662029 18.118649,9.68799342 L20.9074613,11.7796027 C20.9958269,11.8458769 21.0137355,11.9712371 20.9474613,12.0596027 C20.9360904,12.0747638 20.9226224,12.0882318 20.9074613,12.0996027 L18.118649,14.1912119 C18.0302834,14.2574861 17.9049231,14.2395775 17.838649,14.1512119 C17.8126845,14.1165927 17.798649,14.074486 17.798649,14.0312119 L17.798,12.77 L12.89,12.77 L12.89,17.677 L14.1520066,17.6778543 C14.2624635,17.6778543 14.3520066,17.7673974 14.3520066,17.8778543 C14.3520066,17.9211284 14.337971,17.9632351 14.3120066,17.9978543 L12.2203973,20.7866667 C12.1541231,20.8750322 12.0287629,20.8929408 11.9403973,20.8266667 C11.9252362,20.8152958 11.9117682,20.8018278 11.9003973,20.7866667 L9.80878805,17.9978543 C9.74251388,17.9094888 9.76042249,17.7841285 9.84878805,17.7178543 C9.88340729,17.6918899 9.92551401,17.6778543 9.96878805,17.6778543 L11.229,17.677 L11.229,12.77 L6.322,12.77 L6.32214568,14.0312119 C6.32214568,14.1416689 6.23260263,14.2312119 6.12214568,14.2312119 C6.07887164,14.2312119 6.03676492,14.2171764 6.00214568,14.1912119 L3.21333333,12.0996027 C3.12496777,12.0333285 3.10705916,11.9079682 3.17333333,11.8196027 C3.18470418,11.8044416 3.1981722,11.7909735 3.21333333,11.7796027 L6.00214568,9.68799342 C6.09051124,9.62171925 6.21587151,9.63962786 6.28214568,9.72799342 C6.30811011,9.76261266 6.32214568,9.80471938 6.32214568,9.84799342 L6.322,11.109 L11.229,11.109 L11.229,6.201 L9.96878805,6.20135105 C9.8583311,6.20135105 9.76878805,6.111808 9.76878805,6.00135105 C9.76878805,5.95807701 9.78282363,5.91597028 9.80878805,5.88135105 L11.9003973,3.0925387 C11.9666715,3.00417314 12.0920318,2.98626453 12.1803973,3.0525387 Z" id="Combined-Shape-Copy" fill={controlIsActive && isMobile ? secondaryColor : svgFill}></path>
+        </g>
+    </svg>
+);
+MoveMapSvg.propTypes = {
+    isMobile: PropTypes.bool.isRequired,
+    controlIsActive: PropTypes.bool.isRequired
+};
+
+const RotateMapSvg = ({ isMobile, controlIsActive }) => (
+    <svg width={isMobile ? mobileIconSize : iconSize} height={isMobile ? mobileIconSize : iconSize} viewBox="0 0 24 24">
+        <g id="rotate" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+            <path d="M15.9731748,4.0020101 L19.7679812,4.5441253 C19.877328,4.55974627 19.9533078,4.66105267 19.9376869,4.77039947 C19.931567,4.81323859 19.9117177,4.85293719 19.8811183,4.88353656 L18.963234,5.80201604 C21.8658174,9.33732546 21.6660597,14.5669718 18.363961,17.8690705 C14.8492424,21.3837891 9.15075759,21.3837891 5.63603897,17.8690705 C2.12132034,14.3543518 2.12132034,8.65586703 5.63603897,5.1411484 L5.63603897,5.1411484 L6.90883118,6.41394061 C4.09705628,9.22571551 4.09705628,13.7845034 6.90883118,16.5962783 C9.72060608,19.4080532 14.2793939,19.4080532 17.0911688,16.5962783 C19.6895228,13.9979243 19.8867445,9.90769801 17.682834,7.08287017 L16.6284271,8.13622775 C16.5503223,8.21433261 16.4236893,8.21433261 16.3455844,8.13622775 C16.314985,8.10562838 16.2951357,8.06592978 16.2890159,8.02309066 L15.7469007,4.22828427 C15.7312797,4.11893747 15.8072595,4.01763107 15.9166063,4.0020101 C15.9353672,3.99932997 15.9544139,3.99932997 15.9731748,4.0020101 Z" id="Combined-Shape" fill={controlIsActive && isMobile ? secondaryColor : svgFill}></path>
+        </g>
+    </svg>
+);
+RotateMapSvg.propTypes = {
+    isMobile: PropTypes.bool.isRequired,
+    controlIsActive: PropTypes.bool.isRequired
+};
+
+export const UpIcon = ({ mapInMobileMode, clickHandler, title }) =>
+    <Icon style={iconStyle} component={() =>
+        <UpSvg isMobile={mapInMobileMode}/>} onClick={clickHandler} title = {title}/>;
+UpIcon.propTypes = {
+    mapInMobileMode: PropTypes.bool.isRequired,
+    clickHandler: PropTypes.func.isRequired,
+    title: PropTypes.string.isRequired
+};
+
+export const DownIcon = ({ mapInMobileMode, clickHandler, title }) =>
+    <Icon style={iconStyle} component={() =>
+        <DownSvg isMobile={mapInMobileMode}/>} onClick={clickHandler} title = {title}/>;
+DownIcon.propTypes = {
+    mapInMobileMode: PropTypes.bool.isRequired,
+    clickHandler: PropTypes.func.isRequired,
+    title: PropTypes.string.isRequired
+};
+
+export const MoveMapIcon = ({ mapInMobileMode, clickHandler, title, controlIsActive }) =>
+    <Icon style={iconStyle} component={() =>
+        <MoveMapSvg isMobile={mapInMobileMode} controlIsActive={controlIsActive}/>} onClick={clickHandler} title = {title}/>;
+MoveMapIcon.propTypes = {
+    mapInMobileMode: PropTypes.bool.isRequired,
+    clickHandler: PropTypes.func.isRequired,
+    title: PropTypes.string.isRequired,
+    controlIsActive: PropTypes.bool.isRequired
+};
+
+export const RotateMapIcon = ({ mapInMobileMode, clickHandler, title, controlIsActive }) =>
+    <Icon style={iconStyle} component={() =>
+        <RotateMapSvg isMobile={mapInMobileMode} controlIsActive={controlIsActive}/>} onClick={clickHandler} title = {title}/>;
+RotateMapIcon.propTypes = {
+    mapInMobileMode: PropTypes.bool.isRequired,
+    clickHandler: PropTypes.func.isRequired,
+    title: PropTypes.string.isRequired,
+    controlIsActive: PropTypes.bool.isRequired
+};

--- a/bundles/mapping/mapmodule/mapmodule.olcs.js
+++ b/bundles/mapping/mapmodule/mapmodule.olcs.js
@@ -464,12 +464,12 @@ class MapModuleOlCesium extends MapModuleOl {
     _disableMapMoveControls () {
         const styleClass = 'map-move-control-disabled';
         const mapInMobileMode = Oskari.util.isMobile();
-        var controls;
+        var controlSelectors;
 
         if (mapInMobileMode) {
-            controls = ['.mobile-zoom-in', '.mobile-zoom-out', '.mobile-my-location', '.mobile-xy', '.mobile-north'];
+            controlSelectors = this._getMobileMapControlSelectors();
         } else {
-            controls = ['.maprotator', '.coordinatetool', '.mylocationplugin'];
+            controlSelectors = this._getDesktopMapControlSelectors();
             // Zoom bar need more handling than other controls
             const zoomBar = jQuery('.mappluginsContainer').find('.zoombar');
             zoomBar.addClass(styleClass);
@@ -478,7 +478,7 @@ class MapModuleOlCesium extends MapModuleOl {
             slider.slider('disable');
         }
 
-        controls.forEach(controlClass => {
+        controlSelectors.forEach(controlClass => {
             const control = jQuery(controlClass);
             control.addClass(styleClass);
         });
@@ -486,12 +486,12 @@ class MapModuleOlCesium extends MapModuleOl {
     _enableMapMoveControls () {
         const styleClass = 'map-move-control-disabled';
         const mapInMobileMode = Oskari.util.isMobile();
-        var controls;
+        var controlSelectors;
 
         if (mapInMobileMode) {
-            controls = ['.mobile-zoom-in', '.mobile-zoom-out', '.mobile-my-location', '.mobile-xy', '.mobile-north'];
+            controlSelectors = this._getMobileMapControlSelectors();
         } else {
-            controls = ['.maprotator', '.coordinatetool', '.mylocationplugin'];
+            controlSelectors = this._getDesktopMapControlSelectors();
             // Zoom bar need more handling than other controls
             const zoomBar = jQuery('.mappluginsContainer').find('.zoombar');
             zoomBar.removeClass(styleClass);
@@ -500,10 +500,16 @@ class MapModuleOlCesium extends MapModuleOl {
             slider.slider('enable');
         }
 
-        controls.forEach(controlClass => {
+        controlSelectors.forEach(controlClass => {
             const control = jQuery(controlClass);
             control.removeClass(styleClass);
         });
+    }
+    _getMobileMapControlSelectors () {
+        return ['.mobile-zoom-in', '.mobile-zoom-out', '.mobile-my-location', '.mobile-xy', '.mobile-north','.camera-controls-3d i:nth-child(3)', '.camera-controls-3d i:nth-child(4)'];
+    }
+    _getDesktopMapControlSelectors () {
+        return ['.maprotator', '.coordinatetool', '.mylocationplugin'];
     }
     _toRadians (value) {
         return !isNaN(value) ? Cesium.Math.toRadians(value) : undefined;

--- a/bundles/mapping/mapmodule/mapmodule.olcs.js
+++ b/bundles/mapping/mapmodule/mapmodule.olcs.js
@@ -506,10 +506,10 @@ class MapModuleOlCesium extends MapModuleOl {
         });
     }
     _getMobileMapControlSelectors () {
-        return ['.mobile-zoom-in', '.mobile-zoom-out', '.mobile-my-location', '.mobile-xy', '.mobile-north', '.camera-controls-3d i:nth-child(3)', '.camera-controls-3d i:nth-child(4)'];
+        return ['.mobileToolbarContent .mobile-zoom-in', '.mobileToolbarContent .mobile-zoom-out', '.mobileToolbarContent .mobile-my-location', '.mobileToolbarContent .mobile-xy', '.mobileToolbarContent .mobile-north', '.mobileToolbarContent .camera-controls-3d i:nth-child(3)', '.mobileToolbarContent .camera-controls-3d i:nth-child(4)'];
     }
     _getDesktopMapControlSelectors () {
-        return ['.maprotator', '.coordinatetool', '.mylocationplugin'];
+        return ['.mappluginsContainer .maprotator', '.mappluginsContainer .coordinatetool', '.mappluginsContainer .mylocationplugin'];
     }
     _toRadians (value) {
         return !isNaN(value) ? Cesium.Math.toRadians(value) : undefined;

--- a/bundles/mapping/mapmodule/mapmodule.olcs.js
+++ b/bundles/mapping/mapmodule/mapmodule.olcs.js
@@ -471,7 +471,7 @@ class MapModuleOlCesium extends MapModuleOl {
         } else {
             controls = ['.maprotator', '.coordinatetool', '.mylocationplugin'];
             // Zoom bar need more handling than other controls
-            const zoomBar = jQuery('.zoombar');
+            const zoomBar = jQuery('.mappluginsContainer').find('.zoombar');
             zoomBar.addClass(styleClass);
             zoomBar.children().addClass(styleClass);
             const slider = zoomBar.find('.slider');
@@ -493,7 +493,7 @@ class MapModuleOlCesium extends MapModuleOl {
         } else {
             controls = ['.maprotator', '.coordinatetool', '.mylocationplugin'];
             // Zoom bar need more handling than other controls
-            const zoomBar = jQuery('.zoombar');
+            const zoomBar = jQuery('.mappluginsContainer').find('.zoombar');
             zoomBar.removeClass(styleClass);
             zoomBar.children().removeClass(styleClass);
             const slider = zoomBar.find('.slider');

--- a/bundles/mapping/mapmodule/mapmodule.olcs.js
+++ b/bundles/mapping/mapmodule/mapmodule.olcs.js
@@ -506,7 +506,7 @@ class MapModuleOlCesium extends MapModuleOl {
         });
     }
     _getMobileMapControlSelectors () {
-        return ['.mobile-zoom-in', '.mobile-zoom-out', '.mobile-my-location', '.mobile-xy', '.mobile-north','.camera-controls-3d i:nth-child(3)', '.camera-controls-3d i:nth-child(4)'];
+        return ['.mobile-zoom-in', '.mobile-zoom-out', '.mobile-my-location', '.mobile-xy', '.mobile-north', '.camera-controls-3d i:nth-child(3)', '.camera-controls-3d i:nth-child(4)'];
     }
     _getDesktopMapControlSelectors () {
         return ['.maprotator', '.coordinatetool', '.mylocationplugin'];

--- a/bundles/mapping/mapmodule/resources/scss/mapmodule.ol.scss
+++ b/bundles/mapping/mapmodule/resources/scss/mapmodule.ol.scss
@@ -367,3 +367,8 @@ div.mapplugins {
 .oskari-publisher-font-georgia {
   font-family: Georgia, serif !important;
 }
+
+.map-move-control-disabled {
+    opacity: 0.3 !important;
+    pointer-events: none !important;
+}

--- a/packages/mapping/camera-controls-3d/bundle.js
+++ b/packages/mapping/camera-controls-3d/bundle.js
@@ -7,11 +7,11 @@ Oskari.clazz.define("Oskari.mapping.cameracontrols3d.CameraControls3dBundle", fu
 
 }, {
 	"create" : function() {
-		return Oskari.clazz.create("Oskari.mapping.cameracontrols3d.CameraControls3dBundleInstance");
+		return Oskari.clazz.create("Oskari.mapping.cameracontrols3d.instance");
 	}
 }, {
 
-	"protocol" : ["Oskari.bundle.Bundle", "Oskari.mapframework.bundle.extension.ExtensionBundle"],
+	"protocol" : ["Oskari.bundle.Bundle"],
 	"source" : {
 		"scripts" : [{
 			"type" : "text/javascript",
@@ -39,15 +39,14 @@ Oskari.clazz.define("Oskari.mapping.cameracontrols3d.CameraControls3dBundle", fu
 			"Bundle-Identifier" : "camera-controls-3d",
 			"Bundle-Name" : "camera-controls-3d",
 			"Bundle-Author" : [{
-				"Name" : "mm",
+				"Name" : "mmldev",
 				"Organisation" : "nls.fi",
 				"Temporal" : {
 					"Start" : "2019"
 				},
-				"Copyleft" : {
-					"License" : {
-						"License-Name" : "EUPL",
-						"License-Online-Resource" : "http://www.paikkatietoikkuna.fi/license"
+				"Copyleft": {
+					"License": {
+						"License-Name": "EUPL"
 					}
 				}
 			}],

--- a/packages/mapping/camera-controls-3d/bundle.js
+++ b/packages/mapping/camera-controls-3d/bundle.js
@@ -1,0 +1,66 @@
+/**
+ * @class Oskari.mapping.cameracontrols3d.CameraControls3dBundle
+ *
+ * Definition for bundle. See source for details.
+ */
+Oskari.clazz.define("Oskari.mapping.cameracontrols3d.CameraControls3dBundle", function() {
+
+}, {
+	"create" : function() {
+		return Oskari.clazz.create("Oskari.mapping.cameracontrols3d.CameraControls3dBundleInstance");
+	}
+}, {
+
+	"protocol" : ["Oskari.bundle.Bundle", "Oskari.mapframework.bundle.extension.ExtensionBundle"],
+	"source" : {
+		"scripts" : [{
+			"type" : "text/javascript",
+			"src" : "../../../bundles/mapping/camera-controls-3d/instance.js"
+		}, {
+			"type" : "text/javascript",
+			"src" : "../../../bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js"
+		}],
+		"locales" : [{
+			"lang" : "fi",
+			"type" : "text/javascript",
+			"src" : "../../../bundles/mapping/camera-controls-3d/resources/locale/fi.js"
+		}, {
+			"lang" : "sv",
+			"type" : "text/javascript",
+			"src" : "../../../bundles/mapping/camera-controls-3d/resources/locale/sv.js"
+		}, {
+			"lang" : "en",
+			"type" : "text/javascript",
+			"src" : "../../../bundles/mapping/camera-controls-3d/resources/locale/en.js"
+		}]
+	},
+	"bundle" : {
+		"manifest" : {
+			"Bundle-Identifier" : "camera-controls-3d",
+			"Bundle-Name" : "camera-controls-3d",
+			"Bundle-Author" : [{
+				"Name" : "mm",
+				"Organisation" : "nls.fi",
+				"Temporal" : {
+					"Start" : "2019"
+				},
+				"Copyleft" : {
+					"License" : {
+						"License-Name" : "EUPL",
+						"License-Online-Resource" : "http://www.paikkatietoikkuna.fi/license"
+					}
+				}
+			}],
+			"Bundle-Version" : "1.0.0",
+			"Import-Namespace" : ["Oskari", "jquery"],
+			"Import-Bundle" : {}
+		}
+	},
+	/**
+	 * @static
+	 * @property dependencies
+	 */
+	"dependencies" : ["jquery"]
+});
+
+Oskari.bundle_manager.installBundleClass("camera-controls-3d", "Oskari.mapping.cameracontrols3d.CameraControls3dBundle");


### PR DESCRIPTION
First version of 3D camera controls containing:

- Controls to adjust altitude of camera
- Control to set camera to move mode (default, works like before).
- Control to set camera to new rotate mode. In rotate mode camera is in fixed location and camera can be rotated with mouse.

Camera can be either in move mode or in rotate mode and user can toggle between modes. 
In this version map controls adjusting camera position (except pantools containing reset) are disabled at rotate mode because of fixed location of camera. Once changed back to default move mode, all controls are enabled.