### PR TITLE
Fixes to Lodash changes overwriting the global variable

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1,5 +1,4 @@
 import { UnsupportedLayerSrs } from './domain/UnsupportedLayerSrs';
-import { cloneDeep } from 'lodash';
 
 import './domain/AbstractLayer';
 import './domain/LayerComposingModel';
@@ -2096,7 +2095,9 @@ Oskari.clazz.define(
          * @param {Object} style The style object to be applied on all plugins that support changing style.
          */
         changeToolStyle: function (style) {
-            const clonedStyle = cloneDeep(style || {});
+            const clonedStyle = {
+                ...style
+            };
             if (!this._options) {
                 this._options = {};
             }

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1,5 +1,5 @@
 import { UnsupportedLayerSrs } from './domain/UnsupportedLayerSrs';
-import { cloneDeep, sortBy } from 'lodash';
+import { cloneDeep } from 'lodash';
 
 import './domain/AbstractLayer';
 import './domain/LayerComposingModel';
@@ -1290,14 +1290,17 @@ Oskari.clazz.define(
          * @return {Oskari.mapframework.ui.module.common.mapmodule.Plugin[]} index ordered list of registered plugins
          */
         _getSortedPlugins: function () {
-            return sortBy(this._pluginInstances, function (plugin) {
+            const plugins = Object.values(this._pluginInstances);
+            const getIndex = (plugin) => {
                 if (typeof plugin.getIndex === 'function') {
                     return plugin.getIndex();
                 }
                 // index not defined, start after ones that have indexes
                 // This is just for the UI order, functionality shouldn't assume order
                 return 99999999999;
-            });
+            };
+            plugins.sort((a, b) => getIndex(a) - getIndex(b));
+            return plugins;
         },
 
         _adjustMobileMapSize: function () {

--- a/bundles/mapping/mapmodule/AbstractMapModule.test.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.test.js
@@ -1,5 +1,5 @@
+import { afterAll } from '@jest/globals';
 import '../../../src/global';
-// import proj4 from '../../../libraries/Proj4js/proj4js-2.2.1/proj4-src.js';
 import './AbstractMapModule';
 import './service/map.state';
 import jQuery from 'jquery';
@@ -13,15 +13,16 @@ const dummyPlugin = {
     register: () => {},
     setMapModule: () => {}
 };
-let changeStyleCalls = [];
-let changeFontCalls = [];
+const changeStyleCalls = [];
+const changeFontCalls = [];
 const nonUIPlugin = {
     getName: () => 'Non UI plugin',
     register: () => {},
     setMapModule: () => {},
     hasUI: () => false,
     changeToolStyle: (style) => { changeStyleCalls.push(style); },
-    changeFont: (font) => { changeFontCalls.push(font); }
+    changeFont: (font) => { changeFontCalls.push(font); },
+    getIndex: () => 10
 };
 const uiPlugin = {
     getName: () => 'UI plugin',
@@ -29,7 +30,8 @@ const uiPlugin = {
     setMapModule: () => {},
     hasUI: () => true,
     changeToolStyle: (style) => { changeStyleCalls.push(style); },
-    changeFont: (font) => { changeFontCalls.push(font); }
+    changeFont: (font) => { changeFontCalls.push(font); },
+    getIndex: () => 20
 };
 
 describe('MapModule', () => {
@@ -53,6 +55,17 @@ describe('MapModule', () => {
             expect(changeStyleCalls[1]).toEqual('3d-light');
             expect(changeFontCalls.length).toEqual(2);
             expect(changeFontCalls[1]).toBeUndefined();
+        });
+    });
+    describe('_getSortedPlugins', () => {
+        const sorted = mapModule._getSortedPlugins();
+        test('has 3 plugins', () => {
+            expect(sorted.length).toEqual(3);
+        });
+        test('has correct order', () => {
+            expect(sorted[0]).toEqual(nonUIPlugin);
+            expect(sorted[1]).toEqual(uiPlugin);
+            expect(sorted[2]).toEqual(dummyPlugin);
         });
     });
 });

--- a/bundles/mapping/mapmodule/AbstractMapModule.test.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.test.js
@@ -33,6 +33,7 @@ const uiPlugin = {
     changeFont: (font) => { changeFontCalls.push(font); },
     getIndex: () => 20
 };
+afterAll(() => mapModule.stop());
 
 describe('MapModule', () => {
     mapModule.registerPlugin(dummyPlugin);

--- a/bundles/mapping/mapmodule/mapmodule.ol.test.js
+++ b/bundles/mapping/mapmodule/mapmodule.ol.test.js
@@ -4,10 +4,6 @@ import './AbstractMapModule';
 import './mapmodule.ol';
 import './resources/locale/en.js';
 import './service/map.state';
-import jQuery from 'jquery';
-
-const Oskari = window.Oskari;
-global.jQuery = jQuery;
 
 // defaults from mapfull
 const projections = {
@@ -19,8 +15,9 @@ Object.keys(projections).forEach(code => {
 });
 window.proj4 = proj4;
 
-// const mapModule = Oskari.clazz.create('Oskari.mapping.mapmodule.AbstractMapModule', 'Test');
 const mapModule = Oskari.clazz.create('Oskari.mapframework.ui.module.common.MapModule', 'Test');
+// if the mapModule is started make sure to:
+// afterAll(() => mapModule.stop());
 
 describe('MapModule', () => {
     const res = mapModule.getResolutionArray();

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
@@ -2,7 +2,6 @@ import olSourceVector from 'ol/source/Vector';
 import olLayerVector from 'ol/layer/Vector';
 import olFeature from 'ol/Feature';
 import * as olGeom from 'ol/geom';
-import { cloneDeep } from 'lodash';
 
 import '../../request/AddMarkerRequest';
 import '../../request/AddMarkerRequestHandler';
@@ -583,7 +582,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
             var key;
             if (!visible && markerId) { // Check hiding for wanted marker
                 if (this._markers[markerId]) {
-                    this._unVisibleMarkers[markerId] = cloneDeep(this._markers[markerId]);
+                    this._unVisibleMarkers[markerId] = { ...this._markers[markerId] };
                     // remove if found
                     // event is suppressed as this is "modify"
                     this.removeMarkers(true, markerId, true);
@@ -591,7 +590,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
                 }
             } else if (!visible) { // Check hiding for all markers
                 for (key in this._markers) {
-                    this._unVisibleMarkers[key] = cloneDeep(this._markers[key]);
+                    this._unVisibleMarkers[key] = { ...this._markers[key] };
                     // remove if found
                     // event is suppressed as this is "modify"
                     this.removeMarkers(true, key, true);
@@ -599,7 +598,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
                 }
             } else if (markerId) { // Check showing for wanted marker
                 if (this._unVisibleMarkers[markerId]) {
-                    this._markers[markerId] = cloneDeep(this._unVisibleMarkers[markerId]);
+                    this._markers[markerId] = { ...this._unVisibleMarkers[markerId] };
                     // remove if found
                     // event is suppressed as this is "modify"
                     this.addMapMarker(this._markers[markerId], markerId, true);
@@ -607,7 +606,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
                 }
             } else { // Check showing for all markers
                 for (key in this._unVisibleMarkers) {
-                    this._markers[key] = cloneDeep(this._unVisibleMarkers[key]);
+                    this._markers[key] = { ...this._unVisibleMarkers[key] };
                     // remove if found
                     // event is suppressed as this is "modify"
                     this.addMapMarker(this._markers[key], key, true);

--- a/webpack/localizationPlugin.js
+++ b/webpack/localizationPlugin.js
@@ -17,6 +17,7 @@ class LocalizationPlugin {
         this.prevTimestamps = new Map();
         this.appPath = appName ? appName + '/' : '';
     }
+
     apply (compiler) {
         compiler.hooks.emit.tapAsync('LocalizationPlugin', (compilation, callback) => {
             const localeFiles = Array.from(compilation.fileDependencies)
@@ -68,7 +69,7 @@ class LocalizationPlugin {
                 });
 
             const englishLoc = langToLoc.get('en') || new Map();
-            for (let entry of langToLoc.entries()) {
+            for (const entry of langToLoc.entries()) {
                 const lang = entry[0];
                 const langLoc = entry[1];
                 const langOverride = langToOverride.get(lang) || new Map();
@@ -86,7 +87,7 @@ class LocalizationPlugin {
                         return mergedOverride;
                     });
 
-                let fileContent = keyContents.map(content => `Oskari.registerLocalization(${JSON.stringify(content)});`).join('\n');
+                const fileContent = keyContents.map(content => `Oskari.registerLocalization(${JSON.stringify(content)});`).join('\n');
                 compilation.assets[`${this.appPath}oskari_lang_${lang}.js`] = {
                     source () {
                         return fileContent;


### PR DESCRIPTION
Turns out doing `import { cloneDeep, sortBy } from 'lodash';` writes/modifies the `_ ` global variable with full lodash (of the version in package.json) overwriting the (other version) one we link from libraries here: https://github.com/oskariorg/oskari-frontend/blob/1.55.2/packages/framework/bundle/oskariui/bundle.js#L49-L51 which causes all sorts of compatibility issues.