### PR TITLE
Add state handling to admin layer permissions tab

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm.jsx
@@ -43,7 +43,8 @@ const AdminLayerForm = ({
             <TabPane key='permissions' tab={<Message messageKey='permissionsTabTitle'/>}>
                 <PermissionsTabPane
                     rolesAndPermissionTypes={rolesAndPermissionTypes}
-                    permissions={layer.role_permissions} />
+                    permissions={layer.role_permissions}
+                    controller={controller}/>
             </TabPane>
         </Tabs>
         <PaddedButton type='primary' onClick={() => onSave()}>

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionUtil.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionUtil.js
@@ -1,0 +1,22 @@
+// constant used as 'role' to indicate that permission should be set to or removed from all roles
+export const roleAll = 'all';
+
+export const handlePermissionForAllRoles = (checked, permissionsForAllRoles, permission) => {
+    Object.values(permissionsForAllRoles).forEach(permissionsOfRole => {
+        if (checked && !permissionsOfRole.includes(permission)) {
+            permissionsOfRole.push(permission);
+        } else if (!checked && permissionsOfRole.includes(permission)) {
+            permissionsOfRole.splice(
+                permissionsOfRole.indexOf(permission), 1);
+        }
+    });
+};
+
+export const handlePermissionForSingleRole = (permissionsOfRole, permission) => {
+    if (permissionsOfRole.includes(permission)) {
+        permissionsOfRole.splice(
+            permissionsOfRole.indexOf(permission), 1);
+    } else {
+        permissionsOfRole.push(permission);
+    }
+};

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionUtil.test.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionUtil.test.js
@@ -1,0 +1,43 @@
+import { handlePermissionForAllRoles, handlePermissionForSingleRole } from './PermissionUtil';
+
+describe('handlePermissionForAllRoles', () => {
+    test('sets permission correctly to all roles', () => {
+        const checked = true;
+        const permissionsForAllRoles = {
+            role1: ['permission 1', 'permission 2'],
+            role2: ['permission 1']
+        };
+        const permission = 'permission 3';
+
+        handlePermissionForAllRoles(checked, permissionsForAllRoles, permission);
+        expect(permissionsForAllRoles['role1']).toEqual(['permission 1', 'permission 2', 'permission 3']);
+        expect(permissionsForAllRoles['role2']).toEqual(['permission 1', 'permission 3']);
+    });
+    test('removes permission correctly from all roles', () => {
+        const checked = false;
+        const permissionsForAllRoles = {
+            role1: ['permission 1', 'permission 2'],
+            role2: ['permission 1']
+        };
+        const permission = 'permission 1';
+
+        handlePermissionForAllRoles(checked, permissionsForAllRoles, permission);
+        expect(permissionsForAllRoles['role1']).toEqual(['permission 2']);
+        expect(permissionsForAllRoles['role2']).toEqual([]);
+    });
+});
+
+describe('handlePermissionForSingleRole sets permission correctly when', () => {
+    test('permission is not set in layer', () => {
+        const permissionsOfRole = ['permission 1', 'permission 2'];
+        const permission = 'permission 3';
+        handlePermissionForSingleRole(permissionsOfRole, permission);
+        expect(permissionsOfRole).toEqual(['permission 1', 'permission 2', 'permission 3']);
+    });
+    test('permission is set in layer', () => {
+        const permissionsOfRole = ['permission 1', 'permission 2'];
+        const permission = 'permission 1';
+        handlePermissionForSingleRole(permissionsOfRole, permission);
+        expect(permissionsOfRole).toEqual(['permission 2']);
+    });
+});

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionsTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionsTabPane.jsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { PermissionRow } from './PermissionTabPane/PermissionRow';
 import { List, ListItem, Checkbox, Message } from 'oskari-ui';
-import { LocaleConsumer } from 'oskari-ui/util';
+import { LocaleConsumer, Controller } from 'oskari-ui/util';
+import { roleAll } from './PermissionUtil';
 
 const StyledListItem = styled(ListItem)`
     &:first-child > div {
@@ -23,34 +24,7 @@ const ListDiv = styled.div`
     padding-bottom: 20px;
 `;
 
-const checkboxOnChangeHandler = (event) => {
-    // TODO: Replace console.log with controller call to mutate state of selected permissions
-    const role = event.target.role;
-    const permission = event.target.permission;
-    console.log('Checkbox with role ' + role + ' and permission ' + permission);
-};
-
-const renderRow = (modelRow) => {
-    const role = modelRow.isHeaderRow ? 'all' : modelRow.role.id;
-    const rowKey = modelRow.isHeaderRow ? 'header' : modelRow.role.id;
-
-    const checkboxes = modelRow.permissionTypes.map(permission => {
-        return <Checkbox key={permission.id + '_' + role}
-            permissionDescription={permission.localizedText}
-            permission={permission.id}
-            role={role}
-            checked={modelRow.permissions.includes(permission.id)}
-            onChange = {checkboxOnChangeHandler}/>;
-    });
-
-    return (
-        <StyledListItem>
-            <PermissionRow key={rowKey} isHeaderRow={modelRow.isHeaderRow} text={modelRow.text} checkboxes={checkboxes}/>
-        </StyledListItem>
-    );
-};
-
-const PermissionsTabPane = ({ rolesAndPermissionTypes, permissions = {} }) => {
+const PermissionsTabPane = ({ rolesAndPermissionTypes, permissions = {}, controller }) => {
     if (!rolesAndPermissionTypes) {
         return;
     }
@@ -64,7 +38,7 @@ const PermissionsTabPane = ({ rolesAndPermissionTypes, permissions = {} }) => {
     const headerRow = {
         isHeaderRow: true,
         text: <Message messageKey='rights.role'/>,
-        permissions: [],
+        permissions: permissions[roleAll] || [],
         permissionTypes: localizedPermissionTypes
     };
 
@@ -80,14 +54,37 @@ const PermissionsTabPane = ({ rolesAndPermissionTypes, permissions = {} }) => {
 
     const permissionDataModel = [headerRow, ...dataRows];
 
+    const renderRow = (modelRow) => {
+        const role = modelRow.isHeaderRow ? roleAll : modelRow.role.name;
+        const rowKey = modelRow.isHeaderRow ? 'header' : modelRow.role.name;
+
+        const checkboxes = modelRow.permissionTypes.map(permission => {
+            return <Checkbox key={permission.id + '_' + role}
+                permissionDescription={permission.localizedText}
+                permission={permission.id}
+                role={role}
+                checked={modelRow.permissions.includes(permission.id)}
+                onChange = {(event) => controller.handlePermission(event.target.checked, event.target.role, event.target.permission)}/>;
+        });
+
+        return (
+            <StyledListItem>
+                <PermissionRow key={rowKey} isHeaderRow={modelRow.isHeaderRow} text={modelRow.text} checkboxes={checkboxes}/>
+            </StyledListItem>
+        );
+    };
+
     return (
-        <ListDiv><List bordered={false} dataSource={permissionDataModel} renderItem={renderRow}/></ListDiv>
+        <ListDiv>
+            <List bordered={false} dataSource={permissionDataModel} renderItem={renderRow}/>
+        </ListDiv>
     );
 };
 
 PermissionsTabPane.propTypes = {
     rolesAndPermissionTypes: PropTypes.object,
-    permissions: PropTypes.object
+    permissions: PropTypes.object,
+    controller: PropTypes.instanceOf(Controller).isRequired
 };
 
 const contextWrap = LocaleConsumer(PermissionsTabPane);


### PR DESCRIPTION
With changes in this PR, permissions selected in UI are now saved to layer object in form handler and re-rendering of permissions tab is done to reflect updated state of layer permissions. Actual saving of layer is not in scope of this pull request.