### PR TITLE
Build improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "imports-loader": "0.8.0",
     "jest": "24.9.0",
     "jquery": "3.5.1",
-    "jsts": "2.0.8",
+    "jsts": "2.2.0",
     "less": "3.9.0",
     "less-loader": "5.0.0",
     "loader-utils": "1.2.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,16 +9,18 @@ const generateEntries = require('./webpack/generateEntries.js');
 const { NormalModuleReplacementPlugin } = require('webpack');
 
 const proxyPort = 8081;
+// helpers
+const isDirectory = source => lstatSync(source).isDirectory();
+const getDirectories = source => readdirSync(source).map(name => path.join(source, name)).filter(isDirectory);
 
 module.exports = (env, argv) => {
     const isProd = argv.mode === 'production';
 
     const { version, pathParam, publicPathPrefix, theme } = parseParams(env);
-
-    const isDirectory = source => lstatSync(source).isDirectory();
-    const getDirectories = source => readdirSync(source).map(name => path.join(source, name)).filter(isDirectory);
+    // assumes applications are directories under pathParam
     const appsetupPaths = getDirectories(path.resolve(pathParam));
 
+    // entries are configs for each app, plugins accumulate resource copying etc from all the apps
     const { entries, plugins } = generateEntries(appsetupPaths, isProd, __dirname);
     plugins.push(new MiniCssExtractPlugin({
         filename: '[name]/oskari.min.css'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,12 +66,6 @@ module.exports = (env, argv) => {
         config.devServer = {
             port: proxyPort,
             proxy: [{
-                context: ['/transport/cometd'],
-                target: 'ws://localhost:8080',
-                secure: false,
-                changeOrigin: true,
-                ws: true
-            }, {
                 context: ['**', `!/Oskari/dist/${version}/**`, '!/Oskari/bundles/bundle.js'],
                 target: 'http://localhost:8080',
                 secure: false,

--- a/webpack/config.js
+++ b/webpack/config.js
@@ -88,7 +88,10 @@ const BABEL_LOADER_RULE = {
         /libraries/,
         /\.min\.js$/,
         // https://github.com/zloirock/core-js/issues/514 core-js shouldn't be run through babel
-        getExcludedNodeModules(['react-dom', '@ant-design', 'antd', 'core-js'])
+        // getExcludedNodeModules(['react-dom', '@ant-design', 'antd', 'core-js'])
+        // Exclude all but named dependencies (containing es6+)
+        // FIXME: olcs is the problem - adding it takes reeeeaaaally long for build
+        getWhitelistedModules(['oskari-frontend', 'oskari-frontend-contrib', 'jsts', 'olcs'])
     ],
     use: {
         loader: 'babel-loader',


### PR DESCRIPTION
And updated jsts to 2.2.0.

Tried to minimize code that is run through babel to improve build time. Changed config so instead of excluding some dependencies from transpiler the build now uses a list that should be included from node_modules. Namely 'oskari-frontend', 'oskari-frontend-contrib', 'jsts', 'olcs'. These all include ES6 code that need to be transpiled before they are passed to UglifyPlugin. Adding the olcs that is only needed for 3D apps makes the build take 3x or more time. So now we know what is making the build slow but not yet how to handle this.