### PR TITLE
Layerlist 3d layer filter

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1486,7 +1486,7 @@ Oskari.clazz.define(
             this.log.debug('[' + this.getName() + ']' + ' Starting ' + pluginName);
             try {
                 var tryAgainLater = plugin.startPlugin(this.getSandbox());
-                if (tryAgainLater && typeof plugin.redrawUI === 'function') {
+                if (tryAgainLater && (typeof plugin.redrawUI === 'function' || typeof plugin.lazyStartPlugin === 'function')) {
                     this.lazyStartPlugins.push(plugin);
                 }
             } catch (e) {
@@ -1509,10 +1509,18 @@ Oskari.clazz.define(
             this.lazyStartPlugins = [];
 
             tryStartingThese.forEach(function (plugin) {
-                var tryAgainLater = plugin.redrawUI(me.getMobileMode(), !!force);
-                if (tryAgainLater) {
+                let tryRedraw;
+                let tryLazyStart;
+                if (typeof plugin.redrawUI === 'function') {
+                    tryRedraw = plugin.redrawUI(me.getMobileMode(), !!force);
+                }
+                if (typeof plugin.lazyStartPlugin === 'function') {
+                    tryLazyStart = plugin.lazyStartPlugin();
+                }
+                if (tryRedraw || tryLazyStart) {
                     if (force) {
                         me.log.warn('Tried to force a start on plugin, but it still refused to start', plugin.getName());
+                        return;
                     }
                     me.lazyStartPlugins.push(plugin);
                 }

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1486,7 +1486,7 @@ Oskari.clazz.define(
             this.log.debug('[' + this.getName() + ']' + ' Starting ' + pluginName);
             try {
                 var tryAgainLater = plugin.startPlugin(this.getSandbox());
-                if (tryAgainLater && (typeof plugin.redrawUI === 'function' || typeof plugin.lazyStartPlugin === 'function')) {
+                if (tryAgainLater && typeof plugin.redrawUI === 'function') {
                     this.lazyStartPlugins.push(plugin);
                 }
             } catch (e) {
@@ -1509,18 +1509,10 @@ Oskari.clazz.define(
             this.lazyStartPlugins = [];
 
             tryStartingThese.forEach(function (plugin) {
-                let tryRedraw;
-                let tryLazyStart;
-                if (typeof plugin.redrawUI === 'function') {
-                    tryRedraw = plugin.redrawUI(me.getMobileMode(), !!force);
-                }
-                if (typeof plugin.lazyStartPlugin === 'function') {
-                    tryLazyStart = plugin.lazyStartPlugin();
-                }
-                if (tryRedraw || tryLazyStart) {
+                var tryAgainLater = plugin.redrawUI(me.getMobileMode(), !!force);
+                if (tryAgainLater) {
                     if (force) {
                         me.log.warn('Tried to force a start on plugin, but it still refused to start', plugin.getName());
-                        return;
                     }
                     me.lazyStartPlugins.push(plugin);
                 }

--- a/bundles/mapping/mapmodule/resources/locale/en.js
+++ b/bundles/mapping/mapmodule/resources/locale/en.js
@@ -124,6 +124,12 @@ Oskari.registerLocalization(
                 "center" : {
                     "tooltip": "Move to the original map view"
                 }
+            },
+            "Tiles3DLayerPlugin": {
+                "layerFilter": {
+                    "text": "3D layers",
+                    "tooltip": ""
+                }
             }
         },
         "guidedTour": {

--- a/bundles/mapping/mapmodule/resources/locale/fi.js
+++ b/bundles/mapping/mapmodule/resources/locale/fi.js
@@ -124,6 +124,12 @@ Oskari.registerLocalization(
                 "center" : {
                     "tooltip": "Palaa alkutilaan"
                 }
+            },
+            "Tiles3DLayerPlugin": {
+                "layerFilter": {
+                    "text": "3D-tasot",
+                    "tooltip": ""
+                }
             }
         },
         "guidedTour": {

--- a/bundles/mapping/mapmodule/resources/locale/sv.js
+++ b/bundles/mapping/mapmodule/resources/locale/sv.js
@@ -124,6 +124,12 @@ Oskari.registerLocalization(
                 "center" : {
                     "tooltip": "Gå tillbaka till standardvyn för kartvyn"
                 }
+            },
+            "Tiles3DLayerPlugin": {
+                "layerFilter": {
+                    "text": "3D kartlager",
+                    "tooltip": ""
+                }
             }
         },
         "guidedTour": {

--- a/bundles/mapping/tiles3d/plugin/Tiles3DLayerPlugin.js
+++ b/bundles/mapping/tiles3d/plugin/Tiles3DLayerPlugin.js
@@ -19,6 +19,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.Tiles3DLayerPlugin',
         __name: 'Tiles3DLayerPlugin',
         _clazz: 'Oskari.mapframework.mapmodule.Tiles3DLayerPlugin',
         layertype: 'tiles3d',
+        _layerFilterId: '3d',
 
         /**
          * Checks if the layer can be handled by this plugin
@@ -64,12 +65,37 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.Tiles3DLayerPlugin',
                 ]);
                 mapLayerService.registerLayerModel(registerType, clazz, composingModel);
                 mapLayerService.registerLayerModelBuilder(registerType, new Tiles3DModelBuilder());
+                // register layerlist filter for 3D layers
+                mapLayerService.registerLayerFilter(this._layerFilterId, (layer) => {
+                    return layer.isLayerOfType(this.layertype);
+                });
             }
             if (!this.getMapModule().getSupports3D()) {
                 return;
             }
             this._initTilesetClickHandler();
             applyCustomMaterialSettings();
+        },
+        _startPluginImpl: function () {
+            // Add layerlist filter button for 3D layers
+            const layerlistService = Oskari.getSandbox().getService('Oskari.mapframework.service.LayerlistService');
+            if (layerlistService) {
+                const id = this._layerFilterId;
+                layerlistService.registerLayerlistFilterButton(
+                    Oskari.getMsg('MapModule', 'plugin.Tiles3DLayerPlugin.layerFilter.text'),
+                    Oskari.getMsg('MapModule', 'plugin.Tiles3DLayerPlugin.layerFilter.tooltip'),
+                    {
+                        active: 'layer-' + id,
+                        deactive: 'layer-' + id + '-disabled'
+                    },
+                    id);
+            } else {
+                // layer service not ready, request lazy start
+                return true;
+            }
+        },
+        lazyStartPlugin: function () {
+            return this._startPluginImpl();
         },
         /**
          * @method _afterChangeMapLayerOpacityEvent

--- a/bundles/mapping/tiles3d/plugin/Tiles3DLayerPlugin.js
+++ b/bundles/mapping/tiles3d/plugin/Tiles3DLayerPlugin.js
@@ -70,32 +70,29 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.Tiles3DLayerPlugin',
                     return layer.isLayerOfType(this.layertype);
                 });
             }
+            this._registerForLayerFiltering();
             if (!this.getMapModule().getSupports3D()) {
                 return;
             }
             this._initTilesetClickHandler();
             applyCustomMaterialSettings();
         },
-        _startPluginImpl: function () {
-            // Add layerlist filter button for 3D layers
-            const layerlistService = Oskari.getSandbox().getService('Oskari.mapframework.service.LayerlistService');
-            if (layerlistService) {
-                const id = this._layerFilterId;
-                layerlistService.registerLayerlistFilterButton(
-                    Oskari.getMsg('MapModule', 'plugin.Tiles3DLayerPlugin.layerFilter.text'),
-                    Oskari.getMsg('MapModule', 'plugin.Tiles3DLayerPlugin.layerFilter.tooltip'),
-                    {
-                        active: 'layer-' + id,
-                        deactive: 'layer-' + id + '-disabled'
-                    },
-                    id);
-            } else {
-                // layer service not ready, request lazy start
-                return true;
-            }
-        },
-        lazyStartPlugin: function () {
-            return this._startPluginImpl();
+        _registerForLayerFiltering: function () {
+            // Add layerlist filter button for 3D layers after app is started
+            Oskari.on('app.start', () => {
+                const layerlistService = Oskari.getSandbox().getService('Oskari.mapframework.service.LayerlistService');
+                if (layerlistService) {
+                    const id = this._layerFilterId;
+                    layerlistService.registerLayerlistFilterButton(
+                        Oskari.getMsg('MapModule', 'plugin.Tiles3DLayerPlugin.layerFilter.text'),
+                        Oskari.getMsg('MapModule', 'plugin.Tiles3DLayerPlugin.layerFilter.tooltip'),
+                        {
+                            active: 'layer-' + id,
+                            deactive: 'layer-' + id + '-disabled'
+                        },
+                        id);
+                }
+            });
         },
         /**
          * @method _afterChangeMapLayerOpacityEvent


### PR DESCRIPTION
Add filter for 3d layers and button (option for select). LayerlistService isn't ready/registered when mapmodule's plugins are started/registered so made lazyStartPlugin functionality. I'm not sure if this is the right way to handle this.

Localization doesn't have tooltip text for 3d filter. Layerlist select options have both antd tooltip and normal tooltip. We should check tooltips and add tooltip text for 3d.