### PR TITLE
Only add dataprovider/group for userlayer when adding users own ones

### DIFF
--- a/bundles/framework/myplacesimport/service/MyPlacesImportService.js
+++ b/bundles/framework/myplacesimport/service/MyPlacesImportService.js
@@ -137,6 +137,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
         // There might be other userlayer typed layers in maplayerservice from link parameters that might NOT be this users layers.
         // This is used to filter out other users shared layers when listing layers on the My Data functionality.
         mapLayer.markAsInternalDownloadSource();
+        // Add organization and groups for users own datasets (otherwise left empty/data from baselayer)
+        var loclayer = this.instance.getLocalization().layer;
+        mapLayer.setOrganizationName(loclayer.organization);
+        mapLayer.setGroups([{
+            id: 'USERLAYER',
+            name: loclayer.inspire
+        }]);
         // Add the layer to the map layer service
         mapLayerService.addLayer(mapLayer, skipEvent);
         if (typeof cb === 'function') {
@@ -145,5 +152,5 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
         return mapLayer;
     }
 }, {
-    'protocol': ['Oskari.mapframework.service.Service']
+    protocol: ['Oskari.mapframework.service.Service']
 });

--- a/bundles/mapping/mapuserlayers/domain/UserLayerModelBuilder.js
+++ b/bundles/mapping/mapuserlayers/domain/UserLayerModelBuilder.js
@@ -6,7 +6,6 @@ Oskari.clazz.define(
     'Oskari.mapframework.bundle.myplacesimport.domain.UserLayerModelBuilder',
     function (sandbox) {
         this.sandbox = sandbox;
-        this.localization = Oskari.getLocalization('MyPlacesImport');
         this.wfsBuilder = Oskari.clazz.create(
             'Oskari.mapframework.bundle.mapwfs2.domain.WfsLayerModelBuilder',
             sandbox
@@ -20,14 +19,8 @@ Oskari.clazz.define(
          * @param {Oskari.mapframework.service.MapLayerService} maplayerService not really needed here
          */
         parseLayerData: function (layer, mapLayerJson, maplayerService) {
-            var loclayer = this.localization.layer;
             // call parent parseLayerData
             this.wfsBuilder.parseLayerData(layer, mapLayerJson, maplayerService);
-            layer.setOrganizationName(loclayer.organization);
-            layer.setGroups([{
-                id: 'USERLAYER',
-                name: loclayer.inspire
-            }]);
             layer.setDescription(mapLayerJson.description);
             layer.setSource(mapLayerJson.source);
             layer.setRenderingElement(mapLayerJson.renderingElement);


### PR DESCRIPTION
If the user is shown some other users (published/public) layer it will be grouped under "no group"/based on database.