### PR TITLE
Error handling for opacity slider (in wrong place)

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/Footer/OpacitySlider.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/Footer/OpacitySlider.jsx
@@ -27,6 +27,14 @@ const StyledNumberInput = styled(NumberInput)`
 `;
 
 export const OpacitySlider = ({ value, onChange }) => {
+    if (typeof value === 'string') {
+        // defensive measures. Link parameters for layer opacity seems to be sent as string
+        // TODO: fix type issue at its source
+        value = parseInt(value, 10);
+        if (isNaN(value)) {
+            value = 100;
+        }
+    }
     const [sliderValue, setSliderValue] = useState(value);
     const [eventTimeout, setEventTimeout] = useState(null);
     const instantValueChange = val => {


### PR DESCRIPTION
Opacity in map link parameters are thrown in as strings to opacity slider which prints out 20 lines of error output as it expects to receive a number. This fixes the issue but it should be fixed at its root.