### PR TITLE
Publisher map tool fix

### DIFF
--- a/bundles/mapping/mapmodule/plugin/publishertoolbar/PublisherToolbarPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/publishertoolbar/PublisherToolbarPlugin.js
@@ -383,7 +383,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolba
                     var buttonGroup = me.buttonGroups[group],
                         tool;
                     for (tool in buttonGroup.buttons) {
-                        if (!me._buttons.includes(tool)) {
+                        if (me._buttons.includes(tool)) {
                             var buttonConf = buttonGroup.buttons[tool];
                             buttonConf.toolbarid = toolbarId;
                             sandbox.request(this, addToolButtonBuilder(tool, buttonGroup.name, buttonGroup.buttons[tool]));


### PR DESCRIPTION
Add tool button if config buttons includes tool. Fixes the issue where selected tools/buttons doesn't appear and unselected does to published map.