### PR TITLE
Don't use package-lock on oskari-frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ tools/test-results.xml
 bower_components/*
 .DS_Store
 coverage/
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Configure git to ignore it and npm to not create it. This helps in that we don't accidentally commit the lock file. Package-lock should be used on apps instead.