### PR TITLE
Remove deprecated SLD-handling

### DIFF
--- a/bundles/integration/admin-layerselector/templates/layer/wfslayerSettingsTemplateFooter.html
+++ b/bundles/integration/admin-layerselector/templates/layer/wfslayerSettingsTemplateFooter.html
@@ -1,6 +1,6 @@
 
 
-<div class="add-layer-record" <% if (!supportsWFS3) { %>style="display: none"<% } %>>
+<div class="add-layer-record">
     <% 
         var renderMode = model.getOptions() && model.getOptions().renderMode;
         var renderModeLoc = instance.getLocalization('admin').renderMode;
@@ -22,7 +22,7 @@
         </div>
     </div>
 </div>
-<div class="add-layer-record" <% if (!supportsWFS3) { %>style="display: none"<% } %>>
+<div class="add-layer-record">
     <%
         var styles = model.getMVTStylesWithoutSrcLayer();
         styles = styles ? JSON.stringify(styles) : '';
@@ -35,7 +35,7 @@
             placeholder="<%- instance.getLocalization('admin').mvtWfsOskariStylesDesc %>"><%=styles%></textarea>
     </div>
 </div>
-<div class="add-layer-record" <% if (!supportsWFS3) { %>style="display: none"<% } %>>
+<div class="add-layer-record">
     <% var hover = (_.isEmpty(model.getOptions()) || _.isEmpty(model.getOptions().hover)) ? '' : JSON.stringify(model.getOptions().hover); %>
     <div class="add-layer-label-area">
         <label class="add-layer-label" title="<%= instance.getLocalization('admin').mvtHover %>"><%= instance.getLocalization('admin').mvtHover %></label>
@@ -45,7 +45,7 @@
             placeholder="<%- instance.getLocalization('admin').mvtHoverDesc %>"><%=hover%></textarea>
     </div>
 </div>
-<div class="add-layer-record" <% if (!supportsWFS3) { %>style="display: none"<% } %>>
+<div class="add-layer-record">
     <% var clusteringDist = (_.isEmpty(model.getOptions()) || !model.getOptions().clusteringDistance) ? '' : model.getOptions().clusteringDistance; %>
     <div class="add-layer-label-area">
         <label class="add-layer-label" title="<%= instance.getLocalization('admin').clusteringDistance %>"><%= instance.getLocalization('admin').clusteringDistance %></label>
@@ -54,128 +54,4 @@
         <input type="text" class="add-layer-input small layer-options-clustering-distance" value="<%= clusteringDist %>" />&nbsp;px
     </div>
 </div>
-<% if (!supportsWFS3) { %>
-<div class="add-layer-record">
-    <div class="add-layer-label-area">
-        <label for="add-layer-sld-style" class="add-layer-label"  title="<%= instance.getLocalization('admin').addSldStyleDesc %>"><%= instance.getLocalization('admin').addSldStyle %></label>
-    </div>
-    <div class="add-layer-input-area">
-        <div class="input-controls">
-            <select id="add-layer-sld-style" class="admin-sld-styles" multiple="true">
-            </select>
-        </div>
-    </div>
-</div>
-<div class="add-style-send">
-    <div class="add-layer-button-area">
-        <div class="input-controls">
-    <button id="import-layer-style-button" class="import-wfs-style-button"><%= instance.getLocalization('admin').importStyle %></button>
-       </div>
-    </div>
-    <div class="add-layer-style-import-block">
-        <div class="add-layer-record">
-            <div class="add-layer-style-import-title" title="<%= instance.getLocalization('admin').addNewStyle %>"><%= instance.getLocalization('admin').addNewStyle %></div>
-        </div>
-
-    <div class="add-layer-record">
-        <div class="add-layer-label-area">
-            <label for="add-layer-sld-style-sldname" class="add-layer-sld-style-label"  title="<%= instance.getLocalization('admin').sldStyleName %>"><%= instance.getLocalization('admin').sldStyleName %></label>
-        </div>
-        <div class="add-layer-input-area">
-            <div class="style-controls">
-                <input type="text" id="add-layer-sld-style-sldname" class="add-layer-sld-style-sldname mid"
-                       placeholder="<%= instance.getLocalization('admin').sldStyleName %>"
-                       value= "<%= model.getLayerName() %>" />
-                <div class="icon-close mid"></div>
-            </div>
-        </div>
-    </div>
-    <div class="add-layer-record">
-        <div class="add-layer-label-area">
-            <label for="add-layer-sld-file" class="add-layer-sld-file-label"
-                   title="<%= instance.getLocalization('admin').sldFileContentDesc %>"><%= instance.getLocalization('admin').sldFileContent %></label>
-        </div>
-        <div class="add-layer-input-area">
-            <div class="style-controls">
-
-                <textarea rows="3" cols="50" id="add-layer-sld-file" class="add-sld-file long"></textarea>
-            </div>
-        </div>
-    </div>
-    <div class="add-layer-button-area">
-        <div class="style-controls">
-            <button id="import-layer-style-save-button" class="save-wfs-style-button"><%= instance.getLocalization('save') %></button>
-            <button id="import-layer-style-cancel-button" class="cancel-wfs-style-button"><%= instance.getLocalization('cancel') %></button>
-        </div>
-    </div>
-    </div>
-</div>
-<!-- div class="add-layer-record">
-    <button id="add-layer-wfs-button" class="edit-wfs-button"><%= instance.getLocalization('admin').editWfs %></button>
-</div -->
-<div class="add-layer-record">
-    <div class="add-layer-label-area">
-        <label for="add-layer-jobtype" class="add-class-label"
-               title="<%= instance.getLocalization('admin').jobTypeDesc %>"><%=
-            instance.getLocalization('admin').jobTypeDesc %></label>
-    </div>
-    <div class="add-layer-input-area adjacent">
-        <div class="input-controls">
-            <label><%= instance.getLocalization('admin').jobTypes["default"] %> <input type="radio" name="jobtype"
-                                                                                       id="layer-jobtype-default" <%
-                if(model.getVersion() == '1.1.0' ) { %>checked<% } %>
-                class="add-class-input" placeholder="placeholder" value="default" /></label>
-        </div>
-        <div class="input-controls">
-            <label><%= instance.getLocalization('admin').jobTypes["fe"] %> <input type="radio" name="jobtype"
-                                                                                  id="layer-jobtype-fe" <%
-                if(model.getVersion() == '2.0.0' ) { %>checked<% } %> class="add-class-input" placeholder="placeholder"
-                value="oskari-feature-engine" /></label>
-        </div>
-
-    </div>
-</div>
-<div class="add-layer-record">
-    <div class="add-layer-label-area">
-        <label for="add-layer-manualRefresh" class="add-class-label"
-        title="<%= instance.getLocalization('admin').manualRefresh %>"><%=
-        instance.getLocalization('admin').manualRefresh %></label>
-    </div>
-    <div class="add-layer-input-area adjacent">
-        <div class="input-controls">
-
-            <input
-                    type="checkbox"
-                    id="add-layer-manual-refresh"
-                    class="add-class-input"
-                    name="manualRefresh"
-                    placeholder="placeholder"
-            <% if (model.isManualRefresh()) { %>checked<% } %>
-            />
-        </div>
-
-    </div>
-</div>
-<div class="add-layer-record">
-    <div class="add-layer-label-area">
-        <label for="add-layer-resolveDepth" class="add-class-label"
-               title="<%= instance.getLocalization('admin').resolveDepth %>"><%=
-            instance.getLocalization('admin').resolveDepth %></label>
-    </div>
-    <div class="add-layer-input-area adjacent">
-        <div class="input-controls">
-
-            <input
-                    type="checkbox"
-                    id="add-layer-resolve-depth"
-                    class="add-class-input"
-                    name="resolveDepth"
-                    placeholder="placeholder"
-            <% if (model.isResolveDepth()) { %>checked<% } %>
-            />
-        </div>
-
-    </div>
-</div>
-<% } %>
 


### PR DESCRIPTION
And other fields for WFS-layers that are no longer used without the "transport" WFS-backend that was replaced by the new system.

Fixes an issue where the admin gets an error message with the old/current layer admin functionality when opening a WFS-layer for editing.