### PR TITLE
Remove version info from 3D tiles layers

### DIFF
--- a/bundles/mapping/tiles3d/plugin/Tiles3DLayerPlugin.js
+++ b/bundles/mapping/tiles3d/plugin/Tiles3DLayerPlugin.js
@@ -61,7 +61,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.Tiles3DLayerPlugin',
                     LayerComposingModel.STYLES_JSON,
                     LayerComposingModel.EXTERNAL_STYLES_JSON,
                     LayerComposingModel.URL
-                ], ['0.0', '1.0']);
+                ]);
                 mapLayerService.registerLayerModel(registerType, clazz, composingModel);
                 mapLayerService.registerLayerModelBuilder(registerType, new Tiles3DModelBuilder());
             }


### PR DESCRIPTION
Version number is not required by 3D tiles interface. It is provided in the tileset metadata instead.