### PR TITLE
removed functions that don't work with new WFS

### DIFF
--- a/bundles/mapping/mapwfs2/domain/WFSLayer.js
+++ b/bundles/mapping/mapwfs2/domain/WFSLayer.js
@@ -160,30 +160,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapwfs2.domain.WFSLayer',
             this._clickedFeatureListIds = ids;
         },
         /**
-         * @method getClickedGeometries
-         * @return {String[[]..]} featureId, geometry
-         */
-        getClickedGeometries: function () {
-            return this._clickedGeometries;
-        },
-
-        /**
-         * @method setClickedGeometries
-         * @param {String[[]..]} id,geom
-         */
-        setClickedGeometries: function (fgeom) {
-            this._clickedGeometries = fgeom;
-        },
-        /**
-         * @method addClickedGeometries
-         * @param {[]} id,geom
-         */
-        addClickedGeometries: function (fgeom) {
-            for (var j = 0; j < fgeom.length; ++j) {
-                this._clickedGeometries.push(fgeom[j]);
-            }
-        },
-        /**
          * @method setPropertyTypes
          * @param {json} propertyTypes
          */


### PR DESCRIPTION
This can be ignored if there is a chance coming to this.

WFSLayer doesn't get "clickedGeometries" with new WFS because they are set by Mediator, which is not currently used.