### PR TITLE
Fix/minor fixes

### DIFF
--- a/bundles/framework/publisher2/view/PanelMapLayers.js
+++ b/bundles/framework/publisher2/view/PanelMapLayers.js
@@ -53,7 +53,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapLayers',
                 '  <div class="oskariui layer-opacity">' +
                 '    <div class="layout-slider" id="layout-slider"></div> ' +
                 '    <div class="opacity-slider" style="display:inline-block">' +
-                '      <input type="text" name="opacity-slider" class="opacity-slider opacity" id="opacity-slider" />%' +
+                '      <input type="text" name="opacity-slider" class="opacity-slider opacity" />%' +
                 '    </div>' +
                 '  </div>' +
                 '  <br/>' +

--- a/bundles/framework/timeseries/WMSAnimator.js
+++ b/bundles/framework/timeseries/WMSAnimator.js
@@ -1,4 +1,4 @@
-import 'moment';
+import moment from 'moment';
 
 /**
  * @class Oskari.mapframework.bundle.timeseries.WMSAnimator

--- a/bundles/mapping/mapwmts/service/WmtsLayerService.ol.js
+++ b/bundles/mapping/mapwmts/service/WmtsLayerService.ol.js
@@ -66,19 +66,11 @@ Oskari.clazz.define('Oskari.mapframework.wmts.service.WMTSLayerService', functio
                 data: {
                     id: layer.getId()
                 },
-                dataType: 'xml',
+                dataType: 'text',
                 type: 'GET',
                 url: getCapsUrl,
                 success: function (response) {
-                    var responseXml = response;
-
-                    // Fixed IE9 issue when getting capabilities XML.
-                    // If IE9 then response capabilities XML is in reposne.xml
-                    if (response.xml) {
-                        responseXml = response.xml;
-                    }
-
-                    var caps = format.read(responseXml);
+                    var caps = format.read(response);
                     // Check if need reverse matrixset top left coordinates.
                     // Readed by layer attributes reverseMatrixIdsCoordinates property to matrixId specific transforms.
                     // For example layer can be following attribute: { reverseMatrixIdsCoordinates: {'ETRS-TM35FIN':true}}


### PR DESCRIPTION
jQuery fails to parse some capabilities xml files which are fine for openlayers. Openlayers can read string also. Changed to handle response as text. 
https://openlayers.org/en/latest/apidoc/module-ol_format_WMTSCapabilities-WMTSCapabilities.html

Fix timeseries WMSAnimator moment import.

Remove id from publisher opacity input element template. There's no need for id and duplicate ids causes error logging.