### PR TITLE
Handle missing context provider

### DIFF
--- a/src/react/util/contexts/LocaleContext.jsx
+++ b/src/react/util/contexts/LocaleContext.jsx
@@ -16,8 +16,14 @@ export function withLocale (Component) {
         return (
             <LocaleContext.Consumer>
                 {
-                    ({ bundleKey, getMessage = Oskari.getMsg.bind(null, bundleKey) }) =>
-                        <Component bundleKey={bundleKey} getMessage={getMessage} ref={ref} {...props} />
+                    value => {
+                        if (!value) {
+                            // No contex provider, just pass props through.
+                            return <Component ref={ref} {...props} />;
+                        }
+                        const { bundleKey, getMessage = Oskari.getMsg.bind(null, bundleKey) } = value;
+                        return <Component bundleKey={bundleKey} getMessage={getMessage} ref={ref} {...props} />;
+                    }
                 }
             </LocaleContext.Consumer>
         );


### PR DESCRIPTION
Fixes an issue with components using `withLocale` HOC. Missing `LocaleContext.Provider` caused an error.

Now `withLocale` can be used without `LocaleContext.Provider`. `Message` component uses `withLocale` but it also supports passing all the props without the context.