### PR TITLE
Statistics series update fix

### DIFF
--- a/bundles/framework/divmanazer/component/GridSelection.js
+++ b/bundles/framework/divmanazer/component/GridSelection.js
@@ -35,6 +35,11 @@ Oskari.clazz.category(
 
             var selected = this.table.find('th.' + me._columnClsPrefix + columnIndex);
             selected.addClass('selected');
+            const cls = 'selected-effect';
+            selected.addClass(cls);
+            setTimeout(() => {
+                selected.removeClass(cls);
+            }, 1000);
 
             this._selectActivePage();
         },

--- a/bundles/framework/divmanazer/component/SelectList.js
+++ b/bundles/framework/divmanazer/component/SelectList.js
@@ -108,10 +108,12 @@ Oskari.clazz.define('Oskari.userinterface.component.SelectList', function (id) {
         }
         this.update();
     },
-    update: function () {
+    update: function (changed = true) {
         var select = this.element.find('select');
         select.trigger('chosen:updated');
-        select.trigger('change');
+        if (changed) {
+            select.trigger('change');
+        }
     },
     getOptions: function () {
         var chosen = this.element.find('select');
@@ -197,9 +199,10 @@ Oskari.clazz.define('Oskari.userinterface.component.SelectList', function (id) {
     *   updates an already defined chosen with new data
     *   @param {data} data to apply
     */
-    updateOptions: function (data) {
+    updateOptions: function (data, value) {
         var me = this;
         var chosen = this.element.find('select');
+        const previous = chosen.val();
         chosen.trigger('chosen:close');
         chosen.empty();
         // append empty options so we can use the placeholder
@@ -212,6 +215,13 @@ Oskari.clazz.define('Oskari.userinterface.component.SelectList', function (id) {
             option.val(choice.id).text(choice.title);
             chosen.append(option);
         });
+        if (typeof value !== 'undefined') {
+            chosen.val(value);
+            if (previous === value) {
+                this.update(false);
+                return;
+            }
+        }
         this.update();
     },
     getId: function () {

--- a/bundles/statistics/statsgrid2016/components/Datatable.js
+++ b/bundles/statistics/statsgrid2016/components/Datatable.js
@@ -29,7 +29,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function (sandbox, 
                 '<div class="title"></div>' +
                 '<div class="header">' +
                 '   <div class="selection"></div>' +
-                '   <div class="info"></div>' +
                 '</div>' +
                 '<div class="sortby"><div class="orderTitle"></div><div class="order"></div><div style="clear:both;"></div></div>' +
                 '</div>'),
@@ -133,8 +132,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function (sandbox, 
         me.grid.setColumnUIName('region', function (content) {
             var tableHeader = jQuery(me.__templates.tableHeader());
             tableHeader.find('.title').remove();
-            tableHeader.find('.info').html(gridLoc.areaSelection.info);
-
             content.append(tableHeader);
 
             // regionset selection is shown if map is not embedded
@@ -157,7 +154,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function (sandbox, 
                 // Else only show current regionset without info
                 var regionsetDef = me.service.getRegionsets(me.getCurrentRegionset()) || {};
                 tableHeader.find('.selection').html(regionsetDef.name);
-                tableHeader.find('.info').remove();
             }
 
             var sortBy = tableHeader.find('.sortby');
@@ -246,7 +242,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function (sandbox, 
 
         // done is called when we have indicator names for columns
         var done = function () {
-            me.grid.setAutoHeightHeader(30);
+            me.grid.setAutoHeightHeader(15);
             me.grid.setDataModel(model);
             me.grid.renderTo(me.mainEl.find('.grid'));
 

--- a/bundles/statistics/statsgrid2016/components/Datatable.js
+++ b/bundles/statistics/statsgrid2016/components/Datatable.js
@@ -33,9 +33,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function (sandbox, 
                 '<div class="sortby"><div class="orderTitle"></div><div class="order"></div><div style="clear:both;"></div></div>' +
                 '</div>'),
         tableHeaderWithContent: _.template('<div class="statsgrid-grid-table-header-content">' +
-                '<div class="header"><span class="title"></span> </br> </div>' +
+                '<div class="header"></div>' +
                 '<div class="icon icon-close-dark"></div>' +
-                '<div style="clear:both;"></div>' +
                 '<div class="sortby"><div class="orderTitle"></div><div class="order"></div><div style="clear:both;"></div></div>' +
                 '</div>')
     },
@@ -240,22 +239,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function (sandbox, 
         var me = this;
         var log = Oskari.log('Oskari.statistics.statsgrid.Datatable');
 
-        // done is called when we have indicator names for columns
-        var done = function () {
-            me.grid.setAutoHeightHeader(15);
-            me.grid.setDataModel(model);
-            me.grid.renderTo(me.mainEl.find('.grid'));
-
-            var state = me.service.getStateService();
-            var activeIndicator = state.getActiveIndicator();
-            if (activeIndicator) {
-                me.grid.selectColumn(activeIndicator.hash);
-            }
-        };
-        if (!indicators.length) {
-            done();
-            return;
-        }
         indicators.forEach(function (ind, id) {
             var numberFormatter = Oskari.getNumberFormatter(ind.classification.fractionDigits);
             me.grid.setColumnValueRenderer(ind.hash, function (value) {
@@ -266,8 +249,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function (sandbox, 
             });
             me.grid.setColumnUIName(ind.hash, function (content) {
                 var tableHeader = jQuery(me.__templates.tableHeaderWithContent());
-                tableHeader.find('.title').html(gridLoc.source + ' ' + (id + 1) + ':');
-
                 me.service.getUILabels(ind, function (labels) {
                     tableHeader.find('.header').append(labels.full).attr('title', labels.full);
                 });
@@ -355,8 +336,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function (sandbox, 
                     sortBy.find('.orderTitle').attr('title', gridLoc.orderByDescending);
                     order.addClass('desc');
                 }
-
-                tableHeader.on('click', function () {
+                // bind click handler to content element
+                content.on('click', function () {
                     me.service.getStateService().setActiveIndicator(ind.hash);
                 });
 
@@ -366,10 +347,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function (sandbox, 
                 content.css('width', cellWidth + '%');
                 content.append(tableHeader);
             });
-            if (indicators.length - 1 === id) {
-                done();
-            }
         });
+        me.grid.setAutoHeightHeader(15);
+        me.grid.setDataModel(model);
+        me.grid.renderTo(me.mainEl.find('.grid'));
     },
 
     /**
@@ -381,9 +362,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function (sandbox, 
      */
     _handleIndicatorAdded: function (datasrc, indId, selections, series) {
         var log = Oskari.log('Oskari.statistics.statsgrid.Datatable');
-        var src = this.service.getDatasource(datasrc);
-        log.debug('Indicator added ', src, indId, selections, series);
-        this._handleRegionsetChanged(this.getCurrentRegionset());
+        log.debug('Indicator added ', datasrc, indId, selections, series);
+        this._handleRegionsetChanged();
     },
     /**
      * @method  @private handleIndicatorAdded Handle indicator removed
@@ -393,9 +373,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function (sandbox, 
      */
     _handleIndicatorRemoved: function (datasrc, indId, selections) {
         var log = Oskari.log('Oskari.statistics.statsgrid.Datatable');
-        var src = this.service.getDatasource(datasrc);
-        log.debug('Indicator removed', src, indId, selections);
-        this._handleRegionsetChanged(this.getCurrentRegionset());
+        log.debug('Indicator removed', datasrc, indId, selections);
+        this._handleRegionsetChanged();
     },
 
     _bindToEvents: function () {
@@ -440,16 +419,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function (sandbox, 
 
         this.service.on('StatsGrid.ActiveIndicatorChangedEvent', function (event) {
             var current = event.getCurrent();
-            var previous = event.getPrevious();
             log.debug('Active indicator changed! ', current);
-            if (current === previous) { // No change, but event was sent to refresh components
-                me._handleRegionsetChanged();
-            }
             if (current && me.grid) {
                 me.grid.selectColumn(current.hash);
-            }
-            if (!current) {
-                me.updateModel();
             }
         });
         this.service.on('StatsGrid.StateChangedEvent', function (event) {
@@ -497,6 +469,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function (sandbox, 
 
         el.append(main);
         me._handleRegionsetChanged();
+        const active = me.service.getStateService().getActiveIndicator();
+        if (active) {
+            me.grid.selectColumn(active.hash);
+        }
     },
 
     setHeaderHeight: function () {

--- a/bundles/statistics/statsgrid2016/components/SelectedIndicatorsMenu.js
+++ b/bundles/statistics/statsgrid2016/components/SelectedIndicatorsMenu.js
@@ -92,12 +92,14 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SelectedIndicatorsMenu', functi
     },
     _getIndicatorUILabels: function (callback) {
         var options = [];
-        var indicators = this.service.getStateService().getIndicators();
+        const service = this.service.getStateService();
+        var indicators = service.getIndicators();
         if (!indicators.length) {
             // no indicators to list
             callback(options);
             return;
         }
+        const { hash } = service.getActiveIndicator();
         var me = this;
         var count = 0;
         indicators.forEach(function (option) {
@@ -108,7 +110,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SelectedIndicatorsMenu', functi
                     title: label.full
                 });
                 if (count === indicators.length) {
-                    callback(options);
+                    callback(options, hash);
                 }
             });
         });
@@ -149,8 +151,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SelectedIndicatorsMenu', functi
         });
         this.service.on('StatsGrid.ParameterChangedEvent', function (event) {
             if (me._select) {
-                me._getIndicatorUILabels(function (options) {
-                    me._select.updateOptions(options);
+                me._getIndicatorUILabels(function (options, value) {
+                    me._select.updateOptions(options, value);
                 });
             }
         });

--- a/bundles/statistics/statsgrid2016/components/SeriesControl.js
+++ b/bundles/statistics/statsgrid2016/components/SeriesControl.js
@@ -279,8 +279,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SeriesControl', function (sandb
                 }
                 return true;
             }
-            this._updateSeriesIndex(this.seriesService.getSelectedIndex());
         }
+        this._updateSeriesIndex(this.seriesService.getSelectedIndex());
         return false;
     },
     _initValues: function () {
@@ -296,5 +296,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SeriesControl', function (sandb
     _bindToEvents: function () {
         this.service.on('StatsGrid.ActiveIndicatorChangedEvent', event =>
             this._updateValues(event.getCurrent()));
+        this.service.on('StatsGrid.ParameterChangedEvent', () =>
+            this._updateValues());
     }
 });

--- a/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
@@ -303,6 +303,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
             this.service.on('AfterChangeMapLayerOpacityEvent', event => this.render());
             // need to calculate contents max height and check overflow
             this.service.on('MapSizeChangedEvent', event => this.render());
+            // need to update labels
+            this.service.on('StatsGrid.ParameterChangedEvent', () => this.render());
         }
     }, {
         'extend': ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],

--- a/bundles/statistics/statsgrid2016/resources/locale/en.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/en.js
@@ -66,10 +66,8 @@ Oskari.registerLocalization({
             'noResults': 'No data selected',
             'noValues': 'No values for the selected data',
             'areaSelection': {
-                'title': 'AREAL DIVISION',
-                'info': 'Redefine areal division for data from dropdown list'
+                'title': 'AREAL DIVISION'
             },
-            'source': 'Indicator',
             'orderBy': 'Sort',
             'orderByAscending': 'Sort ascending',
             'orderByDescending': 'Sort descending',

--- a/bundles/statistics/statsgrid2016/resources/locale/fi.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/fi.js
@@ -66,10 +66,8 @@ Oskari.registerLocalization({
             'noResults': 'Ei valittuja aineistoja',
             'noValues': 'Ei arvoja valitulla aineistolla',
             'areaSelection': {
-                'title': 'ALUEJAKO',
-                'info': 'Määritä uudelleen millä alueilla haluat tarkastella aineistoja valitsemalla alasvetovalikosta'
+                'title': 'ALUEJAKO'
             },
-            'source': 'Indikaattori',
             'orderBy': 'Lajittele',
             'orderByAscending': 'Lajittele nousevasti',
             'orderByDescending': 'Lajittele laskevasti',

--- a/bundles/statistics/statsgrid2016/resources/locale/fr.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/fr.js
@@ -67,10 +67,8 @@ Oskari.registerLocalization(
             "noResults": "Aucune donnée sélectionnée",
             "noValues": "Aucune valeur pour les données sélectionnées",
             "areaSelection": {
-                "title": "DIVISION DE SUPERFICIE",
-                "info": "Redéfinir la division de superficie pour les données tirées de la liste déroulante"
+                "title": "DIVISION DE SUPERFICIE"
             },
-            "source": "Données",
             "orderBy": "Trier",
             "orderByAscending": "Trier en ordre croissant",
             "orderByDescending": "Trier en ordre décroissant",

--- a/bundles/statistics/statsgrid2016/resources/locale/is.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/is.js
@@ -66,10 +66,8 @@ Oskari.registerLocalization({
             "noResults": "No data selected",
             "noValues": "No values for the selected data",
             "areaSelection": {
-                "title": "AREAL DIVISION",
-                "info": "Redefine areal division for data from dropdown list"
+                "title": "AREAL DIVISION"
             },
-            "source": "Indicator",
             "orderBy": "Sort",
             "orderByAscending": "Sort ascending",
             "orderByDescending": "Sort descending",

--- a/bundles/statistics/statsgrid2016/resources/locale/ru.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/ru.js
@@ -73,10 +73,8 @@ Oskari.registerLocalization(
             "noResults": "Данные не выбраны",
             "noValues": "Нет значений для выбранных данных",
             "areaSelection": {
-                "title": "АРЕАЛ ОБИТАНИЯ",
-                "info": "Пересмотреть ареал обитания для данных из выпадающего списка"
+                "title": "АРЕАЛ ОБИТАНИЯ"
             },
-            "source": "Данные",
             "orderBy": "Сортировать",
             "orderByAscending": "Сортировать по возрастанию",
             "orderByDescending": "Сортировать по убыванию",

--- a/bundles/statistics/statsgrid2016/resources/locale/sv.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/sv.js
@@ -66,10 +66,8 @@ Oskari.registerLocalization({
             'noResults': 'Inga valda datamängder',
             'noValues': 'Inga värden i den valda datamängden',
             'areaSelection': {
-                'title': 'OMRÅDESINDELNING',
-                'info': 'Omdefiniera den önskade områdesindelningen från rullgardinsmenyn.'
+                'title': 'OMRÅDESINDELNING'
             },
-            'source': 'Indikator',
             'orderBy': 'Sortera',
             'orderByAscending': 'Sortera stigande',
             'orderByDescending': 'Sortera sjunkande',

--- a/bundles/statistics/statsgrid2016/resources/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/resources/scss/style.scss
@@ -102,15 +102,12 @@ $flyoutPadding: 16px;
     font-weight: normal;
 
     .header {
-        width: 85%;
         position: absolute;
         top: 5px;
-        .title {
-            font-weight: bold;
-        }
+        margin-right: 25px;
     }
     .icon-warning-light {
-        top: 88%;
+        bottom: 0;
         position: absolute;
         cursor: pointer;
     }
@@ -360,9 +357,11 @@ div.oskari-flyout {
         table.oskari-grid {
             th.selected {
                 background-color: #FDF8D9;
+            }
+            th.selected-effect {
                 animation-name: statsgridcolumnselection;
                 animation-duration: 0.5s;
-                animation-iteration-count: 3;
+                animation-iteration-count: 2;
             }
 
             td {

--- a/bundles/statistics/statsgrid2016/resources/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/resources/scss/style.scss
@@ -370,7 +370,10 @@ div.oskari-flyout {
             }
 
             td:first-child, th:first-child {
-                max-width: 130px;
+                max-width: 140px;
+            }
+            .statsgrid-header-0 {
+                overflow: visible;
             }
         }
 

--- a/bundles/statistics/statsgrid2016/service/StateService.js
+++ b/bundles/statistics/statsgrid2016/service/StateService.js
@@ -155,9 +155,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
                     this.lastSelectedClassification = classification;
                 }
                 if (series) {
-                    const selected = selections[series.id];
-                    this.seriesService.setSelectedValue(selected);
-                    this.seriesService.setValues(series.values);
+                    this.seriesService.setValues(series.values, selections[series.id]);
                 }
             }
             this.activeIndicator = active || null;
@@ -321,7 +319,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
          */
         setActiveIndicator: function (indicatorHash) {
             var me = this;
-
             clearTimeout(me._timers.setActiveIndicator);
 
             // This must be on some way to discard set active indicator if calling repeatly.


### PR DESCRIPTION
Use parameterchange event for series selection change instead of activeindicatorchange.
Remove region select info text and Indicator x: title from datatable.

Fix select overflow visibility.

Don't trigger activeindicatorchange when series selection is changed. Chosen triggered change when options (labels) were updated which triggered activeindicatorchange. Now send's selected value when updating chosen. Selection doesn't change.