### PR TITLE
Layer permissions layout

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionsTabPane/PermissionRow.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionsTabPane/PermissionRow.jsx
@@ -4,8 +4,10 @@ import styled from 'styled-components';
 
 const RowContainer = styled.div`
     display: flex;
-    flex-wrap: wrap;
 `;
+// Add `flex-wrap:wrap;` to let divs inside a row to break/flow to additional rows.
+// Note! This breaks the "table" so it's hard for user to see what permission is being set.
+// Note! Handle table wider than display with another kind of UI (like listing roles as headings and permissions as list under that heading)
 
 const TextColumn = styled.div`
     flex-grow: 1;

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionsTabPane/PermissionRow.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionsTabPane/PermissionRow.jsx
@@ -9,21 +9,31 @@ const RowContainer = styled.div`
 // Note! This breaks the "table" so it's hard for user to see what permission is being set.
 // Note! Handle table wider than display with another kind of UI (like listing roles as headings and permissions as list under that heading)
 
+export const TEXT_COLUMN_SIZE = {
+    width: 195,
+    padding: 5
+};
+
+export const PERMISSION_TYPE_COLUMN_SIZE = {
+    width: 110,
+    padding: 5
+};
+
 const TextColumn = styled.div`
     flex-grow: 1;
-    width: 195px;
-    padding-left: 5px;
+    width: ${TEXT_COLUMN_SIZE.width}px;
+    padding-left: ${TEXT_COLUMN_SIZE.padding}px;
     align-self: ${props => props.isHeaderRow ? 'flex-end' : 'stretch'};
 `;
 
 const StyledPermissionDiv = styled.div`
     flex-grow: 1;
     float: left;
-    width: 110px;
+    width: ${PERMISSION_TYPE_COLUMN_SIZE.width}px;
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
-    padding: 5px !important;
+    padding: ${PERMISSION_TYPE_COLUMN_SIZE.padding}px !important;
 `;
 
 const Break = styled.div`

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionsTabPane/PermissionsTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionsTabPane/PermissionsTabPane.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { PermissionRow } from './PermissionRow';
-import { List, ListItem, Checkbox, Message } from 'oskari-ui';
+import { List, ListItem, Checkbox, Message, Tooltip } from 'oskari-ui';
 import { LocaleConsumer, Controller } from 'oskari-ui/util';
 
 const StyledListItem = styled(ListItem)`
@@ -89,12 +89,15 @@ const PermissionsTabPane = ({ rolesAndPermissionTypes, permissions = {}, control
             }
             // the actual role-based rows
             const role = modelRow.role.name;
-            return <Checkbox key={permission.id + '_' + role}
-                permissionDescription={permission.localizedText}
-                permission={permission.id}
-                role={role}
-                checked={modelRow.permissions.includes(permission.id)}
-                onChange = {(event) => controller.togglePermission(event.target.role, event.target.permission)}/>;
+            return (<Tooltip key={permission.id + '_' + role}
+                title={permission.localizedText}>
+                <Checkbox
+                    permissionDescription={permission.localizedText}
+                    permission={permission.id}
+                    role={role}
+                    checked={modelRow.permissions.includes(permission.id)}
+                    onChange = {(event) => controller.togglePermission(event.target.role, event.target.permission)}/>
+            </Tooltip>);
         });
 
         const rowKey = modelRow.isHeaderRow ? 'header' : modelRow.role.name;

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionsTabPane/PermissionsTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionsTabPane/PermissionsTabPane.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { PermissionRow } from './PermissionRow';
+import { PermissionRow, TEXT_COLUMN_SIZE, PERMISSION_TYPE_COLUMN_SIZE } from './PermissionRow';
 import { List, ListItem, Checkbox, Message, Tooltip } from 'oskari-ui';
 import { LocaleConsumer, Controller } from 'oskari-ui/util';
 
@@ -17,10 +17,15 @@ const StyledListItem = styled(ListItem)`
             background-color: #f3f3f3;
         }
     }
+    width: ${props => props.rowWidth}px;
 `;
 
+// Overflow makes additional/customized permission types available by scrolling
+// It is not ideal at least when there are both many roles and additional permission types
+// But most instances don't have them so it's not a huge issue for first version of the UI
 const ListDiv = styled.div`
-    padding-bottom: 20px;
+    margin-bottom: 20px;
+    overflow: auto;
 `;
 
 function getHeaderPermissions (dataRows, roles) {
@@ -53,7 +58,8 @@ const PermissionsTabPane = ({ rolesAndPermissionTypes, permissions = {}, control
     const { roles, permissionTypes } = rolesAndPermissionTypes;
 
     const localizedPermissionTypes = permissionTypes.map(permission => {
-        permission.localizedText = <Message messageKey={`rights.${permission.id}`} defaultMsg={permission.id} />;
+        // permissions might have server side localization as "name" that defaults to id if not given
+        permission.localizedText = <Message messageKey={`rights.${permission.id}`} defaultMsg={permission.name} />;
         return permission;
     });
 
@@ -73,7 +79,6 @@ const PermissionsTabPane = ({ rolesAndPermissionTypes, permissions = {}, control
         permissions: getHeaderPermissions(dataRows, roles),
         permissionTypes: localizedPermissionTypes
     };
-
     const permissionDataModel = [headerRow, ...dataRows];
 
     const renderRow = (modelRow) => {
@@ -90,7 +95,7 @@ const PermissionsTabPane = ({ rolesAndPermissionTypes, permissions = {}, control
             // the actual role-based rows
             const role = modelRow.role.name;
             return (<Tooltip key={permission.id + '_' + role}
-                title={permission.localizedText}>
+                title={<span>{role}: {permission.localizedText}</span>}>
                 <Checkbox
                     permissionDescription={permission.localizedText}
                     permission={permission.id}
@@ -101,8 +106,12 @@ const PermissionsTabPane = ({ rolesAndPermissionTypes, permissions = {}, control
         });
 
         const rowKey = modelRow.isHeaderRow ? 'header' : modelRow.role.name;
+        // calculate width in case there are additional permission types the background isn't colored properly without it
+        // 200 for role name column and 120/permission type (110 + 5 padding on both side)
+        const rowWidth = (TEXT_COLUMN_SIZE.width + TEXT_COLUMN_SIZE.padding) +
+            (PERMISSION_TYPE_COLUMN_SIZE.width + PERMISSION_TYPE_COLUMN_SIZE.padding * 2) * headerRow.permissionTypes.length;
         return (
-            <StyledListItem>
+            <StyledListItem rowWidth={rowWidth}>
                 <PermissionRow key={rowKey} isHeaderRow={modelRow.isHeaderRow} text={modelRow.text} checkboxes={checkboxes}/>
             </StyledListItem>
         );


### PR DESCRIPTION
Add tooltips for permission checkboxes so it's easier to see what is being selected if the UI breaks from table format.

Make permissions table side-scrolling to support added/customized permission types. It isn't perfect but using default permission types there's no side-scrolling.