### PR TITLE
Add another layer from same service after adding one

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -74,6 +74,7 @@ Oskari.registerLocalization(
             "add": "Add",
             "save": "Save",
             "skipCapabilities": "Add manually",
+            "addNewFromSameService": "Add a new layer from same service",
             "delete": "Remove",
             "style": "Default Style",
             "styleDesc": "Select a default style from the list. If there are several options, users can select a theme in the ‘Selected Layers’ menu.",

--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -73,6 +73,7 @@ Oskari.registerLocalization(
             "ok": "Ok",
             "add": "Add",
             "save": "Save",
+            "skipCapabilities": "Add manually",
             "delete": "Remove",
             "style": "Default Style",
             "styleDesc": "Select a default style from the list. If there are several options, users can select a theme in the ‘Selected Layers’ menu.",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -74,6 +74,7 @@ Oskari.registerLocalization(
             "add": "Lisää",
             "save": "Tallenna",
             "skipCapabilities": "Manuaalinen lisäys",
+            "addNewFromSameService": "Lisää uusi taso samasta palvelusta",
             "delete": "Poista",
             "opacity": "Peittävyys",
             "style": "Oletustyyli",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -73,6 +73,7 @@ Oskari.registerLocalization(
             "ok": "Ok",
             "add": "Lisää",
             "save": "Tallenna",
+            "skipCapabilities": "Manuaalinen lisäys",
             "delete": "Poista",
             "opacity": "Peittävyys",
             "style": "Oletustyyli",

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
@@ -24,8 +24,10 @@ const AdminLayerForm = ({
     getMessage,
     rolesAndPermissionTypes,
     scales
-}) => (
-    <StyledRoot>
+}) => {
+    // For returning to add multiple layers from service endpoint
+    const hasCapabilitiesFetched = !!Object.keys(capabilities).length;
+    return (<StyledRoot>
         { messages.map(({ key, type, args }) =>
             <StyledAlert key={key} type={type} message={
                 <Message messageKey={key} messageArgs={args}/>
@@ -68,25 +70,32 @@ const AdminLayerForm = ({
             <Message messageKey={layer.isNew ? 'add' : 'save'}/>
         </StyledButton>
         { !layer.isNew &&
-            <Confirm
-                title={<Message messageKey='messages.confirmDeleteLayer'/>}
-                onConfirm={() => onDelete()}
-                okText={getMessage('ok')}
-                cancelText={getMessage('cancel')}
-                placement='bottomLeft'
-            >
-                <StyledButton>
-                    <Message messageKey='delete'/>
-                </StyledButton>
-            </Confirm>
+            <React.Fragment>
+                <Confirm
+                    title={<Message messageKey='messages.confirmDeleteLayer'/>}
+                    onConfirm={() => onDelete()}
+                    okText={getMessage('ok')}
+                    cancelText={getMessage('cancel')}
+                    placement='bottomLeft'
+                >
+                    <StyledButton>
+                        <Message messageKey='delete'/>
+                    </StyledButton>
+                </Confirm>
+                { hasCapabilitiesFetched &&
+                    <StyledButton onClick={() => controller.addNewFromSameService() }>
+                        <Message messageKey='addNewFromSameService'/>
+                    </StyledButton>
+                }
+            </React.Fragment>
         }
         { onCancel &&
             <Button onClick={() => onCancel()}>
                 <Message messageKey='close'/>
             </Button>
         }
-    </StyledRoot>
-);
+    </StyledRoot>);
+};
 
 AdminLayerForm.propTypes = {
     controller: PropTypes.instanceOf(Controller).isRequired,

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -57,6 +57,12 @@ class UIHandler extends StateHandler {
     }
     versionSelected (version) {
         const layer = { ...this.getState().layer, version };
+        if (typeof version === 'undefined') {
+            // object spread doesn't work when removing value == returning from manually adding layer/skipping capabilities
+            delete layer.version;
+            // if we are returning we also need to clear name
+            delete layer.name;
+        }
         const propertyFields = this.getPropertyFields(layer);
         if (!version) {
             // for moving back to previous step
@@ -94,6 +100,16 @@ class UIHandler extends StateHandler {
         } else {
             this.log.error('Layer not in capabilities: ' + name);
         }
+    }
+    skipCapabilities () {
+        // force an OGC service to skip the capabilities phase of the wizard since some services are not standard compliant
+        // This is a last ditch effort to support such services.
+        const layer = {
+            name: '',
+            version: '',
+            ...this.getState().layer
+        };
+        this.updateState({ layer });
     }
     setUsername (username) {
         this.updateState({
@@ -712,6 +728,7 @@ const wrapped = controllerMixin(UIHandler, [
     'setUsername',
     'setVersion',
     'setTab',
+    'skipCapabilities',
     'updateCapabilities'
 ]);
 export { wrapped as AdminLayerFormHandler };

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -111,6 +111,19 @@ class UIHandler extends StateHandler {
         };
         this.updateState({ layer });
     }
+    addNewFromSameService () {
+        // initialize state for adding a new layer from the same OGC service (service having capabilities)
+        const state = this.getState();
+        const layer = { ...state.layer };
+        const capabilities = state.capabilities || { existingLayers: {} };
+        // add newly added layer to "existing layers" so it's shown as existing
+        capabilities.existingLayers[layer.name] = state.layer;
+        // delete name for "new" layer so we are taken back to the capabilities layer listing
+        delete layer.name;
+        // delete layer id so we won't modify the one we just added
+        delete layer.id;
+        this.updateState({ layer, capabilities });
+    }
     setUsername (username) {
         this.updateState({
             layer: { ...this.getState().layer, username }
@@ -385,7 +398,7 @@ class UIHandler extends StateHandler {
             return response.json();
         }).then(json => {
             const typesAndRoles = this.getRolesAndPermissionTypes() || {};
-            const { capabilities, ...layer } = this.layerHelper.fromServer(json, {
+            const { ...layer } = this.layerHelper.fromServer(json, {
                 preserve: ['capabilities'],
                 roles: typesAndRoles.roles
             });
@@ -396,7 +409,6 @@ class UIHandler extends StateHandler {
             }
             this.updateState({
                 layer,
-                capabilities,
                 propertyFields: this.getPropertyFields(layer),
                 versions: this.mapLayerService.getVersionsForType(layer.type)
             });
@@ -690,10 +702,8 @@ class UIHandler extends StateHandler {
 }
 
 const wrapped = controllerMixin(UIHandler, [
-    'setPermissionForAll',
-    'togglePermission',
+    'addNewFromSameService',
     'layerSelected',
-    'versionSelected',
     'setAttributes',
     'setAttributionsJSON',
     'setCapabilitiesUpdateRate',
@@ -717,6 +727,7 @@ const wrapped = controllerMixin(UIHandler, [
     'setOpacity',
     'setOptions',
     'setPassword',
+    'setPermissionForAll',
     'setRealtime',
     'setRefreshRate',
     'setRenderMode',
@@ -729,6 +740,8 @@ const wrapped = controllerMixin(UIHandler, [
     'setVersion',
     'setTab',
     'skipCapabilities',
-    'updateCapabilities'
+    'togglePermission',
+    'updateCapabilities',
+    'versionSelected'
 ]);
 export { wrapped as AdminLayerFormHandler };

--- a/bundles/admin/admin-layereditor/view/LayerWizard/LayerWizard.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard/LayerWizard.jsx
@@ -61,6 +61,8 @@ const LayerWizard = ({
     onCancel
 }) => {
     const hasCapabilitiesSupport = propertyFields.includes(CAPABILITIES);
+    // For manual adding of layers/skipping capabilities and returning properly from layer details to service endpoint
+    const hasCapabilitiesFetched = !!Object.keys(capabilities).length;
     const currentStep = getStep(layer, hasCapabilitiesSupport);
     const isFirstStep = currentStep === WIZARD_STEP.INITIAL;
     const isDetailsForOldLayer = !layer.isNew && currentStep === WIZARD_STEP.DETAILS;
@@ -110,7 +112,7 @@ const LayerWizard = ({
                 }
                 { !isFirstStep && !isDetailsForOldLayer &&
                     <Button onClick={() => {
-                        setStep(controller, currentStep - 1, hasCapabilitiesSupport);
+                        setStep(controller, currentStep - 1, hasCapabilitiesFetched && hasCapabilitiesSupport);
                         onCancel();
                     }}>
                         {<Message messageKey='backToPrevious'/>}

--- a/bundles/admin/admin-layereditor/view/LayerWizard/ServiceStep.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard/ServiceStep.jsx
@@ -2,13 +2,14 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Message } from 'oskari-ui';
 import { Controller } from 'oskari-ui/util';
-import { Header, StyledButton } from './styled';
+import { Header, StyledButton, DangerButton } from './styled';
 import { ServiceEndPoint } from '../ServiceEndPoint/ServiceEndPoint';
 
 const {
     URL,
     CESIUM_ION,
-    API_KEY
+    API_KEY,
+    CAPABILITIES
 } = Oskari.clazz.get('Oskari.mapframework.domain.LayerComposingModel');
 
 const hasServiceEndpoint = ({ url, options }, propertyFields) => {
@@ -37,6 +38,7 @@ VersionButton.propTypes = {
 
 export const ServiceStep = ({ layer, controller, versions, propertyFields, loading, credentialsCollapseOpen }) => {
     const versionsDisabled = !hasServiceEndpoint(layer, propertyFields) || loading;
+    const hasCapabilitiesSupport = propertyFields.includes(CAPABILITIES);
     if (versions.length === 0) {
         versions.push('');
     }
@@ -55,6 +57,11 @@ export const ServiceStep = ({ layer, controller, versions, propertyFields, loadi
             { versions.map((version, i) => (
                 <VersionButton key={i} version={version} controller={controller} disabled={versionsDisabled} />
             )) }
+            { hasCapabilitiesSupport &&
+                <DangerButton onClick={() => controller.skipCapabilities()}>
+                    <Message messageKey='skipCapabilities'/>
+                </DangerButton>
+            }
         </Fragment>
     );
 };

--- a/bundles/admin/admin-layereditor/view/LayerWizard/styled.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard/styled.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import { Steps } from 'oskari-ui';
 import styled from 'styled-components';
+import { StyledAlert, StyledButton } from '../styled';
 
-export { StyledAlert, StyledButton } from '../styled';
+export { StyledAlert, StyledButton };
 
 export const Header = styled('h4')``;
 export const Paragraph = styled('p')``;
+
+export const DangerButton = styled(StyledButton)`
+    border-color: #da5151;
+    background-color: #fff1f1;
+`;
 
 const StepsWrapper = styled('div')`
     margin-top: 10px;

--- a/bundles/admin/admin-layereditor/view/styled.jsx
+++ b/bundles/admin/admin-layereditor/view/styled.jsx
@@ -7,6 +7,7 @@ export const StyledAlert = styled(Alert)`;
 
 export const StyledButton = styled(Button)`
     margin-right: 5px;
+    margin-bottom: 5px;
 `;
 
 export const StyledFormField = styled('div')`


### PR DESCRIPTION
Note! Includes commits from #1216

Allow the user to return to capabilities layer listing and select a new layer to add after adding one. Only when adding layers and to services having capabilities  (==capabilities have already been loaded to frontend). In the future we could add support for adding a new layer when editing an existing one but this is a good first step.