### PR TITLE
CameraControls3d set config fix

### DIFF
--- a/bundles/mapping/camera-controls-3d/instance.js
+++ b/bundles/mapping/camera-controls-3d/instance.js
@@ -28,7 +28,8 @@ Oskari.clazz.defineES('Oskari.mapping.cameracontrols3d.instance',
             if (this.plugin) {
                 return;
             }
-            this.plugin = Oskari.clazz.create('Oskari.mapping.cameracontrols3d.CameraControls3dPlugin');
+            const conf = this.conf || {};
+            this.plugin = Oskari.clazz.create('Oskari.mapping.cameracontrols3d.CameraControls3dPlugin', conf);
             this._mapmodule.registerPlugin(this.plugin);
             this._mapmodule.startPlugin(this.plugin);
         }

--- a/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
+++ b/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
@@ -8,7 +8,8 @@ const className = 'Oskari.mapping.cameracontrols3d.CameraControls3dPlugin';
 const shortName = 'CameraControls3dPlugin';
 
 Oskari.clazz.define(className,
-    function () {
+    function (config) {
+        this._config = config;
         this._clazz = className;
         this._defaultLocation = 'top right';
         this._toolOpen = false;

--- a/bundles/mapping/camera-controls-3d/tool/CameraControls3dTool.js
+++ b/bundles/mapping/camera-controls-3d/tool/CameraControls3dTool.js
@@ -52,7 +52,6 @@ Oskari.clazz.define('Oskari.mapping.cameracontrols3d.CameraControls3dTool',
         getValues: function () {
             if (this.state.enabled) {
                 var pluginConfig = this.getPlugin().getConfig();
-                pluginConfig.instance = null;
                 var json = {
                     configuration: {}
                 };


### PR DESCRIPTION
Set config to handle plugin location. Fixes issue with embedded maps where default location isn't used.