### PR TITLE
Dimension change error handling

### DIFF
--- a/bundles/mapping/dimension-change/domain/UnsupportedLayerType.js
+++ b/bundles/mapping/dimension-change/domain/UnsupportedLayerType.js
@@ -7,13 +7,22 @@ export class UnsupportedLayerType extends UnsupportedLayerReason {
         super('dimension', severity);
         const map = Oskari.getSandbox().getMap();
         this.setLayerCheckFunction(layer => {
-            if ((map.getSupports3D() && unsupportedIn3D.includes(layer.getLayerType())) ||
-                (!map.getSupports3D() && unsupportedIn2D.includes(layer.getLayerType()))) {
-                return this;
+            if (isLayerSupported(layer, map.getSupports3D())) {
+                return true;
             }
-            return true;
+            return this;
         });
     }
 }
+
+export const isLayerSupported = (layer, mapSupports3D) => {
+    if (mapSupports3D && unsupportedIn3D.includes(layer.getLayerType())) {
+        return false;
+    }
+    if (!mapSupports3D && unsupportedIn2D.includes(layer.getLayerType())) {
+        return false;
+    }
+    return true;
+};
 
 Oskari.clazz.defineES('Oskari.mapframework.domain.UnsupportedLayerType', UnsupportedLayerType);

--- a/bundles/mapping/dimension-change/domain/UnsupportedLayerType.js
+++ b/bundles/mapping/dimension-change/domain/UnsupportedLayerType.js
@@ -10,12 +10,13 @@ export class UnsupportedLayerType extends UnsupportedLayerReason {
             if (isLayerSupported(layer, map.getSupports3D())) {
                 return true;
             }
+            // not supported -> Return an instance of UnsupportedLayerReason
             return this;
         });
     }
 }
 
-export const isLayerSupported = (layer, mapSupports3D) => {
+export const isLayerSupported = (layer, mapSupports3D = false) => {
     if (mapSupports3D && unsupportedIn3D.includes(layer.getLayerType())) {
         return false;
     }


### PR DESCRIPTION
If target appsetup (3D or 2D) would NOT support any of the current layers don't try to preserve them in link and default to showing the layer on the appsetup config.

This fixes an issue on the sample-application where 2D has a vector tile map layer by default which is not supported in 3D. If the user clicks 3D the resulting page will show an empty globe. With this change the maplayer is changed to one that is supported by 3D. The one supported by 3D is also supported by 2D so returning from 3D to 2D will preserve the current maplayer.