### PR TITLE
Screenshot fix

### DIFF
--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -350,12 +350,12 @@ export class MapModule extends AbstractMapModule {
                     return false;
                 }
                 // Don't include map controls to screenshot
-                return element.className ? element.className.indexOf('mapplugin') === -1 : true;
+                return element.className ? element.className.indexOf('ol-control') === -1 : true;
             }
         };
 
         me.getMap().once('rendercomplete', () => {
-            toPng(me.getMap().getTargetElement(), exportOptions).then((dataUrl) => {
+            toPng(me.getMap().getViewport(), exportOptions).then((dataUrl) => {
                 callback(dataUrl);
             }).catch(err => {
                 me.log.warn('Error producing a screenshot png data url: ' + err);


### PR DESCRIPTION
Pass viewport element instead of map element to toPng() to filter Oskari content away (mapplugins, progressbar, spinner, crosshair,..). 

Change className filter to filter ol-control elements away. Ol controls should be invisible but in openlayers example them are filttered:
https://openlayers.org/en/latest/examples/export-map.html

If we want to filter other elemets we could add oskari-ol-control class to elements or modify filtter.

![image](https://user-images.githubusercontent.com/22147092/75137321-f7a24200-56ef-11ea-89ad-3683ba241878.png)
