### PR TITLE
Statistics diagram resize fix

### DIFF
--- a/bundles/framework/divmanazer/extension/ExtraFlyout.js
+++ b/bundles/framework/divmanazer/extension/ExtraFlyout.js
@@ -203,6 +203,13 @@ Oskari.clazz.define('Oskari.userinterface.extension.ExtraFlyout',
                 'top': top
             });
         },
+        showOnPosition: function () {
+            const { position } = this.getOptions();
+            if (position) {
+                this.move(position.x, position.y, true);
+            }
+            this.show();
+        },
         getPosition: function () {
             if (!this._popup) {
                 return;

--- a/bundles/framework/divmanazer/extension/ExtraFlyout.js
+++ b/bundles/framework/divmanazer/extension/ExtraFlyout.js
@@ -16,7 +16,6 @@ Oskari.clazz.define('Oskari.userinterface.extension.ExtraFlyout',
         // UI text for title
         this.title = title;
         this._visible = true;
-        this._resizable = false;
         this._popup = null;
         /* @property container the DIV element */
         this.container = null;
@@ -64,7 +63,7 @@ Oskari.clazz.define('Oskari.userinterface.extension.ExtraFlyout',
             return this._visible;
         },
         isResizable: function () {
-            return this._resizable;
+            return this.options.resizable === true;
         },
         show: function () {
             var me = this;
@@ -103,7 +102,7 @@ Oskari.clazz.define('Oskari.userinterface.extension.ExtraFlyout',
                 });
                 me._popup = popup;
                 me.bringToTop();
-                me._popup.on('click', function () {
+                me._popup.on('mousedown', function () {
                     me.bringToTop();
                 });
                 me.hide(true);
@@ -121,7 +120,7 @@ Oskari.clazz.define('Oskari.userinterface.extension.ExtraFlyout',
             var me = this;
             this._popup = this.__templates.popup.clone();
 
-            this._popup.on('click', function () {
+            this._popup.on('mousedown', function () {
                 me.bringToTop();
             });
             this.setTitle(this.title);
@@ -215,7 +214,7 @@ Oskari.clazz.define('Oskari.userinterface.extension.ExtraFlyout',
                 return;
             }
             return {
-                width: this._popup.outerWidth(),
+                width: this._popup.width(),
                 height: this._popup.height()
             };
         },
@@ -238,10 +237,6 @@ Oskari.clazz.define('Oskari.userinterface.extension.ExtraFlyout',
             me._popup.draggable({
                 scroll: !!options.scroll,
                 handle: options.handle || '.oskari-flyouttoolbar',
-                start: function () {
-                    // bring this flyout to top when user starts dragging it
-                    me.bringToTop();
-                },
                 stop: function () {
                     // prevent to drag flyout's toolbar out of the viewport's top
                     if (me._popup.position().top < 0) {
@@ -255,34 +250,36 @@ Oskari.clazz.define('Oskari.userinterface.extension.ExtraFlyout',
          * Makes dialog resizable with jQuery
          * @param opts optional options for resizing
          */
-        makeResizable: function (opts) {
+        makeResizable: function (opts = {}) {
             var me = this;
-            opts = opts || {};
-            me.options.resizable = true;
-            me._popup.resizable({
-                minWidth: opts.minWidth || 630,
-                minHeight: opts.minHeight || 400,
-                scroll: !!opts.scroll,
-                handles: opts.handles || 'n,e,s,w,ne,nw,se,sw',
-                handle: opts.handle || '.oskari-flyouttoolbar',
-                start: function () {
-                    // bring this flyout to top when user starts dragging it
-                    me.bringToTop();
-                },
+            this.options.resizable = true;
+            const defaults = {
+                minWidth: 300,
+                minHeight: 200,
+                handles: 'n,e,s,w,ne,nw,se,sw',
+                containment: 'document'
+            };
+            const resizeOpts = { ...defaults, ...opts };
+            const el = this.getElement();
+            el.resizable({
+                ...resizeOpts,
                 stop: function () {
-                    me.options.width = jQuery(this).width();
-                    me.options.height = jQuery(this).height();
-                    me.__render();
-                    me.trigger('resize', me.options);
+                    me.trigger('resize', { ...me.getSize() });
                 }
             });
-            this._resizable = true;
+            // set min size to element, so it can't be smaller than with resize
+            el.css('min-width', resizeOpts.minWidth);
+            el.css('min-height', resizeOpts.minHeight);
+            el.find('.oskari-flyoutcontentcontainer').css('max-height', 'none');
         },
         getElement: function () {
             return this._popup;
         },
         getContent: function () {
             return this._popup.find('.oskari-flyoutcontent');
+        },
+        getOptions: function () {
+            return this.options;
         },
 
         /************************************************************************************************

--- a/bundles/statistics/statsgrid2016/components/Diagram.js
+++ b/bundles/statistics/statsgrid2016/components/Diagram.js
@@ -275,5 +275,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Diagram', function (service, lo
         this.service.on('StatsGrid.RegionsetChangedEvent', function () {
             me.updateUI();
         });
+        this.service.on('StatsGrid.ClassificationChangedEvent', function () {
+            me.updateUI();
+        });
     }
 });

--- a/bundles/statistics/statsgrid2016/components/SelectedIndicatorsMenu.js
+++ b/bundles/statistics/statsgrid2016/components/SelectedIndicatorsMenu.js
@@ -48,7 +48,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SelectedIndicatorsMenu', functi
             me.dropdown = dropdown;
             dropdown.css({
                 width: '100%',
-                'max-width': '400px'
+                'max-width': '380px'
             });
             select.adjustChosen();
 

--- a/bundles/statistics/statsgrid2016/resources/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/resources/scss/style.scss
@@ -545,34 +545,43 @@ div.oskari-flyout {
     * Diagram styles
     * ********************************************/
      &.statsgrid-diagram-flyout {
+        .oskari-flyoutcontentcontainer {
+            overflow: visible;
+            display: flex;
+        }
+        // remove padding to calculate chart size and margins
         .oskari-datacharts {
             position: relative;
-            padding: $flyoutPadding;
+            padding: 0;
             flex: 1;
-            overflow-y: auto;
         }
         .chart-controls {
             display:flex;
             justify-content: center;
             align-items: center;
-            padding: 7px;
+            padding: 20px 20px 28px;
 
            .dropdown {
                 display: flex;
                 max-width: 100%;
            }
         }
+        .chart {
+            overflow-y: auto;
+            display: flex;
+            justify-content: center;
+        }
+        .axisLabel {
+            margin-top: -15px;
+            position: absolute;
+            opacity: 0.8;
+        }
+        .stats-diagram-holder {
+            display: flex;
+            flex-direction: column;
+            align-items: stretch;
+        }
     }
-    .stats-diagram-holder {
-        display: flex;
-        flex-direction: column;
-        align-items: stretch;
-    }
-}
-
-.statsgrid-diagram-flyout .oskari-flyoutcontentcontainer {
-    overflow: visible;
-    display: flex;
 }
 
 /** Toggle buttons */
@@ -814,27 +823,6 @@ div.tab-material-controls div.title {
         padding-top:2em !important;
     }
 }
-.chart {
-    display: flex;
-    justify-content: center;
-}
-.axisLabel {
-    margin-top: -5px;
-    position: absolute;
-    opacity: 0.8;
-}
-.sticky {
-    font-weight: bold;
-    color:#F6F6F6;
-    text-shadow: -1px 0 white, 0 1px white, 1px 0 white, 0 -1px white;
-    overflow: hidden;
-    z-index: 3;
-    max-height: 100%;
-}
-
-.statsgrid-diagram-flyout .oskari-flyoutcontentcontainer {
-    max-width:700px;
-  }
 
 /* ********************************************
  * User indicator form

--- a/bundles/statistics/statsgrid2016/view/DiagramFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/DiagramFlyout.js
@@ -13,20 +13,18 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.DiagramFlyout', function (
         if (!me.getUiElement()) {
             me.createUi();
             me.setContent(me.getUiElement());
-            me.scroll();
         }
     });
-    this.on('resize', function (options) {
-        me._diagram.render(me.getElement().find('.chart'), options);
+    this.on('resize', function (size) {
+        const diagramSize = me.calculateDiagramSize(size);
+        me._diagram.resizeUI(diagramSize);
     });
 }, {
     _template: {
         container: jQuery('<div class="stats-diagram-holder">' +
             '   <div class="chart-controls"></div>' +
-            '   <div class="oskari-datacharts">' +
-            '       <div class="chart">' +
-            '           <div class="axisLabel"></div>' +
-            '       </div>' +
+            '   <div class="chart">' +
+            '       <div class="axisLabel"></div>' +
             '   </div>' +
             '</div>')
     },
@@ -36,9 +34,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.DiagramFlyout', function (
     getUiElement: function () {
         return this.uiElement;
     },
-    scroll: function () {
-        var axisLabel = jQuery('.axisLabel');
-        jQuery(jQuery('.statsgrid-diagram-flyout .oskari-datacharts')).scroll(function () {
+    scroll: function (el) {
+        const axisLabel = el.find('.axisLabel');
+        const chart = el.find('.chart');
+        chart.scroll(function () {
             var scrollAmount = jQuery(this).scrollTop();
             // 14 is the 2% padding-bottom
             if (scrollAmount >= 14) {
@@ -62,14 +61,35 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.DiagramFlyout', function (
         var el = this._template.container.clone();
         this.addClassForContent('oskari-datacharts');
         // this.loc.datacharts.indicatorVar as label?
-        this._indicatorSelector.render(el.find('.chart-controls'));
+        const controls = el.find('.chart-controls');
+        this._indicatorSelector.render(controls);
         this._indicatorSelector.setDropdownWidth('70%');
         this._diagram.createDataSortOption(el.find('.chart-controls .dropdown'));
         // this.loc.datacharts.descColor
         // Oskari.clazz.define('Oskari.statistics.statsgrid.SelectedIndicatorsMenu');
-        var options = { resizable: this.isResizable() };
-        this._diagram.render(el.find('.chart'), options);
+        const diagramSize = this.calculateDiagramSize();
+        this._diagram.render(el.find('.chart'), diagramSize);
         this.setUiElement(el);
+    },
+    /**
+     * @method calculateDiagramSize
+     * @param  {Object} size flyout size
+     * Calculates height for diagram and width for chart
+     * if flyout size isn't given then uses window height
+     */
+    calculateDiagramSize: function (size) {
+        const height = size ? size.height : window.innerHeight - 100;
+        const width = size ? size.width : this.getSize().width;
+        return {
+            maxHeight: this.calculateHeightForContent(height),
+            width: width - 20
+        };
+    },
+    calculateHeightForContent: function (height) {
+        const el = this.getElement();
+        const controls = el.find('.chart-controls').outerHeight() || 73;
+        const toolbar = el.find('.oskari-flyouttoolbar').outerHeight() || 57;
+        return height - controls + toolbar;
     }
 }, {
     extend: ['Oskari.userinterface.extension.ExtraFlyout']

--- a/bundles/statistics/statsgrid2016/view/DiagramFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/DiagramFlyout.js
@@ -34,25 +34,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.DiagramFlyout', function (
     getUiElement: function () {
         return this.uiElement;
     },
-    scroll: function (el) {
-        const axisLabel = el.find('.axisLabel');
-        const chart = el.find('.chart');
-        chart.scroll(function () {
-            var scrollAmount = jQuery(this).scrollTop();
-            // 14 is the 2% padding-bottom
-            if (scrollAmount >= 14) {
-                axisLabel.addClass('sticky');
-                axisLabel.css('margin-top', function () {
-                    return scrollAmount - 15;
-                });
-            } else {
-                if (axisLabel.hasClass('sticky')) {
-                    axisLabel.removeClass('sticky');
-                    axisLabel.css('margin-top', '');
-                }
-            }
-        });
-    },
     createUi: function () {
         if (this.getUiElement()) {
             // already created ui

--- a/bundles/statistics/statsgrid2016/view/DiagramFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/DiagramFlyout.js
@@ -70,7 +70,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.DiagramFlyout', function (
         const el = this.getElement();
         const controls = el.find('.chart-controls').outerHeight() || 73;
         const toolbar = el.find('.oskari-flyouttoolbar').outerHeight() || 57;
-        return height - controls + toolbar;
+        return height - controls - toolbar;
     }
 }, {
     extend: ['Oskari.userinterface.extension.ExtraFlyout']

--- a/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
@@ -53,8 +53,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
         }
         this.datasourceId = datasourceId;
         this.indicatorId = indicatorId;
-        this.show();
         this.createUi();
+        this.showOnPosition();
 
         // set empty values to focus on name field
         this.indicatorForm.setValues();
@@ -183,9 +183,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
             });
         });
         this.setContent(this.uiElement);
-        // options.pos.x/y is injected by FlyoutManager and without
-        // explicit call to move() the flyout opens in seemingly random locations (out of screen etc)
-        this.move(this.options.pos.x, this.options.pos.y, true);
     },
     setSpinnerVisible: function (show) {
         this.uiElement.find('.spinner-holder').css('height', show ? '100px' : '0');


### PR DESCRIPTION
Fixes issue where select (chosen) changes flyout's overflow properties and diagram/chart overflows outside flyout's content. Also diagram controls and x-labels doesn't stay visible while scrolling. Now max-width is set for diagram/chart content so scroll is added to scroll content only. Controls and x-labels stay visible and doesn't have to calculate margin-top for x-labels while scrolling.
https://github.com/oskariorg/oskari-docs/issues/155

Fixes another issue where diagram were rendered wrongly on flyout resize. 

Removed this.resizable from chart.js. It has only to render chart from given size. Doesn't have to know if parent component is resizable. Also changed to use options which contains default values and calculate dimension in one place. Removed ratio calculation and changed to use d3 to get smaller margins if labels is inside chart (actual cutted labels are calculated same way that reserved space for margins).

Extra-flyout sends only size on resize (not options) and doesn't override options. Removed bringToTop from drag and resize and changed click to mousedown. So bringToTop is called only once.

![image](https://user-images.githubusercontent.com/22147092/76831662-67f43d00-6830-11ea-99ef-39c03e7e6466.png)
