### PR TITLE
Only fetch WFS-layer selected attributes/locale once

### DIFF
--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/AbstractLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/AbstractLayerHandler.ol.js
@@ -84,8 +84,8 @@ export class AbstractLayerHandler {
         const { left, bottom, right, top } = this.plugin.getSandbox().getMap().getBbox();
         const propsList = this._getFeaturePropsInExtent(source, [left, bottom, right, top]);
         const fields = getFieldsArray(propsList);
-        // Update fields and locales only if fields is not empty and it has changed
-        if (fields && layer.getFields().length < fields.length) {
+        // Update fields and locales only if fields is empty
+        if (!layer.getFields().length) {
             this.plugin.setWFSProperties(layer, fields);
             return;
         }


### PR DESCRIPTION
The previous implementation didn't work if the layer was configured to NOT show every attribute it had. In that case the features on the map always have more data than we were showing -> triggering a new GetLocalizedPropertyNames query to the server all the time. Now we don't care if the features have more data and always just get the filter/locale once.

Note! This functionality needs a bit of refactoring on the client side as a whole. The selected attributes are currently stored in an array like the localizations but both are stored separately and they they need to have the same order and length to work properly etc. This is terrible but goes back to the system we previously had. TL;DR: This is a bandage.