### PR TITLE
Fix back button for admin wizard

### DIFF
--- a/bundles/admin/admin-layereditor/view/LayerWizard/LayerWizard.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard/LayerWizard.jsx
@@ -111,7 +111,7 @@ const LayerWizard = ({
                 }
                 { !isFirstStep && !isDetailsForOldLayer &&
                     <Button onClick={() => {
-                        setStep(controller, getStep(layer) - 1, hasCapabilitiesSupport);
+                        setStep(controller, currentStep - 1, hasCapabilitiesSupport);
                         onCancel();
                     }}>
                         {<Message messageKey='cancel'/>}


### PR DESCRIPTION
Fixes an issue where clicking "Previous" button on capabilities layer-listing step didn't do anything.