### PR TITLE
Language selector width fix

### DIFF
--- a/bundles/framework/language-selector/components/LanguageSelect.jsx
+++ b/bundles/framework/language-selector/components/LanguageSelect.jsx
@@ -4,7 +4,9 @@ import styled from 'styled-components';
 import { languageNames } from './languageNames';
 
 const StyledSelect = styled('select')`
-    width: 100%;
+    &&& {
+        width: 100%;
+    }
     & option[value="_"][disabled] {
         display: none;
     }


### PR DESCRIPTION
increase specificity to override styling because select:not([class*=ant-] had higher.
