### PR TITLE
Use credentials in layer wizard step 2

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -72,7 +72,9 @@ Oskari.registerLocalization(
                 "invalidHoverJson" : "Invalid Hover JSON syntax.",
                 "invalidAttributeJson" : "Invalid Attribute JSON syntax.",
                 "errorInsertAllreadyExists": "The new map layer has been added. A map layer with same identifier already exists.",
-                "errorFetchUserRolesAndPermissionTypes": "Error occured when fetching user roles and permission types."
+                "errorFetchUserRolesAndPermissionTypes": "Error occured when fetching user roles and permission types.",
+                "errorFetchCapabilities": "Fetching service capabilities failed.",
+                "unauthorizedErrorFetchCapabilities": "Username and password are required by the service."
             },
             "otherLanguages": "Other languages",
             "styleJSON": "Style JSON",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -73,7 +73,9 @@ Oskari.registerLocalization(
                 "invalidHoverJson" : "Hover JSON-syntaksi on virheellinen.",
                 "invalidAttributeJson" : "Ominaisuudet kentän JSON-syntaksi on virheellinen.",
                 "errorInsertAllreadyExists": "Uusi karttataso on lisätty. Samalla tunnisteella on jo olemassa karttataso.",
-                "errorFetchUserRolesAndPermissionTypes": "Käyttäjäroolien ja käyttöoikeustyyppien haku ei onnistunut"
+                "errorFetchUserRolesAndPermissionTypes": "Käyttäjäroolien ja käyttöoikeustyyppien haku ei onnistunut",
+                "errorFetchCapabilities": "Rajapinnan tietojen haku epäonnistui.",
+                "unauthorizedErrorFetchCapabilities": "Palvelu vaatii käyttäjätunnuksen ja salasanan."
             },
             "otherLanguages": "Muut kielet",
             "styleJSON": "Style JSON",

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -72,7 +72,9 @@ Oskari.registerLocalization(
                 "invalidHoverJson" : "Hover JSON-syntaxen är ogiltig.",
                 "invalidAttributeJson" : "Attribut JSON-syntaxen är ogiltig.",
                 "errorInsertAllreadyExists": "Kartlager har lagrats men ett kartlager med samma id existeras.",
-                "errorFetchUserRolesAndPermissionTypes": "Det gick inte att hämta användarroller och behörigheter."
+                "errorFetchUserRolesAndPermissionTypes": "Det gick inte att hämta användarroller och behörigheter.",
+                "errorFetchCapabilities": "Det gick inte att hämta gränssnittsinformation.",
+                "unauthorizedErrorFetchCapabilities": "Användarnamn och lösenord krävs av tjänsten."
             },
             "otherLanguages": "Other languages",
             "styleJSON": "Style JSON",

--- a/bundles/admin/admin-layereditor/view/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerFormHandler.js
@@ -17,7 +17,8 @@ class UIHandler extends StateHandler {
             versions: [],
             capabilities: {},
             messages: [],
-            loading: false
+            loading: false,
+            credentialsCollapseOpen: false
         });
         this.addStateListener(consumer);
         this.fetchRolesAndPermissionTypes();
@@ -385,8 +386,14 @@ class UIHandler extends StateHandler {
         var params = {
             type: layer.type,
             version: version,
-            url: layer.url
+            url: layer.url,
+            user: layer.username,
+            pw: layer.password
         };
+
+        // Remove undefined params
+        Object.keys(params).forEach(key => params[key] === undefined && delete params[key]);
+
         fetch(Oskari.urls.getRoute('LayerAdmin', params), {
             method: 'GET',
             headers: {
@@ -398,14 +405,22 @@ class UIHandler extends StateHandler {
                 this.updateState({
                     layer: { ...this.getState().layer, version }
                 });
+                return response.json();
             } else {
-                this.setMessage('TODO', 'error');
+                if (response.status === 401) {
+                    this.setMessage('messages.unauthorizedErrorFetchCapabilities', 'warning');
+                    this.updateState({ credentialsCollapseOpen: true });
+                } else {
+                    this.setMessage('messages.errorFetchCapabilities', 'error');
+                }
+                return Promise.reject(new Error('Capabilities fetching failed with status code ' + response.status + ' and text ' + response.statusText));
             }
-            return response.json();
         }).then(json => {
             this.updateState({
                 capabilities: json || {}
             });
+        }).catch(error => {
+            this.log.error(error);
         });
     }
 
@@ -437,11 +452,14 @@ class UIHandler extends StateHandler {
     isLoading () {
         return this.loadingCount > 0;
     }
-
     clearMessages () {
         this.updateState({
             messages: []
         });
+    }
+
+    clearCredentialsCollapse () {
+        this.updateState({ credentialsCollapseOpen: false });
     }
 
     handlePermission (checked, role, permission) {

--- a/bundles/admin/admin-layereditor/view/Flyout.js
+++ b/bundles/admin/admin-layereditor/view/Flyout.js
@@ -67,7 +67,7 @@ export class LayerEditorFlyout extends ExtraFlyout {
         ReactDOM.render(uiCode, el.get(0));
     }
     getEditorUI () {
-        const { layer, layerTypes, versions, capabilities, loading, messages, rolesAndPermissionTypes } = this.uiHandler.getState();
+        const { layer, layerTypes, versions, capabilities, loading, messages, rolesAndPermissionTypes, credentialsCollapseOpen } = this.uiHandler.getState();
         const controller = this.uiHandler.getController();
         return (
             <LocaleProvider value={{ bundleKey: 'admin-layereditor' }}>
@@ -77,7 +77,13 @@ export class LayerEditorFlyout extends ExtraFlyout {
                     capabilities={capabilities}
                     loading={loading}
                     layerTypes={layerTypes}
-                    versions = {versions}>
+                    versions = {versions}
+                    messages={messages}
+                    credentialsCollapseOpen={credentialsCollapseOpen}
+                    onCancel={() => {
+                        this.uiHandler.clearMessages();
+                        this.uiHandler.clearCredentialsCollapse();
+                    }}>
                     <AdminLayerForm
                         layer={layer}
                         mapLayerGroups={this.mapLayerGroups}

--- a/bundles/admin/admin-layereditor/view/LayerWizard.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard.jsx
@@ -53,7 +53,7 @@ function getStep (layer) {
 const LayerTypeTitle = ({ layer, LabelComponent }) => (
     <React.Fragment>
         <Message messageKey='wizard.type' LabelComponent={LabelComponent} />
-        { layer.type && <React.Fragment><div style={{ display: 'inline' }}>:</div><div>{layer.type}</div></React.Fragment>}
+        { layer.type && <React.Fragment><span>:</span><div>{layer.type}</div></React.Fragment>}
     </React.Fragment>
 );
 

--- a/bundles/admin/admin-layereditor/view/LayerWizard.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard.jsx
@@ -53,7 +53,7 @@ function getStep (layer) {
 const LayerTypeTitle = ({ layer, LabelComponent }) => (
     <React.Fragment>
         <Message messageKey='wizard.type' LabelComponent={LabelComponent} />
-        { layer.type && `: ${layer.type}` }
+        { layer.type && <React.Fragment><div style={{ display: 'inline' }}>:</div><div>{layer.type}</div></React.Fragment>}
     </React.Fragment>
 );
 

--- a/bundles/admin/admin-layereditor/view/LayerWizard.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard.jsx
@@ -1,11 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Steps, Step, Button, Message } from 'oskari-ui';
+import { Steps, Step, Button, Message, Alert } from 'oskari-ui';
 import { LayerTypeSelection } from './LayerWizard/LayerTypeSelection';
 import { LayerURLForm } from './LayerWizard/LayerURLForm';
 import { LocaleConsumer, Controller } from 'oskari-ui/util';
 import { LayerCapabilitiesListing } from './LayerWizard/LayerCapabilitiesListing';
 import styled from 'styled-components';
+
+const PaddedAlert = styled(Alert)`
+    margin-bottom: 5px;
+`;
+
+const PaddedStepsDiv = styled.div`
+    margin-top: 10px;
+    margin-bottom: 10px;
+`;
 
 const WIZARD_STEP = {
     INITIAL: 0,
@@ -47,6 +56,7 @@ const LayerTypeTitle = ({ layer, LabelComponent }) => (
         { layer.type && `: ${layer.type}` }
     </React.Fragment>
 );
+
 LayerTypeTitle.propTypes = {
     layer: PropTypes.object.isRequired,
     LabelComponent: PropTypes.elementType
@@ -62,21 +72,27 @@ const LayerWizard = ({
     layerTypes = [],
     loading,
     children,
-    versions
+    versions,
+    messages = [],
+    credentialsCollapseOpen,
+    onCancel
 }) => {
     const currentStep = getStep(layer);
     const isFirstStep = currentStep === WIZARD_STEP.INITIAL;
     const isDetailsForOldLayer = !layer.isNew && currentStep === WIZARD_STEP.DETAILS;
     return (
         <div>
-            { (layer.isNew || currentStep !== WIZARD_STEP.DETAILS) &&
-            <Steps current={currentStep}>
-                <Step title={<LayerTypeTitle layer={layer}/>} />
-                <Step title={<Message messageKey='wizard.service'/>} />
-                <Step title={<Message messageKey='wizard.layers'/>} />
-                <Step title={<Message messageKey='wizard.details'/>} />
-            </Steps>
-            }
+            { messages.map(({ key, type }) => <PaddedAlert key={key} message={<Message messageKey={key} />} type={type} />) }
+            <PaddedStepsDiv>
+                { (layer.isNew || currentStep !== WIZARD_STEP.DETAILS) &&
+                <Steps current={currentStep}>
+                    <Step title={<LayerTypeTitle layer={layer}/>} />
+                    <Step title={<Message messageKey='wizard.service'/>} />
+                    <Step title={<Message messageKey='wizard.layers'/>} />
+                    <Step title={<Message messageKey='wizard.details'/>} />
+                </Steps>
+                }
+            </PaddedStepsDiv>
             { currentStep === WIZARD_STEP.INITIAL &&
                 <React.Fragment>
                     <LayerTypeTitle layer={layer} LabelComponent={Header}/>
@@ -94,7 +110,8 @@ const LayerWizard = ({
                         layer={layer}
                         loading={loading}
                         controller={controller}
-                        versions= {versions} />
+                        versions= {versions}
+                        credentialsCollapseOpen = {credentialsCollapseOpen}/>
                 </React.Fragment>
             }
             { currentStep === WIZARD_STEP.LAYER &&
@@ -112,7 +129,10 @@ const LayerWizard = ({
                 </React.Fragment>
             }
             { !isFirstStep && !isDetailsForOldLayer &&
-                <Button onClick={() => setStep(controller, getStep(layer) - 1)}>
+                <Button onClick={() => {
+                    setStep(controller, getStep(layer) - 1);
+                    onCancel();
+                }}>
                     {<Message messageKey='cancel'/>}
                 </Button>
             }
@@ -127,7 +147,10 @@ LayerWizard.propTypes = {
     capabilities: PropTypes.object,
     layerTypes: PropTypes.array,
     children: PropTypes.any,
-    versions: PropTypes.array.isRequired
+    versions: PropTypes.array.isRequired,
+    messages: PropTypes.array,
+    credentialsCollapseOpen: PropTypes.bool.isRequired,
+    onCancel: PropTypes.func.isRequired
 };
 
 const contextWrap = LocaleConsumer(LayerWizard);

--- a/bundles/admin/admin-layereditor/view/LayerWizard/LayerURLForm.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard/LayerURLForm.jsx
@@ -1,24 +1,42 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, UrlInput } from 'oskari-ui';
+import { Button, UrlInput, Message } from 'oskari-ui';
 import { Controller } from 'oskari-ui/util';
+import styled from 'styled-components';
 
-export const LayerURLForm = ({ layer, loading, controller, versions }) => {
+const PaddedUrlInputContainer = styled.div`
+    margin-bottom: 10px;
+`;
+const PaddedButton = styled(Button)`
+    margin-right: 10px;
+`;
+
+export const LayerURLForm = ({ layer, loading, controller, versions, credentialsCollapseOpen }) => {
     const credentials = {
-        defaultOpen: true
+        defaultOpen: credentialsCollapseOpen,
+        allowCredentials: true,
+        panelText: <Message messageKey='usernameAndPassword'/>,
+        usernameText: <Message messageKey='username'/>,
+        passwordText: <Message messageKey='password'/>,
+        usernameValue: layer.username,
+        passwordValue: layer.password,
+        usernameOnChange: controller.setUsername,
+        passwordOnChange: controller.setPassword
     };
     return (
         <React.Fragment>
-            <UrlInput
-                value={layer.url}
-                disabled={loading}
-                credentials={credentials}
-                onChange={(url) => controller.setLayerUrl(url)}
-            />
+            <PaddedUrlInputContainer>
+                <UrlInput
+                    value={layer.url}
+                    disabled={loading}
+                    credentials={credentials}
+                    onChange={(url) => controller.setLayerUrl(url)}
+                />
+            </PaddedUrlInputContainer>
             {versions.map((version, key) => (
-                <Button type="primary" key={key}
+                <PaddedButton type="primary" key={key}
                     onClick={() => controller.setVersion(version)}
-                    disabled={!layer.url || loading}>{version}</Button>
+                    disabled={!layer.url || loading}>{version}</PaddedButton>
             ))}
         </React.Fragment>
     );
@@ -28,5 +46,6 @@ LayerURLForm.propTypes = {
     layer: PropTypes.object,
     loading: PropTypes.bool,
     controller: PropTypes.instanceOf(Controller).isRequired,
-    versions: PropTypes.array.isRequired
+    versions: PropTypes.array.isRequired,
+    credentialsCollapseOpen: PropTypes.bool.isRequired
 };

--- a/src/react/components/UrlInput.jsx
+++ b/src/react/components/UrlInput.jsx
@@ -22,10 +22,6 @@ export class UrlInput extends React.Component {
                 url: undefined
             };
         }
-        if (props.credentials && props.credentials.defaultOpen) {
-            // Panel with this key is open as default
-            this.state.defaultPanel = 'usernameAndPassword';
-        }
     }
     setProtocol (protocol) {
         if (!this.props.onChange) {
@@ -76,11 +72,19 @@ export class UrlInput extends React.Component {
             value: undefined,
             onChange: this.onChange.bind(this)
         };
+
+        let collapseProps = {}
+
+        if (this.props.credentials && this.props.credentials.defaultOpen) {
+            // Panel with this key is open as default
+            collapseProps.activeKey = 'usernameAndPassword';
+        }
+
         return (
             <div>
                 <Input {...processedProps} value={this.state.url} addonBefore={protocolSelect} />&nbsp;
                 {credentials.allowCredentials &&
-                    <Collapse defaultActiveKey={this.state.defaultPanel}>
+                    <Collapse {...collapseProps}>
                         <Panel header={credentials.panelText} key='usernameAndPassword'>
                             <div>
                                 {credentials.usernameText}


### PR DESCRIPTION
This pull request contains following improvements to admin layer wizard step 2:

- Credentials section from UrlInput component is displayed to user. Inserted username and password values are stored to AdminLayerFormHandler and passed in capabilities fetching request to backend.
- Error handling is added and error messages are displayed to user at the top of flyout when needed. In case of HTTP 401 also response credentials collapse is opened.
- Some minor layout fixes