### PR TITLE
Improvements to map layer list for admin users

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -1,6 +1,6 @@
 import { stringify } from 'query-string';
 import { getLayerHelper } from '../LayerHelper';
-import { StateHandler, Messaging, controllerMixin } from 'oskari-ui/util';
+import { StateHandler, controllerMixin } from 'oskari-ui/util';
 import { handlePermissionForAllRoles, handlePermissionForSingleRole, roleAll } from './PermissionUtil';
 
 const LayerComposingModel = Oskari.clazz.get('Oskari.mapframework.domain.LayerComposingModel');

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
@@ -16,6 +16,10 @@ const StyledCollapse = styled(Collapse)`
     }
 `;
 
+const StyledLayerCollapsePanel = styled(LayerCollapsePanel)`
+    padding-left: ${props => props.group.layers.length === 0 ? '27px' : '0px'};
+`;
+
 const LayerCollapse = ({ groups, openGroupTitles, selectedLayerIds, controller }) => {
     if (!Array.isArray(groups) || groups.length === 0) {
         return <Alert showIcon type='info' message={<Message messageKey='errors.noResults'/>}/>;
@@ -30,7 +34,7 @@ const LayerCollapse = ({ groups, openGroupTitles, selectedLayerIds, controller }
                     // This way the content of selected layer ids remains unchanged when a layer in another group gets added on map.
                     // When the properties remain unchanged, we can benefit from memoization.
                     return (
-                        <LayerCollapsePanel key={group.getId()}
+                        <StyledLayerCollapsePanel key={group.getId()}
                             trimmed
                             selectedLayerIds={selectedLayersInGroup}
                             group={group}

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
@@ -69,6 +69,7 @@ const LayerCollapsePanel = (props) => {
     return (
         <StyledCollapsePanel {...propsNeededForPanel}
             header={group.getTitle()}
+            showArrow={layerRows.length > 0 }
             extra={
                 <React.Fragment>
                     {
@@ -82,7 +83,7 @@ const LayerCollapsePanel = (props) => {
                     <Badge inversed={true} count={badgeText}/>
                 </React.Fragment>
             }>
-            <List bordered={false} dataSource={layerRows} renderItem={renderLayer}/>
+            { layerRows.length > 0 && <List bordered={false} dataSource={layerRows} renderItem={renderLayer}/> }
         </StyledCollapsePanel>
     );
 };


### PR DESCRIPTION
Pull request contains following improvements to map layer list for admin users:

- Show collapse open arrow icon only with groups that have layers
- Prevent "No Data" content on empty group collapse

Also removed not user Messaging import.