### PR TITLE
Statistics tile handling

### DIFF
--- a/bundles/framework/divmanazer/instance.js
+++ b/bundles/framework/divmanazer/instance.js
@@ -677,7 +677,6 @@ Oskari.clazz.define('Oskari.userinterface.bundle.ui.UserInterfaceBundleInstance'
                 }
             }
             var extLocation = function (request, me, axis) {
-                // TODO
                 if (request.getExtensionLocation().top || request.getExtensionLocation().left) {
                     me.origExtensionLocation = {};
                 }

--- a/bundles/framework/divmanazer/instance.js
+++ b/bundles/framework/divmanazer/instance.js
@@ -645,25 +645,8 @@ Oskari.clazz.define('Oskari.userinterface.bundle.ui.UserInterfaceBundleInstance'
 
             flyoutInfo = extensionInfo.plugins['Oskari.userinterface.Flyout'];
 
-            /* opening  flyouts 'attached' closes previously attachily opened  flyout(s) */
-            if (state === 'attach' && flyoutInfo) {
-                if (request.getExtensionLocation().top || request.getExtensionLocation().left) {
-                    me.origExtensionLocation = {};
-                }
-
-                var extLocation = function (request, me, axis) {
-                    if (me.origExtensionLocation) {
-                        if (request.getExtensionLocation()[axis]) {
-                            me.origExtensionLocation[axis] = jQuery(flyoutInfo.el).css(axis);
-                            jQuery(flyoutInfo.el).css(axis, request.getExtensionLocation()[axis] + 'px');
-                        } else if (me.origExtensionLocation[axis]) {
-                            jQuery(flyoutInfo.el).css(axis, me.origExtensionLocation[axis]);
-                        }
-                    }
-                };
-                extLocation(request, me, 'top');
-                extLocation(request, me, 'left');
-
+            /* opening extension 'attached' closes previously attachily opened extensions (tile, flyout) */
+            if (state === 'attach') {
                 ops = me.flyoutOps;
                 closeOp = ops.close;
                 for (n = 0, len = extensions.length; n < len; n += 1) {
@@ -682,32 +665,43 @@ Oskari.clazz.define('Oskari.userinterface.bundle.ui.UserInterfaceBundleInstance'
                     if (otherFlyoutInfo) {
                         otherFlyoutPlugin = otherFlyoutInfo.plugin;
                         otherFlyout = otherFlyoutInfo.el;
-
-                        otherExtensionInfo.state = otherState;
                         closeOp.apply(this, [otherFlyout, otherFlyoutPlugin, otherExtensionInfo]);
-
-                        me.notifyExtensionViewStateChange(otherExtensionInfo);
-                    } else {
-                        continue;
                     }
-
                     otherTileInfo = plgnfo['Oskari.userinterface.Tile'];
                     if (otherTileInfo) {
                         otherTile = otherTileInfo.el;
-
                         me.applyTransition(otherTile, otherState, me.tileTransitions);
                     }
+                    otherExtensionInfo.state = otherState;
+                    me.notifyExtensionViewStateChange(otherExtensionInfo);
                 }
             }
+            var extLocation = function (request, me, axis) {
+                // TODO
+                if (request.getExtensionLocation().top || request.getExtensionLocation().left) {
+                    me.origExtensionLocation = {};
+                }
+                if (me.origExtensionLocation) {
+                    if (request.getExtensionLocation()[axis]) {
+                        me.origExtensionLocation[axis] = jQuery(flyoutInfo.el).css(axis);
+                        jQuery(flyoutInfo.el).css(axis, request.getExtensionLocation()[axis] + 'px');
+                    } else if (me.origExtensionLocation[axis]) {
+                        jQuery(flyoutInfo.el).css(axis, me.origExtensionLocation[axis]);
+                    }
+                }
+            };
 
             /* let's transition flyout if one exists */
             if (flyoutInfo) {
                 flyoutPlugin = flyoutInfo.plugin;
                 flyout = flyoutInfo.el;
-
-                // if flyout plugin has a lazyRender created, use it.
-                if (state === 'attach' && flyoutPlugin.lazyRender) {
-                    flyoutPlugin.lazyRender();
+                if (state === 'attach') {
+                    extLocation(request, me, 'top');
+                    extLocation(request, me, 'left');
+                    // if flyout plugin has a lazyRender created, use it.
+                    if (flyoutPlugin.lazyRender) {
+                        flyoutPlugin.lazyRender();
+                    }
                 }
 
                 /**

--- a/bundles/statistics/statsgrid2016/FlyoutManager.js
+++ b/bundles/statistics/statsgrid2016/FlyoutManager.js
@@ -120,5 +120,21 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.FlyoutManager', function (insta
     },
     getFlyout: function (type) {
         return this.flyouts[type];
+    },
+    tileAttached: function () {
+        if (this.service.hasIndicators()) {
+            return;
+        }
+        this.open('search');
+    },
+    tileClosed: function () {
+        this.hide('search');
+    },
+    hideFlyouts: function () {
+        Object.keys(this.flyouts).forEach(type => {
+            if (type === 'search') return;
+            this.hide(type);
+        });
     }
+
 });

--- a/bundles/statistics/statsgrid2016/Tile.js
+++ b/bundles/statistics/statsgrid2016/Tile.js
@@ -131,13 +131,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Tile', function (instance, serv
      * Hides all the extra options (used when tile is "deactivated")
      */
     hideExtensions: function () {
-        var me = this;
-        var extraOptions = me.getExtensions();
+        var extraOptions = this.getExtensions();
         Object.keys(extraOptions).forEach(function (key) {
-            // hide the tile "extra selection"
-            var extension = extraOptions[key];
-            extension.removeClass('material-selected');
-            extension.addClass('hidden');
+            extraOptions[key].addClass('hidden');
         });
         this.flyoutManager.tileClosed();
     },
@@ -146,9 +142,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Tile', function (instance, serv
      * @return {[type]} [description]
      */
     showExtensions: function () {
-        var me = this;
-        var extraOptions = me.getExtensions();
-        this.flyoutManager.init();
+        var extraOptions = this.getExtensions();
         Object.keys(extraOptions).forEach(function (key) {
             extraOptions[key].removeClass('hidden');
         });

--- a/bundles/statistics/statsgrid2016/Tile.js
+++ b/bundles/statistics/statsgrid2016/Tile.js
@@ -134,13 +134,12 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Tile', function (instance, serv
         var me = this;
         var extraOptions = me.getExtensions();
         Object.keys(extraOptions).forEach(function (key) {
-            // hide all flyout
-            me.flyoutManager.hide(key);
             // hide the tile "extra selection"
             var extension = extraOptions[key];
             extension.removeClass('material-selected');
             extension.addClass('hidden');
         });
+        this.flyoutManager.tileClosed();
     },
     /**
      * Shows the tile extra options (when tile is activated)
@@ -153,6 +152,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Tile', function (instance, serv
         Object.keys(extraOptions).forEach(function (key) {
             extraOptions[key].removeClass('hidden');
         });
+        this.flyoutManager.tileAttached();
     },
     /**
      * [getExtensions description]

--- a/bundles/statistics/statsgrid2016/instance.js
+++ b/bundles/statistics/statsgrid2016/instance.js
@@ -243,6 +243,7 @@ Oskari.clazz.define(
                     this._removeStatsLayer();
                     this._setClassificationViewVisible(false);
                     this._setSeriesControlVisible(false);
+                    this.flyoutManager.hideFlyouts();
                 } else {
                     this.statsService.getStateService().getIndicators().forEach(ind => {
                         this.addDataProviderInfo(ind);

--- a/bundles/statistics/statsgrid2016/instance.js
+++ b/bundles/statistics/statsgrid2016/instance.js
@@ -287,22 +287,14 @@ Oskari.clazz.define(
                 this.getSandbox().postRequestByName('userinterface.UpdateExtensionRequest', [this, 'close']);
             },
             'userinterface.ExtensionUpdatedEvent': function (event) {
-                var me = this;
                 // Not handle other extension update events
-                if (event.getExtension().getName() !== me.getName()) {
+                if (event.getExtension().getName() !== this.getName()) {
                     return;
                 }
-                var wasClosed = event.getViewState() === 'close';
-                // moving flyout around will trigger attach states on each move
-                var visibilityChanged = this.visible === wasClosed;
-                this.visible = !wasClosed;
-                if (!visibilityChanged) {
-                    return;
-                }
-                if (wasClosed) {
-                    me.getTile().hideExtensions();
+                if (event.getViewState() === 'close') {
+                    this.getTile().hideExtensions();
                 } else {
-                    me.getTile().showExtensions();
+                    this.getTile().showExtensions();
                 }
             },
             AfterMapLayerRemoveEvent: function (event) {


### PR DESCRIPTION
Changed divmanazer to close other attached tiles which doesn't have flyout. Now statistics tile is closed when other extension is attached. 

When tile is closed search flyout is closed. Search flyout is shown when tile is attached and no indicator's selected. Table, diagram and own inicator flyouts are closed when statistics state is reseted (layer or last indicator removed).