### PR TITLE
Statistics diagram series data fix

### DIFF
--- a/bundles/statistics/statsgrid2016/components/Datatable.js
+++ b/bundles/statistics/statsgrid2016/components/Datatable.js
@@ -400,6 +400,11 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function (sandbox, 
             log.debug('Indicator parameter changed! ');
             me._handleRegionsetChanged();
         });
+        this.service.on('StatsGrid.ClassificationChangedEvent', function (event) {
+            if (event.getChanged().hasOwnProperty('fractionDigits')) {
+                me._handleRegionsetChanged();
+            }
+        });
 
         this.service.on('StatsGrid.RegionSelectedEvent', function (event) {
             log.debug('Region selected! ', event.getRegion());

--- a/bundles/statistics/statsgrid2016/components/Datatable.js
+++ b/bundles/statistics/statsgrid2016/components/Datatable.js
@@ -338,6 +338,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Datatable', function (sandbox, 
                 }
                 // bind click handler to content element
                 content.on('click', function () {
+                    jQuery(this).addClass('selected-effect');
                     me.service.getStateService().setActiveIndicator(ind.hash);
                 });
 

--- a/bundles/statistics/statsgrid2016/components/Diagram.js
+++ b/bundles/statistics/statsgrid2016/components/Diagram.js
@@ -274,6 +274,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Diagram', function (service, lo
         this.service.on('StatsGrid.RegionsetChangedEvent', function () {
             me.updateUI();
         });
+        this.service.on('StatsGrid.ParameterChangedEvent', function () {
+            me.updateUI();
+        });
         this.service.on('StatsGrid.StateChangedEvent', function (event) {
             if (event.isReset()) {
                 me.updateUI();

--- a/bundles/statistics/statsgrid2016/components/Diagram.js
+++ b/bundles/statistics/statsgrid2016/components/Diagram.js
@@ -55,13 +55,11 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Diagram', function (service, lo
             // ui not yet created so no need to update it
             return;
         }
-        if (!this.hasIndicators()) {
+        const indicator = this.service.getStateService().getActiveIndicator();
+        if (!indicator) {
             this.clearChart();
-            this.element.html(this.loc.statsgrid.noResults);
+            el.html(this.loc.statsgrid.noResults);
             return;
-        } else if (this._chartElement) {
-            // reattach possibly detached component
-            el.html(this._chartElement);
         }
         if (this._renderState.inProgress) {
             // handle render being called multiple times in quick succession
@@ -71,24 +69,19 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Diagram', function (service, lo
             return;
         }
         this._renderState.inProgress = true;
-        this.getIndicatorData(this.getIndicator(), function (data) {
-            if (!data) {
-                me._renderDone();
-                return;
-            }
+        this.getIndicatorData(indicator, function (data) {
             var isUndefined = function (element) {
                 return element.value === undefined;
             };
-
-            if (data.every(isUndefined)) {
+            if (!data || data.every(isUndefined)) {
                 me.clearChart();
                 me._renderDone();
-                me.element.html(me.loc.statsgrid.noValues);
+                el.html(me.loc.statsgrid.noValues);
                 return;
             }
-            var classificationOpts = me.service.getStateService().getClassificationOpts(me.getIndicator().hash);
-            var fractionDigits = typeof classificationOpts.fractionDigits === 'number' ? classificationOpts.fractionDigits : 1;
-            var formatter = Oskari.getNumberFormatter(fractionDigits);
+            const { fractionDigits } = indicator.classification;
+            const digits = typeof fractionDigits === 'number' ? fractionDigits : 1;
+            var formatter = Oskari.getNumberFormatter(digits);
             const { maxHeight, width } = me._size;
             var chartOpts = {
                 colors: me.getColorScale(data),
@@ -111,6 +104,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Diagram', function (service, lo
                 me._chartElement = me.createBarCharts(data, chartOpts);
                 el.html(me._chartElement);
             } else {
+                // reattach possibly detached component
+                el.html(me._chartElement);
                 me.getChartInstance().redraw(data, chartOpts);
             }
 
@@ -167,31 +162,28 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Diagram', function (service, lo
             chart.clear();
         }
     },
-    getIndicator: function () {
-        return this.service.getStateService().getActiveIndicator();
-    },
     hasIndicators: function () {
         return this.service.getStateService().hasIndicators();
     },
-    getIndicatorData: function (indicator, callback) {
-        if (!indicator) {
-            callback();
-            return;
-        }
-        this.service.getCurrentDataset(function (err, response) {
+    getIndicatorData: function (ind, callback) {
+        const setId = this.service.getStateService().getRegionset();
+        const { datasource, indicator, selections, series } = ind;
+        this.service.getRegions(setId, (err, regions) => {
             if (err) {
                 callback();
                 return;
             }
-            var indicatorData = [];
-            response.data.forEach(function (dataItem) {
-                indicatorData.push({
-                    name: dataItem.name,
-                    value: dataItem.values[indicator.hash],
-                    id: dataItem.id
+            this.service.getIndicatorData(datasource, indicator, selections, series, setId, (err, data) => {
+                if (err) {
+                    callback();
+                    return;
+                }
+                const response = regions.map(({ id, name }) => {
+                    const value = data[id];
+                    return { id, name, value };
                 });
+                callback(response);
             });
-            callback(indicatorData);
         });
     },
     /**

--- a/bundles/statistics/statsgrid2016/components/IndicatorList.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorList.js
@@ -40,7 +40,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorList', function (servi
         me.service.on('StatsGrid.IndicatorEvent', function (event) {
             me._updateIndicatorList();
         });
-        me.service.on('StatsGrid.ActiveIndicatorChangedEvent', function (event) {
+        me.service.on('StatsGrid.ParameterChangedEvent', function (event) {
             me._updateIndicatorList();
         });
         me.service.on('StatsGrid.StateChangedEvent', function (event) {

--- a/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
+++ b/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
@@ -455,6 +455,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
             // Always show the active indicator
             me.render(state.getRegion());
         });
+        me.service.on('StatsGrid.ParameterChangedEvent', function (event) {
+            me.render(state.getRegion());
+        });
 
         me.service.on('StatsGrid.RegionsetChangedEvent', function (event) {
             // Need to update the map

--- a/bundles/statistics/statsgrid2016/event/ClassificationChangedEvent.js
+++ b/bundles/statistics/statsgrid2016/event/ClassificationChangedEvent.js
@@ -9,9 +9,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.event.ClassificationChangedEven
      * @method create called automatically on construction
      * @static
      */
-    function (current, previous) {
+    function (current, changed = {}) {
         this.current = current;
-        this.previous = previous;
+        this.changed = changed;
     }, {
         /**
          * @method getName
@@ -22,18 +22,18 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.event.ClassificationChangedEven
             return 'StatsGrid.ClassificationChangedEvent';
         },
         /**
-         * Current active indicator
+         * Active indicator's classification
          * @return {Object}
          */
         getCurrent: function () {
             return this.current;
         },
         /**
-         * Previously active indicator
+         * Updated value
          * @return {Object}
          */
-        getPrevious: function () {
-            return this.previous;
+        getChanged: function () {
+            return this.changed;
         }
     }, {
         'protocol': ['Oskari.mapframework.event.Event']

--- a/bundles/statistics/statsgrid2016/service/StateService.js
+++ b/bundles/statistics/statsgrid2016/service/StateService.js
@@ -101,7 +101,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
                     if (indicator) {
                         indicator.classification[key] = value;
                         if (eventBuilder) {
-                            this.sandbox.notifyAll(eventBuilder(indicator.classification));
+                            this.sandbox.notifyAll(eventBuilder(indicator.classification, { [key]: value }));
                         }
                     }
                 },
@@ -112,7 +112,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
                             indicator.classification[key] = obj[key];
                         });
                         if (eventBuilder) {
-                            this.sandbox.notifyAll(eventBuilder(indicator.classification));
+                            this.sandbox.notifyAll(eventBuilder(indicator.classification, obj));
                         }
                     }
                 }

--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -526,6 +526,7 @@
             }
             return regionsets;
         },
+        // FIXME: getIndicatorData returns error if dataset contains serie which is outside of current selection
         getCurrentDataset: function (callback) {
             var me = this;
             if (typeof callback !== 'function') {


### PR DESCRIPTION
Changed diagram to use own getIndicatorData instead of service getCurrentDataset. getCurrentDataset doesn't work if there is more than one series and selected value is outside of value range. Diagram shows data only for active indicator so it doesn't need whole dataset. Even data table doesn't use services getCurrentDataset. Maybe we should remove it.

ClassificationChangedEvent had getPrevious method but previous classification wasn't set. Changed to getChanged which returns updated/changed object. User can update only single values with classification plugin (or min,max pair with slider). It's easy to catch changed value and components doesn't need whole previous classification. So component doesn't have to check if specific value is updated (current.value !== previous.value). Data table is re-rendered only if fractionDigits is changed.

Some event listeners were missing or changed to listen parameter changed instead of active indicator.

Added selected effect for data table header to get fast response for user click.