### PR TITLE
Mobile tools svg fix

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1214,7 +1214,7 @@ Oskari.clazz.define(
             var mobileDiv = this.getMobileDiv();
             var toolbar = mobileDiv.find('.mobileToolbarContent');
 
-            if (toolbar.find('.toolbar_mobileToolbar').children().length === 0) {
+            if (toolbar.find('.toolbar_mobileToolbar').children().length === 0 && !mobileDiv.find('.mapplugin').length) {
                 // plugins didn't add any content -> hide it so the empty bar is not visible
                 mobileDiv.hide();
             } else {

--- a/bundles/mapping/time-control-3d/plugin/TimeControl3dPlugin.js
+++ b/bundles/mapping/time-control-3d/plugin/TimeControl3dPlugin.js
@@ -64,10 +64,10 @@ class TimeControl3dPlugin extends BasicMapModulePlugin {
         this.redrawUI(Oskari.util.isMobile());
     }
 
-    redrawUI (mapInMobileMode) {
+    redrawUI (mapInMobileMode, forced) {
         this._isMobile = mapInMobileMode;
         this.teardownUI();
-        this._createUI();
+        return this._createUI(forced);
     }
 
     _createEventHandlers () {
@@ -107,11 +107,13 @@ class TimeControl3dPlugin extends BasicMapModulePlugin {
         ReactDOM.unmountComponentAtNode(this._popupContent.get(0));
     }
 
-    _createUI () {
+    _createUI (forced) {
         let el;
         if (this._isMobile) {
             el = this._createMobileControlElement();
-            this._addToMobileToolBar(el);
+            if (this._addToMobileToolBar(el, forced)) {
+                return true;
+            };
         } else {
             el = this._createControlElement();
             this.addToPluginContainer(el);
@@ -149,10 +151,22 @@ class TimeControl3dPlugin extends BasicMapModulePlugin {
             />, el.get(0));
     }
 
-    _addToMobileToolBar (el) {
-        // TODO: create method or request for svg based mobile tools
-        const mobileToolbar = jQuery('.toolbar_mobileToolbar .toolrow');
-        mobileToolbar.append(el);
+    _addToMobileToolBar (el, forced) {
+        // TODO: create mapmodule method and tools service for svg based mobile tools
+        const toolbar = jQuery('.toolbar_' + this.getMapModule().getMobileToolbar());
+        const toolrow = toolbar.find('.toolrow');
+        if (toolrow.length) {
+            toolrow.append(el);
+            return false;
+        }
+        // there's no other tools added, add toolrow
+        if (forced) {
+            const row = jQuery('<div class="toolrow"></div>');
+            row.append(el);
+            toolbar.append(row);
+            return false;
+        }
+        return true; // waiting for toolbar
     }
 
     _toggleToolState () {


### PR DESCRIPTION
Try again to add svg based mobile tool elements if toolbar isn't ready. Force add toolrow if there's no other tools. Added mapmodule to check if mobiletoolbar contains mapplugins to hide/show toolbar. Mobile search is added as mapplugin not as tool. Tried to add like tool to toolrow, but css styling didn't work properly. 