### PR TITLE
Admin layerselector scheduled update fix

### DIFF
--- a/bundles/integration/admin-layerselector/View.js
+++ b/bundles/integration/admin-layerselector/View.js
@@ -76,7 +76,7 @@ Oskari.clazz.define('Oskari.integration.bundle.admin-layerselector.View', functi
                 this._scheduledLayers.push(layer);
             }
         } else {
-            this._scheduledLayers = mapLayerService.getAllLayers();
+            this._scheduledLayers = mapLayerService.getAllLayers().slice();
         }
     },
     /**
@@ -88,7 +88,7 @@ Oskari.clazz.define('Oskari.integration.bundle.admin-layerselector.View', functi
         var sandbox = this.getSandbox(),
             // populate layer list
             mapLayerService = sandbox.getService('Oskari.mapframework.service.MapLayerService');
-        var success = false;
+        var success = true;
         if (this.view !== null && this.view !== undefined) {
             if (blnForceCreate || !this._scheduledLayers || this._scheduledLayers.length > 30) {
                 // if more than 30 layers require update -> make full re-render


### PR DESCRIPTION
Shallow copy layer list to prevent to push new layers to map layer service's layer list. Fixes the issue where admin user has duplicate layers on map layer service.

Changed to return true if view isn't initialized to stop schedule update check. Initializing view force updates so there is no need to check if view is initialized (500ms interval).