### PR TITLE
Measurements

### DIFF
--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
@@ -988,13 +988,7 @@ Oskari.clazz.define(
                 var mapmodule = this.getMapModule();
                 if (geom instanceof olGeom.Polygon) {
                     area = mapmodule.getGeomArea(geom);
-                    if (area < 10000) {
-                        area = area.toFixed(0) + ' m&sup2;';
-                    } else if (area > 1000000) {
-                        area = (area / 1000000).toFixed(3) + ' km&sup2;';
-                    } else {
-                        area = (area / 10000).toFixed(2) + ' ha';
-                    }
+                    area = mapmodule.formatMeasurementResult(area, 'area');
                     if (area) {
                         area = area.replace('.', ',');
                     }
@@ -1009,11 +1003,7 @@ Oskari.clazz.define(
                     }
                 } else if (geom instanceof olGeom.LineString) {
                     length = mapmodule.getGeomLength(geom);
-                    if (length < 1000) {
-                        length = length.toFixed(0) + ' m';
-                    } else {
-                        length = (length / 1000).toFixed(3) + ' km';
-                    }
+                    length = mapmodule.formatMeasurementResult(length, 'line');
                     if (length) {
                         length = length.replace('.', ',');
                     }

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
@@ -975,55 +975,51 @@ Oskari.clazz.define(
          * - displays measurement result on feature
          * @param {ol/MapBrowserEvent} evt
          */
-        pointerMoveHandler: function (evt) {
-            var me = this;
-            evt = evt || {};
-            var tooltipCoord = evt.coordinate;
-            if (me._sketch) {
-                var output,
-                    area,
-                    length,
-                    overlay;
-                var geom = (me._sketch.getGeometry());
-                var mapmodule = this.getMapModule();
-                if (geom instanceof olGeom.Polygon) {
-                    area = mapmodule.getGeomArea(geom);
-                    area = mapmodule.formatMeasurementResult(area, 'area');
-                    if (area) {
-                        area = area.replace('.', ',');
-                    }
-                    output = area;
-                    tooltipCoord = geom.getInteriorPoint().getCoordinates();
-                    // for Polygon-drawing checking itself-intersection
-                    if (me._featuresValidity[me._sketch.getId()] === false) {
-                        output = '';
-                        if (me._showIntersectionWarning) {
-                            output = me._loc.intersectionNotAllowed;
-                        }
-                    }
-                } else if (geom instanceof olGeom.LineString) {
-                    length = mapmodule.getGeomLength(geom);
-                    length = mapmodule.formatMeasurementResult(length, 'line');
-                    if (length) {
-                        length = length.replace('.', ',');
-                    }
-                    output = length;
-                    tooltipCoord = geom.getLastCoordinate();
-                }
-                if (me.getOpts('showMeasureOnMap') && tooltipCoord) {
-                    overlay = me._overlays[me._sketch.getId()];
-                    if (overlay) {
-                        var ii = jQuery('div.' + me._tooltipClassForMeasure + '.' + me._sketch.getId());
-                        ii.html(output);
-                        if (output === '') {
-                            ii.addClass('withoutText');
-                        } else {
-                            ii.removeClass('withoutText');
-                        }
-                        overlay.setPosition(tooltipCoord);
-                    }
-                }
+        pointerMoveHandler: function (evt = {}) {
+            const me = this;
+            let tooltipCoord = evt.coordinate;
+            if (!me._sketch || !me.getOpts('showMeasureOnMap')) {
+                // if no drawing of we don't want to show it on map -> skip
+                return;
             }
+            const geom = (me._sketch.getGeometry());
+            const mapmodule = this.getMapModule();
+            let output;
+            if (geom instanceof olGeom.Polygon) {
+                tooltipCoord = geom.getInteriorPoint().getCoordinates();
+                // for Polygon-drawing checking itself-intersection
+                if (me._featuresValidity[me._sketch.getId()] === false) {
+                    output = '';
+                    if (me._showIntersectionWarning) {
+                        output = me._loc.intersectionNotAllowed;
+                    }
+                } else {
+                    // all good - get actual measurement
+                    const area = mapmodule.getGeomArea(geom);
+                    output = mapmodule.formatMeasurementResult(area, 'area');
+                }
+            } else if (geom instanceof olGeom.LineString) {
+                const length = mapmodule.getGeomLength(geom);
+                output = mapmodule.formatMeasurementResult(length, 'line');
+                tooltipCoord = geom.getLastCoordinate();
+            }
+            if (!tooltipCoord) {
+                // we don't know where we should show this
+                return;
+            }
+            const overlay = me._overlays[me._sketch.getId()];
+            if (!overlay) {
+                // no overlay to update
+                return;
+            }
+            var ii = jQuery('div.' + me._tooltipClassForMeasure + '.' + me._sketch.getId());
+            ii.html(output);
+            if (output === '') {
+                ii.addClass('withoutText');
+            } else {
+                ii.removeClass('withoutText');
+            }
+            overlay.setPosition(tooltipCoord);
         },
         /**
          * @method addModifyInteraction

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -396,17 +396,14 @@ export class MapModule extends AbstractMapModule {
      *
      * http://gis.stackexchange.com/questions/142062/openlayers-3-linestring-getlength-not-returning-expected-value
      * "Bottom line: if your view is 4326 or 3857, don't use getLength()."
+     * https://openlayers.org/en/latest/apidoc/module-ol_sphere.html
      */
     getGeomArea (geometry) {
         if (!geometry || (geometry.getType() !== 'Polygon' && geometry.getType() !== 'MultiPolygon')) {
             return 0;
         }
         var sourceProj = this.getMap().getView().getProjection();
-        if (sourceProj.getUnits() !== 'degrees') {
-            return geometry.getArea();
-        }
-        var geom = geometry.clone().transform(sourceProj, 'EPSG:4326');
-        return Math.abs(olSphere.getArea(geom, { projection: 'EPSG:4326', radius: 6378137 }));
+        return olSphere.getArea(geometry, { projection: sourceProj });
     }
 
     /**
@@ -418,23 +415,14 @@ export class MapModule extends AbstractMapModule {
      *
      * http://gis.stackexchange.com/questions/142062/openlayers-3-linestring-getlength-not-returning-expected-value
      * "Bottom line: if your view is 4326 or 3857, don't use getLength()."
+     * https://openlayers.org/en/latest/apidoc/module-ol_sphere.html
      */
     getGeomLength (geometry) {
-        var length = 0;
         if (!geometry || geometry.getType() !== 'LineString') {
             return 0;
         }
         var sourceProj = this.getMap().getView().getProjection();
-        if (sourceProj.getUnits() !== 'degrees') {
-            return geometry.getLength();
-        }
-        var coordinates = geometry.getCoordinates();
-        for (var i = 0, ii = coordinates.length - 1; i < ii; ++i) {
-            var c1 = olProj.transform(coordinates[i], sourceProj, 'EPSG:4326');
-            var c2 = olProj.transform(coordinates[i + 1], sourceProj, 'EPSG:4326');
-            length += olSphere.getDistance(c1, c2, 6378137);
-        }
-        return length;
+        return olSphere.getLength(geometry, { projection: sourceProj });
     }
 
     /**

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -446,6 +446,7 @@ export class MapModule extends AbstractMapModule {
         if (typeof measurement !== 'number') {
             return;
         }
+        const zoomedForAccuracy = this.getResolution() < 1;
 
         if (drawMode === 'area') {
             // 1 000 000 m² === 1 km²
@@ -455,7 +456,7 @@ export class MapModule extends AbstractMapModule {
                 unit = ' km²';
             } else if (measurement < 10000) {
                 result = measurement;// (Math.round(100 * measurement) / 100);
-                decimals = 0;
+                decimals = zoomedForAccuracy ? 1 : 0;
                 unit = ' m²';
             } else {
                 result = measurement / 10000; // (Math.round(100 * measurement) / 100);
@@ -470,7 +471,7 @@ export class MapModule extends AbstractMapModule {
                 unit = ' km';
             } else {
                 result = measurement; // (Math.round(100 * measurement) / 100);
-                decimals = 0;
+                decimals = zoomedForAccuracy ? 1 : 0;
                 unit = ' m';
             }
         } else {


### PR DESCRIPTION
Use ol/sphere to calculate measurements instead of geometry.getArea()/getLength(). Fixes an issue where measurements on maps using projections like EPSG:3857 shows very wrong results on polar countries.

Also tuned measurement result to show the first decimal when the user has zoomed in for it to be accurate enough.