### PR TITLE
Make Message component localized

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm.jsx
@@ -6,7 +6,7 @@ import { AdditionalTabPane } from './AdminLayerForm/AdditionalTabPane';
 import { PermissionsTabPane } from './AdminLayerForm/PermissionsTabPane';
 import { StyledRoot } from './AdminLayerForm/StyledFormComponents';
 import { withLocale, withMutator } from 'oskari-ui/util';
-import { Confirm, Alert, Button, Tabs, TabPane } from 'oskari-ui';
+import { Confirm, Alert, Button, Tabs, TabPane, Message } from 'oskari-ui';
 import styled from 'styled-components';
 
 const PaddedButton = styled(Button)`
@@ -26,7 +26,6 @@ const AdminLayerForm = ({
     onDelete,
     onSave,
     getMessage,
-    Message,
     rolesAndPermissionTypes
 }) => (
     <StyledRoot>
@@ -81,7 +80,6 @@ AdminLayerForm.propTypes = {
     onSave: PropTypes.func,
     onDelete: PropTypes.func,
     getMessage: PropTypes.func.isRequired,
-    Message: PropTypes.elementType.isRequired,
     rolesAndPermissionTypes: PropTypes.object
 };
 

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TextInput, TextAreaInput } from 'oskari-ui';
+import { TextInput, TextAreaInput, Message } from 'oskari-ui';
 import { StyledTab, StyledComponent } from './StyledFormComponents';
 import { withLocale } from 'oskari-ui/util';
 
-export const AdditionalTabPane = withLocale(({ layer, service, getMessage, Message }) => (
+export const AdditionalTabPane = withLocale(({ layer, service, getMessage }) => (
     <StyledTab>
         <Message messageKey='metainfoId'/>
         <StyledComponent>

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { DataProviderSelect } from './DataProviderSelect';
-import { TextInput, UrlInput } from 'oskari-ui';
+import { TextInput, UrlInput, Message } from 'oskari-ui';
 import { MapLayerGroups } from './MapLayerGroups';
 import { StyledTab, StyledComponentGroup, StyledComponent } from './StyledFormComponents';
 import { withLocale } from 'oskari-ui/util';
@@ -9,7 +9,7 @@ import { LocalizedLayerInfo } from './LocalizedLayerInfo';
 import { OtherLanguagesPane } from './OtherLanguagesPane';
 
 const GeneralTabPane = (props) => {
-    const { mapLayerGroups, dataProviders, layer, service, Message } = props;
+    const { mapLayerGroups, dataProviders, layer, service } = props;
     const lang = Oskari.getLang();
     const credentialProps = {
         allowCredentials: true,

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/LocalizedLayerInfo.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/LocalizedLayerInfo.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TextInput } from 'oskari-ui';
+import { TextInput, Message } from 'oskari-ui';
 import { withLocale } from 'oskari-ui/util';
 import { StyledComponent } from './StyledFormComponents';
 
-export const LocalizedLayerInfo = withLocale(({ layer, lang, service, getMessage, Message }) => {
+export const LocalizedLayerInfo = withLocale(({ layer, lang, service, getMessage }) => {
     const selectedLang = Oskari.getLang();
     const name = layer[`name_${lang}`];
     const description = layer[`title_${lang}`];

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/MapLayerGroups.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/MapLayerGroups.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Checkbox, Collapse, CollapsePanel, List, ListItem } from 'oskari-ui';
+import { Checkbox, Collapse, CollapsePanel, List, ListItem, Message } from 'oskari-ui';
 import { withLocale } from 'oskari-ui/util';
 
-export const MapLayerGroups = withLocale(({ layer, mapLayerGroups, service, lang, Message }) => {
+export const MapLayerGroups = withLocale(({ layer, mapLayerGroups, service, lang }) => {
     const dataSource = mapLayerGroups.map(group =>
         <Checkbox key={group.id}
             onChange={(evt) => service.setMapLayerGroup(evt.target.checked, group)}

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/OtherLanguagesPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/OtherLanguagesPane.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Collapse, CollapsePanel } from 'oskari-ui';
+import { Collapse, CollapsePanel, Message } from 'oskari-ui';
 import { withLocale } from 'oskari-ui/util';
 import { LocalizedLayerInfo } from './LocalizedLayerInfo';
 
-export const OtherLanguagesPane = withLocale(({ layer, service, lang, Message }) => (
+export const OtherLanguagesPane = withLocale(({ layer, service, lang }) => (
     <Collapse>
         <CollapsePanel header={<Message messageKey='otherLanguages'/>}>
             {

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionsTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionsTabPane.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { PermissionRow } from './PermissionTabPane/PermissionRow';
-import { List, ListItem, Checkbox } from 'oskari-ui';
+import { List, ListItem, Checkbox, Message } from 'oskari-ui';
 import { withLocale } from 'oskari-ui/util';
 
 const StyledListItem = styled(ListItem)`
@@ -50,7 +50,7 @@ const renderRow = (modelRow) => {
     );
 };
 
-const PermissionsTabPane = ({ rolesAndPermissionTypes, permissions = {}, Message }) => {
+const PermissionsTabPane = ({ rolesAndPermissionTypes, permissions = {} }) => {
     if (!rolesAndPermissionTypes) {
         return;
     }
@@ -87,8 +87,7 @@ const PermissionsTabPane = ({ rolesAndPermissionTypes, permissions = {}, Message
 
 PermissionsTabPane.propTypes = {
     rolesAndPermissionTypes: PropTypes.object,
-    permissions: PropTypes.object,
-    Message: PropTypes.elementType.isRequired
+    permissions: PropTypes.object
 };
 
 const contextWrap = withLocale(PermissionsTabPane);

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { StyleSelect } from './StyleSelect';
 import { StyledTab, StyledComponent, StyledColumnLeft, StyledColumnRight } from './StyledFormComponents';
-import { Slider, TextAreaInput, Opacity } from 'oskari-ui';
+import { Slider, TextAreaInput, Opacity, Message } from 'oskari-ui';
 import { withLocale } from 'oskari-ui/util';
 import styled from 'styled-components';
 
@@ -13,7 +13,7 @@ const VerticalComponent = styled(StyledComponent)`
 `;
 
 const VisualizationTabPane = (props) => {
-    const { layer, service, Message } = props;
+    const { layer, service } = props;
     return (
         <StyledTab>
             <StyledColumnLeft>
@@ -53,8 +53,7 @@ const VisualizationTabPane = (props) => {
 VisualizationTabPane.propTypes = {
     layer: PropTypes.object,
     service: PropTypes.any,
-    visualizationProps: PropTypes.any,
-    Message: PropTypes.elementType.isRequired
+    visualizationProps: PropTypes.any
 };
 
 const contextWrap = withLocale(VisualizationTabPane);

--- a/bundles/admin/admin-layereditor/view/LayerWizard.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Steps, Step, Button } from 'oskari-ui';
+import { Steps, Step, Button, Message } from 'oskari-ui';
 import { LayerTypeSelection } from './LayerWizard/LayerTypeSelection';
 import { LayerURLForm } from './LayerWizard/LayerURLForm';
 import { withLocale, withMutator } from 'oskari-ui/util';
@@ -41,7 +41,7 @@ function getStep (layer) {
     return WIZARD_STEP.DETAILS;
 }
 
-const LayerTypeTitle = withLocale(({ layer, Message, LabelComponent }) => (
+const LayerTypeTitle = withLocale(({ layer, LabelComponent }) => (
     <React.Fragment>
         <Message messageKey='wizard.type' LabelComponent={LabelComponent} />
         { layer.type && `: ${layer.type}` }
@@ -57,8 +57,7 @@ const LayerWizard = ({
     capabilities = {},
     layerTypes = [],
     loading,
-    children,
-    Message
+    children
 }) => {
     const currentStep = getStep(layer);
     const isFirstStep = currentStep === WIZARD_STEP.INITIAL;
@@ -118,7 +117,6 @@ const LayerWizard = ({
 LayerWizard.propTypes = {
     layer: PropTypes.object.isRequired,
     mutator: PropTypes.object.isRequired,
-    Message: PropTypes.elementType.isRequired,
     loading: PropTypes.bool,
     capabilities: PropTypes.object,
     layerTypes: PropTypes.array,

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Filter/Filter.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Filter/Filter.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Select, Option, Tooltip } from 'oskari-ui';
+import { Select, Option, Tooltip, Message } from 'oskari-ui';
 import { Mutator, withLocale } from 'oskari-ui/util';
 import { Labelled } from '../Labelled';
 
-const Filter = ({ filters, activeFilterId, mutator, Message }) => {
+const Filter = ({ filters, activeFilterId, mutator }) => {
     let tooltip;
     let activeFilterProps = {};
     if (activeFilterId) {
@@ -45,8 +45,7 @@ const filterBtnShape = {
 Filter.propTypes = {
     filters: PropTypes.arrayOf(PropTypes.shape(filterBtnShape)).isRequired,
     activeFilterId: PropTypes.string,
-    mutator: PropTypes.instanceOf(Mutator).isRequired,
-    Message: PropTypes.elementType.isRequired
+    mutator: PropTypes.instanceOf(Mutator).isRequired
 };
 
 const memoized = React.memo(withLocale(Filter));

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Labelled.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Labelled.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Message } from 'oskari-ui';
 import { withLocale } from 'oskari-ui/util';
 import styled from 'styled-components';
 
@@ -16,7 +17,7 @@ const Elastic = styled('div')`
     }
 `;
 
-const Labelled = ({ messageKey, children, Message }) =>
+const Labelled = ({ messageKey, children }) =>
     <Elastic>
         { messageKey &&
             <Message messageKey={messageKey} LabelComponent={Label} />
@@ -29,8 +30,7 @@ Labelled.propTypes = {
     children: PropTypes.oneOfType([
         PropTypes.arrayOf(PropTypes.element),
         PropTypes.element
-    ]).isRequired,
-    Message: PropTypes.elementType.isRequired
+    ]).isRequired
 };
 
 const wrapped = withLocale(Labelled);

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/Layer/LayerTools.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/Layer/LayerTools.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { WarningIcon, Tooltip } from 'oskari-ui';
+import { WarningIcon, Tooltip, Message } from 'oskari-ui';
 import { Mutator, withLocale } from 'oskari-ui/util';
 import { TimeSerieIcon } from '../../../CustomIcons';
 import { LayerIcon } from '../../../LayerIcon';
@@ -50,7 +50,7 @@ const getStatusColor = status => {
     }
 };
 
-const LayerTools = ({ model, mutator, Message }) => {
+const LayerTools = ({ model, mutator }) => {
     const backendStatus = getBackendStatus(model);
     const infoIcon = {
         classes: ['layer-info']
@@ -86,8 +86,7 @@ const LayerTools = ({ model, mutator, Message }) => {
 
 LayerTools.propTypes = {
     model: PropTypes.object.isRequired,
-    mutator: PropTypes.instanceOf(Mutator).isRequired,
-    Message: PropTypes.elementType.isRequired
+    mutator: PropTypes.instanceOf(Mutator).isRequired
 };
 
 const wrapped = withLocale(LayerTools);

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Collapse } from 'oskari-ui';
+import { Collapse, Message } from 'oskari-ui';
 import { withLocale } from 'oskari-ui/util';
 import { LayerCollapsePanel } from './LayerCollapsePanel';
 import { Alert } from '../Alert';
@@ -16,7 +16,7 @@ const StyledCollapse = styled(Collapse)`
     }
 `;
 
-const LayerCollapse = ({ groups, openGroupTitles, selectedLayerIds, mutator, Message }) => {
+const LayerCollapse = ({ groups, openGroupTitles, selectedLayerIds, mutator }) => {
     if (!Array.isArray(groups) || groups.length === 0) {
         return <Alert showIcon type='info' message={<Message messageKey='errors.noResults'/>}/>;
     }
@@ -48,8 +48,7 @@ LayerCollapse.propTypes = {
     openGroupTitles: PropTypes.array.isRequired,
     filtered: PropTypes.array,
     selectedLayerIds: PropTypes.array.isRequired,
-    mutator: PropTypes.any.isRequired,
-    Message: PropTypes.elementType.isRequired
+    mutator: PropTypes.any.isRequired
 };
 
 const wrapped = withLocale(LayerCollapse);

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerList.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerList.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { shapes } from '../propTypes';
-import { Button, Spin, Tooltip, Icon } from 'oskari-ui';
+import { Button, Spin, Tooltip, Icon, Message } from 'oskari-ui';
 import { Mutator, withLocale } from 'oskari-ui/util';
 import { LayerCollapse } from './LayerCollapse/';
 import { Filter, Search } from './Filter/';
@@ -64,7 +64,7 @@ const Indicator = ({ show, children }) => {
 };
 
 const LayerList = React.forwardRef((props, ref) => {
-    const { error, loading = false, updating = false, mutator, Message } = props;
+    const { error, loading = false, updating = false, mutator } = props;
     if (error) {
         return <Alert showIcon type="error" description={error}/>;
     }
@@ -122,8 +122,7 @@ LayerList.propTypes = {
     filter: shapes.stateful.isRequired,
     showAddButton: PropTypes.bool,
     grouping: PropTypes.shape(grouping).isRequired,
-    mutator: PropTypes.instanceOf(Mutator).isRequired,
-    Message: PropTypes.elementType.isRequired
+    mutator: PropTypes.instanceOf(Mutator).isRequired
 };
 
 const wrapped = withLocale(React.memo(LayerList));

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerViewTabs.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerViewTabs.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { shapes } from './propTypes';
 import styled from 'styled-components';
-import { Tabs, TabPane } from 'oskari-ui';
+import { Tabs, TabPane, Message } from 'oskari-ui';
 import { Mutator, withMutator, withLocale } from 'oskari-ui/util';
 import { LayerList } from './LayerList/';
 import { SelectedLayers, SelectedTab } from './SelectedLayers/';
@@ -30,7 +30,7 @@ const focus = ref => {
     }
 };
 
-const LayerViewTabs = ({ tab, layerList, selectedLayers, autoFocusSearch, mutator, Message }) => {
+const LayerViewTabs = ({ tab, layerList, selectedLayers, autoFocusSearch, mutator }) => {
     const searchTermInputRef = useRef(null);
     useEffect(() => {
         if (autoFocusSearch) {
@@ -74,8 +74,7 @@ LayerViewTabs.propTypes = {
     selectedLayers: shapes.stateful.isRequired,
     tab: PropTypes.string,
     autoFocusSearch: PropTypes.bool,
-    mutator: PropTypes.instanceOf(Mutator).isRequired,
-    Message: PropTypes.elementType.isRequired
+    mutator: PropTypes.instanceOf(Mutator).isRequired
 };
 
 const contextWrap = withMutator(withLocale(LayerViewTabs));

--- a/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/Footer/StyleSettings.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/Footer/StyleSettings.jsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Icon, Select, Option, InputGroup, Button } from 'oskari-ui';
+import { Icon, Select, Option, InputGroup, Button, Message } from 'oskari-ui';
 import { withLocale } from 'oskari-ui/util';
 import { THEME_COLOR } from '..';
 
@@ -25,7 +25,7 @@ const getOption = (style) => (
     </Option>
 );
 
-export const StyleSettings = withLocale(({ layer, onChange, Message }) => {
+export const StyleSettings = withLocale(({ layer, onChange }) => {
     const styles = layer.getStyles();
     const styleTool = layer.getTool('ownStyle');
     const currentStyle = layer.getCurrentStyle();

--- a/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/LayerBox.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/LayerBox.jsx
@@ -5,7 +5,7 @@ import { Footer } from './Footer/';
 import { Mutator, withLocale } from 'oskari-ui/util';
 import { Draggable } from 'react-beautiful-dnd';
 import { Row, Col, ColAuto, ColAutoRight } from './Grid';
-import { Icon } from 'oskari-ui';
+import { Icon, Message } from 'oskari-ui';
 import { EyeOpen, EyeShut, DragIcon } from '../../CustomIcons';
 
 const StyledBox = styled.div`
@@ -25,7 +25,7 @@ const Publishable = styled.span`
     margin-left: 5px;
 `;
 
-const LayerBox = ({ layer, index, visibilityInfo, mutator, Message }) => {
+const LayerBox = ({ layer, index, visibilityInfo, mutator }) => {
     const name = layer.getName();
     const organizationName = layer.getOrganizationName();
     const publishable = layer.getPermission('publish');
@@ -98,8 +98,7 @@ LayerBox.propTypes = {
     layer: PropTypes.object.isRequired,
     index: PropTypes.number.isRequired,
     visibilityInfo: PropTypes.object.isRequired,
-    mutator: PropTypes.instanceOf(Mutator).isRequired,
-    Message: PropTypes.elementType.isRequired
+    mutator: PropTypes.instanceOf(Mutator).isRequired
 };
 
 const wrapped = withLocale(LayerBox);

--- a/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/SelectedTab.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/SelectedTab.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { Message } from 'oskari-ui';
 import { withLocale } from 'oskari-ui/util';
 import styled, { css, keyframes } from 'styled-components';
 
@@ -31,7 +32,7 @@ const StyledBadge = styled.div`
         animation-iteration-count: ${BLINK_COUNT};`}
 `;
 
-export const SelectedTab = withLocale(({ num, messageKey, Message }) => {
+export const SelectedTab = withLocale(({ num, messageKey }) => {
     const [isBlinking, setBlinking] = useState(true);
     // Prevents blinking when flyout is hidden and shown again.
     useEffect(() => {

--- a/src/react/components/Message.jsx
+++ b/src/react/components/Message.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { withLocale } from 'oskari-ui/util';
 import styled from 'styled-components';
 
 const Label = styled('div')`
     display: inline-block;
 `;
 
-export const Message = ({ bundleKey, messageKey, messageArgs, getMessage, LabelComponent = Label }) => {
+const Message = ({ bundleKey, messageKey, messageArgs, getMessage, LabelComponent = Label }) => {
     if (!messageKey) {
         return null;
     }
@@ -19,11 +20,13 @@ export const Message = ({ bundleKey, messageKey, messageArgs, getMessage, LabelC
         </LabelComponent>
     );
 };
-
 Message.propTypes = {
     bundleKey: PropTypes.string.isRequired,
-    messageKey: PropTypes.string.isRequired,
+    messageKey: PropTypes.string,
     messageArgs: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
     getMessage: PropTypes.func,
     LabelComponent: PropTypes.elementType
 };
+
+const wrapped = withLocale(Message);
+export { wrapped as Message };

--- a/src/react/util/contexts/LocaleContext.jsx
+++ b/src/react/util/contexts/LocaleContext.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Message } from 'oskari-ui';
 
 /**
  * The context takes an object with two properties as a parameter. { bundleKey, getMessage }
@@ -17,11 +16,8 @@ export function withLocale (Component) {
         return (
             <LocaleContext.Consumer>
                 {
-                    ({ bundleKey, getMessage = Oskari.getMsg.bind(null, bundleKey) }) => {
-                        const BundleMessage = messageProps =>
-                            <Message {...messageProps} bundleKey={bundleKey} getMessage={getMessage} />;
-                        return <Component {...props} getMessage={getMessage} Message={BundleMessage} ref={ref} />;
-                    }
+                    ({ bundleKey, getMessage = Oskari.getMsg.bind(null, bundleKey) }) =>
+                        <Component bundleKey={bundleKey} getMessage={getMessage} ref={ref} {...props} />
                 }
             </LocaleContext.Consumer>
         );


### PR DESCRIPTION
Wrapped `Message` with `withLocale` so it can be directly imported from `oskari-ui` and used without `bundleKey` property.

Removed `Message` property from `LocaleContext`. 