### PR TITLE
Layer updates for admin

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -155,7 +155,10 @@ Oskari.registerLocalization(
                 "connectionErrorFetchCapabilities": "Connection could not be established to the service. Check the interface URL.",
                 "parsingErrorFetchCapabilities": "The response from the service didn't match the requested standard. Check the map layer type and/or version.",
                 "deleteSuccess" : "Deleted",
-                "deleteFailed" : "Delete failed"
+                "deleteFailed" : "Delete failed",
+                "updateCapabilitiesFail": "Fetching service capabilities failed. Interface URL, type or version could be wrong or the service is currently down.",
+                "errorFetchLayerFailed": "Fetching layer details failed. The layer might have been removed or you don't have permission for the layer.",
+                "errorFetchLayerEnduserFailed": "Fetching layer details for the layer listing failed. Did you add 'View' permission for a role that you have?"
             },
             "otherLanguages": "Other languages",
             "stylesJSON": "Style definitions (JSON)",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -156,7 +156,10 @@ Oskari.registerLocalization(
                 "connectionErrorFetchCapabilities": "Pyynnön lähettäminen palveluun ei onnistunut. Tarkista rajapinnan osoite.",
                 "parsingErrorFetchCapabilities": "Palvelusta saatua vastausta ei saatu tulkittua. Tarkista rajapinnan tyyppi ja versio.",
                 "deleteSuccess" : "Poistettu",
-                "deleteFailed" : "Poisto epäonnistui"
+                "deleteFailed" : "Poisto epäonnistui",
+                "updateCapabilitiesFail": "Rajapinnan tietojen haku epäonnistui. Tason osoite, tyyppi tai versio voi olla väärin tai rajapinta on tällä hetkellä pois käytöstä.",
+                "errorFetchLayerFailed": "Tason tietojen haku epäonnistui. Taso on mahdollisesti poistettu tai sinulla ei ole siihen oikeuksia.",
+                "errorFetchLayerEnduserFailed": "Tason tietojen haku listauksen päivittämistä varten epäonnistui. Tallensithan katseluoikeuden roolille joka sinulla on?"
             },
             "otherLanguages": "Muut kielet",
             "stylesJSON": "Tyylimääritykset (JSON)",

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -155,7 +155,8 @@ Oskari.registerLocalization(
                 "connectionErrorFetchCapabilities": "Anslutning till tjänsten kunde inte etableras. Kolla gränssnittets URL.",
                 "parsingErrorFetchCapabilities": "Tjänstens svar kan inte tolkas. Kolla kartlagrets typ och/eller version.",
                 "deleteSuccess" : "Utgår",
-                "deleteFailed" : "Borttagningen misslyckades"
+                "deleteFailed" : "Borttagningen misslyckades",
+                "updateCapabilitiesFail": "Sökning till gränssnittet returnerar ingen data. Kartlagrets adress, typ eller version kan vara felaktig eller gränssnitt tjänsten fungerar för tillfället inte."
             },
             "otherLanguages": "Andra språk",
             "stylesJSON": "Stildefinitioner (JSON)",

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
@@ -5,11 +5,37 @@ import { VisualizationTabPane } from './VisualizationTabPane';
 import { AdditionalTabPane } from './AdditionalTabPane';
 import { PermissionsTabPane } from './PermissionsTabPane';
 import { LocaleConsumer, Controller } from 'oskari-ui/util';
-import { Confirm, Button, Tabs, TabPane, Message } from 'oskari-ui';
+import { Confirm, Button, Tabs, TabPane, Message, Tooltip } from 'oskari-ui';
 import { StyledRoot, StyledAlert, StyledButton } from './styled';
 import { Mandatory, MandatoryIcon } from './Mandatory';
 
 const LayerComposingModel = Oskari.clazz.get('Oskari.mapframework.domain.LayerComposingModel');
+
+const getValidationMessage = (validationErrorMessages = []) => {
+    return (<div>
+        <Message messageKey={'validation.mandatoryMsg'} />
+        <ul>{ validationErrorMessages
+            .map(field => <li key={field}><Message messageKey={`fields.${field}`}/></li>)}
+        </ul>
+    </div>);
+};
+
+const SaveButton = ({ isNew, onSave, validationErrors = [] }) => {
+    const btn = (<StyledButton type='primary' onClick={() => onSave()} disabled={validationErrors.length}>
+        <Message messageKey={isNew ? 'add' : 'save'}/>
+    </StyledButton>);
+    if (!validationErrors.length) {
+        return btn;
+    }
+    return (<Tooltip title={getValidationMessage(validationErrors)}>{btn}</Tooltip>);
+};
+
+SaveButton.propTypes = {
+    isNew: PropTypes.bool.isRequired,
+    onSave: PropTypes.func.isRequired,
+    validationErrors: PropTypes.array
+};
+const MemoedSaveButton = React.memo(SaveButton);
 
 const AdminLayerForm = ({
     controller,
@@ -27,6 +53,7 @@ const AdminLayerForm = ({
     getMessage,
     rolesAndPermissionTypes,
     validators = {},
+    validationErrors = [],
     scales
 }) => {
     // For returning to add multiple layers from service endpoint
@@ -76,9 +103,7 @@ const AdminLayerForm = ({
                     controller={controller}/>
             </TabPane>
         </Tabs>
-        <StyledButton type='primary' onClick={() => onSave()}>
-            <Message messageKey={layer.isNew ? 'add' : 'save'}/>
-        </StyledButton>
+        <MemoedSaveButton layer={layer.isNew} onSave={onSave} validationErrors={validationErrors} />
         { !layer.isNew &&
             <React.Fragment>
                 <Confirm
@@ -122,6 +147,7 @@ AdminLayerForm.propTypes = {
     getMessage: PropTypes.func.isRequired,
     rolesAndPermissionTypes: PropTypes.object,
     validators: PropTypes.object,
+    validationErrors: PropTypes.arrayOf(PropTypes.string),
     tab: PropTypes.string.isRequired,
     scales: PropTypes.array.isRequired
 };

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
@@ -103,7 +103,7 @@ const AdminLayerForm = ({
                     controller={controller}/>
             </TabPane>
         </Tabs>
-        <MemoedSaveButton layer={layer.isNew} onSave={onSave} validationErrors={validationErrors} />
+        <MemoedSaveButton isNew={!!layer.isNew} onSave={onSave} validationErrors={validationErrors} />
         { !layer.isNew &&
             <React.Fragment>
                 <Confirm

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -401,7 +401,7 @@ class UIHandler extends StateHandler {
         }).then(response => {
             this.ajaxFinished();
             if (!response.ok) {
-                Messaging.error('TODO');
+                Messaging.error(getMessage('messages.errorFetchLayerFailed'));
             }
             return response.json();
         }).then(json => {
@@ -490,12 +490,12 @@ class UIHandler extends StateHandler {
         }).then(response => {
             this.ajaxFinished();
             if (!response.ok) {
-                Messaging.error('TODO');
+                Messaging.error(getMessage('messages.errorFetchLayerEnduserFailed'));
             }
             return response.json();
         }).then(json => {
             if (json.layers.length !== 1) {
-                Messaging.error('TODO');
+                Messaging.error(getMessage('messages.errorFetchLayerEnduserFailed'));
                 return;
             }
             const layer = json.layers[0];
@@ -516,7 +516,7 @@ class UIHandler extends StateHandler {
         } else if (layerData.id) {
             this.createlayer(layerData);
         } else {
-            Messaging.error('TODO');
+            Messaging.error(getMessage('messages.errorFetchLayerEnduserFailed'));
         }
     }
     createlayer (layerData) {

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -468,7 +468,6 @@ class UIHandler extends StateHandler {
             }
         }).then(data => {
             // layer data will be the same as for editing == admin data
-            Messaging.warn('Reload page to see changes for end user - Work in progress...');
             // refresh current layer data from server after saving just in case to prevent possible out-of-sync
             this.fetchLayer(data.id, true);
             // Update layer for end-user as that model is different than admin uses

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -501,7 +501,17 @@ class UIHandler extends StateHandler {
             const layer = json.layers[0];
             // this is needed because maplayer service expects groups to be found on layer when creating/updating
             // TODO: refactor maplayer service groups handling
-            layer.groups = groups.map(id => ({ id }));
+            layer.groups = groups.map(id => {
+                const item = {
+                    id
+                };
+                const group = this.mapLayerGroups.find(g => g.id === id);
+                if (!group) {
+                    return item;
+                }
+                item.name = Oskari.getLocalized(group.name);
+                return item;
+            });
             this.refreshEndUserLayer(layerId, layer);
         });
     }
@@ -759,6 +769,9 @@ class UIHandler extends StateHandler {
             updateFailed();
             this.log.error(error);
         });
+    }
+    setMapLayerGroups (mapLayerGroups) {
+        this.mapLayerGroups = mapLayerGroups;
     }
 
     fetchLayerAdminMetadata () {

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -468,11 +468,11 @@ class UIHandler extends StateHandler {
             this.fetchLayer(data.id, true);
             // Update layer for end-user as that model is different than admin uses
             // end-user layer is AbstractLayer-based model -> make another request to get that JSON.
-            this.fetchLayerForEndUser(data.id);
+            this.fetchLayerForEndUser(data.id, layerPayload.group_ids);
         }).catch(error => this.log.error(error));
     }
 
-    fetchLayerForEndUser (layerId) {
+    fetchLayerForEndUser (layerId, groups = []) {
         // send id as parameter so we don't get the whole layer listing
         var url = Oskari.urls.getRoute('GetHierarchicalMapLayerGroups', {
             srs: Oskari.getSandbox().getMap().getSrsName(),
@@ -496,7 +496,11 @@ class UIHandler extends StateHandler {
                 Messaging.error('TODO');
                 return;
             }
-            this.refreshEndUserLayer(layerId, json.layers[0]);
+            const layer = json.layers[0];
+            // this is needed because maplayer service expects groups to be found on layer when creating/updating
+            // TODO: refactor maplayer service groups handling
+            layer.groups = groups.map(id => ({ id }));
+            this.refreshEndUserLayer(layerId, layer);
         });
     }
     refreshEndUserLayer (layerId, layerData = {}) {

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -389,6 +389,7 @@ class UIHandler extends StateHandler {
     fetchLayer (id, keepCapabilities = false) {
         this.clearMessages();
         if (!id) {
+            // adding new layer
             this.resetLayer();
             return;
         }
@@ -410,6 +411,8 @@ class UIHandler extends StateHandler {
                 preserve: ['capabilities'],
                 roles: typesAndRoles.roles
             });
+            // remove possible existing flag since we loaded the layer -> it is not new
+            delete layer.isNew;
             if (layer.warn) {
                 // currently only option for warning on this is "updateCapabilitiesFail"
                 Messaging.warn(getMessage(`messages.${layer.warn}`));

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -522,17 +522,12 @@ class UIHandler extends StateHandler {
     createlayer (layerData) {
         const mapLayer = this.mapLayerService.createMapLayer(layerData);
 
-        if (layerData.baseLayerId && layerData.baseLayerId !== -1) {
-            // If this is a sublayer, add it to its parent's sublayer array
-            this.mapLayerService.addSubLayer(layerData.baseLayerId, mapLayer);
+        // Register layer to the map layer service.
+        if (this.mapLayerService._reservedLayerIds[mapLayer.getId()] !== true) {
+            this.mapLayerService.addLayer(mapLayer);
         } else {
-            // Otherwise just add it to the map layer service.
-            if (this.mapLayerService._reservedLayerIds[mapLayer.getId()] !== true) {
-                this.mapLayerService.addLayer(mapLayer);
-            } else {
-                Messaging.error(getMessage('messages.errorInsertAllreadyExists'));
-                // should we update if layer already exists??? mapLayerService.updateLayer(e.layerData.id, e.layerData);
-            }
+            Messaging.error(getMessage('messages.errorInsertAllreadyExists'));
+            // should we update if layer already exists??? mapLayerService.updateLayer(e.layerData.id, e.layerData);
         }
     }
     getValidatorFunctions (layerType) {

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -9,6 +9,8 @@ const DEFAULT_TAB = 'general';
 
 const getMessage = (key, args) => <Message messageKey={key} messageArgs={args} bundleKey='admin-layereditor' />;
 
+const __VALIDATOR_CACHE = {};
+
 class UIHandler extends StateHandler {
     constructor (consumer) {
         super();
@@ -534,6 +536,9 @@ class UIHandler extends StateHandler {
         }
     }
     getValidatorFunctions (layerType) {
+        if (__VALIDATOR_CACHE[layerType]) {
+            return __VALIDATOR_CACHE[layerType];
+        }
         const hasValue = (value) => {
             if (typeof value === 'string') {
                 return value.trim().length > 0;
@@ -583,6 +588,7 @@ class UIHandler extends StateHandler {
         mandatoryFields.forEach(field => {
             wrappers[field] = (layer) => hasValue(getValue(layer, field));
         });
+        __VALIDATOR_CACHE[layerType] = wrappers;
         return wrappers;
     }
     getValidatorFor (key) {
@@ -778,6 +784,8 @@ class UIHandler extends StateHandler {
                     loading: this.isLoading(),
                     metadata: data
                 });
+                // invalidate cache if it was populated
+                Object.keys(__VALIDATOR_CACHE).forEach(key => delete __VALIDATOR_CACHE[key]);
             }).catch(error => {
                 this.log.error(error);
                 Messaging.error('messages.errorFetchUserRolesAndPermissionTypes');

--- a/bundles/admin/admin-layereditor/view/Flyout.js
+++ b/bundles/admin/admin-layereditor/view/Flyout.js
@@ -51,6 +51,7 @@ export class LayerEditorFlyout extends ExtraFlyout {
     }
     setMapLayerGroups (mapLayerGroups) {
         this.mapLayerGroups = mapLayerGroups;
+        this.uiHandler.setMapLayerGroups(mapLayerGroups);
         this.update();
     }
     update () {

--- a/bundles/admin/admin-layereditor/view/Flyout.js
+++ b/bundles/admin/admin-layereditor/view/Flyout.js
@@ -101,6 +101,7 @@ export class LayerEditorFlyout extends ExtraFlyout {
                         messages={messages}
                         rolesAndPermissionTypes={this.uiHandler.getAdminMetadata()}
                         validators={this.uiHandler.getValidatorFunctions(layer.type)}
+                        validationErrors={this.uiHandler.validateUserInputValues(layer)}
                         tab={tab}
                         scales={scales}
                         onDelete={() => this.uiHandler.deleteLayer()}

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
@@ -29,12 +29,14 @@ const LayerCollapse = ({ groups, openGroupTitles, selectedLayerIds, controller }
             {
                 groups.map(group => {
                     const layerIds = group.getLayers().map(lyr => lyr.getId());
+                    // layerNames are used in key so renaming will update the UI
+                    const layerNames = group.getLayers().map(lyr => lyr.getName());
                     const selectedLayersInGroup = selectedLayerIds.filter(id => layerIds.includes(id));
                     // Passes only ids the component is interested in.
                     // This way the content of selected layer ids remains unchanged when a layer in another group gets added on map.
                     // When the properties remain unchanged, we can benefit from memoization.
                     return (
-                        <StyledLayerCollapsePanel key={group.getId()}
+                        <StyledLayerCollapsePanel key={group.getId() + layerNames.join()}
                             trimmed
                             selectedLayerIds={selectedLayersInGroup}
                             group={group}

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
@@ -167,7 +167,7 @@ class ViewHandler extends StateHandler {
                 const layerId = event.getLayerId();
                 const operation = event.getOperation();
 
-                if (['sticky'].includes(operation)) {
+                if (operation === 'sticky') {
                     this._refreshLayer(layerId);
                 } else if (['add', 'remove', 'update'].includes(operation)) {
                     this.updateLayerGroups();

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
@@ -139,7 +139,7 @@ class ViewHandler extends StateHandler {
      * "Module" name for event handling
      */
     getName () {
-        return 'LayerCollapse.CollapseService';
+        return 'LayerCollapse.CollapseService.' + this.groupingMethod;
     }
 
     /**
@@ -167,9 +167,9 @@ class ViewHandler extends StateHandler {
                 const layerId = event.getLayerId();
                 const operation = event.getOperation();
 
-                if (['update', 'sticky'].includes(operation)) {
+                if (['sticky'].includes(operation)) {
                     this._refreshLayer(layerId);
-                } else if (['add', 'remove'].includes(operation)) {
+                } else if (['add', 'remove', 'update'].includes(operation)) {
                     this.updateLayerGroups();
                 } else if (operation === 'tool') {
                     if (layerId) {

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/util.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/util.js
@@ -29,10 +29,14 @@ export const groupLayers = (layers, method, tools, allGroups = [], allDataProvid
     let group = null;
     let groupForOrphans = null;
 
-    const determineGroupId = (layerGroups, layerAdmin) => {
+    const determineGroupId = (layerGroups = [], layerAdmin) => {
         let groupId;
         if (method === 'getInspireName') {
-            groupId = layerGroups[0] ? layerGroups[0].id : undefined;
+            if (layerGroups.length) {
+                groupId = layerGroups[0] ? layerGroups[0].id : undefined;
+            } else {
+                groupId = -1;
+            }
         } else {
             groupId = layerAdmin ? layerAdmin.organizationId : undefined;
         }
@@ -46,7 +50,7 @@ export const groupLayers = (layers, method, tools, allGroups = [], allDataProvid
         .filter(layer => !layer.getMetaType || layer.getMetaType() !== 'published')
         .forEach(layer => {
             let groupAttr = layer[method]();
-            let groupId = determineGroupId(layer._groups, layer.admin);
+            let groupId = determineGroupId(layer.getGroups(), layer.admin);
 
             // If grouping can be determined, create group if already not created
             if (!group || (typeof groupAttr !== 'undefined' && groupAttr !== '' && group.getTitle() !== groupAttr)) {

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerViewTabsHandler.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerViewTabsHandler.js
@@ -99,10 +99,15 @@ class ViewHandler extends StateHandler {
                 }
             },
             'MapLayerEvent': event => {
+                const layerId = event.getLayerId();
+                if (['add', 'remove'].includes(event.getOperation()) && layerId) {
+                    // refresh layer list on add/remove when layerId is provided
+                    this.getLayerListHandler().updateState({});
+                    return;
+                }
                 if (!['update', 'sticky', 'tool'].includes(event.getOperation())) {
                     return;
                 }
-                const layerId = event.getLayerId();
                 if (layerId) {
                     const { layers } = this.selectedLayersHandler.getState();
                     if (!layers.find(layer => layer.getId() === layerId)) {

--- a/bundles/framework/layerselector2/model/LayerGroup.class.js
+++ b/bundles/framework/layerselector2/model/LayerGroup.class.js
@@ -46,6 +46,10 @@ export class LayerGroup {
      * @param {Layer} layer
      */
     addLayer (layer) {
+        if (this.searchIndex[layer.getId()]) {
+            // Tried adding the same layer again
+            return;
+        }
         this.layers.push(layer);
         this.searchIndex[layer.getId()] = this._getSearchIndex(layer);
     }

--- a/bundles/mapping/mapmodule/domain/AbstractLayer.js
+++ b/bundles/mapping/mapmodule/domain/AbstractLayer.js
@@ -1295,7 +1295,7 @@ Oskari.clazz.define(
         },
         /**
          * @method @public setGroups
-         * @param {Array} groups groups array [{id:1,name:name"}]
+         * @param {Array} groups groups array [{id:1,name:"name"}]
          */
         setGroups: function (groups) {
             this._groups = groups || [{ id: -1, name: '' }];


### PR DESCRIPTION
- Update the internal state after admin adds/updates/removes a layer so page doesn't need to be reloaded to see the change
- Improve performance for field validation
- Added translations
- Changed error messaging from TODO to actual messages
- Save button is now disabled until form is valid (might be changed still)