### PR TITLE
Revert "Fix layer response handling"

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -359,7 +359,7 @@ class UIHandler extends StateHandler {
             }
             return response.json();
         }).then(json => {
-            const { capabilities, ...layer } = this.layerHelper.fromServer(json.layer, {
+            const { capabilities, ...layer } = this.layerHelper.fromServer(json, {
                 preserve: ['capabilities']
             });
             if (layer.warn) {


### PR DESCRIPTION
Reverts oskariorg/oskari-frontend#1162 because the new server side route doens't use that additional key.