### PR TITLE
Changes to scale limit UI for admin/layer-editor

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -70,6 +70,7 @@ Oskari.registerLocalization(
             },
             "editor-tool": "Edit layer",
             "flyout-title": "Layer administration",
+            "fieldNoRestriction": "No restriction",
             "generalTabTitle": "General",
             "visualizationTabTitle": "Visualization",
             "additionalTabTitle": "Additional",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -70,6 +70,7 @@ Oskari.registerLocalization(
             },
             "editor-tool": "Muokkaa tasoa",
             "flyout-title": "Karttatasohallinta",
+            "fieldNoRestriction": "Ei rajoitusta",
             "generalTabTitle": "Yleiset",
             "visualizationTabTitle": "Visualisointi",
             "additionalTabTitle": "Lisätiedot",

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -70,6 +70,7 @@ Oskari.registerLocalization(
             },
             "editor-tool": "Editera kartlager",
             "flyout-title": "Administrering av kartlager",
+            "fieldNoRestriction": "Ingen begränsning",
             "generalTabTitle": "Allmän",
             "visualizationTabTitle": "Visualisering",
             "additionalTabTitle": "Ytterligare",

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/Numeric.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/Numeric.jsx
@@ -38,6 +38,7 @@ export const Numeric = ({
     messageKey,
     infoKeys,
     suffix = '',
+    prefix = '',
     allowNegative = defaultOptions.allowNegative,
     allowZero = defaultOptions.allowZero,
     value = '',
@@ -47,7 +48,7 @@ export const Numeric = ({
     const validationOptions = { allowNegative, allowZero };
 
     const parseNumber = value => {
-        const num = value.replace(suffix, '');
+        const num = value.replace(suffix, '').replace(prefix, '');
         return (!Oskari.util.isNumber(num) && num !== '-') ? '' : num;
     };
 
@@ -58,7 +59,7 @@ export const Numeric = ({
         if (!Oskari.util.isNumber(value)) {
             return '';
         }
-        return value + suffix;
+        return prefix + value + suffix;
     };
 
     let input =
@@ -91,6 +92,7 @@ Numeric.propTypes = {
     messageKey: PropTypes.string,
     infoKeys: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.string, PropTypes.any]),
     suffix: PropTypes.string,
+    prefix: PropTypes.string,
     allowNegative: PropTypes.bool,
     allowZero: PropTypes.bool,
     onChange: PropTypes.func.isRequired,

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Message, Slider, Icon } from 'oskari-ui';
 import { Numeric } from '../Numeric';
-import { Controller } from 'oskari-ui/util';
+import { LocaleConsumer, Controller } from 'oskari-ui/util';
 import styled from 'styled-components';
 
 const VerticalComponent = styled('div')`
@@ -24,35 +24,75 @@ const SliderContainer = styled('div')`
     padding-bottom: 15px;
 `;
 
-const getClosestMatch = (arr, value) => (
-    arr.reduce((best, cur) => (Math.abs(cur - value) < Math.abs(best - value) ? cur : best))
-);
-
-const getLevel = (scale, levelToScale) => {
-    const level = Object.keys(levelToScale).find(key => levelToScale[key] === scale);
-    return parseInt(level);
+const Scale = ({ layer, scales = [], controller, getMessage }) => {
+    const locNoLimit = getMessage('fieldNoRestriction');
+    let { minscale, maxscale } = normalizeScales(layer);
+    const mapScales = scales.slice(0);
+    // console.log(getMinZoom(minscale, scales), getMaxZoom(maxscale, scales));
+    const maxZoomLevel = mapScales.length - 1;
+    const layerMaxZoom = getMaxZoom(maxscale, mapScales);
+    const layerMinZoom = getMinZoom(minscale, mapScales);
+    return (
+        <React.Fragment>
+            <VerticalComponent>
+                <table>
+                    <tbody>
+                        <tr>
+                            <td width="15%">Max scale</td>
+                            <td><Numeric
+                                prefix="1:"
+                                placeholder={locNoLimit}
+                                value={ maxscale }
+                                allowNegative={false}
+                                allowZero={false}
+                                onChange={value => controller.setMinAndMaxScale([minscale, value])} /> {layerMaxZoom}</td>
+                        </tr>
+                        <tr>
+                            <td width="15%">Min scale</td>
+                            <td><Numeric
+                                prefix="1:"
+                                placeholder={locNoLimit}
+                                value={ minscale }
+                                allowNegative={false}
+                                allowZero={false}
+                                onChange={value => controller.setMinAndMaxScale([value, maxscale])} /> {layerMinZoom}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </VerticalComponent>
+            <VerticalComponent>
+                <Message messageKey='fields.scale' LabelComponent={CenteredLabel} />
+                <Icon type='plus-circle'/>
+                <SliderContainer>
+                    <Slider
+                        vertical
+                        range
+                        reversed
+                        tipFormatter={createTooltipFormatter(mapScales, locNoLimit)}
+                        step={1}
+                        marks={createSliderLabels(mapScales, locNoLimit)}
+                        min={-1}
+                        max={maxZoomLevel + 1}
+                        value={ [layerMinZoom, layerMaxZoom] }
+                        onChange={values => {
+                            console.log(...values);
+                            controller.setMinAndMaxScale(values.map(zoomLevel => mapScales[zoomLevel]));
+                        }} />
+                </SliderContainer>
+                <Icon type='minus-circle'/>
+            </VerticalComponent>
+        </React.Fragment>
+    );
 };
 
-const getLayerValues = (layer, levelToScale, defaultValues) => {
-    const { minscale, maxscale } = layer;
-    const scaleOptions = Object.values(levelToScale);
-    let [ min, max ] = defaultValues;
-    if (minscale > 0) {
-        min = getClosestMatch(scaleOptions, minscale);
-        min = getLevel(min, levelToScale);
-    }
-    if (maxscale > 0) {
-        max = getClosestMatch(scaleOptions, maxscale);
-        max = getLevel(max, levelToScale);
-    }
-    return [ min, max ];
+Scale.propTypes = {
+    layer: PropTypes.object.isRequired,
+    scales: PropTypes.array.isRequired,
+    controller: PropTypes.instanceOf(Controller).isRequired,
+    getMessage: PropTypes.func.isRequired
 };
 
-// Allow user to set values outside the system scale array.
-const maxScaleOption = 1; // 1:1
-const halfALevel = 0.5;
-
-function getScales (layer) {
+function normalizeScales (layer) {
     let { minscale, maxscale } = layer;
     if (minscale === -1) {
         minscale = '';
@@ -66,108 +106,53 @@ function getScales (layer) {
     };
 }
 
-// assumes scales go from big to small as they do on mapmodule
 function getMinZoom (minscale, scales) {
-    if (!minscale || minscale < 0) {
-        return 0;
-    }
-    const index = scales.findIndex(s => minscale >= s);
-    if (index === -1) {
-        return 0;
-    }
-    return index;
+    return getZoomLevel(minscale, scales, -1);
+}
+
+function getMaxZoom (maxscale, scales) {
+    return getZoomLevel(maxscale, scales, scales.length);
 }
 
 // assumes scales go from big to small as they do on mapmodule
-function getMaxZoom (maxscale, scales) {
-    const maxZoom = scales.length - 1;
-    if (!maxscale || maxscale < 0) {
-        return maxZoom;
+function getZoomLevel (scale, mapScales, defaultValue) {
+    if (scale < 0) {
+        return defaultValue;
     }
-    const index = scales.findIndex(s => maxscale >= s) - 1;
-    if (index < 0) {
-        return maxZoom;
+    const index = mapScales.findIndex(s => scale >= s);
+    if (index === -1) {
+        return defaultValue;
     }
     return index;
 }
 
-export const Scale = ({ layer, scales, controller }) => {
-    let { minscale, maxscale } = getScales(layer);
-    // console.log(getMinZoom(minscale, scales), getMaxZoom(maxscale, scales));
-    const maxScale = scales[scales.length - 1];
-    let maxZoomLevel = scales.length - 1;
-    const levelToScale = {};
+function createSliderLabels (scales = [], locNoLimit) {
+    // labels every 5 levels
     const marks = {
-        0: '0',
-        5: '5',
-        10: '10'
+        '-1': locNoLimit,
+        [scales.length]: locNoLimit
     };
-    if (maxZoomLevel > 10) {
+    scales.forEach((scale, index) => {
+        if (index % 5 === 0) {
+            marks[index] = '' + index;
+        }
+    });
+    const maxZoomLevel = scales.length - 1;
+    // add label to the last one as well
+    if (maxZoomLevel % 5 !== 0) {
         marks[maxZoomLevel] = maxZoomLevel;
     }
-    if (scales[maxZoomLevel] !== maxScaleOption) {
-        // Allow one step over the max level
-        maxZoomLevel += halfALevel;
-        levelToScale[maxZoomLevel] = maxScaleOption;
-    }
-    scales.forEach((scale, i) => {
-        levelToScale[i] = scale;
-        if (scale === maxScale) {
-            return;
+    return marks;
+}
+
+function createTooltipFormatter (scales, locNoLimit) {
+    const maxZoom = scales.length - 1;
+    return function (value) {
+        if (value === -1 || value > maxZoom) {
+            return locNoLimit;
         }
-        const nextScale = scales[i + 1];
-        // Add one option to the middle of zoom levels
-        levelToScale[i + halfALevel] = Math.round(scale - (scale - nextScale) / 2);
-    });
-    return (
-        <React.Fragment>
-            <VerticalComponent>
-                <Message messageKey='fields.scale' LabelComponent={CenteredLabel} />
-                <Icon type='plus-circle'/>
-                <SliderContainer>
-                    <Slider
-                        vertical
-                        range
-                        reversed
-                        tipFormatter={value => `1:${levelToScale[value].toLocaleString()}`}
-                        step={halfALevel}
-                        marks={marks}
-                        min={0}
-                        max={maxZoomLevel}
-                        defaultValue={getLayerValues(layer, levelToScale, [0, maxZoomLevel])}
-                        onChange={values => controller.setMinAndMaxScale(values.map(zoomLevel => levelToScale[zoomLevel]))} />
-                </SliderContainer>
-                <Icon type='minus-circle'/>
-                <table>
-                    <tbody>
-                        <tr>
-                            <td width="15%">Min scale</td>
-                            <td><Numeric
-                                prefix="1:"
-                                placeholder="Ei rajoitusta"
-                                value={ minscale }
-                                allowNegative={false}
-                                allowZero={false}
-                                onChange={value => controller.setMinAndMaxScale([value, maxscale])} /> {getMinZoom(minscale, scales)}</td>
-                        </tr>
-                        <tr>
-                            <td width="15%">Max scale</td>
-                            <td><Numeric
-                                prefix="1:"
-                                placeholder="Ei rajoitusta"
-                                value={ maxscale }
-                                allowNegative={false}
-                                allowZero={false}
-                                onChange={value => controller.setMinAndMaxScale([minscale, value])} /> {getMaxZoom(maxscale, scales)}</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </VerticalComponent>
-        </React.Fragment>
-    );
-};
-Scale.propTypes = {
-    layer: PropTypes.object.isRequired,
-    scales: PropTypes.array.isRequired,
-    controller: PropTypes.instanceOf(Controller).isRequired
-};
+        return `${value} / ${maxZoom}`;
+    };
+}
+const contextWrap = LocaleConsumer(Scale);
+export { contextWrap as Scale };

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.jsx
@@ -28,7 +28,6 @@ const Scale = ({ layer, scales = [], controller, getMessage }) => {
     const locNoLimit = getMessage('fieldNoRestriction');
     let { minscale, maxscale } = normalizeScales(layer);
     const mapScales = scales.slice(0);
-    // console.log(getMinZoom(minscale, scales), getMaxZoom(maxscale, scales));
     const maxZoomLevel = mapScales.length - 1;
     const layerMaxZoom = getMaxZoom(maxscale, mapScales);
     const layerMinZoom = getMinZoom(minscale, mapScales);
@@ -74,10 +73,7 @@ const Scale = ({ layer, scales = [], controller, getMessage }) => {
                         min={-1}
                         max={maxZoomLevel + 1}
                         value={ [layerMinZoom, layerMaxZoom] }
-                        onChange={values => {
-                            console.log(...values);
-                            controller.setMinAndMaxScale(values.map(zoomLevel => mapScales[zoomLevel]));
-                        }} />
+                        onChange={values => controller.setMinAndMaxScale(values.map(zoomLevel => mapScales[zoomLevel]))} />
                 </SliderContainer>
                 <Icon type='minus-circle'/>
             </VerticalComponent>
@@ -127,18 +123,19 @@ function getZoomLevel (scale, mapScales, defaultValue) {
 }
 
 function createSliderLabels (scales = [], locNoLimit) {
-    // labels every 5 levels
+    // Not restricted at each end
     const marks = {
         '-1': locNoLimit,
         [scales.length]: locNoLimit
     };
+    // labels every 5 levels
     scales.forEach((scale, index) => {
         if (index % 5 === 0) {
             marks[index] = '' + index;
         }
     });
     const maxZoomLevel = scales.length - 1;
-    // add label to the last one as well
+    // add label for the last zoom level as well
     if (maxZoomLevel % 5 !== 0) {
         marks[maxZoomLevel] = maxZoomLevel;
     }

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.jsx
@@ -12,16 +12,20 @@ const VerticalComponent = styled('div')`
     margin-left: 25%;
 `;
 
-const CenteredLabel = styled('div')`
-    text-align: center;
+const FieldLabel = styled('div')`
     padding-bottom: 5px;
 `;
 
 const SliderContainer = styled('div')`
-    padding-left: 10%;
+    padding-left: 20%;
     height: 200px;
     padding-top: 15px;
     padding-bottom: 15px;
+
+    .ant-slider-mark-text {
+        padding-bottom: 3px;
+        font-size: 11px;
+    }
 `;
 
 const ScaleInput = styled(Numeric)`
@@ -31,7 +35,7 @@ const ScaleInput = styled(Numeric)`
 
 const StyledIcon = styled(Icon)`
 text-align: left;
-padding-left: 6%;
+padding-left: 16%;
 `;
 
 const Scale = ({ layer, scales = [], controller, getMessage }) => {
@@ -43,7 +47,7 @@ const Scale = ({ layer, scales = [], controller, getMessage }) => {
     const layerMinZoom = getMinZoom(minscale, mapScales);
     return (
         <VerticalComponent>
-            <Message messageKey='fields.scale' LabelComponent={CenteredLabel} />
+            <Message messageKey='fields.scale' LabelComponent={FieldLabel} />
             <ScaleInput
                 prefix="1:"
                 placeholder={locNoLimit}

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.jsx
@@ -18,10 +18,20 @@ const CenteredLabel = styled('div')`
 `;
 
 const SliderContainer = styled('div')`
-    padding-left: calc(50% - 2px);
+    padding-left: 10%;
     height: 200px;
     padding-top: 15px;
     padding-bottom: 15px;
+`;
+
+const ScaleInput = styled(Numeric)`
+    width: 90%;
+    margin: 10px 0;
+`;
+
+const StyledIcon = styled(Icon)`
+text-align: left;
+padding-left: 6%;
 `;
 
 const Scale = ({ layer, scales = [], controller, getMessage }) => {
@@ -32,52 +42,38 @@ const Scale = ({ layer, scales = [], controller, getMessage }) => {
     const layerMaxZoom = getMaxZoom(maxscale, mapScales);
     const layerMinZoom = getMinZoom(minscale, mapScales);
     return (
-        <React.Fragment>
-            <VerticalComponent>
-                <table>
-                    <tbody>
-                        <tr>
-                            <td width="15%">Max scale</td>
-                            <td><Numeric
-                                prefix="1:"
-                                placeholder={locNoLimit}
-                                value={ maxscale }
-                                allowNegative={false}
-                                allowZero={false}
-                                onChange={value => controller.setMinAndMaxScale([minscale, value])} /> {layerMaxZoom}</td>
-                        </tr>
-                        <tr>
-                            <td width="15%">Min scale</td>
-                            <td><Numeric
-                                prefix="1:"
-                                placeholder={locNoLimit}
-                                value={ minscale }
-                                allowNegative={false}
-                                allowZero={false}
-                                onChange={value => controller.setMinAndMaxScale([value, maxscale])} /> {layerMinZoom}</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </VerticalComponent>
-            <VerticalComponent>
-                <Message messageKey='fields.scale' LabelComponent={CenteredLabel} />
-                <Icon type='plus-circle'/>
-                <SliderContainer>
-                    <Slider
-                        vertical
-                        range
-                        reversed
-                        tipFormatter={createTooltipFormatter(mapScales, locNoLimit)}
-                        step={1}
-                        marks={createSliderLabels(mapScales, locNoLimit)}
-                        min={-1}
-                        max={maxZoomLevel + 1}
-                        value={ [layerMinZoom, layerMaxZoom] }
-                        onChange={values => controller.setMinAndMaxScale(values.map(zoomLevel => mapScales[zoomLevel]))} />
-                </SliderContainer>
-                <Icon type='minus-circle'/>
-            </VerticalComponent>
-        </React.Fragment>
+        <VerticalComponent>
+            <Message messageKey='fields.scale' LabelComponent={CenteredLabel} />
+            <ScaleInput
+                prefix="1:"
+                placeholder={locNoLimit}
+                value={ maxscale }
+                allowNegative={false}
+                allowZero={false}
+                onChange={value => controller.setMinAndMaxScale([minscale, value])} />
+            <StyledIcon type='plus-circle'/>
+            <SliderContainer>
+                <Slider
+                    vertical
+                    range
+                    reversed
+                    tipFormatter={createTooltipFormatter(mapScales, locNoLimit)}
+                    step={1}
+                    marks={createSliderLabels(mapScales, locNoLimit)}
+                    min={-1}
+                    max={maxZoomLevel + 1}
+                    value={ [layerMinZoom, layerMaxZoom] }
+                    onChange={values => controller.setMinAndMaxScale(values.map(zoomLevel => mapScales[zoomLevel]))} />
+            </SliderContainer>
+            <StyledIcon type='minus-circle'/>
+            <ScaleInput
+                prefix="1:"
+                placeholder={locNoLimit}
+                value={ minscale }
+                allowNegative={false}
+                allowZero={false}
+                onChange={value => controller.setMinAndMaxScale([value, maxscale])} />
+        </VerticalComponent>
     );
 };
 

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.stories.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.stories.js
@@ -5,10 +5,14 @@ import { Scale } from './Scale';
 
 import '../../../../../../src/global';
 
+function getMessage () {
+    return 'No restriction';
+}
+
 function getController (state, setState) {
-    console.log(arguments);
     return {
         setMinAndMaxScale: ([ minscale, maxscale ]) => {
+            console.log(minscale, maxscale);
             setState({
                 minscale,
                 maxscale
@@ -33,7 +37,7 @@ storiesOf('Scale', module)
             <Parent>
                 {(state = {}, setState) => (
                     <React.Fragment>
-                        <Scale layer={state} scales={scales} controller={getController(state, setState)} />
+                        <Scale layer={state} scales={scales} controller={getController(state, setState)} getMessage={getMessage} />
                         Scales: { JSON.stringify(scales) }
                         <pre>State:
                             { JSON.stringify(state, null, 2) }

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.stories.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.stories.js
@@ -12,7 +12,6 @@ function getMessage () {
 function getController (state, setState) {
     return {
         setMinAndMaxScale: ([ minscale, maxscale ]) => {
-            console.log(minscale, maxscale);
             setState({
                 minscale,
                 maxscale

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.stories.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.stories.js
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { storiesOf } from '@storybook/react';
+import { Scale } from './Scale';
+
+import '../../../../../../src/global';
+
+function getController (state, setState) {
+    console.log(arguments);
+    return {
+        setMinAndMaxScale: ([ minscale, maxscale ]) => {
+            setState({
+                minscale,
+                maxscale
+            });
+        }
+    };
+}
+
+const scales = [5805343, 2902671, 1451336, 725668, 362834, 181417, 90708, 45354, 22677, 11339, 5669, 2835, 1417, 709];
+
+function Parent ({ children, ...props }) {
+    const [state, setState] = useState();
+    return <div>{children(state, setState)}</div>;
+}
+Parent.propTypes = {
+    children: PropTypes.any.isRequired
+};
+
+storiesOf('Scale', module)
+    .add('without text', () => {
+        return (
+            <Parent>
+                {(state = {}, setState) => (
+                    <React.Fragment>
+                        <Scale layer={state} scales={scales} controller={getController(state, setState)} />
+                        Scales: { JSON.stringify(scales) }
+                        <pre>State:
+                            { JSON.stringify(state, null, 2) }
+                        </pre>
+                    </React.Fragment>
+                )}
+            </Parent>
+        );
+    });

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/preset-env": "7.9.5",
     "@babel/preset-react": "7.9.4",
     "@babel/runtime-corejs3": "7.9.2",
-    "@storybook/react": "5.1.11",
+    "@storybook/react": "5.3.18",
     "@types/jest": "24.0.18",
     "antd": "3.26.7",
     "babel-loader": "8.1.0",

--- a/src/react/components/Radio.jsx
+++ b/src/react/components/Radio.jsx
@@ -4,5 +4,6 @@ import styled from 'styled-components';
 
 export const Radio = {
     Group: styled(AntRadio.Group)``,
-    Button: styled(AntRadio.Button)``
+    Button: styled(AntRadio.Button)``,
+    Choice: styled(AntRadio)``
 };


### PR DESCRIPTION
- Change layer scale restrictions component so user can input restrictions and the slider can be used for visualizing which zoom-levels will fit the restrictions
- Zoom level marks are now calculated based on the map config. Previously labels only worked properly with 11-15 zoom levels.
- Added prefix support for Numeric-component
- Updated storybook dependency