### PR TITLE
Layer admin UI tuning

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -69,6 +69,7 @@ Oskari.registerLocalization(
             "selectMapLayerGroupsButton": "Select groups",
             "cancel": "Cancel",
             "close": "Close",
+            "backToPrevious": "Back to previous step",
             "ok": "Ok",
             "add": "Add",
             "save": "Save",

--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -135,6 +135,7 @@ Oskari.registerLocalization(
                 "saveFailed": "A system error occurred. Data has not been updated.",
                 "confirmDeleteLayer": "The map layer will be removed. Do you want to continue?",
                 "confirmDeleteGroup": "The group will be removed. Do you want to continue?",
+                "confirmDuplicatedLayer": "The map layer has been registered previously. Are you sure you want to duplicate it?",
                 "errorRemoveLayer": "The map layer could not be removed.",
                 "errorInsertAllreadyExists": "The new map layer has been added. A map layer with same identifier already exists.",
                 "errorFetchUserRolesAndPermissionTypes": "Error occured when fetching user roles and permission types.",

--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -68,6 +68,7 @@ Oskari.registerLocalization(
             "mapLayerGroups": "Maplayer groups",
             "selectMapLayerGroupsButton": "Select groups",
             "cancel": "Cancel",
+            "close": "Close",
             "ok": "Ok",
             "add": "Add",
             "save": "Save",

--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -90,6 +90,11 @@ Oskari.registerLocalization(
                 "updateFailed": "Capablities re-check failed.",
                 "updateFailedWithReason": "Capablities re-check failed: {reason}"
             },
+            "layerStatus": {
+                "existing": "The map layer is already registered to this service. By selecting this you will be adding a duplicate layer.",
+                "problematic": "There were some issues parsing the capabilities for this layer. This layer might not work properly if added.",
+                "unsupported": "According to capabilities this layer doesn't support projections used on this service. This layer might not work properly if added."
+            },
             "opacity": "Opacity",
             "scale": "Scale",
             "metadataIdDesc": "The metadata file identifier is an XML file identifier. It is fetched automatically from the GetCapabilities response.",

--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -123,6 +123,7 @@ Oskari.registerLocalization(
             "validation": {
                 "dataprovider": "Dataprovider is mandatory.",
                 "nopermissions": "Layer doesn't have any permissions.",
+                "locale": "Name for end-user is mandatory.",
                 "styles" : "Invalid JSON syntax in Style definitions.",
                 "externalStyles" : "Invalid JSON syntax in 3rd party style definitions.",
                 "hover" : "Invalid JSON syntax in Feature highlighting and tooltip.",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -92,7 +92,7 @@ Oskari.registerLocalization(
                 "updateFailedWithReason": "GetCapabilities päivitys epäonnistui: {reason}"
             },
             "layerStatus": {
-                "existing": "Taso on jo rekisteröity palveluun",
+                "existing": "Taso on jo rekisteröity palveluun. Valitsemalla tämän tulet lisäämään saman tason useampaan kertaan.",
                 "problematic": "Tason capabilities parsinnassa ongelmia. Taso ei välttämättä toimi oikein.",
                 "unsupported": "Taso ei capabilitiesin mukaan tue käytössä olevia projektioita. Taso ei välttämättä toimi oikein."
             },
@@ -135,6 +135,7 @@ Oskari.registerLocalization(
                 "saveFailed": "Järjestelmässä tapahtui virhe. Tietoja ei ole tallennettu.",
                 "confirmDeleteLayer": "Karttataso poistetaan. Haluatko jatkaa?",
                 "confirmDeleteGroup": "Ryhmä poistetaan. Haluatko jatkaa?",
+                "confirmDuplicatedLayer": "Taso on jo rekisteröity palveluun. Haluatko varmasti lisätä saman tason moneen kertaan?",
                 "errorRemoveLayer": "Karttatason poisto ei onnistunut.",
                 "errorInsertAllreadyExists": "Uusi karttataso on lisätty. Samalla tunnisteella on jo olemassa karttataso.",
                 "errorFetchUserRolesAndPermissionTypes": "Käyttäjäroolien ja käyttöoikeustyyppien haku ei onnistunut",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -68,6 +68,7 @@ Oskari.registerLocalization(
             "mapLayerGroups": "Tason ryhmät",
             "selectMapLayerGroupsButton": "Valitse ryhmät",
             "cancel": "Peruuta",
+            "close": "Sulje",
             "ok": "Ok",
             "add": "Lisää",
             "save": "Tallenna",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -91,6 +91,11 @@ Oskari.registerLocalization(
                 "updateFailed": "GetCapabilities päivitys epäonnistui.",
                 "updateFailedWithReason": "GetCapabilities päivitys epäonnistui: {reason}"
             },
+            "layerStatus": {
+                "existing": "Taso on jo rekisteröity palveluun",
+                "problematic": "Tason capabilities parsinnassa ongelmia. Taso ei välttämättä toimi oikein.",
+                "unsupported": "Taso ei capabilitiesin mukaan tue käytössä olevia projektioita. Taso ei välttämättä toimi oikein."
+            },
             "scale": "Mittakaava",
             "metadataIdDesc": "Metatiedon tiedostotunniste on XML-muotoisen metatietotiedoston tiedostotunniste. Se haetaan automaattisesti GetCapabilities-vastausviestistä.",
             "metadataId": "Metatiedon tiedostotunniste",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -69,6 +69,7 @@ Oskari.registerLocalization(
             "selectMapLayerGroupsButton": "Valitse ryhmät",
             "cancel": "Peruuta",
             "close": "Sulje",
+            "backToPrevious": "Takaisin edelliseen vaiheeseen",
             "ok": "Ok",
             "add": "Lisää",
             "save": "Tallenna",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -123,6 +123,7 @@ Oskari.registerLocalization(
             "validation": {
                 "dataprovider": "Tiedontuottaja on pakollinen tieto.",
                 "nopermissions": "Tasolle ei ole asetettu oikeuksia",
+                "locale": "Tasolle ei ole annettu nimeä oletuskielelle.",
                 "styles" : "Tyylimääritysten JSON-syntaksi on virheellinen.",
                 "externalStyles" : "Kolmannen osapuolen tyylimääritysten JSON-syntaksi on virheellinen.",
                 "hover" : "Kohteen korostus ja tooltip JSON-syntaksi on virheellinen.",

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
@@ -82,7 +82,7 @@ const AdminLayerForm = ({
         }
         { onCancel &&
             <Button onClick={() => onCancel()}>
-                <Message messageKey='cancel'/>
+                <Message messageKey='close'/>
             </Button>
         }
     </StyledRoot>

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -462,6 +462,12 @@ class UIHandler extends StateHandler {
         if (!this.hasAnyPermissions(layer.role_permissions)) {
             validationErrors.push(getMessage('validation.nopermissions'));
         }
+        const loc = layer.locale || {};
+        const defaultLang = Oskari.getSupportedLanguages()[0];
+        const defaultLocale = loc[defaultLang] || {};
+        if (!defaultLocale.name) {
+            validationErrors.push(getMessage('validation.locale'));
+        }
         this.validateJsonValue(layer.tempStylesJSON, 'validation.styles', validationErrors);
         this.validateJsonValue(layer.tempExternalStylesJSON, 'validation.externalStyles', validationErrors);
         this.validateJsonValue(layer.tempHoverJSON, 'validation.hover', validationErrors);

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/DataProvider.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/DataProvider.jsx
@@ -6,7 +6,7 @@ import { StyledFormField } from '../styled';
 
 export const DataProvider = ({ layer, dataProviders, controller }) => (
     <Fragment>
-        <Message messageKey='dataProvider'/>
+        <Message messageKey='dataProvider'/> (*)
         <StyledFormField>
             <Select
                 showSearch

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/LocalizedNames.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/LocalizedNames.jsx
@@ -24,6 +24,9 @@ const getLabels = bundleKey => {
             subtitle: getMsg(`${langPrefix}.descplaceholder`, [language])
         };
     });
+    // mark mandatory field
+    const defaultLanguage = Oskari.getSupportedLanguages()[0];
+    labels[defaultLanguage].name = labels[defaultLanguage].name + ' (*)';
     return labels;
 };
 

--- a/bundles/admin/admin-layereditor/view/LayerWizard/LayerCapabilitiesListing.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard/LayerCapabilitiesListing.jsx
@@ -1,24 +1,13 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { List, ListItem, Popover } from 'oskari-ui';
+import { List, ListItem, Icon, Tooltip, Message } from 'oskari-ui';
 import { LayerCapabilitiesFilter } from './LayerCapabilitiesFilter';
 
 export const StyledListItem = styled(ListItem)`
 :hover {
-    color: white;
-    background-color: palevioletred;
+    background-color: #ffd400;
 }
-
-${({ item }) => item.isExisting && `
-background-color: palegreen;
-`}
-${({ item }) => item.isProblematic && `
-background-color: orange;
-`}
-${({ item }) => item.isUnsupported && `
-background-color: lightcoral;
-`}
 `;
 export const StylePopUl = styled.ul`
 max-width: 400px;
@@ -114,21 +103,26 @@ const filterLayers = (layers, filter) => {
 
 const getItem = (onSelect, item) => {
     return (
-        <Popover content={generateContent(item)} title={item.title} placement="right">
-            <StyledListItem onClick={() => onSelect(item.layer)} item={item}>
-                {item.layer.name} / {item.title}
-            </StyledListItem>
-        </Popover>
+        <StyledListItem onClick={() => onSelect(item.layer)} item={item}>
+            {item.layer.name} / {item.title} {getIcon(item)}
+        </StyledListItem>
     );
 };
 
-// FIXME: this is dummy content to show tech details/for debugging
-const generateContent = (item) => (
-    <StylePopUl>
-        <StylePopLi>Exists: {'' + item.isExisting}</StylePopLi>
-        <StylePopLi>Problematic: {'' + item.isProblematic}</StylePopLi>
-        <StylePopLi>Unsupported: {'' + item.isUnsupported}</StylePopLi>
-        <StylePopLi>{JSON.stringify(item.layer)}</StylePopLi>
-    </StylePopUl>
-
-);
+const getIcon = (item) => {
+    // <Tooltip title={message}>
+    if (item.isExisting) {
+        return (<Tooltip title={<Message key={item.name} messageKey="layerStatus.existing" />}>
+            <Icon type="check-circle" theme="twoTone" twoToneColor="#52c41a" />
+        </Tooltip>);
+    } else if (item.isProblematic) {
+        return (<Tooltip title={<Message key={item.name} messageKey="layerStatus.problematic" />}>
+            <Icon type="question-circle" theme="twoTone" twoToneColor="#ffde00" />
+        </Tooltip>);
+    } else if (item.isUnsupported) {
+        return (<Tooltip title={<Message key={item.name} messageKey="layerStatus.unsupported" />}>
+            <Icon type="warning" theme="twoTone" twoToneColor="#ab0000" />
+        </Tooltip>);
+    }
+    return null;
+};

--- a/bundles/admin/admin-layereditor/view/LayerWizard/LayerWizard.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard/LayerWizard.jsx
@@ -113,7 +113,7 @@ const LayerWizard = ({
                         setStep(controller, currentStep - 1, hasCapabilitiesSupport);
                         onCancel();
                     }}>
-                        {<Message messageKey='cancel'/>}
+                        {<Message messageKey='backToPrevious'/>}
                     </Button>
                 }
             </LoadingIndicator>

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerIcon.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerIcon.jsx
@@ -4,7 +4,7 @@ import { ImageLayerIcon, DataLayerIcon, UserDataIcon, ThreeDIcon } from './Custo
 
 // TODO replace logic with layer plugins registering their icons.
 export const LayerIcon = ({ type, ...rest }) => {
-    if (['wmts', 'wms'].includes(type)) {
+    if (['wmts', 'wms', 'arcgis93', 'arcgis'].includes(type)) {
         return <ImageLayerIcon {...rest} />;
     }
     if (['wfs'].includes(type)) {

--- a/src/react/util/extras/Messaging.js
+++ b/src/react/util/extras/Messaging.js
@@ -108,7 +108,7 @@ class Messaging {
         notification.config({
             placement: 'topLeft',
             top: 50,
-            duration: 4.5
+            duration: 10
         });
     }
     /** @param {Messaging~Options} option */


### PR DESCRIPTION
- Change button label on layer details form: Cancel -> Close
- Change button label on layer wizard for registering layer: Cancel -> Back to previous step
- Replaced different status colors on capabilities layer listing step with icons and tooltips
- Added confirm for duplicating a layer
- Added validation: end-user name is mandatory for default language
- Change layer icon to identify supported ArcGIS layer types and mark them as raster layers
- Add a dummy asterisk for mandatory fields (TODO: more elegant solution)
- Change default notification duration from 4.5s to 10s. (TODO: make admin notifications "sticky" so user has to acknowledge them in order for them to disappear?)