### PR TITLE
Change action route for getting capabilities

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -420,6 +420,9 @@ class UIHandler extends StateHandler {
                 return Promise.reject(Error('Save failed'));
             }
         }).then(data => {
+            // FIXME: layer data will be the same as for editing == admin data
+            // To get the layer json for "end-user" frontend for creating
+            // an AbstractLayer-based model -> make another request to get that JSON.
             if (layer.id) {
                 data.groups = layer.groups;
                 this.updateLayer(layer.id, data);

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -354,6 +354,11 @@ class UIHandler extends StateHandler {
             const { capabilities, ...layer } = this.layerHelper.fromServer(json, {
                 preserve: ['capabilities']
             });
+            if (layer.warn) {
+                // currently only option for warning on this is "updateCapabilitiesFail"
+                this.setMessage(`messages.${layer.warn}`, 'warning');
+                delete layer.warn;
+            }
             this.updateState({
                 layer,
                 capabilities,

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -508,7 +508,7 @@ class UIHandler extends StateHandler {
         // Remove undefined params
         Object.keys(params).forEach(key => params[key] === undefined && delete params[key]);
 
-        fetch(Oskari.urls.getRoute('LayerAdmin', params), {
+        fetch(Oskari.urls.getRoute('ServiceCapabilities', params), {
             method: 'GET',
             headers: {
                 'Accept': 'application/json'

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -351,7 +351,7 @@ class UIHandler extends StateHandler {
             }
             return response.json();
         }).then(json => {
-            const { capabilities, ...layer } = this.layerHelper.fromServer(json.layer, {
+            const { capabilities, ...layer } = this.layerHelper.fromServer(json, {
                 preserve: ['capabilities']
             });
             this.updateState({

--- a/bundles/admin/admin-layereditor/view/LayerHelper.js
+++ b/bundles/admin/admin-layereditor/view/LayerHelper.js
@@ -30,8 +30,16 @@ export const getLayerHelper = () => {
 
     const toServer = layer => {
         // Remove role 'all' from permissions as this was only used for UI state handling purposes
+        // TODO: Add some generic mapping for fields so we don't have to maintain fromServer and toServer.
         const payload = {
             ...layer,
+            dataprovider_id: layer.dataProviderId,
+            group_ids: layer.groups,
+            gfi_type: layer.gfiType,
+            gfi_xslt: layer.gfiXslt,
+            gfi_content: layer.gfiContent,
+            legend_image: layer.legendImage,
+            capabilities_update_rate_sec: layer.capabilitiesUpdateRate,
             attributes: toJson(layer.attributes),
             options: toJson(layer.options)
         };

--- a/bundles/admin/admin-layereditor/view/LayerHelper.js
+++ b/bundles/admin/admin-layereditor/view/LayerHelper.js
@@ -10,7 +10,7 @@ export const getLayerHelper = () => {
             attributes: layer.attributes || {},
             options: layer.options || {},
             dataProviderId: `${layer.dataprovider_id}`,
-            groups: layer.groups || [],
+            groups: layer.group_ids || [],
             gfiContent: layer.gfi_content,
             gfiType: layer.gfi_type,
             gfiXslt: layer.gfi_xslt,
@@ -19,7 +19,7 @@ export const getLayerHelper = () => {
         };
         setupTemporaryFields(transformed);
         let removeKeys = [
-            'dataprovider_id', 'organization', 'capabilities', 'gfi_content', 'gfi_type', 'gfi_xslt', 'legend_image', 'capabilities_update_rate_sec'
+            'dataprovider_id', 'group_ids', 'capabilities', 'gfi_content', 'gfi_type', 'gfi_xslt', 'legend_image', 'capabilities_update_rate_sec'
         ];
         if (Array.isArray(options.preserve)) {
             removeKeys = removeKeys.filter(key => !options.preserve.includes(key));

--- a/bundles/admin/admin-layereditor/view/LayerHelper.js
+++ b/bundles/admin/admin-layereditor/view/LayerHelper.js
@@ -9,16 +9,17 @@ export const getLayerHelper = () => {
             ...layer,
             attributes: layer.attributes || {},
             options: layer.options || {},
-            dataProviderId: `${layer.organization_id}`,
+            dataProviderId: `${layer.dataprovider_id}`,
             groups: layer.groups || [],
             gfiContent: layer.gfi_content,
             gfiType: layer.gfi_type,
             gfiXslt: layer.gfi_xslt,
-            legendImage: layer.legend_image
+            legendImage: layer.legend_image,
+            capabilitiesUpdateRate: layer.capabilities_update_rate_sec
         };
         setupTemporaryFields(transformed);
         let removeKeys = [
-            'organization_id', 'organization', 'capabilities', 'gfi_content', 'gfi_type', 'gfi_xslt', 'legend_image'
+            'dataprovider_id', 'organization', 'capabilities', 'gfi_content', 'gfi_type', 'gfi_xslt', 'legend_image', 'capabilities_update_rate_sec'
         ];
         if (Array.isArray(options.preserve)) {
             removeKeys = removeKeys.filter(key => !options.preserve.includes(key));


### PR DESCRIPTION
A new action route was added in oskariorg/oskari-server#511 for getting capabilities. Change frontend to use it as oskariorg/oskari-server#512 will remove capabilities fetching from LayerAdmin action route.