### PR TITLE
GetinfoPlugin wfs result fix

### DIFF
--- a/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
+++ b/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
@@ -178,7 +178,6 @@ Oskari.clazz.define(
                 popupDOM,
                 popup;
             jQuery(contentDiv).addClass('infoboxPopupNoMargin');
-
             if (isMarker) {
                 var markerPosition = mapModule.getSvgMarkerPopupPxPosition(marker);
                 offsetX = markerPosition.x;
@@ -556,19 +555,18 @@ Oskari.clazz.define(
                     // No content left, close popup
                     this.close(popupId);
                 } else {
+                    const { colourScheme, font, title, lonlat } = popup;
                     this._renderPopup(
                         popupId,
                         contentData,
-                        popup.title,
-                        popup.lonlat,
-                        popup.colourScheme,
-                        popup.font,
+                        title,
+                        lonlat,
+                        { colourScheme, font },
                         true
                     );
                 }
             }
         },
-
         setAdaptable: function (isAdaptable) {
             this.adaptable = isAdaptable;
         },

--- a/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
+++ b/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
@@ -245,7 +245,6 @@ Oskari.clazz.define(
                 });
                 mapModule.getMap().addOverlay(popup);
                 popup.setPosition(lonlatArray);
-                setTimeout(me._panMapToShowPopup.bind(me, lonlatArray, positioning), 0);
 
                 jQuery(popup.div).css('overflow', 'visible');
                 jQuery(popup.groupDiv).css('overflow', 'visible');
@@ -320,6 +319,9 @@ Oskari.clazz.define(
                 } else {
                     me._adaptPopupSize(id, refresh);
                 }
+            }
+            if (popupType === 'desktop') {
+                setTimeout(me._panMapToShowPopup.bind(me, lonlatArray, positioning), 0);
             }
             me._setClickEvent(id, popup, contentData, additionalTools, isInMobileMode);
         },

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoHandler.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoHandler.js
@@ -29,7 +29,6 @@ Oskari.clazz.define(
                     lon: request.getLon(),
                     lat: request.getLat()
                 };
-                this.getInfoPlugin.clickLocation = lonlat;
                 this.getInfoPlugin.handleGetInfo(lonlat);
             } else if (request.getName() === 'MapModulePlugin.GetFeatureInfoActivationRequest') {
                 this.getInfoPlugin.setEnabled(request.isEnabled());

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
@@ -100,9 +100,6 @@ Oskari.clazz.define(
                     }
                     this.handleGetInfo(click);
                 },
-                AfterMapMoveEvent: function (evt) {
-                    this._cancelAjaxRequest();
-                },
                 AfterMapLayerRemoveEvent: function (evt) {
                     this._refreshGfiInfo('remove', evt.getMapLayer().getId());
                 },

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
@@ -31,7 +31,7 @@ Oskari.clazz.define(
             jqhr: null,
             timestamp: null
         };
-        me.clickLocation = null;
+        me._location = null;
 
         /* templates */
         me.template = {};
@@ -74,7 +74,15 @@ Oskari.clazz.define(
 
             // hide infobox if open
             this._closeGfiInfo();
-            this.clickLocation = null;
+        },
+        setLocation: function (lonlat) {
+            this._location = lonlat;
+        },
+        getLocation: function () {
+            return this._location;
+        },
+        resetLocation: function () {
+            this._location = null;
         },
 
         _createEventHandlers: function () {
@@ -87,14 +95,13 @@ Oskari.clazz.define(
                         // disabled, do nothing
                         return;
                     }
-
+                    const click = evt.getLonLat();
+                    const lonlat = this.getLocation();
                     // remove old popup
-                    this._closeGfiInfo();
-
-                    this.clickLocation = {
-                        lonlat: evt.getLonLat()
-                    };
-                    this.handleGetInfo(this.clickLocation.lonlat);
+                    if (!lonlat || lonlat.lon !== click.lon || lonlat.lat !== click.lat) {
+                        this._closeGfiInfo();
+                    }
+                    this.handleGetInfo(click);
                 },
                 AfterMapMoveEvent: function (evt) {
                     this._cancelAjaxRequest();
@@ -407,8 +414,8 @@ Oskari.clazz.define(
                 var reqBuilder = Oskari.requestBuilder('InfoBox.HideInfoBoxRequest');
                 this.getSandbox().request(this, reqBuilder(this.infoboxId));
             }
+            this.resetLocation();
         },
-
         /**
          * Shows given content in given location using infobox bundle
          *
@@ -426,7 +433,6 @@ Oskari.clazz.define(
                 colourScheme: params.colourScheme,
                 font: params.font
             };
-
             if (reqBuilder) {
                 var request = reqBuilder(
                     params.infoboxId,
@@ -435,6 +441,7 @@ Oskari.clazz.define(
                     data.lonlat,
                     options
                 );
+                this.setLocation(data.lonlat);
                 this.getSandbox().request(this, request);
             }
         },
@@ -451,7 +458,7 @@ Oskari.clazz.define(
             var reqB,
                 req;
 
-            if (this.clickLocation) {
+            if (this.getLocation()) {
                 reqB = Oskari.requestBuilder(
                     'InfoBox.RefreshInfoBoxRequest'
                 );
@@ -473,15 +480,13 @@ Oskari.clazz.define(
          */
         _handleInfoBoxEvent: function (evt) {
             var sandbox = this.getSandbox(),
-                clickLoc = this.clickLocation,
+                lonlat = this.getLocation(),
                 contentId = evt.getContentId(),
                 contentLayer,
                 clickEventB,
                 clickEvent;
-
             if (evt.getId() === this.infoboxId &&
-                evt.isOpen() &&
-                _.isObject(clickLoc)) {
+                evt.isOpen() && lonlat) {
                 if (contentId) {
                     // If there's a specific layer id and it's selected
                     // we can directly get info for that
@@ -489,14 +494,14 @@ Oskari.clazz.define(
                         contentId
                     );
                     if (contentLayer) {
-                        this.handleGetInfo(clickLoc.lonlat, [contentLayer]);
+                        this.handleGetInfo(lonlat, [contentLayer]);
                     }
                 } else {
                     // Otherwise, we need to actually send `MapClickedEvent`
                     // and not just call `handleGetInfo` since then
                     // we'd only get the WMS feature info.
                     clickEventB = Oskari.eventBuilder('MapClickedEvent');
-                    clickEvent = clickEventB(clickLoc.lonlat);
+                    clickEvent = clickEventB(lonlat);
                     // Timeout needed since the layer plugins haven't
                     // necessarily done their job of adding the layer yet.
                     setTimeout(function () {

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
@@ -68,10 +68,7 @@ Oskari.clazz.define(
             this._config.ignoredLayerTypes = Array.from(ignoredLayerTypes);
         },
 
-        _destroyControlElement: function () {
-            // Slight misuse of the function, but I don't want to override
-            // _stopPluginImpl.
-
+        _stopPluginImpl: function () {
             // hide infobox if open
             this._closeGfiInfo();
         },


### PR DESCRIPTION
Publisher stops and restarts plugins. When getinfo plugin is restarted it gets mapclickedevent after VectorLayerPlugin. VectorLayerPlugin gets gfi result faster than wms because it gathers result in frontend. GetinfoPlugin mapclick closes opened wfs popup.  Added location check for mapclick to fix this issue. If popup is opened in same location than mapclick, GetInfoPlugin doesn't close popup.

Fixed issue where wfs result pan map cancels wms requests. Refresh didn't pan map.
Fixed issue with renderPopup options param.