### PR TITLE
Get dataproviders from maplayer service

### DIFF
--- a/bundles/admin/admin-layereditor/instance.js
+++ b/bundles/admin/admin-layereditor/instance.js
@@ -224,7 +224,7 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
             const flyout = this._getFlyout();
             const layerService = this._getLayerService();
             flyout.setLocale(this.loc);
-            flyout.setDataProviders(this._getDataProviders());
+            flyout.setDataProviders(layerService.getDataProviders());
             flyout.setMapLayerGroups(layerService.getAllLayerGroups());
             flyout.setLayer(layerService.findMapLayer(layerId));
             if (flyout.isVisible()) {


### PR DESCRIPTION
Fix bug which prevents layer admin flyout opening. With changes in https://github.com/oskariorg/oskari-frontend/pull/1140, dataproviders are now available from maplayer service.