### PR TITLE
WFSLayer update custom style

### DIFF
--- a/bundles/mapping/mapwfs2/domain/WFSLayer.js
+++ b/bundles/mapping/mapwfs2/domain/WFSLayer.js
@@ -386,11 +386,9 @@ export class WFSLayer extends VectorTileLayer {
     selectStyle (styleName) {
         // Select style with logic in AbstractLayer
         super.selectStyle(styleName);
-        // If style one of custom styles, set it to WFSLayer
+        // update custom style
         const style = this._userStyles.filter(style => style.name === styleName)[0];
-        if (style) {
-            this.setCustomStyle(style);
-        }
+        this.setCustomStyle(style);
     }
 }
 


### PR DESCRIPTION
getCustomStyle() returned latest used user style even current style isn't user style. getCustomStyle() is used in printout to check if selected style is user's own style. Now returns undefined if custom style isn't selected.