### PR TITLE
Admin support mvt

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -20,6 +20,8 @@ Oskari.registerLocalization(
             "permissionsTabTitle": "Permissions",
             "interfaceAddress": "Interface URL",
             "apiKey": "Api key",
+            "attributions": "Attributions",
+            "tileGrid": "Tile grid",
             "username": "Username",
             "password": "Password",
             "usernameAndPassword": "Username and password",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -20,6 +20,8 @@ Oskari.registerLocalization(
             "permissionsTabTitle": "Oikeudet",
             "interfaceAddress": "Rajapinnan osoite",
             "apiKey": "Api key",
+            "attributions": "Lähdeviitteet",
+            "tileGrid": "Tiilimatriisi",
             "username": "Käyttäjätunnus",
             "password": "Salasana",
             "usernameAndPassword": "Käyttäjätunnus ja salasana",

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -20,6 +20,8 @@ Oskari.registerLocalization(
             "permissionsTabTitle": "Permissions",
             "interfaceAddress": "Gränssnitten address",
             "apiKey": "Api key",
+            "attributions": "Tillskrivningar",
+            "tileGrid": "Rutmatris",
             "username": "Användarsnamn",
             "password": "Lösenord",
             "usernameAndPassword": "Användarsnamn och lösenord",

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/AdditionalTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/AdditionalTabPane.jsx
@@ -8,6 +8,7 @@ import { GfiType } from './GfiType';
 import { GfiContent } from './GfiContent';
 import { GfiStyle } from './GfiStyle';
 import { Attributes } from './Attributes';
+import { Attributions } from './Attributions';
 import { MetadataId } from './MetadataId';
 import { CapabilitiesUpdate } from './CapabilitiesUpdate';
 
@@ -33,7 +34,7 @@ export const AdditionalTabPane = ({ layer, capabilities = {}, propertyFields, co
                 <CapabilitiesUpdate layer={layer} controller={controller} />
             }
             { propertyFields.includes(ATTRIBUTIONS) &&
-                <ATTRIBUTIONS layer={layer} controller={controller} />
+                <Attributions layer={layer} controller={controller} />
             }
             { propertyFields.includes(SELECTED_TIME) &&
                 <SelectedTime layer={layer} capabilities={capabilities} controller={controller} />

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/AdditionalTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/AdditionalTabPane.jsx
@@ -21,6 +21,7 @@ const {
     GFI_CONTENT,
     GFI_TYPE,
     GFI_XSLT,
+    ATTRIBUTIONS,
     ATTRIBUTES
 } = LayerComposingModel;
 
@@ -30,6 +31,9 @@ export const AdditionalTabPane = ({ layer, capabilities = {}, propertyFields, co
         <Fragment>
             { propertyFields.includes(CAPABILITIES) &&
                 <CapabilitiesUpdate layer={layer} controller={controller} />
+            }
+            { propertyFields.includes(ATTRIBUTIONS) &&
+                <ATTRIBUTIONS layer={layer} controller={controller} />
             }
             { propertyFields.includes(SELECTED_TIME) &&
                 <SelectedTime layer={layer} capabilities={capabilities} controller={controller} />

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/Attributions.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/Attributions.jsx
@@ -7,15 +7,13 @@ import { JsonInput } from '../JsonInput';
 import { InfoTooltip } from '../InfoTooltip';
 
 const template =
-`
-[
+`[
     {
         "label": "© MyOrganization",
         "link": "https://linktomycopyrights"
     },
     ...
-]
-`;
+]`;
 export const Attributions = ({ layer, controller }) => (
     <Fragment>
         <Message messageKey='attributions'/>

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/Attributions.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/Attributions.jsx
@@ -1,0 +1,34 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { Message } from 'oskari-ui';
+import { Controller } from 'oskari-ui/util';
+import { StyledFormField } from '../VisualizationTabPane/styled';
+import { JsonInput } from '../JsonInput';
+import { InfoTooltip } from '../InfoTooltip';
+
+const template =
+`
+[
+    {
+        "label": "© MyOrganization",
+        "link": "https://linktomycopyrights"
+    },
+    ...
+]
+`;
+export const Attributions = ({ layer, controller }) => (
+    <Fragment>
+        <Message messageKey='attributions'/>
+        <InfoTooltip message={<pre>{template}</pre>} />
+        <StyledFormField>
+            <JsonInput
+                rows={6}
+                value={layer.tempTileGridJSON}
+                onChange={evt => controller.setAttributionsJSON(evt.target.value)} />
+        </StyledFormField>
+    </Fragment>
+);
+Attributions.propTypes = {
+    layer: PropTypes.object.isRequired,
+    controller: PropTypes.instanceOf(Controller).isRequired
+};

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -191,6 +191,12 @@ class UIHandler extends StateHandler {
     setHoverJSON (json) {
         this.updateOptionsJsonProperty(json, 'tempHoverJSON', 'hover');
     }
+    setTileGridJSON (json) {
+        this.updateOptionsJsonProperty(json, 'tempTileGridJSON', 'tileGrid');
+    }
+    setAttributionsJSON (json) {
+        this.updateOptionsJsonProperty(json, 'tempAttributionsJSON', 'attributions');
+    }
     updateOptionsJsonProperty (json, jsonPropKey, dataPropKey) {
         const layer = { ...this.getState().layer };
         layer[jsonPropKey] = json;
@@ -446,6 +452,8 @@ class UIHandler extends StateHandler {
         this.validateJsonValue(layer.tempExternalStylesJSON, 'validation.externalStyles', validationErrors);
         this.validateJsonValue(layer.tempHoverJSON, 'validation.hover', validationErrors);
         this.validateJsonValue(layer.tempAttributesJSON, 'validation.attributes', validationErrors);
+        this.validateJsonValue(layer.tempAttributionsJSON, 'validation.attributions', validationErrors);
+        this.validateJsonValue(layer.tempTileGridJSON, 'validation.tileGrid', validationErrors);
         return validationErrors;
     }
 
@@ -627,6 +635,7 @@ const wrapped = controllerMixin(UIHandler, [
     'handlePermission',
     'layerSelected',
     'setAttributes',
+    'setAttributionsJSON',
     'setCapabilitiesUpdateRate',
     'setClusteringDistance',
     'setDataProviderId',
@@ -654,6 +663,7 @@ const wrapped = controllerMixin(UIHandler, [
     'setSelectedTime',
     'setStyle',
     'setStyleJSON',
+    'setTileGridJSON',
     'setType',
     'setUsername',
     'setVersion',

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/GeneralTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/GeneralTabPane.jsx
@@ -7,6 +7,7 @@ import { Name } from './Name';
 import { LocalizedNames } from './LocalizedNames';
 import { DataProvider } from './DataProvider';
 import { Groups } from './Groups';
+import { TileGrid } from './TileGrid';
 
 const {
     API_KEY,
@@ -16,6 +17,7 @@ const {
     ORGANIZATION_NAME,
     NAME,
     SRS,
+    TILE_GRID,
     URL
 } = Oskari.clazz.get('Oskari.mapframework.domain.LayerComposingModel');
 
@@ -26,6 +28,9 @@ const GeneralTabPane = ({ mapLayerGroups, dataProviders, layer, capabilities, pr
         }
         { propertyFields.includes(SRS) &&
             <Srs layer={layer} controller={controller} propertyFields={propertyFields} capabilities={capabilities} />
+        }
+        { propertyFields.includes(TILE_GRID) &&
+            <TileGrid layer={layer} controller={controller} />
         }
         { propertyFields.includes(NAME) &&
             <Name layer={layer} controller={controller} />

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/TileGrid.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/TileGrid.jsx
@@ -7,13 +7,11 @@ import { JsonInput } from '../JsonInput';
 import { InfoTooltip } from '../InfoTooltip';
 
 const template =
-`
-{
+`{
     "origin": [-548576, 8388608],
     "resolutions": [8192, ..., 0.25],
     "tileSize": [256, 256]
-}
-`;
+}`;
 export const TileGrid = ({ layer, controller }) => (
     <Fragment>
         <Message messageKey='tileGrid'/>

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/TileGrid.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/TileGrid.jsx
@@ -1,0 +1,32 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { Message } from 'oskari-ui';
+import { Controller } from 'oskari-ui/util';
+import { StyledFormField } from '../VisualizationTabPane/styled';
+import { JsonInput } from '../JsonInput';
+import { InfoTooltip } from '../InfoTooltip';
+
+const template =
+`
+{
+    "origin": [-548576, 8388608],
+    "resolutions": [8192, ..., 0.25],
+    "tileSize": [256, 256]
+}
+`;
+export const TileGrid = ({ layer, controller }) => (
+    <Fragment>
+        <Message messageKey='tileGrid'/>
+        <InfoTooltip message={<pre>{template}</pre>} />
+        <StyledFormField>
+            <JsonInput
+                rows={6}
+                value={layer.tempTileGridJSON}
+                onChange={evt => controller.setTileGridJSON(evt.target.value)} />
+        </StyledFormField>
+    </Fragment>
+);
+TileGrid.propTypes = {
+    layer: PropTypes.object.isRequired,
+    controller: PropTypes.instanceOf(Controller).isRequired
+};

--- a/bundles/admin/admin-layereditor/view/LayerHelper.js
+++ b/bundles/admin/admin-layereditor/view/LayerHelper.js
@@ -46,18 +46,22 @@ export const getLayerHelper = () => {
         layer.role_permissions.all = [];
         // Add temp json fields to keep the state on invalid json syntax
         layer.tempAttributesJSON = toJson(layer.attributes);
-        layer.tempStylesJSON = toJson(layer.options.styles);
+        layer.tempAttributionsJSON = toJson(layer.options.attributions);
         layer.tempExternalStylesJSON = toJson(layer.options.externalStyles);
         layer.tempHoverJSON = toJson(layer.options.hover);
+        layer.tempStylesJSON = toJson(layer.options.styles);
+        layer.tempTileGridJSON = toJson(layer.options.tileGrid);
         layer.isNew = !layer.id;
     };
 
     const removeTemporaryFields = layer => {
         delete layer.role_permissions.all;
         delete layer.tempAttributesJSON;
-        delete layer.tempStylesJSON;
+        delete layer.tempAttributionsJSON;
         delete layer.tempExternalStylesJSON;
         delete layer.tempHoverJSON;
+        delete layer.tempStylesJSON;
+        delete layer.tempTileGridJSON;
         delete layer.isNew;
     };
 

--- a/bundles/mapping/mapmodule/domain/LayerComposingModel.js
+++ b/bundles/mapping/mapmodule/domain/LayerComposingModel.js
@@ -26,7 +26,7 @@ const PROPERTY_FIELDS = [
     'SRS',
     'STYLE',
     'STYLES_JSON',
-    'TILE_MATRIX',
+    'TILE_GRID',
     'URL',
     'VERSION',
     'WFS_RENDER_MODE'

--- a/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
@@ -10,6 +10,7 @@ import mapboxStyleFunction from 'ol-mapbox-style/stylefunction';
 import { LAYER_ID, LAYER_HOVER, LAYER_TYPE, FTR_PROPERTY_ID } from '../../domain/constants';
 
 const AbstractMapLayerPlugin = Oskari.clazz.get('Oskari.mapping.mapmodule.AbstractMapLayerPlugin');
+const LayerComposingModel = Oskari.clazz.get('Oskari.mapframework.domain.LayerComposingModel');
 
 /**
  * @class Oskari.mapframework.mapmodule.VectorTileLayerPlugin
@@ -35,7 +36,18 @@ class VectorTileLayerPlugin extends AbstractMapLayerPlugin {
         // register domain builder
         const mapLayerService = this.getSandbox().getService('Oskari.mapframework.service.MapLayerService');
         if (mapLayerService) {
-            mapLayerService.registerLayerModel(this.layertype + 'layer', this._getLayerModelClass());
+            const composingModel = new LayerComposingModel([
+                LayerComposingModel.ATTRIBUTIONS,
+                LayerComposingModel.CREDENTIALS,
+                LayerComposingModel.EXTERNAL_STYLES_JSON,
+                LayerComposingModel.HOVER_JSON,
+                LayerComposingModel.SRS,
+                LayerComposingModel.STYLE,
+                LayerComposingModel.STYLES_JSON,
+                LayerComposingModel.TILE_GRID,
+                LayerComposingModel.URL
+            ]);
+            mapLayerService.registerLayerModel(this.layertype + 'layer', this._getLayerModelClass(), composingModel);
             mapLayerService.registerLayerModelBuilder(this.layertype + 'layer', this._getModelBuilder());
         }
         this.getSandbox().getService('Oskari.mapframework.service.VectorFeatureService').registerLayerType(this.layertype, this);


### PR DESCRIPTION
New form inputs: `TileGrid` & `Attributions`.
Admin support for vector tile layers.