### PR TITLE
Remove credentials autocomplete when asking for service url

### DIFF
--- a/src/react/components/UrlInput.jsx
+++ b/src/react/components/UrlInput.jsx
@@ -88,11 +88,11 @@ export class UrlInput extends React.Component {
                         <Panel header={credentials.panelText} key='usernameAndPassword'>
                             <div>
                                 {credentials.usernameText}
-                                <div><TextInput value={credentials.usernameValue} type='text' onChange={(evt) => credentials.usernameOnChange(evt.target.value)} /></div>
+                                <div><TextInput autoComplete='off' value={credentials.usernameValue} type='text' onChange={(evt) => credentials.usernameOnChange(evt.target.value)} /></div>
                             </div>
                             <div>
                                 {credentials.passwordText}
-                                <div><TextInput value={credentials.passwordValue} type='password' onChange={(evt) => credentials.passwordOnChange(evt.target.value)} /></div>
+                                <div><TextInput autoComplete='off' value={credentials.passwordValue} type='password' onChange={(evt) => credentials.passwordOnChange(evt.target.value)} /></div>
                             </div>
                         </Panel>
                     </Collapse>


### PR DESCRIPTION
Autocomplete tends to fill in credentials immediately when the inputs hit the DOM. This results in accidental credentials insertion to services that don't require authentication. 99,9% times the credentials autocompleted aren't the correct ones for the service as the browser fills in credentials for the current domain instead of the service we are configuring.