### PR TITLE
Statistics state handling

### DIFF
--- a/bundles/statistics/statsgrid2016/FlyoutManager.js
+++ b/bundles/statistics/statsgrid2016/FlyoutManager.js
@@ -87,7 +87,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.FlyoutManager', function (insta
             const searchFlyout = me.flyouts['search'];
             searchFlyout.showOnPosition();
             this.trigger('show', 'search');
-            const { pos: { x: searchX } } = searchFlyout.getOptions();
+            const { position: { x: searchX } } = searchFlyout.getOptions();
             const x = searchX + searchFlyout.getSize().width + 5;
             const y = this._positionY;
             flyout.move(x, y, true);

--- a/bundles/statistics/statsgrid2016/components/Datatable.js
+++ b/bundles/statistics/statsgrid2016/components/Datatable.js
@@ -460,6 +460,11 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function (sandbox, 
                 me.updateModel();
             }
         });
+        this.service.on('StatsGrid.StateChangedEvent', function (event) {
+            if (event.isReset()) {
+                me.updateModel();
+            }
+        });
         me._bindedEvents = true;
     },
 

--- a/bundles/statistics/statsgrid2016/components/Datatable.js
+++ b/bundles/statistics/statsgrid2016/components/Datatable.js
@@ -387,10 +387,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function (sandbox, 
         var log = Oskari.log('Oskari.statistics.statsgrid.Datatable');
         var src = this.service.getDatasource(datasrc);
         log.debug('Indicator added ', src, indId, selections, series);
-        var state = this.service.getStateService();
-        var hash = this.service.getStateService().getHash(datasrc, indId, selections, series);
-
-        state.setActiveIndicator(hash);
         this._handleRegionsetChanged(this.getCurrentRegionset());
     },
     /**

--- a/bundles/statistics/statsgrid2016/components/Diagram.js
+++ b/bundles/statistics/statsgrid2016/components/Diagram.js
@@ -46,7 +46,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Diagram', function (service, lo
             // ui not yet created so no need to update it
             return;
         }
-
         if (!this.hasIndicators()) {
             this.clearChart();
             this.element.html(this.loc.statsgrid.noResults);
@@ -273,6 +272,11 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Diagram', function (service, lo
         });
         this.service.on('StatsGrid.RegionsetChangedEvent', function () {
             me.updateUI();
+        });
+        this.service.on('StatsGrid.StateChangedEvent', function (event) {
+            if (event.isReset()) {
+                me.updateUI();
+            }
         });
     }
 });

--- a/bundles/statistics/statsgrid2016/components/IndicatorList.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorList.js
@@ -43,6 +43,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorList', function (servi
         me.service.on('StatsGrid.ActiveIndicatorChangedEvent', function (event) {
             me._updateIndicatorList();
         });
+        me.service.on('StatsGrid.StateChangedEvent', function (event) {
+            me._updateIndicatorList();
+        });
     },
     /**
      * @method _getIndicators
@@ -114,7 +117,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorList', function (servi
         var removeAllBtn = me._removeAllBtn;
         removeAllBtn.setTitle(me.loc('indicatorList.removeAll'));
         removeAllBtn.setHandler(function () {
-            me._removeAllIndicators();
+            me.service.getStateService().resetState();
         });
         // Add button to content
         removeAllBtn.insertTo(content);
@@ -122,14 +125,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorList', function (servi
         this.element.append(content);
         // Update indicator list
         me._updateIndicatorList();
-    },
-    /**
-     * @method _removeAllIndicators
-     * Removes all indicators via {Oskari.statistics.statsgrid.StateService}
-     */
-    _removeAllIndicators: function () {
-        this.service.getStateService().reset();
-        this._updateIndicatorList();
     },
     /**
      * @method _updateIndicatorList

--- a/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
+++ b/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
@@ -190,7 +190,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
             });
             const borders = regionsWithoutValue.map(id => 'border' + id);
             const removes = regionsWithoutValue.concat(borders);
-
             sandbox.postRequestByName('MapModulePlugin.RemoveFeaturesFromMapRequest', ['id', removes, me.LAYER_ID]);
         }
         addFeaturesRequestParams.forEach(params => {
@@ -476,6 +475,13 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
 
         me.service.on('StatsGrid.ClassificationChangedEvent', function (event) {
             // Classification changed, need update map
+            me.render(state.getRegion());
+        });
+        me.service.on('StatsGrid.StateChangedEvent', function (event) {
+            if (event.isReset()) {
+                me._clearRegions();
+                return;
+            }
             me.render(state.getRegion());
         });
 

--- a/bundles/statistics/statsgrid2016/components/SelectedIndicatorsMenu.js
+++ b/bundles/statistics/statsgrid2016/components/SelectedIndicatorsMenu.js
@@ -154,6 +154,11 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SelectedIndicatorsMenu', functi
                 });
             }
         });
+        this.service.on('StatsGrid.StateChangedEvent', function (event) {
+            if (event.isReset() && me._select) {
+                me._select.clearOptions();
+            }
+        });
     }
 
 });

--- a/bundles/statistics/statsgrid2016/components/classification/Classification.jsx
+++ b/bundles/statistics/statsgrid2016/components/classification/Classification.jsx
@@ -33,9 +33,6 @@ class Classification extends React.Component {
 
     render () {
         const { classifications, pluginState } = this.props;
-        if (!pluginState.visible) {
-            return null;
-        }
         const isEdit = this.state.isEdit;
         let containerClass = pluginState.transparent ? 'statsgrid-classification-container transparent-classification' : 'statsgrid-classification-container';
 

--- a/bundles/statistics/statsgrid2016/components/classification/Classification.jsx
+++ b/bundles/statistics/statsgrid2016/components/classification/Classification.jsx
@@ -17,6 +17,9 @@ class Classification extends React.Component {
     componentDidUpdate () {
         this.props.onRenderChange(this.state.isEdit);
     }
+    componentDidMount () {
+        this.props.onRenderChange(false);
+    }
     handleToggleClassification () {
         this.setState(oldState => ({ isEdit: !oldState.isEdit }));
     }

--- a/bundles/statistics/statsgrid2016/event/StateChangedEvent.js
+++ b/bundles/statistics/statsgrid2016/event/StateChangedEvent.js
@@ -1,0 +1,27 @@
+/**
+ * Used to notify that state services whole state is changed.
+ *
+ * @class Oskari.statistics.statsgrid.event.StateChangedEvent
+ */
+Oskari.clazz.define('Oskari.statistics.statsgrid.event.StateChangedEvent',
+    /**
+     * @method create called automatically on construction
+     * @static
+     */
+    function (reset = false) {
+        this.reset = reset;
+    }, {
+        /**
+         * @method getName
+         * Returns event name
+         * @return {String} The event name.
+         */
+        getName: function () {
+            return 'StatsGrid.StateChangedEvent';
+        },
+        isReset: function () {
+            return this.reset;
+        }
+    }, {
+        'protocol': ['Oskari.mapframework.event.Event']
+    });

--- a/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
@@ -17,12 +17,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
         me._instance = instance;
         me._clazz = 'Oskari.statistics.statsgrid.ClassificationPlugin';
         me._index = 9;
-
-        if (instance.isEmbedded()) {
-            this._defaultLocation = config.legendLocation;
-        } else {
-            this._defaultLocation = 'right bottom';
-        }
+        this._defaultLocation = me._config.legendLocation || 'right bottom';
         me._fixedLocation = true;
         me._name = 'ClassificationPlugin';
         me.element = null;
@@ -45,6 +40,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
         this._overflowedOffset = null;
         this._previousIsEdit = false;
         this.indicatorData = {};
+        this._bindToEvents();
+        this.service.getStateService().initClassificationPluginState(this._config, this._instance.isEmbedded());
     }, {
         _createControlElement: function () {
             if (this.element !== null) {
@@ -67,7 +64,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
             this._overflowCheck();
         },
         render: function (activeClassfication) {
-            if (!this.node) return;
+            if (!this.node) {
+                this.buildUI();
+                return;
+            }
             const stateService = this.service.getStateService();
             const activeIndicator = stateService.getActiveIndicator();
             const regionset = stateService.getRegionset();
@@ -205,13 +205,15 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
         },
         teardownUI: function () {
             var element = this.getElement();
-            // detach old element from screen
-            if (element) {
+            if (this.node) {
                 ReactDOM.unmountComponentAtNode(this.node);
-                this.removeFromPluginContainer(element, true);
-                this.element = null;
-                this.trigger('hide');
+                this.node = null;
             }
+            if (element) {
+                this.removeFromPluginContainer(element);
+                this.element = null;
+            }
+            this.trigger('hide');
         },
         buildUI: function () {
             if (this.element) {
@@ -219,10 +221,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
             }
             this.addToPluginContainer(this._createControlElement());
             this._makeDraggable();
-            this._overflowCheck();
             this.node = this.element.get(0);
-            this.service.getStateService().initClassificationPluginState(this._config, this._instance.isEmbedded());
-            this._bindToEvents();
             this.render();
         },
         _makeDraggable: function () {

--- a/bundles/statistics/statsgrid2016/plugin/SeriesControlPlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/SeriesControlPlugin.js
@@ -33,6 +33,12 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SeriesControlPlugin',
             this.element ? this.teardownUI() : this._buildUI();
             return !!this.element;
         },
+        hasUI: function () {
+            // Plugin has ui element but returns false, because
+            // otherwise publisher would stop this plugin and start it again when leaving the publisher,
+            // instance updates visibility
+            return false;
+        },
         teardownUI: function () {
             this._isMobileVisible = false;
             if (this.element) {

--- a/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
@@ -1,23 +1,35 @@
 Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractStatsPluginTool', function () {
 }, {
     /**
-    * Get stats layer.
-    * @method @private _getStatsLayer
-    *
-    * @return found stats layer, if not found then null
+    * @method @private _isStatsActive
+    * @return true when stats layer is on the map, false if removed
     */
-    _getStatsLayer: function () {
-        return Oskari.getSandbox().findAllSelectedMapLayers().find(lyr => lyr.getId() === 'STATS_LAYER');
+    _isStatsActive: function () {
+        return Oskari.getSandbox().isLayerAlreadySelected('STATS_LAYER');
     },
     /**
      * @method isDisplayed Is displayed.
      * @returns {Boolean} true, if stats layer is on the map or data contains statsdrid conf
      */
     isDisplayed: function (data) {
-        if (this._getStatsLayer()) {
+        if (this._isStatsActive()) {
             return true;
         }
         return Oskari.util.keyExists(data, 'configuration.statsgrid.conf');
+    },
+    getConfiguration: function (conf = {}) {
+        // just to make sure if user removes the statslayer while in publisher
+        // if there is no statslayer on map -> don't setup tools configuration
+        if (!this._isStatsActive) {
+            return {};
+        }
+        return {
+            configuration: {
+                statsgrid: {
+                    conf
+                }
+            }
+        };
     }
 }, {
     'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool']

--- a/bundles/statistics/statsgrid2016/publisher/ClassificationToggleTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/ClassificationToggleTool.js
@@ -47,7 +47,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationToggleTool
         var stats = Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid');
         if (stats) {
             stats.togglePlugin.removeTool(this.id);
-            stats.getStatisticsService().getStateService().resetClassificationPluginState('visible');
+            stats.updateClassficationViewVisibility();
         }
     }
 }, {

--- a/bundles/statistics/statsgrid2016/publisher/ClassificationToggleTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/ClassificationToggleTool.js
@@ -12,7 +12,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationToggleTool
             data.configuration.statsgrid.conf.classification === true;
         this.setEnabled(enabled);
     },
-    getTool: function (stateData) {
+    getTool: function () {
         var me = this;
         if (!me.__tool) {
             me.__tool = {
@@ -41,26 +41,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationToggleTool
         }
     },
     getValues: function () {
-        var me = this;
-        var statsGridState = me.__sandbox.getStatefulComponents().statsgrid.getState();
-
-        var statslayerOnMap = this._getStatsLayer();
-        if (!statslayerOnMap || !statsGridState) {
-            return null;
-        }
-        if (!me.state.enabled) {
-            return null;
-        }
-        return {
-            configuration: {
-                statsgrid: {
-                    state: statsGridState,
-                    conf: {
-                        classification: me.state.enabled
-                    }
-                }
-            }
-        };
+        return this.getConfiguration({ classification: this.isEnabled() });
     },
     stop: function () {
         var stats = Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid');

--- a/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
@@ -12,10 +12,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationTool', fun
         'Oskari.mapframework.bundle.mapmodule.plugin.IndexMapPlugin'
     ],
     init: function (pdata) {
-        var stats = Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid');
-        if (stats) {
-            stats.createClassficationView();
-        }
         if (pdata && Oskari.util.keyExists(pdata, 'configuration.statsgrid.conf') && pdata.configuration.statsgrid.conf.allowClassification !== false) {
             this.setEnabled(true);
         } else {
@@ -51,29 +47,19 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationTool', fun
         }
     },
     getValues: function () {
-        var me = this;
-        var statsGridState = me.__sandbox.getStatefulComponents().statsgrid.getState();
-        // just to make sure if user removes the statslayer while in publisher
-        // if there is no statslayer on map -> don't setup publishedgrid
-        // otherwise always return the state even if grid is not selected so
-        //  publishedgrid gets the information it needs to render map correctly
-        var statslayerOnMap = this._getStatsLayer();
-        if (statslayerOnMap && statsGridState) {
-            // without view = true -> the sidepanel is not shown when the statsgrid bundle starts
-            statsGridState.view = me.state.enabled;
+        const allowClassification = this.isEnabled();
+        const legendLocation = 'bottom right';
+        if (this._isStatsActive()) {
             return {
                 configuration: {
                     statsgrid: {
-                        conf: {
-                            allowClassification: me.state.enabled,
-                            legendLocation: 'bottom right'
-                        }
+                        conf: { allowClassification, legendLocation },
+                        state: this.__sandbox.getStatefulComponents().statsgrid.getState()
                     }
                 }
             };
-        } else {
-            return {};
         }
+        return {};
     },
     /**
     * Stop tool.

--- a/bundles/statistics/statsgrid2016/publisher/DiagramTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/DiagramTool.js
@@ -41,26 +41,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.DiagramTool', function (
         }
     },
     getValues: function () {
-        var me = this;
-        var statsGridState = me.__sandbox.getStatefulComponents().statsgrid.getState();
-
-        var statslayerOnMap = this._getStatsLayer();
-        if (!statslayerOnMap || !statsGridState) {
-            return null;
-        }
-        if (!me.state.enabled) {
-            return null;
-        }
-        return {
-            configuration: {
-                statsgrid: {
-                    state: statsGridState,
-                    conf: {
-                        diagram: me.state.enabled
-                    }
-                }
-            }
-        };
+        return this.getConfiguration({ diagram: this.isEnabled() });
     },
     stop: function () {
         var stats = Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid');

--- a/bundles/statistics/statsgrid2016/publisher/OpacityTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/OpacityTool.js
@@ -40,26 +40,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.OpacityTool', function (
         stats.getStatisticsService().getStateService().updateClassificationPluginState('transparent', enabled);
     },
     getValues: function () {
-        var me = this;
-        var statsGridState = me.__sandbox.getStatefulComponents().statsgrid.getState();
-
-        var statslayerOnMap = this._getStatsLayer();
-        if (!statslayerOnMap || !statsGridState) {
-            return null;
-        }
-        if (!me.state.enabled) {
-            return null;
-        }
-        return {
-            configuration: {
-                statsgrid: {
-                    state: statsGridState,
-                    conf: {
-                        transparent: me.state.enabled
-                    }
-                }
-            }
-        };
+        return this.getConfiguration({ transparent: this.isEnabled() });
     },
     stop: function () {
         const service = Oskari.getSandbox().getService('Oskari.statistics.statsgrid.StatisticsService');

--- a/bundles/statistics/statsgrid2016/publisher/SeriesToggleTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/SeriesToggleTool.js
@@ -50,26 +50,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.SeriesToggleTool', funct
         return seriesFound;
     },
     getValues: function () {
-        var me = this;
-        var statsGridState = me.__sandbox.getStatefulComponents().statsgrid.getState();
-
-        var statslayerOnMap = this._getStatsLayer();
-        if (!statslayerOnMap || !statsGridState) {
-            return null;
-        }
-        if (!me.state.enabled) {
-            return null;
-        }
-        return {
-            configuration: {
-                statsgrid: {
-                    state: statsGridState,
-                    conf: {
-                        series: me.state.enabled
-                    }
-                }
-            }
-        };
+        return this.getConfiguration({ series: this.isEnabled() });
     },
     stop: function () {
         var stats = Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid');

--- a/bundles/statistics/statsgrid2016/publisher/StatsTableTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/StatsTableTool.js
@@ -1,6 +1,6 @@
 Oskari.clazz.define('Oskari.mapframework.publisher.tool.StatsTableTool', function () {
 }, {
-    index: 0,
+    index: 1,
     group: 'data',
     allowedLocations: [],
     allowedSiblings: [],
@@ -64,26 +64,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.StatsTableTool', functio
         }
     },
     getValues: function () {
-        var me = this;
-        var statsGridState = me.__sandbox.getStatefulComponents().statsgrid.getState();
-        // just to make sure if user removes the statslayer while in publisher
-        // if there is no statslayer on map -> don't setup statsgrid
-        // otherwise always return the state even if grid is not selected so
-        // statsgrid gets the information it needs to render map correctly
-        var statslayerOnMap = this._getStatsLayer();
-        if (!statslayerOnMap || !statsGridState) {
-            return null;
-        }
-        return {
-            configuration: {
-                statsgrid: {
-                    state: statsGridState,
-                    conf: {
-                        grid: me.state.enabled
-                    }
-                }
-            }
-        };
+        return this.getConfiguration({ grid: this.isEnabled() });
     },
     stop: function () {
         var stats = Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid');

--- a/bundles/statistics/statsgrid2016/service/SeriesService.js
+++ b/bundles/statistics/statsgrid2016/service/SeriesService.js
@@ -268,6 +268,12 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SeriesService',
             var onEvent = function () {
                 me.collectGroupStats(me._updateActiveIndicator.bind(me));
             };
+            statisticsService.on('StatsGrid.StateChangedEvent', evt => {
+                if (evt.isReset()) {
+                    return;
+                }
+                this.collectGroupStats();
+            });
             statisticsService.on('StatsGrid.RegionsetChangedEvent', onEvent);
             statisticsService.on('StatsGrid.IndicatorEvent', function (evt) {
                 if (evt.series) {

--- a/bundles/statistics/statsgrid2016/service/StateService.js
+++ b/bundles/statistics/statsgrid2016/service/StateService.js
@@ -79,8 +79,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
                 this.updateClassificationPluginState(key, defaults[key]);
             }
         },
-        updateClassificationPluginState: function (key, value) {
-            if (this.classificationPluginState[key] === value) {
+        updateClassificationPluginState: function (key, value, force) {
+            if (!force && this.classificationPluginState[key] === value) {
                 return;
             }
             this.classificationPluginState[key] = value;
@@ -171,7 +171,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
                     id: ind.indicator,
                     selections: ind.selections,
                     series: ind.series,
-                    classification: this.getClassificationOpts(ind.hash)
+                    classification: ind.classification || this.getClassificationOpts(ind.hash)
                 };
             });
             const activeInd = this.getActiveIndicator();
@@ -217,7 +217,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
             var me = this;
 
             // if region is same than previous then unselect region
-            if (region && region === me.activeRegion) {
+            if (region === me.activeRegion) {
                 region = null;
             }
             clearTimeout(me._timers.setActiveRegion);
@@ -435,13 +435,14 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
                 // active was the one removed -> reset active
                 this.setActiveIndicator();
             }
-            // notify
-            var eventBuilder = Oskari.eventBuilder('StatsGrid.IndicatorEvent');
-            this.sandbox.notifyAll(eventBuilder(datasrc, indicator, selections, series, true));
-
-            // if no indicators then reset active region
-            if (this.indicators.length === 0) {
-                this.toggleRegion(null);
+            if (this.hasIndicators()) {
+                // notify
+                var eventBuilder = Oskari.eventBuilder('StatsGrid.IndicatorEvent');
+                this.sandbox.notifyAll(eventBuilder(datasrc, indicator, selections, series, true));
+            } else {
+                // if no indicators then reset state
+                // last indicator removal should act like all indicators or layer was removed
+                this.resetState();
             }
 
             return removedIndicator;

--- a/bundles/statistics/statsgrid2016/service/StateService.js
+++ b/bundles/statistics/statsgrid2016/service/StateService.js
@@ -32,7 +32,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
             },
             classificationPluginState: {
                 editEnabled: true,
-                visible: true,
                 transparent: false
             }
         };
@@ -79,8 +78,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
                 this.updateClassificationPluginState(key, defaults[key]);
             }
         },
-        updateClassificationPluginState: function (key, value, force) {
-            if (!force && this.classificationPluginState[key] === value) {
+        updateClassificationPluginState: function (key, value) {
+            if (this.classificationPluginState[key] === value) {
                 return;
             }
             this.classificationPluginState[key] = value;

--- a/packages/statistics/statsgrid/bundle.js
+++ b/packages/statistics/statsgrid/bundle.js
@@ -144,6 +144,9 @@ Oskari.clazz.define("Oskari.statistics.statsgrid.StatsGridBundle",
                 "src": "../../../bundles/statistics/statsgrid2016/event/ParameterChangedEvent.js"
             }, {
                 "type": "text/javascript",
+                "src": "../../../bundles/statistics/statsgrid2016/event/StateChangedEvent.js"
+            }, {
+                "type": "text/javascript",
                 "src": "../../../bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js"
             }, {
                 "type": "text/javascript",


### PR DESCRIPTION
When all indicators or stats layer is removed components has to be notified about indicator events. If there is lot of indicators calling remove/add indicator will trigger many events (including active indicator changed). It's quite heavy operation and components may receive events in random order. So it's safer to notify with one event. Added new StateChangedEvent to notify that state is set or reset. Changed resetState and setState to init indicators, active indicator, regionset and region and notify with new event. Publisher also removes and adds layer and resets and sets state.

 If all indicators, last indicator or layer is removed state is reseted to work unified way. 

Changed instance to call stop or buildui for classification plugin when visibility is changed. Removed visiblity from state and react rendering. Now doesn't render empty plugin and controlling visibility is done same way with series plugin.

Changes:
- when all indicators are removed: classification is closed, dataproviders are updated
- layer is removed when there is no indicators selected
- entering/leaving publisher: if layer is hidden, don't render plugins
- leaving publisher: timeseriesplugin isn't rendered if serie isn't active
- entering publisher: classification plugins default location fix
- publisher tools: added state multiple times and jquery clone copied indicator list contents -> duplicate indicators ( setstate contains filter to remove duplicate for backwards compatibility)