### PR TITLE
Statistics indicator dropdown size

### DIFF
--- a/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorSelection.js
@@ -173,7 +173,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorSelection', function (
         var indicOptions = {
             placeholder: panelLoc.selectIndicatorPlaceholder,
             multi: true,
-            disabled: true
+            disabled: true,
+            allowOverflow: true
         };
         var indicSelect = new SelectList();
         var indicDropdown = indicSelect.create(null, indicOptions);

--- a/bundles/statistics/statsgrid2016/components/SelectList.js
+++ b/bundles/statistics/statsgrid2016/components/SelectList.js
@@ -71,25 +71,30 @@ export class SelectList extends FormComponent {
                     // Drowpdown's bottom is visible
                     return;
                 }
+                if (this.options.allowOverflow) {
+                    container.css('overflow', 'visible');
+                    return;
+                }
                 // Open up
                 dropdown.addClass('up');
-                if (dropdown.offset().top > containerTop + topMargin) {
+                const topOverflow = containerTop + topMargin - dropdown.offset().top;
+                if (topOverflow < 0) {
                     // Drowpdown's top is visible
                     return;
                 }
-                // Open starting from the top of the container
-                dropdown.removeClass('up');
-                dropdown.css('bottom', '');
-                dropdown.css('top', '0');
-                const top = containerTop - dropdown.offset().top + topMargin;
-                dropdown.css('top', top + 'px');
+                // Make dropdowns top visible by reducing option list height
+                const optsEl = dropdown.find('.options');
+                optsEl.css('max-height', optsEl.height() - topOverflow);
             });
             selected.on('sumo:closed', () => {
                 // reset previous settings
                 const dropdown = this._element.find('div.optWrapper');
+                if (this.options.allowOverflow) {
+                    dropdown.parents('div.oskari-flyoutcontentcontainer').css('overflow', '');
+                    return; // no need to modify css
+                }
                 dropdown.removeClass('up');
-                dropdown.css('top', '');
-                dropdown.css('bottom', '');
+                dropdown.find('.options').css('max-height', '');
             });
         }
     }

--- a/bundles/statistics/statsgrid2016/resources/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/resources/scss/style.scss
@@ -173,9 +173,7 @@ div.oskari-flyout {
         max-width: 700px;
         min-width: 400px;
 
-        label span {
-            /* Indicator selection form */
-            width: 200px;
+        .stats-series-selection {
             display: inline-block;
         }
 


### PR DESCRIPTION
Add allowOverflow option for selectList (sumo). When true flyout's container element overflow is set visible when dropdown is opened and removed when closed.

Also changed dropdown to decrease options list height if overflow isn't allowed and defined to open down.

Fixes the issue where dropdown is opened over search/select

![overflow](https://user-images.githubusercontent.com/22147092/75436620-8ff12e80-595d-11ea-90f0-4df5f72cff68.PNG)

![up](https://user-images.githubusercontent.com/22147092/75436618-8ec00180-595d-11ea-934f-2de8ea7b8aba.PNG)
