### PR TITLE
Removed unusable functions due to not using Mediator

### DIFF
--- a/bundles/mapping/mapwfs2/domain/WFSLayer.js
+++ b/bundles/mapping/mapwfs2/domain/WFSLayer.js
@@ -161,32 +161,6 @@ export class WFSLayer extends VectorTileLayer {
     }
 
     /**
-     * @method getClickedGeometries
-     * @return {String[[]..]} featureId  geometry
-     */
-    getClickedGeometries () {
-        return this._clickedGeometries;
-    }
-
-    /**
-     * @method setClickedGeometries
-     * @param {String[[]..]} id geom
-     */
-    setClickedGeometries (fgeom) {
-        this._clickedGeometries = fgeom;
-    }
-
-    /**
-     * @method addClickedGeometries
-     * @param {[]} id geom
-     */
-    addClickedGeometries (fgeom) {
-        for (var j = 0; j < fgeom.length; ++j) {
-            this._clickedGeometries.push(fgeom[j]);
-        }
-    }
-
-    /**
      * @method setPropertyTypes
      * @param {json} propertyTypes
      */


### PR DESCRIPTION
This can be ignored if there is a chance coming to this.

WFSLayer doesn't get "clickedGeometries" with new WFS because they are set by Mediator, which is not currently used.

Re-did the pull request due to accidentally using old fork of develop.