### PR TITLE
Add defaultMsg option for <Message />

### DIFF
--- a/src/react/components/Message.jsx
+++ b/src/react/components/Message.jsx
@@ -31,13 +31,20 @@ const Label = styled('div')`
  *     <Message messageKey="hello" messageArgs={['Jack']}/>
  * </LocaleProvider>
  */
-const Message = ({ bundleKey, messageKey, messageArgs, getMessage, children, LabelComponent = Label }) => {
+const Message = ({ bundleKey, messageKey, messageArgs, defaultMsg, getMessage, children, LabelComponent = Label }) => {
     if (!messageKey) {
         return null;
     }
-    const message = typeof getMessage === 'function'
-        ? getMessage(messageKey, messageArgs)
-        : Oskari.getMsg(bundleKey, messageKey, messageArgs);
+    let message = messageKey;
+    if (typeof getMessage === 'function') {
+        message = getMessage(messageKey, messageArgs);
+    } else {
+        message = Oskari.getMsg(bundleKey, messageKey, messageArgs);
+    }
+    // If we didn't find localization AND we have default value -> use it
+    if (message === messageKey && defaultMsg) {
+        message = defaultMsg;
+    }
     return (
         <LabelComponent onClick={() => Oskari.log().debug(`Text clicked - ${bundleKey}: ${messageKey}`)}>
             { message }
@@ -48,6 +55,7 @@ const Message = ({ bundleKey, messageKey, messageArgs, getMessage, children, Lab
 Message.propTypes = {
     bundleKey: PropTypes.string.isRequired,
     messageKey: PropTypes.string,
+    defaultMsg: PropTypes.string,
     messageArgs: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
     getMessage: PropTypes.func,
     children: PropTypes.node,


### PR DESCRIPTION
Add an optional default value for Message-tag. The tag prints out the messageKey by default if localization isn't found but on certain cases we might want to default to some other text on the UI. For example in layer admin a user-friendly label could be searched with messageKey `layertypes.{type}` but we would only like to show the `{type}` part if localization is not available.

So <Message messageKey={`layertypes.${type}`} /> would printout something like 'layertypes.wfslayer' but if we do <Message messageKey={`layertypes.${type}`} defaultMsg={type} /> we would get the 'wfslayer' which is a better default. You could also use it to provide the english version for the text but that is not advisable since we are relying on english language having the most complete localization for some tools. Not sure if we should just keep the messageKeys shorter to accomplish the same but it looks nicer on the localization file having some structure in it.