### PR TITLE
Hide delete button when adding theme/data provider

### DIFF
--- a/bundles/admin/admin-layereditor/instance.js
+++ b/bundles/admin/admin-layereditor/instance.js
@@ -357,33 +357,36 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
                     }
                 });
             });
-            this.themeFlyout.setDeleteAction((id, deleteLayers) => {
-                const me = this;
-                this.themeFlyout.setLoading(true);
-                jQuery.ajax({
-                    type: 'DELETE',
-                    url: Oskari.urls.getRoute('MapLayerGroups', { id: id, deleteLayers: deleteLayers }),
-                    success: response => {
-                        this.themeFlyout.setLoading(false);
-                        this.themeFlyout.hide();
-                        this._getLayerService().deleteLayerGroup(response.id, response.parentId, deleteLayers);
-                        // Inform user with popup
-                        const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
-                        dialog.show(' ', me.loc('messages.deleteSuccess'));
-                        dialog.fadeout();
-                    },
-                    error: (jqXHR, textStatus, errorThrown) => {
-                        this.themeFlyout.setLoading(false);
-                        // Inform user with popup
-                        const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
-                        dialog.show(' ', me.loc('messages.deleteFailed'));
-                        dialog.fadeout();
-                        // Log error
-                        const errorText = Oskari.util.getErrorTextFromAjaxFailureObjects(jqXHR, errorThrown);
-                        Oskari.log('admin-layereditor').error(errorText);
-                    }
+            if (id) {
+                // only add a delete action if we have something to delete
+                this.themeFlyout.setDeleteAction((id, deleteLayers) => {
+                    const me = this;
+                    this.themeFlyout.setLoading(true);
+                    jQuery.ajax({
+                        type: 'DELETE',
+                        url: Oskari.urls.getRoute('MapLayerGroups', { id: id, deleteLayers: deleteLayers }),
+                        success: response => {
+                            this.themeFlyout.setLoading(false);
+                            this.themeFlyout.hide();
+                            this._getLayerService().deleteLayerGroup(response.id, response.parentId, deleteLayers);
+                            // Inform user with popup
+                            const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+                            dialog.show(' ', me.loc('messages.deleteSuccess'));
+                            dialog.fadeout();
+                        },
+                        error: (jqXHR, textStatus, errorThrown) => {
+                            this.themeFlyout.setLoading(false);
+                            // Inform user with popup
+                            const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+                            dialog.show(' ', me.loc('messages.deleteFailed'));
+                            dialog.fadeout();
+                            // Log error
+                            const errorText = Oskari.util.getErrorTextFromAjaxFailureObjects(jqXHR, errorThrown);
+                            Oskari.log('admin-layereditor').error(errorText);
+                        }
+                    });
                 });
-            });
+            }
             return this.themeFlyout;
         }
 
@@ -459,33 +462,36 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
                     }
                 });
             });
-            this.dataProviderFlyout.setDeleteAction((id, deleteLayers) => {
-                const me = this;
-                this.dataProviderFlyout.setLoading(true);
-                jQuery.ajax({
-                    type: 'DELETE',
-                    url: Oskari.urls.getRoute('DataProvider', { id: id, deleteLayers: deleteLayers }),
-                    success: response => {
-                        this.dataProviderFlyout.setLoading(false);
-                        this.dataProviderFlyout.hide();
-                        this._getLayerService().deleteDataProvider(response, deleteLayers);
-                        // Inform user with popup
-                        const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
-                        dialog.show(' ', me.loc('messages.deleteSuccess'));
-                        dialog.fadeout();
-                    },
-                    error: (jqXHR, textStatus, errorThrown) => {
-                        this.dataProviderFlyout.setLoading(false);
-                        // Inform user with popup
-                        const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
-                        dialog.show(' ', me.loc('messages.deleteFailed'));
-                        dialog.fadeout();
-                        // Log error
-                        const errorText = Oskari.util.getErrorTextFromAjaxFailureObjects(jqXHR, errorThrown);
-                        Oskari.log('admin-layereditor').error(errorText);
-                    }
+            if (id) {
+                // only add a delete action if we have something to delete
+                this.dataProviderFlyout.setDeleteAction((id, deleteLayers) => {
+                    const me = this;
+                    this.dataProviderFlyout.setLoading(true);
+                    jQuery.ajax({
+                        type: 'DELETE',
+                        url: Oskari.urls.getRoute('DataProvider', { id: id, deleteLayers: deleteLayers }),
+                        success: response => {
+                            this.dataProviderFlyout.setLoading(false);
+                            this.dataProviderFlyout.hide();
+                            this._getLayerService().deleteDataProvider(response, deleteLayers);
+                            // Inform user with popup
+                            const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+                            dialog.show(' ', me.loc('messages.deleteSuccess'));
+                            dialog.fadeout();
+                        },
+                        error: (jqXHR, textStatus, errorThrown) => {
+                            this.dataProviderFlyout.setLoading(false);
+                            // Inform user with popup
+                            const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+                            dialog.show(' ', me.loc('messages.deleteFailed'));
+                            dialog.fadeout();
+                            // Log error
+                            const errorText = Oskari.util.getErrorTextFromAjaxFailureObjects(jqXHR, errorThrown);
+                            Oskari.log('admin-layereditor').error(errorText);
+                        }
+                    });
                 });
-            });
+            }
             return this.dataProviderFlyout;
         }
     }

--- a/bundles/admin/admin-layereditor/view/LocalizingFlyout.jsx
+++ b/bundles/admin/admin-layereditor/view/LocalizingFlyout.jsx
@@ -67,6 +67,7 @@ export class LocalizingFlyout extends ExtraFlyout {
             <LocaleProvider value={{ bundleKey: this.instance.getName() }}>
                 <LocalizedContent { ...this.uiHandler.getState() }
                     controller={controller}
+                    isNew={!this.id}
                     deleteMapLayersText={this.deleteMapLayersText}
                     layerCountInGroup={this.layerCountInGroup}/>
             </LocaleProvider>
@@ -167,8 +168,7 @@ const Buttons = styled('div')`
 const DeleteLayersCheckbox = styled(Checkbox)`
     padding-top: 15px;
 `;
-
-const LocalizedContent = ({ loading, labels, value, headerMessageKey, controller, deleteMapLayersText, layerCountInGroup, deleteLayers }) => {
+const LocalizedContent = ({ loading, labels, value, headerMessageKey, controller, isNew, deleteMapLayersText, layerCountInGroup, deleteLayers }) => {
     const Component = (
         <Container>
             <Header>
@@ -189,25 +189,13 @@ const LocalizedContent = ({ loading, labels, value, headerMessageKey, controller
                 <Button onClick={() => controller.cancel()}>
                     <Message messageKey='cancel'/>
                 </Button>
-                <Confirm
-                    title={<React.Fragment>
-                        <div>
-                            <Message messageKey='messages.confirmDeleteGroup'/>
-                        </div>
-                        { layerCountInGroup > 0 &&
-                            <DeleteLayersCheckbox checked={deleteLayers} onChange={ evt => controller.setDeleteLayers(evt.target.checked)}>
-                                {deleteMapLayersText + ' (' + layerCountInGroup + ')'}
-                            </DeleteLayersCheckbox>
-                        }
-                    </React.Fragment>}
-                    onConfirm={() => controller.delete()}
-                    okText={<Message messageKey='ok'/>}
-                    cancelText={<Message messageKey='cancel'/>}
-                    placement='bottomLeft'>
-                    <Button>
-                        <Message messageKey='delete'/>
-                    </Button>
-                </Confirm>
+                { !isNew &&
+                <DeleteButton
+                    controller={controller}
+                    deleteMapLayersText={deleteMapLayersText}
+                    layerCountInGroup={layerCountInGroup}
+                    deleteLayers={deleteLayers} />
+                }
                 <Button onClick={() => controller.save()} type='primary'>
                     <Message messageKey='save'/>
                 </Button>
@@ -223,6 +211,35 @@ LocalizedContent.propTypes = {
     loading: PropTypes.bool,
     labels: PropTypes.object,
     value: PropTypes.object,
+    isNew: PropTypes.bool,
     headerMessageKey: PropTypes.string,
+    controller: PropTypes.instanceOf(Controller)
+};
+
+const DeleteButton = ({ controller, deleteMapLayersText, layerCountInGroup, deleteLayers }) => {
+    return (<Confirm
+        title={<React.Fragment>
+            <div>
+                <Message messageKey='messages.confirmDeleteGroup'/>
+            </div>
+            { layerCountInGroup > 0 &&
+                <DeleteLayersCheckbox checked={deleteLayers} onChange={ evt => controller.setDeleteLayers(evt.target.checked)}>
+                    {deleteMapLayersText + ' (' + layerCountInGroup + ')'}
+                </DeleteLayersCheckbox>
+            }
+        </React.Fragment>}
+        onConfirm={() => controller.delete()}
+        okText={<Message messageKey='ok'/>}
+        cancelText={<Message messageKey='cancel'/>}
+        placement='bottomLeft'>
+        <Button>
+            <Message messageKey='delete'/>
+        </Button>
+    </Confirm>);
+};
+DeleteButton.propTypes = {
+    deleteMapLayersText: PropTypes.string,
+    layerCountInGroup: PropTypes.number,
+    deleteLayers: PropTypes.bool,
     controller: PropTypes.instanceOf(Controller)
 };


### PR DESCRIPTION
If The Thing to be added doesn't have an id yet -> skip showing delete as it will always result in an error.