### PR TITLE
Lower log level to increase performance

### DIFF
--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/util/style.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/util/style.js
@@ -130,8 +130,7 @@ const getStyleForGeometry = (geometry, styleTypes) => {
     case 'GeometryCollection':
         const geometries = geometry.getGeometries();
         if (geometries && geometries.length > 0) {
-            const geometryNames = geometries.map(g => g.getType());
-            log.info('Received GeometryCollection with geometries ' + geometryNames + '. Using first one to determine feature style.');
+            log.debug('Received GeometryCollection. Using first feature to determine feature style.');
             style = getStyleForGeometry(geometries[0], styleTypes);
         } else {
             log.info('Received GeometryCollection without geometries. Feature style cannot be determined.');


### PR DESCRIPTION
Logging 10000 messages in a short timeframe takes way too much processing power and this is not essential in any way. If a developer wants to see this message he can set the logger to output debug info. For everyone else this is at least 2x performance boost when a layer has GeometryCollection as feature type.