### PR TITLE
Get dataprovider id correctly for layerlisting

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/util.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/util.js
@@ -50,7 +50,7 @@ export const groupLayers = (layers, method, tools, allGroups = [], allDataProvid
         .filter(layer => !layer.getMetaType || layer.getMetaType() !== 'published')
         .forEach(layer => {
             let groupAttr = layer[method]();
-            let groupId = determineGroupId(layer.getGroups(), layer.admin);
+            let groupId = determineGroupId(layer.getGroups(), layer.getAdmin());
 
             // If grouping can be determined, create group if already not created
             if (!group || (typeof groupAttr !== 'undefined' && groupAttr !== '' && group.getTitle() !== groupAttr)) {


### PR DESCRIPTION
Fixes an issue where updating layer dataprovider with admin had some funky side-effects for layer listing. The layer "admin" object was fetched from wrong variable. Now uses getter from AbstractLayer instead.