### PR TITLE
Pass arguments to super constructor

### DIFF
--- a/bundles/mapping/mapmyplaces/domain/MyPlacesLayer.js
+++ b/bundles/mapping/mapmyplaces/domain/MyPlacesLayer.js
@@ -7,7 +7,7 @@ const WFSLayer = Oskari.clazz.get('Oskari.mapframework.bundle.mapwfs2.domain.WFS
 
 export class MyPlacesLayer extends WFSLayer {
     constructor () {
-        super();
+        super(...arguments);
         /* Layer Type */
         this._layerType = 'MYPLACES';
         this._metaType = 'MYPLACES';

--- a/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
+++ b/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
@@ -19,11 +19,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmyplaces.domain.MyPlacesLayer
             var me = this;
             var loclayer = me.localization.layer;
 
-            // set options before parsing wfs spesific layer data
-            if (mapLayerJson.options) {
-                layer.setOptions(mapLayerJson.options);
-            }
-
             // call parent parseLayerData
             this.wfsBuilder.parseLayerData(layer, mapLayerJson, maplayerService);
             this.wfsBuilder.setDefaultRenderMode(layer, 'vector');

--- a/bundles/mapping/mapuserlayers/domain/UserLayer.js
+++ b/bundles/mapping/mapuserlayers/domain/UserLayer.js
@@ -7,7 +7,7 @@ const WFSLayer = Oskari.clazz.get('Oskari.mapframework.bundle.mapwfs2.domain.WFS
 
 export class UserLayer extends WFSLayer {
     constructor () {
-        super();
+        super(...arguments);
         this._layerType = 'USERLAYER';
         this._metaType = 'USERLAYER';
         this.description = undefined;

--- a/bundles/mapping/mapwfs2/domain/WFSLayer.js
+++ b/bundles/mapping/mapwfs2/domain/WFSLayer.js
@@ -8,7 +8,7 @@ const VectorTileLayer = Oskari.clazz.get('Oskari.mapframework.mapmodule.VectorTi
 
 export class WFSLayer extends VectorTileLayer {
     constructor () {
-        super();
+        super(...arguments);
         /* Layer Type */
         this._layerType = 'WFS';
         this._featureData = true;


### PR DESCRIPTION
Pass arguments to super constructor to set layer options correctly. Layer options contains configured styles. Fixes issue where wfs, userlayer and myplaces layers' configured styles didn't work.