### PR TITLE
Add flag to userlayers that have been loaded via myplacesimport

### DIFF
--- a/bundles/framework/myplacesimport/UserLayersTab.js
+++ b/bundles/framework/myplacesimport/UserLayersTab.js
@@ -10,24 +10,20 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.UserLayersTab',
      */
 
     function (instance) {
-        var me = this;
-        var p;
-        me.instance = instance;
-        me.loc = Oskari.getMsg.bind(null, 'MyPlacesImport');
-        me.layerMetaType = 'USERLAYER';
-        me.visibleFields = [
+        this.instance = instance;
+        this.loc = Oskari.getMsg.bind(null, 'MyPlacesImport');
+        this.layerMetaType = 'USERLAYER';
+        this.visibleFields = [
             'name', 'description', 'source', 'edit', 'remove'
         ];
-        me.grid = undefined;
-        me.container = undefined;
+        this.grid = undefined;
+        this.container = undefined;
 
         // templates
-        me.template = {};
-        for (p in me.__templates) {
-            if (me.__templates.hasOwnProperty(p)) {
-                me.template[p] = jQuery(me.__templates[p]);
-            }
-        }
+        this.template = {};
+        Object.keys(this.__templates).forEach(templateName => {
+            this.template[templateName] = jQuery(this.__templates[templateName]);
+        });
     }, {
         __templates: {
             'main': '<div class="oskari-user-layers-tab"></div>',
@@ -80,7 +76,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.UserLayersTab',
                 return link;
             });
             // setup localization
-            _.each(this.visibleFields, function (field) {
+            this.visibleFields.forEach((field) => {
                 grid.setColumnUIName(field, me.loc('tab.grid.' + field));
             });
 
@@ -91,11 +87,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.UserLayersTab',
             return me.container;
         },
         refresh: function () {
-            if (this.container) {
-                this.container.empty();
-                this.grid.setDataModel(this._getGridModel());
-                this.grid.renderTo(this.container);
+            if (!this.container) {
+                return;
             }
+            this.container.empty();
+            this.grid.setDataModel(this._getGridModel());
+            this.grid.renderTo(this.container);
         },
         /**
          * Confirms delete for given layer and deletes it if confirmed. Also shows
@@ -105,20 +102,19 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.UserLayersTab',
          * @private
          */
         _confirmDeleteUserLayer: function (data) {
-            var me = this;
             var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
             var okBtn = Oskari.clazz.create('Oskari.userinterface.component.Button');
 
-            okBtn.setTitle(me.loc('tab.buttons.delete'));
+            okBtn.setTitle(this.loc('tab.buttons.delete'));
             okBtn.addClass('primary');
 
-            okBtn.setHandler(function () {
-                me._deleteUserLayer(data.id);
+            okBtn.setHandler(() => {
+                this._deleteUserLayer(data.id);
                 dialog.close();
             });
-            var cancelBtn = dialog.createCloseButton(me.loc('tab.buttons.cancel'));
-            var confirmMsg = me.loc('tab.confirmDeleteMsg', { name: data.name });
-            dialog.show(me.loc('tab.deleteLayer'), confirmMsg, [cancelBtn, okBtn]);
+            var cancelBtn = dialog.createCloseButton(this.loc('tab.buttons.cancel'));
+            var confirmMsg = this.loc('tab.confirmDeleteMsg', { name: data.name });
+            dialog.show(this.loc('tab.deleteLayer'), confirmMsg, [cancelBtn, okBtn]);
             dialog.makeModal();
         },
         /**
@@ -161,26 +157,24 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.UserLayersTab',
          */
         _deleteSuccess: function (layerId) {
             var me = this;
-            var sandbox = me.instance.sandbox;
-            var service = sandbox.getService('Oskari.mapframework.service.MapLayerService');
+            const sandbox = me.instance.sandbox;
+            const service = sandbox.getService('Oskari.mapframework.service.MapLayerService');
 
             // Remove layer from grid... this is really ugly, but so is jumping
             // through hoops to masquerade as a module
-            var model = me.grid.getDataModel().data;
-            var i;
-            var gridModel = Oskari.clazz.create('Oskari.userinterface.component.GridModel');
-            for (i = 0; i < model.length; i++) {
-                if (model[i].id !== layerId) {
-                    gridModel.addData(model[i]);
+            const model = me.grid.getDataModel().data;
+            const gridModel = Oskari.clazz.create('Oskari.userinterface.component.GridModel');
+            model.forEach(row => {
+                if (row.id !== layerId) {
+                    gridModel.addData(row);
                 }
-            }
+            });
             me.grid.setDataModel(gridModel);
             me.grid.renderTo(me.container);
 
             // TODO: shouldn't maplayerservice send removelayer request by default on remove layer?
             // also we need to do it before service.remove() to avoid problems on other components
-            var removeMLrequestBuilder = Oskari.requestBuilder('RemoveMapLayerRequest');
-            var request = removeMLrequestBuilder(layerId);
+            const request = Oskari.requestBuilder('RemoveMapLayerRequest')(layerId);
             sandbox.request(me.instance, request);
             service.removeLayer(layerId);
 
@@ -195,8 +189,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.UserLayersTab',
          * @private
          */
         _deleteFailure: function () {
-            var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
-            var okBtn = dialog.createCloseButton(this.loc('tab.buttons.ok'));
+            const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+            const okBtn = dialog.createCloseButton(this.loc('tab.buttons.ok'));
             dialog.show(this.loc('tab.error.title'), this.loc('tab.error.deleteMsg'), [okBtn]);
         },
         /**
@@ -204,16 +198,15 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.UserLayersTab',
          *
          * @method _getGridModel
          * @private
-         * @param {jQuery} container
          */
-        _getGridModel: function (container) {
-            var service = this.instance.sandbox.getService('Oskari.mapframework.service.MapLayerService');
-            var layers = service.getAllLayersByMetaType(this.layerMetaType);
-            var gridModel = Oskari.clazz.create('Oskari.userinterface.component.GridModel');
+        _getGridModel: function () {
+            const service = this.instance.sandbox.getService('Oskari.mapframework.service.MapLayerService');
+            const layers = service.getAllLayersByMetaType(this.layerMetaType);
+            const gridModel = Oskari.clazz.create('Oskari.userinterface.component.GridModel');
 
             gridModel.setIdField('id');
 
-            _.each(layers, function (layer) {
+            layers.forEach(function (layer) {
                 if (gridModel.data.length === 0) {
                     gridModel.addData({
                         'id': layer.getId(),
@@ -231,7 +224,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.UserLayersTab',
                         break;
                     }
                 }
-                if (!idDouble) {
+                if (!idDouble && layer.isInternalDownloadSource()) {
                     gridModel.addData({
                         'id': layer.getId(),
                         'name': layer.getName(),

--- a/bundles/framework/myplacesimport/service/MyPlacesImportService.js
+++ b/bundles/framework/myplacesimport/service/MyPlacesImportService.js
@@ -1,67 +1,61 @@
 /**
  * @class Oskari.mapframework.bundle.myplacesimport.MyPlacesImportService
  */
-Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportService',
-/**
- * @method create called automatically on construction
- * @static
- */
-    function (instance) {
-        this.instance = instance;
-        this.sandbox = instance.sandbox;
-        this.urls = {};
+Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportService', function (instance) {
+    this.instance = instance;
+    this.sandbox = instance.sandbox;
+    this.urls = {};
 
-        var srsName = this.sandbox.getMap().getSrsName();
-        this.urls.create = Oskari.urls.getRoute('CreateUserLayer') + '&srs=' + srsName;
-        this.urls.get = Oskari.urls.getRoute('GetUserLayers') + '&srs=' + srsName;
-        this.urls.edit = Oskari.urls.getRoute('EditUserLayer');
-        this.urls.getStyle = Oskari.urls.getRoute('GetUserLayerStyle');
-    }, {
-        __name: 'MyPlacesImport.MyPlacesImportService',
-        __qname: 'Oskari.mapframework.bundle.myplacesimport.MyPlacesImportService',
-        getQName: function () {
-            return this.__qname;
-        },
-        getName: function () {
-            return this.__name;
-        },
-        /**
+    const srsName = this.sandbox.getMap().getSrsName();
+    this.urls.create = Oskari.urls.getRoute('CreateUserLayer', { srs: srsName });
+    this.urls.get = Oskari.urls.getRoute('GetUserLayers', { srs: srsName });
+    this.urls.edit = Oskari.urls.getRoute('EditUserLayer');
+    this.urls.getStyle = Oskari.urls.getRoute('GetUserLayerStyle');
+}, {
+    __name: 'MyPlacesImport.MyPlacesImportService',
+    __qname: 'Oskari.mapframework.bundle.myplacesimport.MyPlacesImportService',
+    getQName: function () {
+        return this.__qname;
+    },
+    getName: function () {
+        return this.__name;
+    },
+    /**
      * Initializes the service (does nothing atm).
      *
      * @method init
      */
-        init: function () {
-        },
-        /**
+    init: function () {},
+    /**
      * Returns the url used to send the file data to.
      *
      * @method getFileImportUrl
      * @return {String}
      */
-        getFileImportUrl: function () {
-            return this.urls.create;
-        },
-        /**
+    getFileImportUrl: function () {
+        return this.urls.create;
+    },
+    /**
      * Returns the url used to update layer.
      *
      * @method getEditLayerUrl
      * @return {String}
      */
-        getEditLayerUrl: function () {
-            return this.urls.edit;
-        },
+    getEditLayerUrl: function () {
+        return this.urls.edit;
+    },
 
-        /**
+    /**
      * Returns the url used to get userlayer style.
      *
      * @method getUserLayerStyleUrl
      * @return {String}
      */
-        getGetUserLayerStyleUrl: function () {
-            return this.urls.getStyle;
-        },
+    getGetUserLayerStyleUrl: function () {
+        return this.urls.getStyle;
+    },
 
-        /**
+    /**
      * Retrieves the user layers (with the id param only the specified layer)
      * from the backend and adds them to the map layer service.
      *
@@ -70,60 +64,56 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
      * @param  {Function} errorCb (optional)
      * @param  {String} id (optional)
      */
-        getUserLayers: function (successCb, errorCb, id) {
-            var me = this,
-                url = this.urls.get;
+    getUserLayers: function (successCb, errorCb, id) {
+        const me = this;
+        let url = this.urls.get;
 
-            if (id) url += ('&id=' + id);
+        if (id) {
+            url = url + '&id=' + id;
+        }
 
-            jQuery.ajax({
-                url: url,
-                type: 'GET',
-                dataType: 'json',
-                beforeSend: function (x) {
-                    if (x && x.overrideMimeType) {
-                        x.overrideMimeType('application/j-son;charset=UTF-8');
-                    }
-                },
-                success: function (response) {
-                    if (response) {
-                        me._addLayersToService(response.userlayers, successCb);
-                    }
-                },
-                error: function (jqXHR, textStatus) {
-                    if (_.isFunction(errorCb) && jqXHR.status !== 0) {
-                        errorCb(jqXHR, textStatus);
-                    }
+        jQuery.ajax({
+            url: url,
+            type: 'GET',
+            dataType: 'json',
+            success: function (response) {
+                if (response) {
+                    me._addLayersToService(response.userlayers, successCb);
                 }
-            });
-        },
+            },
+            error: function (jqXHR, textStatus) {
+                if (typeof errorCb === 'function' && jqXHR.status !== 0) {
+                    errorCb(jqXHR, textStatus);
+                }
+            }
+        });
+    },
 
-        /**
+    /**
      * Update userlayer name, source and description
      *
      * @method updateLayer
      * @param {String} id
      * @param {Object} updatedLayer
      */
-        updateLayer: function (id, updatedLayer) {
-            var mapLayerService = this.sandbox
-                    .getService('Oskari.mapframework.service.MapLayerService'),
-                layer = mapLayerService.findMapLayer(id),
-                request = Oskari.requestBuilder('MapModulePlugin.MapLayerUpdateRequest')(id, true),
-                layerIsSelected = this.sandbox.isLayerAlreadySelected(id),
-                evt = Oskari.eventBuilder('MapLayerEvent')(id, 'update');
-            layer.setName(updatedLayer.name);
-            layer.setSource(updatedLayer.source);
-            layer.setDescription(updatedLayer.description);
-            layer.setOptions(updatedLayer.options);
+    updateLayer: function (id, updatedLayer) {
+        const mapLayerService = this.sandbox
+            .getService('Oskari.mapframework.service.MapLayerService');
+        const layer = mapLayerService.findMapLayer(id);
+        layer.setName(updatedLayer.name);
+        layer.setSource(updatedLayer.source);
+        layer.setDescription(updatedLayer.description);
+        layer.setOptions(updatedLayer.options);
 
-            this.sandbox.notifyAll(evt);
-            if (layerIsSelected) {
-                this.instance.sandbox.request(this.instance, request);
-                this.instance.sandbox.postRequestByName('ChangeMapLayerStyleRequest', [layer.getId()]);
-            }
-        },
-        /**
+        var evt = Oskari.eventBuilder('MapLayerEvent')(id, 'update');
+        this.sandbox.notifyAll(evt);
+        if (this.sandbox.isLayerAlreadySelected(id)) {
+            // update layer on map
+            this.instance.sandbox.postRequestByName('MapModulePlugin.MapLayerUpdateRequest', [id, true]);
+            this.instance.sandbox.postRequestByName('ChangeMapLayerStyleRequest', [layer.getId()]);
+        }
+    },
+    /**
      * Adds the layers to the map layer service.
      *
      * @method _addLayersToService
@@ -131,18 +121,19 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
      * @param {JSON[]} layers
      * @param {Function} cb
      */
-        _addLayersToService: function (layers, cb) {
-            var me = this;
-            _.each(layers, function (layerJson) {
-                me.addLayerToService(layerJson, true);
-            });
-            if (_.isFunction(cb)) cb();
-            if (layers && layers.length > 0) {
-                var event = Oskari.eventBuilder('MapLayerEvent')(null, 'add'); // to-do: check if null is valid parameter here
-                me.sandbox.notifyAll(event); // add user layers programmatically since normal link processing
-            }
-        },
-        /**
+    _addLayersToService: function (layers = [], cb) {
+        layers.forEach((layerJson) => {
+            this.addLayerToService(layerJson, true);
+        });
+        if (typeof cb === 'function') {
+            cb();
+        }
+        if (layers.length > 0) {
+            const event = Oskari.eventBuilder('MapLayerEvent')(null, 'add'); // null as id triggers mass update
+            this.sandbox.notifyAll(event);
+        }
+    },
+    /**
      * Adds one layer to the map layer service
      * and calls the cb with the added layer model if provided.
      *
@@ -151,17 +142,21 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
      * @param {Boolean} skip add maplayer even in map-layer-service
      * @param {Function} cb (optional)
      */
-        addLayerToService: function (layerJson, skipEvent, cb) {
-            var mapLayerService = this.sandbox
-                    .getService('Oskari.mapframework.service.MapLayerService'),
-                // Create the layer model
-                mapLayer = mapLayerService.createMapLayer(layerJson);
-            // Add the layer to the map layer service
-            mapLayerService.addLayer(mapLayer, skipEvent);
-            if (_.isFunction(cb)) cb(mapLayer);
-
-            return mapLayer;
+    addLayerToService: function (layerJson, skipEvent, cb) {
+        const mapLayerService = this.sandbox.getService('Oskari.mapframework.service.MapLayerService');
+        // Create the layer model
+        const mapLayer = mapLayerService.createMapLayer(layerJson);
+        // mark that this has been added by this bundle.
+        // There might be other userlayer typed layers in maplayerservice from link parameters that might NOT be this users layers.
+        // This is used to filter out other users shared layers when listing layers on the My Data functionality.
+        mapLayer.markAsInternalDownloadSource();
+        // Add the layer to the map layer service
+        mapLayerService.addLayer(mapLayer, skipEvent);
+        if (typeof cb === 'function') {
+            cb(mapLayer);
         }
-    }, {
-        'protocol': ['Oskari.mapframework.service.Service']
-    });
+        return mapLayer;
+    }
+}, {
+    'protocol': ['Oskari.mapframework.service.Service']
+});

--- a/bundles/mapping/mapuserlayers/domain/UserLayer.js
+++ b/bundles/mapping/mapuserlayers/domain/UserLayer.js
@@ -45,6 +45,17 @@ export class UserLayer extends WFSLayer {
         return this.renderingElement;
     }
 
+    /**
+     * Internal information as link params might produce userlayers that are NOT this users layers in the maplayerservice
+     * @param {String} src set by myplacesimport if this is truely
+     */
+    markAsInternalDownloadSource () {
+        this.__internalFlagForUsersOwnLayers = true;
+    }
+    isInternalDownloadSource () {
+        return this.__internalFlagForUsersOwnLayers;
+    }
+
     isFilterSupported () {
         // this defaults to false in AbstractLayer, but WFSLayer returns true.
         // Not sure if this is something we want, but it's the same behavior as before but NOT having


### PR DESCRIPTION
Loads of formatting changes here and replaced lodash with native functions where found.

The actual change is with UserLayer model with two new functions: `markAsInternalDownloadSource()` and `isInternalDownloadSource()`. Layers loaded with myplacesimport are marked to be the current users layers and My Data listing for userlayers are filtered to include only the marked ones. Previously any shared userlayers (referenced in url parameters) were also listed as users layers. The server does validate the owner and refused to edit or delete such layers but it was misleading when such layers might show up on My data.