### PR TITLE
Statistics datasource info fix

### DIFF
--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -356,29 +356,6 @@ Oskari.clazz.define(
         },
 
         /**
-         * @method _addIndicatorsToDataSourcesDialog
-         * Adds indicators to the data sources dialog.
-         *
-         * @param {Object} indicators
-         *
-         */
-        _addIndicatorsToDataSourcesDialog: function (indicators) {
-            if (!this.dataSourcesDialog) {
-                return;
-            }
-            var me = this;
-            this._service.removeGroup('indicators');
-            this._service.addGroup('indicators', me._loc.indicatorsHeader);
-            // add initial layers
-            Object.keys(indicators).forEach(function (id) {
-                me._service.addItemToGroup('indicators', {
-                    'id': id,
-                    'name': indicators[id].title,
-                    'source': indicators[id].organization
-                });
-            });
-        },
-        /**
          * @method updateLabels
          * Adds functionality to plugin
          *

--- a/bundles/statistics/statsgrid2016/components/IndicatorList.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorList.js
@@ -14,7 +14,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorList', function (servi
         indicator: _.template(
             `<li>
                 <div>
-                    \${name}
+                    <span title="\${full}">\${name}</span>
                     <div class="indicator-list-info icon-info"/>
                     <div class="indicator-list-remove icon-close" data-ind-hash="\${indHash}"/>
                 </div>
@@ -67,7 +67,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorList', function (servi
         indicators.forEach(function (ind, id) {
             me.service.getUILabels(ind, function (labels) {
                 var indElem = jQuery(me.__templates.indicator({
-                    name: me._getIndicatorText(labels.indicator, labels.params),
+                    name: me._getIndicatorText(labels),
+                    full: labels.full,
                     indHash: ind.hash
                 }));
                 content.find('.statsgrid-indicator-list').append(indElem);
@@ -83,10 +84,11 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorList', function (servi
         });
         return content;
     },
-    _getIndicatorText (indicator, params) {
-        var cutLength = 55;
+    _getIndicatorText (labels) {
+        const { indicator, params, full } = labels;
+        let cutLength = 60;
         const dots = '... ';
-        if (indicator && indicator.length > cutLength) {
+        if (indicator && full.length > cutLength) {
             if (params) {
                 cutLength = cutLength - dots.length - params.length;
                 return indicator.substring(0, cutLength) + dots + params;
@@ -95,7 +97,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorList', function (servi
                 return indicator.substring(0, cutLength) + dots;
             }
         } else {
-            return indicator;
+            return full;
         }
     },
     /**

--- a/bundles/statistics/statsgrid2016/instance.js
+++ b/bundles/statistics/statsgrid2016/instance.js
@@ -204,7 +204,7 @@ Oskari.clazz.define(
                 return;
             }
             var dsid = ds + '_' + id;
-            if (wasRemoved) {
+            if (wasRemoved === true) {
                 // the check if necessary if the same indicator is added more than once with different selections
                 if (!this.statsService.getStateService().isSelected(ds, id)) {
                     // if this was the last dataset for the datasource & indicator. Remove it.
@@ -243,7 +243,6 @@ Oskari.clazz.define(
                     evt.getDatasource(),
                     evt.getIndicator(),
                     evt.getSelections(),
-                    evt.getSeries(),
                     evt.isRemoved());
 
                 this._updateClassficationViewVisibility();


### PR DESCRIPTION
Fix the issue where series indicator wasn't added to data sources. Also removing indicators didn't update data sources.

Added full label for indicators list if doesn't need to cut. Population -> Population (2012). Also added full label to tooltip because some indicator names are so long that cutted label doesn't give info enough. Tooltip is also in classification popup.

Removed unused _addIndicatorsToDataSourcesDialog from DataPlugin because indicators are added via service.