### PR TITLE
3d map fixes

### DIFF
--- a/api/mapping/mapmodule/event/TimeChangedEvent.md
+++ b/api/mapping/mapmodule/event/TimeChangedEvent.md
@@ -3,20 +3,16 @@
 Notifies of changed time
 
 ## Parameters
-
+(* means the parameter is required)
 <table>
     <tr>
         <th>Name</th><th>Type</th><th>Description</th><th>Default value</th>
     </tr>
     <tr>
-        <td>Time</td>
-        <td>String</td>
-        <td>ISOString of date and time formatted as YYYY-MM-DDTHH:mm:ss.sssZ
-         ```
-           1970-01-01T09:00:00.000Z
-         ```
-        </td>
-        <td></td>
+        <td> \* time</td><td>String</td><td>time formatted as HH:mm</td><td></td>
+    </tr>
+    <tr>
+        <td> \* date </td><td>String</td><td>date formatted as DD/mm</td><td></td>
     </tr>
 </table>
 
@@ -30,7 +26,19 @@ Event occurs after SetTimeRequest
 Returns name of the event
 
 ### getTime()
-Returns setTime of the event
+Returns time of the event
+
+### getDate()
+Returns date of the event
+
+### getParams()
+Returns all parameters of the event as an object:
+```javascript
+{
+    'date': this.getDate(),
+    'time': this.getTime()
+};
+```
 
 ## Related api
 

--- a/api/mapping/mapmodule/request/getuserlocationrequest.md
+++ b/api/mapping/mapmodule/request/getuserlocationrequest.md
@@ -80,7 +80,7 @@ var options = {
     timeout: 15000,
     addToMap: true
 };
-Oskari.getSandbox().postRequestByName('MyLocationPlugin.GetUserLocationRequest'[true, options]);
+Oskari.getSandbox().postRequestByName('MyLocationPlugin.GetUserLocationRequest', [true, options]);
 ```
 
 Remove user location from the map:

--- a/bundles/framework/featuredata2/PopupHandler.js
+++ b/bundles/framework/featuredata2/PopupHandler.js
@@ -155,13 +155,17 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.PopupHandler',
             instructions.append(this.loc.instructions);
             content.append(instructions);
 
-            var selectOptions = me.template.selectOptions.clone(),
-                selectFromTop = jQuery(selectOptions).find('#select-from-top-layer'),
-                selectFromAll = jQuery(selectOptions).find('#select-from-all-layers');
-            selectFromTop.find('span').html(this.loc.selectFromTop);
-            selectFromTop.find('input').prop('checked', true);
-            selectFromAll.find('span').html(this.loc.selectAll);
+            const selectOptions = me.template.selectOptions.clone();
+            const selectFromTop = selectOptions.find('#select-from-top-layer');
+            const selectFromAll = selectOptions.find('#select-from-all-layers');
 
+            selectFromTop.find('span').html(this.loc.selectFromTop);
+            selectFromAll.find('span').html(this.loc.selectAll);
+            if (this.WFSLayerService.isSelectFromAllLayers()) {
+                selectFromAll.find('input').prop('checked', true);
+            } else {
+                selectFromTop.find('input').prop('checked', true);
+            }
             selectFromTop.on('click', function () {
                 me.WFSLayerService.setSelectFromAllLayers(false);
             });
@@ -200,7 +204,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.PopupHandler',
             dialog.moveTo('#toolbar div.toolrow[tbgroup=default-selectiontools]', 'top');
             this.dialog = dialog;
             this.isOpen = true;
-
             // tick the select from all layers - checkbox, if it was on previously
             if (me.WFSLayerService.isSelectFromAllLayers()) {
                 jQuery('input[type=checkbox][name=selectAll]').prop('checked', true);

--- a/bundles/framework/featuredata2/PopupHandler.js
+++ b/bundles/framework/featuredata2/PopupHandler.js
@@ -204,10 +204,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.PopupHandler',
             dialog.moveTo('#toolbar div.toolrow[tbgroup=default-selectiontools]', 'top');
             this.dialog = dialog;
             this.isOpen = true;
-            // tick the select from all layers - checkbox, if it was on previously
-            if (me.WFSLayerService.isSelectFromAllLayers()) {
-                jQuery('input[type=checkbox][name=selectAll]').prop('checked', true);
-            }
         },
 
         close: function (selectDefault) {

--- a/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
+++ b/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
@@ -30,6 +30,9 @@ Oskari.clazz.define(className,
             this.handler.resetToInitialState();
             this.redrawUI(Oskari.util.isMobile());
         },
+        isRotating: function () {
+            return this.handler.getActiveMapMoveMethod() === 'rotate';
+        },
         /**
          * Handle plugin UI and change it when desktop / mobile mode
          * @method  @public redrawUI

--- a/bundles/mapping/dimension-change/instance.js
+++ b/bundles/mapping/dimension-change/instance.js
@@ -65,7 +65,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.dimension-change.DimensionChange
         if (this.conf.uuid) {
             extraParams.uuid = this.conf.uuid;
         }
-        const blackListed = ['coord', 'zoomLevel', 'rotate', 'cam'];
+        const blackListed = ['coord', 'zoomLevel', 'rotate', 'cam', 'time'];
         const mapQueryStr = this._sandbox.generateMapLinkParameters(extraParams);
         const mapParams = Oskari.util.getRequestParameters(mapQueryStr);
         window.location.href = url + '?' + Object.keys(mapParams)

--- a/bundles/mapping/mapmodule/mapmodule.olcs.js
+++ b/bundles/mapping/mapmodule/mapmodule.olcs.js
@@ -528,7 +528,6 @@ class MapModuleOlCesium extends MapModuleOl {
                 }
                 camera.setView(view);
                 this._map3D.getCamera().updateView();
-                this.updateDomain();
             }
         } else {
             // Cesium is not ready yet. Fire after it has been initialized properly.

--- a/bundles/mapping/mapmodule/mapmodule.olcs.js
+++ b/bundles/mapping/mapmodule/mapmodule.olcs.js
@@ -529,7 +529,7 @@ class MapModuleOlCesium extends MapModuleOl {
     }
     /**
      * Function to reset map move mode and 3D camera controls to default.
-     * This is needed since user might click reset map view on panbuttons when camera is in rotate mode.
+     * This is needed since user might click reset map view or pan map on panbuttons when camera is in rotate mode.
      */
     _resetMoveMode () {
         this.setCameraToMoveMode();
@@ -564,10 +564,18 @@ class MapModuleOlCesium extends MapModuleOl {
             return true;
         }
     }
+    panMapByPixels (pX, pY) {
+        const plugin = this._pluginInstances.CameraControls3dPlugin;
+        if (plugin && plugin.isRotating()) {
+            this._resetMoveMode();
+        }
+        super.panMapByPixels(pX, pY, true, true);
+    }
 
     setCameraToMoveMode () {
         const camera = this.getCesiumScene().camera;
         camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+        this._map3D.getCamera().updateView();
         this._enableMapMoveControls();
     }
     _disableMapMoveControls () {

--- a/bundles/mapping/mapmodule/mapmodule.olcs.js
+++ b/bundles/mapping/mapmodule/mapmodule.olcs.js
@@ -690,14 +690,18 @@ class MapModuleOlCesium extends MapModuleOl {
             // 3d map now only supports one animation so ignore the parameter, and just fly
             this._flyTo(location[0], location[1], cameraHeight, animationDuration, camera, complete);
             return true;
-        } else {
-            const view = this.getMap().getView();
-            const zoomValue = zoom.type === 'scale' ? view.getZoomForResolution(zoom.value) : zoom.value;
-            view.setCenter([lonlat.lon, lonlat.lat]);
-            view.setZoom(zoomValue);
-            this.notifyMoveEnd();
-            return true;
         }
+        if (!isNaN(zoom)) {
+            // backwards compatibility
+            zoom = { type: 'zoom', value: zoom };
+        }
+
+        const view = this.getMap().getView();
+        const zoomValue = zoom.type === 'scale' ? view.getZoomForResolution(zoom.value) : zoom.value;
+        view.setCenter([lonlat.lon, lonlat.lat]);
+        view.setZoom(zoomValue);
+        this.notifyMoveEnd();
+        return true;
     }
 
     /**

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/ReqEventHandler.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/ReqEventHandler.js
@@ -70,7 +70,12 @@ export class ReqEventHandler {
                 if (plugin.WFSLayerService.getAnalysisWFSLayerId()) {
                     targetLayers = [plugin.WFSLayerService.getAnalysisWFSLayerId()];
                 } else {
-                    targetLayers = plugin.WFSLayerService.isSelectFromAllLayers() ? plugin.getAllLayerIds() : [plugin.WFSLayerService.getTopWFSLayer()];
+                    if (plugin.WFSLayerService.isSelectFromAllLayers()) {
+                        targetLayers = plugin.getAllLayerIds();
+                    } else {
+                        const layerId = plugin.WFSLayerService.getTopWFSLayer();
+                        targetLayers = layerId ? [layerId] : [];
+                    }
                 }
                 targetLayers.forEach(layerId => {
                     const layer = getSelectedLayer(layerId);

--- a/bundles/mapping/mapwfs2/service/WFSLayerService.js
+++ b/bundles/mapping/mapwfs2/service/WFSLayerService.js
@@ -22,7 +22,7 @@ Oskari.clazz.define(
         me.WFSFeatureSelections = [];
         me.selectedWFSLayers = [];
         me.selectedWFSLayerIds = [];
-        me.selectFromAllLayers = null;
+        me.selectFromAllLayers = false;
         me.selectionToolsActive = null;
         me.analysisWFSLayerId = null;
 


### PR DESCRIPTION
Panning map while map is in rotate mode breaks view. While changing to move mode camera.updateView() fix this . Also pan map has to wait until _resetMoveMode is ready.

Added time to dimension-change blacklisted params.

Select features from map (drawing) caused js error to console if there wasn't any wfs layer on the map. Also fixed dialog to remember/init select from all. 

Add zoom (number) backwards compatibility for 3d mapmodule centerMap method to avoid undefined zoom set to ol map. This caused strange behavior after centering map by layer content. Maybe we should add normalizeZoom which handles different zoom presentations in one place. Notice that resolution value is stored to zoom object as scale which is confusing.

Removed updateDomain from setCamera. Camera has event listener on moveend which calls notifymoveend (updates domain). Fixes issue where history back didn't filter location update which add new history point clearing move forward history. ol map and olcs camera have event listeners to call notifymoveend. I think that we should remove other notifymoveend calls and check updateDomain calls because these can break many things while animating map.