### PR TITLE
Printout png content options

### DIFF
--- a/bundles/framework/printout/resources/locale/en.js
+++ b/bundles/framework/printout/resources/locale/en.js
@@ -65,11 +65,11 @@ Oskari.registerLocalization(
                 }
             },
             "content": {
-                "label": "Map Title",
+                "label": "Additional content",
                 "tooltip": "",
                 "pngNote": "PNG-print will not include additional information.",
                 "mapTitle": {
-                    "placeholder": "Add a title for the map"
+                    "placeholder": "Title"
                 },
                 "pageLogo": {
                     "label": "Include logo",

--- a/bundles/framework/printout/resources/locale/en.js
+++ b/bundles/framework/printout/resources/locale/en.js
@@ -74,7 +74,7 @@ Oskari.registerLocalization(
                     "tooltip": "You can hide the logo if necessary."
                 },
                 "pageScale": {
-                    "label": "Add a scale to the map printout",
+                    "label": "Include scale bar",
                     "tooltip": "Add a scale to the map, if you want."
                 },
                 "pageDate": {

--- a/bundles/framework/printout/resources/locale/en.js
+++ b/bundles/framework/printout/resources/locale/en.js
@@ -64,11 +64,13 @@ Oskari.registerLocalization(
                     "pdf": "PDF document"
                 }
             },
-            "mapTitle": {
-                "label": "Map Title",
-                "tooltip": "Add a title for the map."
-            },
             "content": {
+                "label": "Map Title",
+                "tooltip": "",
+                "pngNote": "PNG-print will not include additional information.",
+                "mapTitle": {
+                    "placeholder": "Add a title for the map"
+                },
                 "pageLogo": {
                     "label": "Include logo",
                     "tooltip": "You can hide the logo if necessary."

--- a/bundles/framework/printout/resources/locale/fi.js
+++ b/bundles/framework/printout/resources/locale/fi.js
@@ -67,9 +67,9 @@ Oskari.registerLocalization(
             "content": {
                 "label": "Näytettävät tiedot",
                 "tooltip": "Valitse tulosteessa näytettävät tiedot.",
-                "pngNote": "PNG-tulosteelle ei lisätä allaolevia tietoja.",
+                "pngNote": "PNG-tulosteelle ei lisätä alla olevia tietoja.",
                 "mapTitle": {
-                    "placeholder": "Lisää otsikko"
+                    "placeholder": "Otsikko"
                 },
                 "pageLogo": {
                     "label": "Näytä palvelun logo",

--- a/bundles/framework/printout/resources/locale/fi.js
+++ b/bundles/framework/printout/resources/locale/fi.js
@@ -54,41 +54,40 @@ Oskari.registerLocalization(
             },
             "settings": {
                 "label": "Lisäasetukset",
-                "tooltip": "Valitse asetukset karttatulosteelle.",
-
-                "format": {
-                    "label": "Tiedostomuoto",
-                    "tooltip": "Valitse tiedostomuoto, jossa haluat tulosteen.",
-                    "options": {
-                        "png": "PNG-kuva",
-                        "pdf": "PDF-dokumentti"
-                    }
+                "tooltip": "Valitse asetukset karttatulosteelle."
+            },
+            "format": {
+                "label": "Tiedostomuoto",
+                "tooltip": "Valitse tiedostomuoto, jossa haluat tulosteen.",
+                "options": {
+                    "png": "PNG-kuva",
+                    "pdf": "PDF-dokumentti"
+                }
+            },
+            "content": {
+                "label": "Näytettävät tiedot",
+                "tooltip": "Valitse tulosteessa näytettävät tiedot.",
+                "pngNote": "PNG-tulosteelle ei lisätä allaolevia tietoja.",
+                "mapTitle": {
+                    "placeholder": "Lisää otsikko"
                 },
-                "content": {
-                    "label": "Näytettävät tiedot",
-                    "tooltip": "Valitse tulosteessa näytettävät tiedot.",
-                    "png": "PNG-tulosteelle ei lisätä allaolevia tietoja.",
-                    "mapTitle": {
-                        "placeholder": "Lisää otsikko"
-                    },
-                    "pageLogo": {
-                        "label": "Näytä palvelun logo",
-                        "tooltip": "Näytä tulosteessa tämän palvelun logo."
-                    },
-                    "pageScale": {
-                        "label": "Näytä mittakaava",
-                        "tooltip": "Näytä tulosteessa kartan mittakaava."
-                    },
-                    "pageDate": {
-                        "label": "Näytä päivämäärä",
-                        "tooltip": "Näytä tulosteessa sen laatimispäivämäärä."
-                    },
-                    "pageTimeSeriesTime": {
-                        "label": "Näytä aikasarjan ajanhetki",
-                        "tooltip": "Näytä tulosteessa aikasarjan ajanhetki.",
-                        "printLabel": "Aikasarjan ajanhetki"
-                    }
+                "pageLogo": {
+                    "label": "Näytä palvelun logo",
+                    "tooltip": "Näytä tulosteessa tämän palvelun logo."
                 },
+                "pageScale": {
+                    "label": "Näytä mittakaava",
+                    "tooltip": "Näytä tulosteessa kartan mittakaava."
+                },
+                "pageDate": {
+                    "label": "Näytä päivämäärä",
+                    "tooltip": "Näytä tulosteessa sen laatimispäivämäärä."
+                },
+                "pageTimeSeriesTime": {
+                    "label": "Näytä aikasarjan ajanhetki",
+                    "tooltip": "Näytä tulosteessa aikasarjan ajanhetki.",
+                    "printLabel": "Aikasarjan ajanhetki"
+                }
             },
             "help": "Ohje",
             "error": {

--- a/bundles/framework/printout/resources/locale/fi.js
+++ b/bundles/framework/printout/resources/locale/fi.js
@@ -54,38 +54,41 @@ Oskari.registerLocalization(
             },
             "settings": {
                 "label": "Lisäasetukset",
-                "tooltip": "Valitse asetukset karttatulosteelle."
-            },
-            "format": {
-                "label": "Tiedostomuoto",
-                "tooltip": "Valitse tiedostomuoto, jossa haluat tulosteen.",
-                "options": {
-                    "png": "PNG-kuva",
-                    "pdf": "PDF-dokumentti"
-                }
-            },
-            "mapTitle": {
-                "label": "Näytettävät tiedot",
-                "tooltip": "Valitse tulosteessa näytettävät tiedot."
-            },
-            "content": {
-                "pageLogo": {
-                    "label": "Näytä palvelun logo",
-                    "tooltip": "Näytä tulosteessa tämän palvelun logo."
+                "tooltip": "Valitse asetukset karttatulosteelle.",
+
+                "format": {
+                    "label": "Tiedostomuoto",
+                    "tooltip": "Valitse tiedostomuoto, jossa haluat tulosteen.",
+                    "options": {
+                        "png": "PNG-kuva",
+                        "pdf": "PDF-dokumentti"
+                    }
                 },
-                "pageScale": {
-                    "label": "Näytä mittakaava",
-                    "tooltip": "Näytä tulosteessa kartan mittakaava."
+                "content": {
+                    "label": "Näytettävät tiedot",
+                    "tooltip": "Valitse tulosteessa näytettävät tiedot.",
+                    "png": "PNG-tulosteelle ei lisätä allaolevia tietoja.",
+                    "mapTitle": {
+                        "placeholder": "Lisää otsikko"
+                    },
+                    "pageLogo": {
+                        "label": "Näytä palvelun logo",
+                        "tooltip": "Näytä tulosteessa tämän palvelun logo."
+                    },
+                    "pageScale": {
+                        "label": "Näytä mittakaava",
+                        "tooltip": "Näytä tulosteessa kartan mittakaava."
+                    },
+                    "pageDate": {
+                        "label": "Näytä päivämäärä",
+                        "tooltip": "Näytä tulosteessa sen laatimispäivämäärä."
+                    },
+                    "pageTimeSeriesTime": {
+                        "label": "Näytä aikasarjan ajanhetki",
+                        "tooltip": "Näytä tulosteessa aikasarjan ajanhetki.",
+                        "printLabel": "Aikasarjan ajanhetki"
+                    }
                 },
-                "pageDate": {
-                    "label": "Näytä päivämäärä",
-                    "tooltip": "Näytä tulosteessa sen laatimispäivämäärä."
-                },
-                "pageTimeSeriesTime": {
-                    "label": "Näytä aikasarjan ajanhetki",
-                    "tooltip": "Näytä tulosteessa aikasarjan ajanhetki.",
-                    "printLabel": "Aikasarjan ajanhetki"
-                }
             },
             "help": "Ohje",
             "error": {

--- a/bundles/framework/printout/resources/locale/sv.js
+++ b/bundles/framework/printout/resources/locale/sv.js
@@ -64,11 +64,13 @@ Oskari.registerLocalization(
                     "pdf": "PDF dokument"
                 }
             },
-            "mapTitle": {
-                "label": "Kart rubrik",
-                "tooltip": "Lägg till rubrik för kartan"
-            },
             "content": {
+                "label": "Kart rubrik",
+                "tooltip": "",
+                "pngNote": "",
+                "mapTitle": {
+                    "placeholder": "Lägg till rubrik för kartan"
+                },
                 "pageLogo": {
                     "label": "Inkludera logotyp i utskriften",
                     "tooltip": "Du kan dölja logotyp vid behov."

--- a/bundles/framework/printout/resources/locale/sv.js
+++ b/bundles/framework/printout/resources/locale/sv.js
@@ -65,11 +65,11 @@ Oskari.registerLocalization(
                 }
             },
             "content": {
-                "label": "Kart rubrik",
+                "label": "Synlig information",
                 "tooltip": "",
-                "pngNote": "",
+                "pngNote": "Tilläggsinformationen ingår ej i PNG-utskriftet.",
                 "mapTitle": {
-                    "placeholder": "Lägg till rubrik för kartan"
+                    "placeholder": "Rubrik"
                 },
                 "pageLogo": {
                     "label": "Inkludera logotyp i utskriften",

--- a/bundles/framework/printout/resources/scss/style.scss
+++ b/bundles/framework/printout/resources/scss/style.scss
@@ -70,11 +70,6 @@ div.printout {
             }
         }
     }
-
-    div.basic_publisher div.content {
-        padding: 10px;
-    }
-
 }
 
 div.printout div.startview div.icon-info,
@@ -100,7 +95,7 @@ div.field select {
 }
 
 .printout_format_label,
-.printout_title_label {
+.printout_content_title {
     font-weight: bold;
     margin: 5px 0;
 }
@@ -126,7 +121,7 @@ div.basic_printout {
 
     > div.header {
         background-color: #FDF8D9;
-        padding: 5px 10px;
+        padding: 10px 10px 0px;
 
         div.icon-close {
             float: right;
@@ -136,7 +131,7 @@ div.basic_printout {
 
     > div.content {
         overflow: auto;
-        height: 89%;
+        height: calc(100% - 46px);
     }
 
     div.tool {

--- a/bundles/framework/printout/resources/scss/style.scss
+++ b/bundles/framework/printout/resources/scss/style.scss
@@ -111,6 +111,9 @@ div.field select {
 
 .printout_settings_cont {
     margin: 10px 5px;
+    input:disabled+label {
+        color: #cccccc;
+    }
 }
 
 /* Buttons */

--- a/bundles/framework/printout/resources/scss/style.scss
+++ b/bundles/framework/printout/resources/scss/style.scss
@@ -99,6 +99,15 @@ div.field select {
     font-weight: bold;
     margin: 5px 0;
 }
+.printout_content {
+    .printout_content_title {
+        display: flex;
+    }
+    .icon-warning-light {
+        float: right;
+        margin-left: 12px;
+    }
+}
 
 .printout_settings_cont {
     margin: 10px 5px;

--- a/bundles/framework/printout/view/BasicPrintout.js
+++ b/bundles/framework/printout/view/BasicPrintout.js
@@ -58,7 +58,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
         me.timeseriesPlugin = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModuleTimeseriesControlPlugin');
         me.scales = null;
     }, {
-        // TODO: check namings tool, optionPage, optionTool
         __templates: {
             preview: '<div><img /><span></span></div>',
             previewNotes: '<div class="previewNotes"><span></span></div>',

--- a/bundles/framework/printout/view/BasicPrintout.js
+++ b/bundles/framework/printout/view/BasicPrintout.js
@@ -221,7 +221,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
             panel.getHeader().append(tooltipCont);
             var format = this.template.format.clone();
             format.find('.printout_format_label').html(this.loc.format.label);
-
+            const tempValues = {};
             FORMAT_OPTIONS.forEach((option, i) => {
                 const { name, mime } = option;
                 var toolContainer = this.template.optionTool.clone();
@@ -239,10 +239,20 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
                 });
                 input.on('change', function () {
                     if (name === 'png') {
-                        contentOptions.find('input').prop('disabled', true);
+                        contentOptions.find('input:checkbox').each(function () {
+                            tempValues[this.value] = this.checked;
+                        }).prop('checked', false).prop('disabled', true);
+                        tempValues.mapTitle = mapTitleInput.val();
+                        mapTitleInput.val('');
+                        mapTitleInput.prop('disabled', true);
                         title.append(pngNote);
                     } else {
-                        contentOptions.find('input').prop('disabled', false);
+                        contentOptions.find('input:checkbox').prop('disabled', false)
+                            .each(function () {
+                                this.checked = !!tempValues[this.value];
+                            });
+                        mapTitleInput.val(tempValues.mapTitle || '');
+                        mapTitleInput.prop('disabled', false);
                         pngNote.remove();
                     }
                 });
@@ -256,7 +266,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
             const pngNote = this.template.pngNote.clone();
             pngNote.attr('title', this.loc.content.pngNote);
             var mapTitle = this.template.mapTitleInput.clone();
-            mapTitle.find('input').attr('placeholder', this.loc.content.mapTitle.placeholder);
+            const mapTitleInput = mapTitle.find('input');
+            mapTitleInput.attr('placeholder', this.loc.content.mapTitle.placeholder);
             contentOptions.append(mapTitle);
             const options = [...PAGE_OPTIONS];
             if (this._isTimeSeriesActive()) {

--- a/bundles/framework/printout/view/BasicPrintout.js
+++ b/bundles/framework/printout/view/BasicPrintout.js
@@ -68,12 +68,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
             help: '<div class="help icon-info"></div>',
             main: '<div class="basic_printout">' + '<div class="header">' + '<div class="icon-close">' + '</div>' + '<h3></h3>' + '</div>' + '<div class="content">' + '</div>' + '<form method="post" target="map_popup_111" id="oskari_print_formID" style="display:none" action="" ><input name="geojson" type="hidden" value="" id="oskari_geojson"/><input name="tiles" type="hidden" value="" id="oskari_tiles"/><input name="tabledata" type="hidden" value="" id="oskari_print_tabledata"/><input name="customStyles" type="hidden" value=""/></form>' + '</div>',
             format: '<div class="printout_format_cont printout_settings_cont"><div class="printout_format_label"></div></div>',
-            mapTitleInput: '<input class="printout_title_field" type="text">', // TODO printout_settings_cont??
+            mapTitleInput: '<div class="printout_option_cont printout_settings_cont"><input class="printout_title_field" type="text"></div>',
             optionPage: '<div class="printout_option_cont printout_settings_cont">' + '<input type="checkbox" />' + '<label></label></div>',
             optionTool: '<div class="tool">' + '<input type="radio"/>' + '<label class="printout_radiolabel"></label></div>',
             scaleSelection: '<div class="scaleselection">' + '<select name="scaleselect" />' + '</div>',
-            contentOptions: '<div class="printout_content"><div class="printout_content_title"/></div>', // printout_settings_cont?? check format
-            contentNotification: '<div class="icon-warning-light"/>'
+            contentOptions: '<div class="printout_content"><div class="printout_content_title"></div><div class="printout_content_options"></div></div>',
+            pngNote: '<div class="icon-warning-light"/>'
         },
         /**
          * @public @method render
@@ -244,17 +244,22 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
                     if (name === 'png') {
                         contentOptions.addClass('oskari-hidden');
                         contentOptions.find('input').prop('disabled', true);
+                        title.append(pngNote);
                     } else {
                         contentOptions.removeClass('oskari-hidden');
                         contentOptions.find('input').prop('disabled', false);
+                        pngNote.remove();
                     }
                 });
                 format.append(toolContainer);
             });
             contentPanel.append(format);
             /* --- options available for pdf --- */
-            const contentOptions = me.template.contentOptions.clone();
-            contentOptions.find('.printout_content_title').html(loc.content.label);
+            const optionsContainer = me.template.contentOptions.clone();
+            const title = optionsContainer.find('.printout_content_title').html(loc.content.label);
+            const contentOptions = optionsContainer.find('.printout_content_options');
+            const pngNote = me.template.pngNote.clone();
+            pngNote.attr('title', this.loc.settings.content.pngNote);
             var mapTitleInput = me.template.mapTitleInput.clone();
             mapTitleInput.attr('placeholder', loc.content.mapTitle.placeholder);
             contentOptions.append(mapTitleInput);
@@ -270,7 +275,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
                 opt.find('label').html(label).attr('for', id);
                 contentOptions.append(opt);
             });
-            contentPanel.append(contentOptions);
+            contentPanel.append(optionsContainer);
             // scale line on print isn't implemented for non-metric projections so hide the choice here.
             var mapmodule = me.instance.sandbox.findRegisteredModuleInstance('MainMapModule');
             if (mapmodule.getProjectionUnits() !== 'm') {

--- a/bundles/framework/printout/view/BasicPrintout.js
+++ b/bundles/framework/printout/view/BasicPrintout.js
@@ -211,24 +211,22 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
          * @return {jQuery} Returns the created panel
          */
         _createSettingsPanel: function () {
-            var me = this;
-            const loc = this.loc.settings;
             var panel = Oskari.clazz.create('Oskari.userinterface.component.AccordionPanel');
             panel.addClass('printsettings');
-            panel.setTitle(loc.label);
+            panel.setTitle(this.loc.settings.label);
             var contentPanel = panel.getContainer();
             // tooltip
-            var tooltipCont = me.template.help.clone();
-            tooltipCont.attr('title', loc.tooltip);
+            var tooltipCont = this.template.help.clone();
+            tooltipCont.attr('title', this.loc.settings.tooltip);
             panel.getHeader().append(tooltipCont);
-            var format = me.template.format.clone();
-            format.find('.printout_format_label').html(loc.format.label);
+            var format = this.template.format.clone();
+            format.find('.printout_format_label').html(this.loc.format.label);
 
-            FORMAT_OPTIONS.forEach(function (option, i) {
+            FORMAT_OPTIONS.forEach((option, i) => {
                 const { name, mime } = option;
-                var toolContainer = me.template.optionTool.clone();
+                var toolContainer = this.template.optionTool.clone();
                 const id = 'printout-format-' + name;
-                const label = loc.format.options[name];
+                const label = this.loc.format.options[name];
                 toolContainer.find('label').append(label).attr('for', id);
                 const input = toolContainer.find('input');
                 if (i === 0) {
@@ -240,13 +238,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
                     id
                 });
                 input.on('change', function () {
-                    // TODO don't hide title and add warning icon
                     if (name === 'png') {
-                        contentOptions.addClass('oskari-hidden');
                         contentOptions.find('input').prop('disabled', true);
                         title.append(pngNote);
                     } else {
-                        contentOptions.removeClass('oskari-hidden');
                         contentOptions.find('input').prop('disabled', false);
                         pngNote.remove();
                     }
@@ -255,31 +250,31 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
             });
             contentPanel.append(format);
             /* --- options available for pdf --- */
-            const optionsContainer = me.template.contentOptions.clone();
-            const title = optionsContainer.find('.printout_content_title').html(loc.content.label);
+            const optionsContainer = this.template.contentOptions.clone();
+            const title = optionsContainer.find('.printout_content_title').html(this.loc.content.label);
             const contentOptions = optionsContainer.find('.printout_content_options');
-            const pngNote = me.template.pngNote.clone();
-            pngNote.attr('title', this.loc.settings.content.pngNote);
-            var mapTitleInput = me.template.mapTitleInput.clone();
-            mapTitleInput.attr('placeholder', loc.content.mapTitle.placeholder);
-            contentOptions.append(mapTitleInput);
+            const pngNote = this.template.pngNote.clone();
+            pngNote.attr('title', this.loc.content.pngNote);
+            var mapTitle = this.template.mapTitleInput.clone();
+            mapTitle.find('input').attr('placeholder', this.loc.content.mapTitle.placeholder);
+            contentOptions.append(mapTitle);
             const options = [...PAGE_OPTIONS];
             if (this._isTimeSeriesActive()) {
                 options.push(TIME_OPTION);
             }
-            options.forEach(function (value) {
-                var opt = me.template.optionPage.clone();
+            options.forEach(value => {
+                var opt = this.template.optionPage.clone();
                 const id = 'printout-page-' + value;
                 opt.find('input').attr({ id, value }).prop('checked', true);
-                const label = loc.content[value].label;
+                const label = this.loc.content[value].label;
                 opt.find('label').html(label).attr('for', id);
                 contentOptions.append(opt);
             });
             contentPanel.append(optionsContainer);
             // scale line on print isn't implemented for non-metric projections so hide the choice here.
-            var mapmodule = me.instance.sandbox.findRegisteredModuleInstance('MainMapModule');
+            var mapmodule = this.instance.sandbox.findRegisteredModuleInstance('MainMapModule');
             if (mapmodule.getProjectionUnits() !== 'm') {
-                me.contentOptionDivs.pageScale.css('display', 'none');
+                this.contentOptionDivs.pageScale.css('display', 'none');
             }
             return panel;
         },

--- a/bundles/framework/printout/view/BasicPrintout.js
+++ b/bundles/framework/printout/view/BasicPrintout.js
@@ -58,6 +58,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
         me.timeseriesPlugin = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModuleTimeseriesControlPlugin');
         me.scales = null;
     }, {
+        // TODO: check namings tool, optionPage, optionTool
         __templates: {
             preview: '<div><img /><span></span></div>',
             previewNotes: '<div class="previewNotes"><span></span></div>',
@@ -67,11 +68,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
             help: '<div class="help icon-info"></div>',
             main: '<div class="basic_printout">' + '<div class="header">' + '<div class="icon-close">' + '</div>' + '<h3></h3>' + '</div>' + '<div class="content">' + '</div>' + '<form method="post" target="map_popup_111" id="oskari_print_formID" style="display:none" action="" ><input name="geojson" type="hidden" value="" id="oskari_geojson"/><input name="tiles" type="hidden" value="" id="oskari_tiles"/><input name="tabledata" type="hidden" value="" id="oskari_print_tabledata"/><input name="customStyles" type="hidden" value=""/></form>' + '</div>',
             format: '<div class="printout_format_cont printout_settings_cont"><div class="printout_format_label"></div></div>',
-            mapTitle: '<div class="printout_title_cont printout_settings_cont"><div class="printout_title_label"></div><input class="printout_title_field" type="text"></div>',
+            mapTitleInput: '<input class="printout_title_field" type="text">', // TODO printout_settings_cont??
             optionPage: '<div class="printout_option_cont printout_settings_cont">' + '<input type="checkbox" />' + '<label></label></div>',
             optionTool: '<div class="tool">' + '<input type="radio"/>' + '<label class="printout_radiolabel"></label></div>',
             scaleSelection: '<div class="scaleselection">' + '<select name="scaleselect" />' + '</div>',
-            contentOptions: '<div class=""/>'
+            contentOptions: '<div class="printout_content"><div class="printout_content_title"/></div>', // printout_settings_cont?? check format
+            contentNotification: '<div class="icon-warning-light"/>'
         },
         /**
          * @public @method render
@@ -210,22 +212,23 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
          */
         _createSettingsPanel: function () {
             var me = this;
+            const loc = this.loc.settings;
             var panel = Oskari.clazz.create('Oskari.userinterface.component.AccordionPanel');
             panel.addClass('printsettings');
-            panel.setTitle(me.loc.settings.label);
+            panel.setTitle(loc.label);
             var contentPanel = panel.getContainer();
             // tooltip
             var tooltipCont = me.template.help.clone();
-            tooltipCont.attr('title', me.loc.settings.tooltip);
+            tooltipCont.attr('title', loc.tooltip);
             panel.getHeader().append(tooltipCont);
             var format = me.template.format.clone();
-            format.find('.printout_format_label').html(me.loc.format.label);
+            format.find('.printout_format_label').html(loc.format.label);
 
             FORMAT_OPTIONS.forEach(function (option, i) {
                 const { name, mime } = option;
                 var toolContainer = me.template.optionTool.clone();
                 const id = 'printout-format-' + name;
-                const label = me.loc.format.options[name];
+                const label = loc.format.options[name];
                 toolContainer.find('label').append(label).attr('for', id);
                 const input = toolContainer.find('input');
                 if (i === 0) {
@@ -237,9 +240,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
                     id
                 });
                 input.on('change', function () {
+                    // TODO don't hide title and add warning icon
                     if (name === 'png') {
+                        contentOptions.addClass('oskari-hidden');
                         contentOptions.find('input').prop('disabled', true);
                     } else {
+                        contentOptions.removeClass('oskari-hidden');
                         contentOptions.find('input').prop('disabled', false);
                     }
                 });
@@ -248,10 +254,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
             contentPanel.append(format);
             /* --- options available for pdf --- */
             const contentOptions = me.template.contentOptions.clone();
-            var mapTitle = me.template.mapTitle.clone();
-            mapTitle.find('.printout_title_label').html(me.loc.mapTitle.label);
-            mapTitle.find('.printout_title_field').attr('placeholder', me.loc.mapTitle.label);
-            contentOptions.append(mapTitle);
+            contentOptions.find('.printout_content_title').html(loc.content.label);
+            var mapTitleInput = me.template.mapTitleInput.clone();
+            mapTitleInput.attr('placeholder', loc.content.mapTitle.placeholder);
+            contentOptions.append(mapTitleInput);
             const options = [...PAGE_OPTIONS];
             if (this._isTimeSeriesActive()) {
                 options.push(TIME_OPTION);
@@ -260,7 +266,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
                 var opt = me.template.optionPage.clone();
                 const id = 'printout-page-' + value;
                 opt.find('input').attr({ id, value }).prop('checked', true);
-                const label = me.loc.content[value].label;
+                const label = loc.content[value].label;
                 opt.find('label').html(label).attr('for', id);
                 contentOptions.append(opt);
             });


### PR DESCRIPTION
Disable and clear content options and show warning icon when png is selected. Remember values if pdf is re-selected.

Fix localization and content height.