### PR TITLE
Reset styles set from OpenLayers ol.css

### DIFF
--- a/bundles/mapping/mapmodule/resources/scss/indexmap.ol.scss
+++ b/bundles/mapping/mapmodule/resources/scss/indexmap.ol.scss
@@ -7,20 +7,6 @@ $lightIcon: url("../images/world_light.svg");
 div.mapplugin.indexmap {
     text-align: left;
 
-    .olControlOverviewMapElement {
-        /* Hide by default, control's maximize: false doesn't seem to do anything */
-        display: none;
-        background-color: #FFFFFF;
-        border-color: #D0D0D0;
-        border-left-width: 2px;
-        border-style: solid;
-        border-top-width: 2px;
-        padding: 5px;
-        margin-left: $toggleSize;
-        margin-right: 0;
-        margin-bottom: -$toggleSize;
-    }
-
     div.icon {
         width: $toggleSize !important;
         height: $toggleSize !important;
@@ -113,14 +99,7 @@ div.mapplugin.indexmap {
 .right {
     div.mapplugin.indexmap {
         text-align: right;
-
-        .olControlOverviewMapElement {
-            margin-left: 0;
-            margin-right: $toggleSize;
-        }
-
     }
-
 }
 
 /**

--- a/bundles/mapping/mapmodule/resources/scss/indexmap.ol.scss
+++ b/bundles/mapping/mapmodule/resources/scss/indexmap.ol.scss
@@ -106,7 +106,8 @@ div.mapplugin.indexmap {
     .mapplugin.ol_indexmap {
         width: 150px !important;
         height:150px !important;
-        display: inline;}
+        display: inline;
+    }
 }
 
 .right {
@@ -125,6 +126,10 @@ div.mapplugin.indexmap {
 /**
   ol specific
  */
+div.ol-overviewmap.ol-control {
+    /* reset positioning that is set in ol/ol.css so the indexmap isn't opened outside the browser window */ 
+    position: inherit;
+}
 .ol-overviewmap .ol-overviewmap-map {
     border: 1px solid #3c3c3c;
     height: 150px;

--- a/bundles/mapping/mapmodule/resources/scss/scalebar.ol.scss
+++ b/bundles/mapping/mapmodule/resources/scss/scalebar.ol.scss
@@ -12,18 +12,6 @@ div.mapplugin.scalebar {
     border-left: 1px solid black;
     border-right: 1px solid black;
 
-/*
-    border-left: 2px solid #000000;
-    border-bottom: 2px solid #000000;
-    border-right: 2px solid #000000;
-*/
-/*
-    div.ol-scale-line {
-        div.ol-scale-line-inner {
-            padding: 2px;
-        }
-    }
-*/
     div {
         // Add a slight brightening to the bg so the scale is visible on dark backgrounds
         background-color: rgba(255, 255, 255, 0.2);
@@ -45,7 +33,21 @@ div.mapplugin.scalebar {
     }
 
     div.ol-scale-line {
+        /* reset styles that are set ny ol/ol.css */
+        /* all: unset; works in chrome but not in IE */
+        border-radius: inherit;
+        background: inherit;
+        bottom: inherit;
+        left: inherit;
+        padding: inherit;
+        position: inherit;
         div.ol-scale-line-inner {
+            /* reset styles that are set ny ol/ol.css */
+            border: inherit;
+            border-top: inherit;
+            color: inherit;
+            font-size: inherit;
+            margin: inherit;
             &::before {
               content:'';
               padding-left: 5px;


### PR DESCRIPTION
ol.css was added to fix an issue with the Openlayers stop-events functionality in #1259. This resulted in scale bar being visually different and hard to read. This restores the old style.

Also fixes indexmap positioning that was changed with the addition of ol.css.