### PR TITLE
Better error messaging for capabilities parsing

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -133,6 +133,9 @@ Oskari.registerLocalization(
                 "errorFetchUserRolesAndPermissionTypes": "Error occured when fetching user roles and permission types.",
                 "errorFetchCapabilities": "Fetching service capabilities failed.",
                 "unauthorizedErrorFetchCapabilities": "Username and password are required by the service.",
+                "timeoutErrorFetchCapabilities": "Request timed out before getting response from service. Check the interface URL.",
+                "connectionErrorFetchCapabilities": "Connection could not be established to the service. Check the interface URL.",
+                "parsingErrorFetchCapabilities": "The response from the service didn't match the requested standard. Check the map layer type and/or version.",
                 "deleteSuccess" : "Deleted",
                 "deleteFailed" : "Delete failed"
             },

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -133,6 +133,9 @@ Oskari.registerLocalization(
                 "errorFetchUserRolesAndPermissionTypes": "Käyttäjäroolien ja käyttöoikeustyyppien haku ei onnistunut",
                 "errorFetchCapabilities": "Rajapinnan tietojen haku epäonnistui.",
                 "unauthorizedErrorFetchCapabilities": "Palvelu vaatii käyttäjätunnuksen ja salasanan.",
+                "timeoutErrorFetchCapabilities": "Pyyntö aikakatkaistiin ennen kuin palvelusta saatiin tietoja. Tarkista rajapinnan osoite.",
+                "connectionErrorFetchCapabilities": "Pyynnön lähettäminen palveluun ei onnistunut. Tarkista rajapinnan osoite.",
+                "parsingErrorFetchCapabilities": "Palvelusta saatua vastausta ei saatu tulkittua. Tarkista rajapinnan tyyppi ja versio.",
                 "deleteSuccess" : "Poistettu",
                 "deleteFailed" : "Poisto epäonnistui"
             },

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -544,7 +544,17 @@ class UIHandler extends StateHandler {
                 if (response.status === 401) {
                     Messaging.warn(getMessage('messages.unauthorizedErrorFetchCapabilities'));
                     this.updateState({ credentialsCollapseOpen: true });
+                } else if (response.status === 408) {
+                    // timeout when calling service
+                    Messaging.warn(getMessage('messages.timeoutErrorFetchCapabilities'));
+                } else if (response.status === 400) {
+                    // other connection issues when calling service
+                    Messaging.warn(getMessage('messages.connectionErrorFetchCapabilities'));
+                } else if (response.status === 417) {
+                    // response from the service was not what we expected/parsing problem
+                    Messaging.warn(getMessage('messages.parsingErrorFetchCapabilities'));
                 } else {
+                    // generic error
                     Messaging.error(getMessage('messages.errorFetchCapabilities'));
                 }
                 return Promise.reject(new Error('Capabilities fetching failed with status code ' + response.status + ' and text ' + response.statusText));


### PR DESCRIPTION
Provide admin information about timeout/connection issue/problems parsing the response in addition to credentials requirement/generic error message. Based on oskariorg/oskari-server#532 and oskariorg/oskari-server#533