### PR TITLE
Fix templates and naming

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -123,7 +123,7 @@ Oskari.registerLocalization(
             "stylesJSON": "Style definitions (JSON)",
             "externalStylesJSON": "3rd party style definitions (JSON)",
             "externalStyleFormats": "Supported formats: 3D Tiles, Mapbox",
-            "hoverJSON": "Feature highlighting and tooltip (JSON)",
+            "hover": "Feature highlighting and tooltip (JSON)",
             "ion": {
                 "title": "Cesium ion",
                 "assetId": "Asset ID",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -123,7 +123,7 @@ Oskari.registerLocalization(
             "stylesJSON": "Tyylimääritykset (JSON)",
             "externalStylesJSON": "Kolmannen osapuolen tyylimääritykset (JSON)",
             "externalStyleFormats": "Tuetut muodot: 3D Tiles, Mapbox",
-            "hoverJSON": "Kohteen korostus ja tooltip (JSON)",
+            "hover": "Kohteen korostus ja tooltip (JSON)",
             "ion": {
                 "title": "Cesium ion",
                 "assetId": "Asset ID",

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -122,7 +122,7 @@ Oskari.registerLocalization(
             "stylesJSON": "Stildefinitioner (JSON)",
             "externalStylesJSON": "Stildefinitioner av tredjeparts (JSON)",
             "externalStyleFormats": "Stödda format: 3D Tiles, Mapbox",
-            "hoverJSON": "Hover (JSON)",
+            "hover": "Hover (JSON)",
             "ion": {
                 "title": "Cesium ion",
                 "assetId": "Asset ID",

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/ExternalStyleJson.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/ExternalStyleJson.jsx
@@ -6,8 +6,11 @@ import { StyledFormField } from './styled';
 import { JsonInput } from '../JsonInput';
 import { InfoTooltip } from '../InfoTooltip';
 
-const template = '{\n  "My external json style": { ... },\n  ...\n}';
-
+const template =
+`{
+    "My external json style": { ... },
+    ...
+}`;
 export const ExternalStyleJson = ({ layer, controller }) => (
     <Fragment>
         <Message messageKey='externalStylesJSON'/>

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Hover.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Hover.jsx
@@ -6,11 +6,18 @@ import { StyledFormField } from './styled';
 import { JsonInput } from '../JsonInput';
 import { InfoTooltip } from '../InfoTooltip';
 
-const template = '{\n  "featureStyle": {...},\n  "content": [\n    {"key": "Feature Data"},\n    {"key": "ID", "valueProperty": "id"}\n  ]\n}';
+const template =
+`{
+    "featureStyle": {...},
+    "content": [
+        {"key": "Feature Data"},
+        {"key": "ID", "valueProperty": "id"}
+    ]
+}`;
 
-export const HoverJson = ({ layer, controller }) => (
+export const Hover = ({ layer, controller }) => (
     <Fragment>
-        <Message messageKey='hoverJSON'/>
+        <Message messageKey='hover'/>
         <InfoTooltip message={<pre>{template}</pre>} />
         <StyledFormField>
             <JsonInput
@@ -20,7 +27,7 @@ export const HoverJson = ({ layer, controller }) => (
         </StyledFormField>
     </Fragment>
 );
-HoverJson.propTypes = {
+Hover.propTypes = {
     layer: PropTypes.object.isRequired,
     controller: PropTypes.instanceOf(Controller).isRequired
 };

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/StyleJson.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/StyleJson.jsx
@@ -6,8 +6,14 @@ import { StyledFormField } from './styled';
 import { JsonInput } from '../JsonInput';
 import { InfoTooltip } from '../InfoTooltip';
 
-const template = '{\n  "My style 1": {\n    "featureStyle": {...},\n    "optionalStyles": [{...}]\n  },\n  ...\n}';
-
+const template =
+`{
+    "My style 1": {
+        "featureStyle": {...},
+        "optionalStyles": [{...}]
+    },
+    ...
+}`;
 export const StyleJson = ({ layer, controller }) => (
     <Fragment>
         <Message messageKey='stylesJSON'/>

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VisualizationTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VisualizationTabPane.jsx
@@ -5,7 +5,7 @@ import { Opacity } from './Opacity';
 import { Style } from './Style';
 import { StyleJson } from './StyleJson';
 import { ExternalStyleJson } from './ExternalStyleJson';
-import { HoverJson } from './HoverJson';
+import { Hover } from './Hover';
 import { Scale } from './Scale';
 import { ClusteringDistance } from './ClusteringDistance';
 import { WfsRenderMode } from './WfsRenderMode';
@@ -18,7 +18,7 @@ const {
     STYLE,
     STYLES_JSON,
     EXTERNAL_STYLES_JSON,
-    HOVER_JSON,
+    HOVER,
     SCALE
 } = Oskari.clazz.get('Oskari.mapframework.domain.LayerComposingModel');
 
@@ -43,8 +43,8 @@ export const VisualizationTabPane = ({ layer, capabilities, propertyFields, cont
             { propertyFields.includes(EXTERNAL_STYLES_JSON) &&
                 <ExternalStyleJson layer={layer} controller={controller} />
             }
-            { propertyFields.includes(HOVER_JSON) &&
-                <HoverJson layer={layer} controller={controller} />
+            { propertyFields.includes(HOVER) &&
+                <Hover layer={layer} controller={controller} />
             }
         </StyledColumn.Left>
         <StyledColumn.Right>

--- a/bundles/mapping/mapmodule/domain/LayerComposingModel.js
+++ b/bundles/mapping/mapmodule/domain/LayerComposingModel.js
@@ -12,7 +12,7 @@ const PROPERTY_FIELDS = [
     'GFI_TYPE',
     'GFI_XSLT',
     'GROUPS',
-    'HOVER_JSON',
+    'HOVER',
     'LEGEND_IMAGE',
     'LOCALIZED_NAMES',
     'METADATAID',

--- a/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
@@ -40,7 +40,7 @@ class VectorTileLayerPlugin extends AbstractMapLayerPlugin {
                 LayerComposingModel.ATTRIBUTIONS,
                 LayerComposingModel.CREDENTIALS,
                 LayerComposingModel.EXTERNAL_STYLES_JSON,
-                LayerComposingModel.HOVER_JSON,
+                LayerComposingModel.HOVER,
                 LayerComposingModel.SRS,
                 LayerComposingModel.STYLE,
                 LayerComposingModel.STYLES_JSON,

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
@@ -94,7 +94,7 @@ export class WfsVectorLayerPlugin extends AbstractMapLayerPlugin {
             LayerComposingModel.CAPABILITIES,
             LayerComposingModel.CLUSTERING_DISTANCE,
             LayerComposingModel.CREDENTIALS,
-            LayerComposingModel.HOVER_JSON,
+            LayerComposingModel.HOVER,
             LayerComposingModel.SRS,
             LayerComposingModel.STYLE,
             LayerComposingModel.STYLES_JSON,


### PR DESCRIPTION
String template cleaning.
Refactored `HoverJson` -> `Hover`.

Contains commits from https://github.com/oskariorg/oskari-frontend/pull/1153