### PR TITLE
Fix bug related refresh in own places

### DIFF
--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
@@ -149,11 +149,14 @@ export class VectorLayerHandler extends AbstractLayerHandler {
         if (!layer) {
             return;
         }
-        const source = this._getLayerSource(layer);
-        if (!source) {
-            return;
-        }
-        source.clear();
+        const olLayers = this.plugin.getOLMapLayers(layer.getId());
+        olLayers.forEach(olLayer => {
+            const source = olLayer.getSource();
+            if (!source) {
+                return;
+            }
+            source.refresh();
+        });
         this._loadFeaturesForLayer(layer);
     }
     /**
@@ -275,13 +278,14 @@ export class VectorLayerHandler extends AbstractLayerHandler {
         if (olLayers.length === 0) {
             return;
         }
-        const olLayer = olLayers[0];
-        if (!this._shouldLoadFeatures(olLayer, resolution)) {
-            return;
-        }
-        const strategy = this.loadingStrategies['' + lyr.getId()];
-        strategy(extent, resolution).forEach(tileExt => {
-            olLayer.getSource().loadFeatures(tileExt, resolution, projection);
+        olLayers.forEach(olLayer => {
+            if (!this._shouldLoadFeatures(olLayer, resolution)) {
+                return;
+            }
+            const strategy = this.loadingStrategies['' + lyr.getId()];
+            strategy(extent, resolution).forEach(tileExt => {
+                olLayer.getSource().loadFeatures(tileExt, resolution, projection);
+            });
         });
     }
 


### PR DESCRIPTION
This PR contains fix for bug where previously added own place disappeared from map when new own place was added. For myplaces layer there are two openlayers layer instances one with VectorSource and one with Cluster Source. As a change in this PR, both of these sources are now refreshed using refresh function instead of clear. More about changed behaviour of mentioned funtions can be read from link below:

https://github.com/openlayers/openlayers/blob/master/changelog/upgrade-notes.md#change-of-the-behavior-of-the-vector-sources-clear-and-refresh-methods