### PR TITLE
Revert "Bump jquery from 3.4.1 to 3.5.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "gm": "1.23.1",
     "imports-loader": "0.8.0",
     "jest": "24.9.0",
-    "jquery": "3.5.0",
+    "jquery": "3.4.1",
     "jsts": "2.0.8",
     "less": "3.9.0",
     "less-loader": "5.0.0",


### PR DESCRIPTION
Reverts oskariorg/oskari-frontend#1276