### PR TITLE
Fix layer removal and enable "add from same service" for capabilities enabled layer types

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
@@ -9,6 +9,8 @@ import { Confirm, Button, Tabs, TabPane, Message } from 'oskari-ui';
 import { StyledRoot, StyledAlert, StyledButton } from './styled';
 import { Mandatory, MandatoryIcon } from './Mandatory';
 
+const LayerComposingModel = Oskari.clazz.get('Oskari.mapframework.domain.LayerComposingModel');
+
 const AdminLayerForm = ({
     controller,
     mapLayerGroups,
@@ -28,7 +30,7 @@ const AdminLayerForm = ({
     scales
 }) => {
     // For returning to add multiple layers from service endpoint
-    const hasCapabilitiesFetched = !!Object.keys(capabilities).length;
+    const hasCapabilitiesSupport = propertyFields.includes(LayerComposingModel.CAPABILITIES);
     let validPermissions = true;
     const permissionValidator = validators['role_permissions'];
     if (typeof permissionValidator === 'function') {
@@ -90,7 +92,7 @@ const AdminLayerForm = ({
                         <Message messageKey='delete'/>
                     </StyledButton>
                 </Confirm>
-                { hasCapabilitiesFetched &&
+                { hasCapabilitiesSupport &&
                     <StyledButton onClick={() => controller.addNewFromSameService() }>
                         <Message messageKey='addNewFromSameService'/>
                     </StyledButton>

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -587,18 +587,13 @@ class UIHandler extends StateHandler {
     }
 
     deleteLayer () {
-        // FIXME: This should use LayerAdmin route instead but this probably works anyway
         const { layer } = this.getState();
-        fetch(Oskari.urls.getRoute('DeleteLayer'), {
-            method: 'POST',
-            headers: {
-                'Accept': 'application/json',
-                'Content-Type': 'application/x-www-form-urlencoded'
-            },
-            body: stringify(layer)
+        fetch(Oskari.urls.getRoute('LayerAdmin', { id: layer.id }), {
+            method: 'DELETE'
         }).then(response => {
             if (response.ok) {
-                // TODO handle this, just close the flyout?
+                // TODO: handle this somehow/close the flyout?
+                this.resetLayer();
             } else {
                 Messaging.error(getMessage('messages.errorRemoveLayer'));
             }

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -607,6 +607,7 @@ class UIHandler extends StateHandler {
             if (response.ok) {
                 // TODO: handle this somehow/close the flyout?
                 this.resetLayer();
+                this.mapLayerService.removeLayer(layer.id);
             } else {
                 Messaging.error(getMessage('messages.errorRemoveLayer'));
             }

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -1548,6 +1548,9 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
          *  layerModel if found matching id or null if not found
          */
         findMapLayer: function (id, layerList) {
+            if (typeof id === 'undefined') {
+                return;
+            }
             if (!layerList) {
                 layerList = this._loadedLayersList;
             }


### PR DESCRIPTION
Removal now "works" as in the layer is deleted from server with the correct action route and frontend is refreshed with the removal. The layer admin is now reset after layer removal to the "adding new layer" state (maybe should close the flyout on delete?).

Previously the "add layer from same service" button was only shown after adding a new layer. There was a bug where it was also shown for layers from different services (if the user edited after a layer from a different service after adding one from another). This was fixed and the button is now shown for any existing layer if the layer type uses a capabilities document.