### PR TITLE
Fix layerselector part 2

### DIFF
--- a/bundles/framework/layerselector2/Flyout.js
+++ b/bundles/framework/layerselector2/Flyout.js
@@ -318,6 +318,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
                 }
                 group.addLayer(layer);
             });
+            // Groups without layers shouldn't happen because groups are gathered _FROM_ layers
+            // Don't know why this would be checked here.
             return Object.values(groups).filter(group => {
                 return group.getLayers().length > 0;
             });

--- a/bundles/framework/layerselector2/Flyout.js
+++ b/bundles/framework/layerselector2/Flyout.js
@@ -292,22 +292,22 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
 
         /**
          * @method _getLayerGroups
+         * @param layers Gather groups from layer list. Grouping method is a 
+         * @param groupingMethod function name on layer objects to get the name for group
          * @private
          */
-        _getLayerGroups: function (layers, groupingMethod) {
-            var me = this;
+        _getLayerGroups: function (layers = [], groupingMethod) {
             const groups = {};
-
-            // sort layers by grouping & name
-            layers.sort(function (a, b) {
-                return me._layerListComparator(a, b, groupingMethod);
-            });
             layers.forEach((layer, n) => {
                 if (typeof layer.getMetaType === 'function' && layer.getMetaType() === 'published') {
                     // skip published layers
                     return;
                 }
-                let groupAttr = layer[groupingMethod]();
+                if (typeof layer.groupingMethod !== 'function') {
+                    // log "invalid grouping type"?
+                    return;
+                }
+                const groupAttr = layer[groupingMethod]();
                 let group = groups[groupAttr];
                 if (!group) {
                     group = Oskari.clazz.create(
@@ -318,10 +318,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
                 }
                 group.addLayer(layer);
             });
-            var sortedGroupList = jQuery.grep(Object.values(groups), function (group) {
+            return Object.values(groups).filter(group => {
                 return group.getLayers().length > 0;
             });
-            return sortedGroupList;
         },
 
         /**

--- a/bundles/framework/layerselector2/Flyout.js
+++ b/bundles/framework/layerselector2/Flyout.js
@@ -295,36 +295,30 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * @private
          */
         _getLayerGroups: function (layers, groupingMethod) {
-            var me = this,
-                groupList = [],
-                group = null,
-                n,
-                layer,
-                groupAttr;
+            var me = this;
+            const groups = {};
 
             // sort layers by grouping & name
             layers.sort(function (a, b) {
                 return me._layerListComparator(a, b, groupingMethod);
             });
-
-            for (n = 0; n < layers.length; n += 1) {
-                layer = layers[n];
-                if (layer.getMetaType && layer.getMetaType() === 'published') {
+            layers.forEach((layer, n) => {
+                if (typeof layer.getMetaType === 'function' && layer.getMetaType() === 'published') {
                     // skip published layers
-                    continue;
+                    return;
                 }
-                groupAttr = layer[groupingMethod]();
-                if (!group || group.getTitle() !== groupAttr) {
+                let groupAttr = layer[groupingMethod]();
+                let group = groups[groupAttr];
+                if (!group) {
                     group = Oskari.clazz.create(
                         'Oskari.mapframework.bundle.layerselector2.model.LayerGroup',
-                        groupAttr
+                        'generated_' + n, groupingMethod, groupAttr
                     );
-                    groupList.push(group);
+                    groups[groupAttr] = group;
                 }
-
                 group.addLayer(layer);
-            }
-            var sortedGroupList = jQuery.grep(groupList, function (group, index) {
+            });
+            var sortedGroupList = jQuery.grep(Object.values(groups), function (group) {
                 return group.getLayers().length > 0;
             });
             return sortedGroupList;
@@ -341,8 +335,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
          * @param {String} groupingMethod method name to sort by
          */
         _layerListComparator: function (a, b, groupingMethod) {
-            var nameA = a[groupingMethod]().toLowerCase(),
-                nameB = b[groupingMethod]().toLowerCase();
+            let nameA = a[groupingMethod]().toLowerCase();
+            let nameB = b[groupingMethod]().toLowerCase();
             if (nameA === nameB && (a.getName() && b.getName())) {
                 nameA = a.getName().toLowerCase();
                 nameB = b.getName().toLowerCase();

--- a/bundles/framework/layerselector2/Flyout.js
+++ b/bundles/framework/layerselector2/Flyout.js
@@ -318,11 +318,16 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
                 }
                 group.addLayer(layer);
             });
-            // Groups without layers shouldn't happen because groups are gathered _FROM_ layers
-            // Don't know why this would be checked here.
-            return Object.values(groups).filter(group => {
-                return group.getLayers().length > 0;
-            });
+            // sort groups alphabetically by title
+            const sortedGroups = Object.values(groups)
+                .sort((a, b) => Oskari.util.naturalSort(a.getTitle(), b.getTitle()))
+                .forEach(group => {
+                    // sort layers in group alphabetically by name
+                    var layers = group.getLayers()
+                        .sort((a, b) => Oskari.util.naturalSort(a.getName(), b.getName()));
+                    group.layers = layers;
+                });
+            return sortedGroups;
         },
 
         /**

--- a/bundles/framework/layerselector2/Flyout.js
+++ b/bundles/framework/layerselector2/Flyout.js
@@ -303,57 +303,31 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
                     // skip published layers
                     return;
                 }
-                if (typeof layer.groupingMethod !== 'function') {
+                if (typeof layer[groupingMethod] !== 'function') {
                     // log "invalid grouping type"?
                     return;
                 }
-                const groupAttr = layer[groupingMethod]();
-                let group = groups[groupAttr];
+                const groupTitle = layer[groupingMethod]();
+                let group = groups[groupTitle];
                 if (!group) {
                     group = Oskari.clazz.create(
                         'Oskari.mapframework.bundle.layerselector2.model.LayerGroup',
-                        'generated_' + n, groupingMethod, groupAttr
+                        'generated_' + n, groupingMethod, groupTitle
                     );
-                    groups[groupAttr] = group;
+                    groups[groupTitle] = group;
                 }
                 group.addLayer(layer);
             });
             // sort groups alphabetically by title
-            const sortedGroups = Object.values(groups)
-                .sort((a, b) => Oskari.util.naturalSort(a.getTitle(), b.getTitle()))
-                .forEach(group => {
-                    // sort layers in group alphabetically by name
-                    var layers = group.getLayers()
-                        .sort((a, b) => Oskari.util.naturalSort(a.getName(), b.getName()));
-                    group.layers = layers;
-                });
+            let sortedGroups = Object.values(groups)
+                .sort((a, b) => Oskari.util.naturalSort(a.getTitle(), b.getTitle()));
+            // sort layers inside groups alphabetically by name
+            sortedGroups.forEach(group => {
+                var layers = group.getLayers()
+                    .sort((a, b) => Oskari.util.naturalSort(a.getName(), b.getName()));
+                group.setLayers(layers);
+            });
             return sortedGroups;
-        },
-
-        /**
-         * @method _layerListComparator
-         * Uses the private property #grouping to sort layer objects in the wanted order for rendering
-         * The #grouping property is the method name that is called on layer objects.
-         * If both layers have same group, they are ordered by layer.getName()
-         * @private
-         * @param {Oskari.mapframework.domain.WmsLayer/Oskari.mapframework.domain.WfsLayer/Oskari.mapframework.domain.VectorLayer/Object} a comparable layer 1
-         * @param {Oskari.mapframework.domain.WmsLayer/Oskari.mapframework.domain.WfsLayer/Oskari.mapframework.domain.VectorLayer/Object} b comparable layer 2
-         * @param {String} groupingMethod method name to sort by
-         */
-        _layerListComparator: function (a, b, groupingMethod) {
-            let nameA = a[groupingMethod]().toLowerCase();
-            let nameB = b[groupingMethod]().toLowerCase();
-            if (nameA === nameB && (a.getName() && b.getName())) {
-                nameA = a.getName().toLowerCase();
-                nameB = b.getName().toLowerCase();
-            }
-            if (nameA < nameB) {
-                return -1;
-            }
-            if (nameA > nameB) {
-                return 1;
-            }
-            return 0;
         },
 
         /**

--- a/bundles/framework/layerselector2/Flyout.js
+++ b/bundles/framework/layerselector2/Flyout.js
@@ -292,7 +292,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerselector2.Flyout',
 
         /**
          * @method _getLayerGroups
-         * @param layers Gather groups from layer list. Grouping method is a 
+         * @param layers Gather groups from layer list
          * @param groupingMethod function name on layer objects to get the name for group
          * @private
          */

--- a/bundles/framework/layerselector2/model/LayerGroup.class.js
+++ b/bundles/framework/layerselector2/model/LayerGroup.class.js
@@ -67,6 +67,9 @@ export class LayerGroup {
     getLayers () {
         return this.layers;
     }
+    setLayers (newLayers = []) {
+        this.layers = newLayers;
+    }
     _getSearchIndex (layer) {
         var val = layer.getName() + ' ' +
             layer.getInspireName() + ' ' +


### PR DESCRIPTION
The constructor for Oskari.mapframework.bundle.layerselector2.model.LayerGroup was changed but this code used the old parameters resulting in "nameless" groups.