### PR TITLE
Use layer types and versions from MapLayerService in Wizard

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerFormService.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerFormService.js
@@ -380,9 +380,6 @@ export class AdminLayerFormService {
         return this.layer;
     }
 
-    getLayerTypes () {
-        return ['wfslayer', 'wmslayer'];
-    }
     isLoading () {
         return this.loadingCount > 0;
     }

--- a/bundles/admin/admin-layereditor/view/Flyout.js
+++ b/bundles/admin/admin-layereditor/view/Flyout.js
@@ -16,6 +16,8 @@ export class LayerEditorFlyout extends ExtraFlyout {
         this.dataProviders = [];
         this.mapLayerGroups = [];
         this.service = new AdminLayerFormService(() => this.update());
+        this.mapLayerService = Oskari.getSandbox().getService('Oskari.mapframework.service.MapLayerService');
+        this.mapLayerService.addStateListener(() => this.update());
         this.on('show', () => {
             if (!this.getElement()) {
                 this.createUi();
@@ -67,18 +69,20 @@ export class LayerEditorFlyout extends ExtraFlyout {
         ReactDOM.render(uiCode, el.get(0));
     }
     getEditorUI () {
+        const layer = this.service.getLayer();
         return (
             <LocaleContext.Provider value={{ bundleKey: 'admin-layereditor' }}>
                 <MutatorContext.Provider value={this.service}>
                     <LayerWizard
-                        layer={this.service.getLayer()}
+                        layer={layer}
                         capabilities={this.service.getCapabilities()}
                         loading={this.service.isLoading()}
-                        layerTypes={this.service.getLayerTypes()}>
+                        layerTypes={this.mapLayerService.getLayerTypes()}
+                        versions = {this.mapLayerService.getVersionsForType(layer.type)}>
                         <AdminLayerForm
                             mapLayerGroups={this.mapLayerGroups}
                             dataProviders={this.dataProviders}
-                            layer={this.service.getLayer()}
+                            layer={layer}
                             messages={this.service.getMessages()}
                             rolesAndPermissionTypes={this.service.getRolesAndPermissionTypes()}
                             onDelete={() => this.service.deleteLayer()}

--- a/bundles/admin/admin-layereditor/view/Flyout.js
+++ b/bundles/admin/admin-layereditor/view/Flyout.js
@@ -17,7 +17,7 @@ export class LayerEditorFlyout extends ExtraFlyout {
         this.mapLayerGroups = [];
         this.service = new AdminLayerFormService(() => this.update());
         this.mapLayerService = Oskari.getSandbox().getService('Oskari.mapframework.service.MapLayerService');
-        this.mapLayerService.addStateListener(() => this.update());
+        this.mapLayerService.on('availableVersionsUpdated', () => this.update());
         this.on('show', () => {
             if (!this.getElement()) {
                 this.createUi();

--- a/bundles/admin/admin-layereditor/view/LayerWizard.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard.jsx
@@ -58,7 +58,8 @@ const LayerWizard = ({
     layerTypes = [],
     loading,
     children,
-    Message
+    Message,
+    versions
 }) => {
     const currentStep = getStep(layer);
     const isFirstStep = currentStep === WIZARD_STEP.INITIAL;
@@ -89,7 +90,8 @@ const LayerWizard = ({
                     <LayerURLForm
                         layer={layer}
                         loading={loading}
-                        service={mutator} />
+                        service={mutator}
+                        versions= {versions} />
                 </React.Fragment>
             }
             { currentStep === WIZARD_STEP.LAYER &&
@@ -122,7 +124,8 @@ LayerWizard.propTypes = {
     loading: PropTypes.bool,
     capabilities: PropTypes.object,
     layerTypes: PropTypes.array,
-    children: PropTypes.any
+    children: PropTypes.any,
+    versions: PropTypes.array.isRequired
 };
 
 const contextWrap = withMutator(withLocale(LayerWizard));

--- a/bundles/admin/admin-layereditor/view/LayerWizard/LayerURLForm.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard/LayerURLForm.jsx
@@ -2,16 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, UrlInput } from 'oskari-ui';
 
-const versionsAvailable = {
-    'wmslayer': ['1.1.1', '1.3.0'],
-    'wfslayer': ['1.1.0', '2.0.0', '3.0']
-};
-
-function getVersions (type) {
-    return versionsAvailable[type] || [];
-}
-
-export const LayerURLForm = ({ layer, loading, service }) => {
+export const LayerURLForm = ({ layer, loading, service, versions }) => {
     const credentials = {
         defaultOpen: true
     };
@@ -22,7 +13,7 @@ export const LayerURLForm = ({ layer, loading, service }) => {
                 disabled={loading}
                 credentials={credentials}
                 onChange={(url) => service.setLayerUrl(url)} />
-            {getVersions(layer.type).map((version, key) => (
+            {versions.map((version, key) => (
                 <Button type="primary" key={key}
                     onClick={() => service.setVersion(version)}
                     disabled={!layer.url || loading}>{version}</Button>
@@ -34,5 +25,6 @@ export const LayerURLForm = ({ layer, loading, service }) => {
 LayerURLForm.propTypes = {
     layer: PropTypes.object,
     loading: PropTypes.bool,
-    service: PropTypes.any
+    service: PropTypes.object,
+    versions: PropTypes.array.isRequired
 };

--- a/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol.js
@@ -18,6 +18,7 @@ Oskari.clazz.define(
      */
     function () {
         this._log = Oskari.log(this.getName());
+        this.availableVersions = ['1.1.1', '1.3.0'];
     },
     {
         __name: 'WmsLayerPlugin',
@@ -26,6 +27,11 @@ Oskari.clazz.define(
 
         getLayerTypeSelector: function () {
             return 'WMS';
+        },
+
+        _initImpl () {
+            const mapLayerService = Oskari.getSandbox().getService('Oskari.mapframework.service.MapLayerService');
+            mapLayerService.registerLayerModel(this.getLayerTypeSelector().toLowerCase() + 'layer', 'Oskari.mapframework.domain.WmsLayer', this.availableVersions);
         },
 
         _createPluginEventHandlers: function () {

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -76,7 +76,6 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
         };
 
         Oskari.makeObservable(this);
-        this.stateListeners = [];
     }, {
         /** @static @property __qname fully qualified name for service */
         __qname: 'Oskari.mapframework.service.MapLayerService',
@@ -948,7 +947,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
             this.typeMapping[type] = modelRef;
             if (availableVersionsForType) {
                 this.availableVersions[type] = availableVersionsForType;
-                this.notify();
+                this.trigger('availableVersionsUpdated');
             }
         },
         getVersionsForType (type) {
@@ -956,12 +955,6 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
         },
         getLayerTypes () {
             return Object.keys(this.availableVersions) || [];
-        },
-        addStateListener (consumer) {
-            this.stateListeners.push(consumer);
-        },
-        notify () {
-            this.stateListeners.forEach(consumer => consumer());
         },
         /**
          * @method unregisterLayerModel

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
@@ -29,6 +29,7 @@ export class WfsVectorLayerPlugin extends AbstractMapLayerPlugin {
         this.vectorLayerHandler = new VectorLayerHandler(this);
         this.mvtLayerHandler = new MvtLayerHandler(this);
         this.layerHandlersByLayerId = {};
+        this.availableVersions = ['1.1.0', '2.0.0', '3.0'];
     }
 
     /* ---- AbstractMapModulePlugin functions ---- */
@@ -86,7 +87,7 @@ export class WfsVectorLayerPlugin extends AbstractMapLayerPlugin {
         if (!this.mapLayerService || !this.vectorFeatureService) {
             return;
         }
-        this.mapLayerService.registerLayerModel(this.getLayerTypeSelector(), 'Oskari.mapframework.bundle.mapwfs2.domain.WFSLayer');
+        this.mapLayerService.registerLayerModel(this.getLayerTypeSelector(), 'Oskari.mapframework.bundle.mapwfs2.domain.WFSLayer', this.availableVersions);
         this.mapLayerService.registerLayerModelBuilder(this.getLayerTypeSelector(), new WfsLayerModelBuilder(sandbox));
         this.vectorFeatureService.registerLayerType(this.layertype, this);
         sandbox.registerService(this.WFSLayerService);


### PR DESCRIPTION
This PR contains changes to use layer types and versions from MapLayerService in layer wizard. WFS and WMS layer plugins provide their own supported versions to MapLayerService in registerLayerModel call.