### PR TITLE
Make popup click detection more generic

### DIFF
--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -153,7 +153,7 @@ export class MapModule extends AbstractMapModule {
             // - Most others composedPath() https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath
             // - Polyfilled for IE/Edge on src/polyfills.js
             var path = event.path || (event.composedPath && event.composedPath()) || [];
-            const foundInfoBox = path.find(item => item.id === 'getinforesult');
+            const foundInfoBox = path.find(item => (item.className || '').indexOf('olPopup') !== -1);
             return typeof foundInfoBox !== 'undefined';
         }
 


### PR DESCRIPTION
Previous implementation detected click on GFI-popups but things like RPC-triggered infoboxes and "nearest address" features don't work with this. This change makes detecting clicks on popups more generic.