### PR TITLE
Refactor mylocation plugin

### DIFF
--- a/bundles/mapping/mapmodule/LocationModule.js
+++ b/bundles/mapping/mapmodule/LocationModule.js
@@ -144,8 +144,9 @@ export function getLocationCoords () {
     return _locationCoords;
 };
 export function stopUserLocationWatch () {
-    if (navigator.geolocation) {
+    if (navigator.geolocation && _locationWatch !== null) {
         navigator.geolocation.clearWatch(_locationWatch);
+        _locationWatch = null;
     }
 };
 

--- a/bundles/mapping/mapmodule/plugin/mylocation/MyLocationPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/mylocation/MyLocationPlugin.js
@@ -153,12 +153,13 @@ Oskari.clazz.define(
          */
         _setupRequest: function () {
             const opts = this._trackingOptions;
+            const sb = Oskari.getSandbox();
             if (opts) {
                 if (this._tracking) {
-                    this.getSandbox().postRequestByName('StopUserLocationTrackingRequest');
+                    sb.postRequestByName('StopUserLocationTrackingRequest');
                     this._setTracking(false);
                 } else {
-                    this.getSandbox().postRequestByName('StartUserLocationTrackingRequest', [opts]);
+                    sb.postRequestByName('StartUserLocationTrackingRequest', [opts]);
                     this._setTracking(true);
                 }
             } else if (!this._waiting) {

--- a/bundles/mapping/mapmodule/plugin/mylocation/MyLocationPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/mylocation/MyLocationPlugin.js
@@ -48,21 +48,21 @@ Oskari.clazz.define(
         /**
          * @private @method _createControlElement
          * Creates the DOM element that will be placed on the map
-         *
-         *
          * @return {jQuery}
          * Plugin jQuery element
          */
         _createControlElement: function () {
-            var me = this,
-                el = this._templates.plugin.clone();
-            el.on('click', function () {
-                me._toggleMode();
-            });
-
+            const el = this._templates.plugin.clone();
             el.attr('title', this.loc('plugin.MyLocationPlugin.tooltip'));
-
+            this._bindIcon(el);
+            this._element = el;
             return el;
+        },
+
+        _bindIcon: function (el) {
+            el.on('click', () => {
+                this._toggleMode();
+            });
         },
 
         /**
@@ -71,18 +71,16 @@ Oskari.clazz.define(
          *
          */
         _setLayerToolsEditModeImpl: function () {
-            var me = this;
-            if (!me.getElement()) {
+            const el = this.getElement();
+            if (!el) {
                 return;
             }
-            if (me.inLayerToolsEditMode()) {
+            if (this.inLayerToolsEditMode()) {
                 // disable icon
-                me.getElement().off('click');
+                el.off('click');
             } else {
                 // enable icon
-                me.getElement().on('click', function () {
-                    me._setupLocation();
-                });
+                this._bindIcon(el);
             }
         },
 
@@ -173,7 +171,6 @@ Oskari.clazz.define(
                 // no point in drawing the ui if we are not visible or enabled
                 return;
             }
-            var me = this;
             var mobileDefs = this.getMobileDefs();
 
             // don't do anything now if request is not available.
@@ -187,9 +184,9 @@ Oskari.clazz.define(
             if (!toolbarNotReady && mapInMobileMode) {
                 this.addToolbarButtons(mobileDefs.buttons, mobileDefs.buttonGroup);
             } else {
-                me._element = me._createControlElement();
-                me.refresh();
-                this.addToPluginContainer(me._element);
+                this._createControlElement();
+                this.refresh();
+                this.addToPluginContainer(this.getElement());
             }
 
             this._handleStartMode();


### PR DESCRIPTION
Fixes the issue where error location may cause unwanted mapmove if maps extent contains 0,0 coordinate (e.g. 3d map). Reason for this was that _checkIfOutsideViewport was outside of error handling and default mode (single) wasn't handled properly. Also UserLocationEvent sends null lon, lat if has errors which finally causes 0,0 coordinate.
https://oskari.org/api/events#unreleased/mapping/mapmodule/event/userlocationevent.md

Fixed also issue where first start tracking request didn't work. Atleast Firefox didn't like that clearWatch was called with null id.

I didn't like _toggleMode method which switches mode between 'single' and 'continuous' if configuration has 'continuous' mode. And with configured 'continuous' mode click fires single location request and start tracking request by turns without notifying user. If we were lucky and we got location then location is either added to map or map was centered. With errors we got popup with single request and nothing with tracking request. 

Now configured mode sets trakingOptions in _handleStartMode if 'continuous' and clicking icon either set tracking on or off. If tracking is on then icon style is toggled. Tracking mode has now error handling. CenterMapAutomatically uses longer timeout and doesn't inform on errors. Works like GeoLocationPlugin (except zoomlevel and highAccuracy). We could remove GeoLocationPlugin and add configuration for MyLocationPlugin if view contains GeoLocationPlugin.

Functionally changes are that stopping tracking doesn't fire single location request (continuous mode fires only start/stop tracking requests).

Should still work like documented in:
https://oskari.org/api/bundles#unreleased/mapping/mapmodule  =>  My Location Plugin
