### PR TITLE
Printout load file with post request

### DIFF
--- a/bundles/framework/printout/instance.js
+++ b/bundles/framework/printout/instance.js
@@ -49,7 +49,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.PrintoutBundleInstance'
          * @method getName
          * @return {String} the name for the component
          */
-        'getName': function () {
+        getName: function () {
             return this.__name;
         },
         /**
@@ -82,7 +82,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.PrintoutBundleInstance'
          * @method start
          * Implements BundleInstance protocol start method
          */
-        'start': function () {
+        start: function () {
             var me = this;
 
             if (me.started) {
@@ -157,15 +157,18 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.PrintoutBundleInstance'
          * @method init
          * Implements Module protocol init method - does nothing atm
          */
-        'init': function () {
+        init: function () {
             return null;
         },
         /**
          * @method update
          * Implements BundleInstance protocol update method - does nothing atm
          */
-        'update': function () {
+        update: function () {
 
+        },
+        getService: function () {
+            return this.printService;
         },
         /**
          * @method onEvent
@@ -287,7 +290,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.PrintoutBundleInstance'
          * @method stop
          * Implements BundleInstance protocol stop method
          */
-        'stop': function () {
+        stop: function () {
             if (this.printout) {
                 this.printout.destroy();
                 this.printout = undefined;
@@ -465,5 +468,5 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.PrintoutBundleInstance'
          * @property {String[]} protocol
          * @static
          */
-        'protocol': ['Oskari.bundle.BundleInstance', 'Oskari.mapframework.module.Module', 'Oskari.userinterface.Extension', 'Oskari.userinterface.Stateful']
+        protocol: ['Oskari.bundle.BundleInstance', 'Oskari.mapframework.module.Module', 'Oskari.userinterface.Extension', 'Oskari.userinterface.Stateful']
     });

--- a/bundles/framework/printout/service/PrintService.js
+++ b/bundles/framework/printout/service/PrintService.js
@@ -67,8 +67,26 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.service.PrintService',
                     }
                 }
             });
+        },
+        fetchPrint: function (url, payload, successCb, errorCb) {
+            fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                responseType: 'blob',
+                body: JSON.stringify(payload)
+            }).then(response => {
+                if (response.ok) {
+                    return response.blob();
+                } else {
+                    return Promise.reject(new Error('Failed to get print'));
+                }
+            }).then(blob => {
+                successCb(blob);
+            }).catch(error => errorCb(error));
         }
 
     }, {
-        'protocol': ['Oskari.mapframework.service.Service']
+        protocol: ['Oskari.mapframework.service.Service']
     });

--- a/bundles/framework/printout/view/BasicPrintout.js
+++ b/bundles/framework/printout/view/BasicPrintout.js
@@ -632,6 +632,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
             };
             const errorCb = error => {
                 Oskari.log('BasicPrintout').error(error);
+                const popup = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+                popup.show(this.loc.error.title, this.loc.error.saveFailed, [popup.createCloseButton()]);
                 showSpinner(false);
             };
             this.instance.getService().fetchPrint(printUrl, payload, successCb, errorCb);
@@ -654,16 +656,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
             }
             const paramsList = Object.keys(params).map(key => '&' + key + '=' + params[key]);
             const url = Oskari.urls.getRoute('GetPrint') + '&' + maplinkArgs + paramsList.join('');
-            const hasCustomStyles = Object.keys(customStyles).length > 0;
-            // We need to use the POST method if there's custom styles.
-            if (hasCustomStyles) {
-                Oskari.log('BasicPrintout').debug('PRINT POST URL ' + url);
-                this.getPostPrint(url, params, customStyles);
-            } else {
-                // Otherwise GET is satisfiable.
-                Oskari.log('BasicPrintout').debug('PRINT URL ' + url);
-                this.openURLinWindow(url);
-            }
+
+            Oskari.log('BasicPrintout').debug('PRINT POST URL ' + url);
+            this.getPostPrint(url, params, customStyles);
         },
 
         /**

--- a/bundles/framework/printout/view/BasicPrintout.js
+++ b/bundles/framework/printout/view/BasicPrintout.js
@@ -65,7 +65,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
             tool: '<div class="tool ">' + '<input type="checkbox"/>' + '<label></label></div>',
             buttons: '<div class="buttons"></div>',
             help: '<div class="help icon-info"></div>',
-            main: '<div class="basic_printout">' + '<div class="header">' + '<div class="icon-close">' + '</div>' + '<h3></h3>' + '</div>' + '<div class="content">' + '</div>' + '<form method="post" target="map_popup_111" id="oskari_print_formID" style="display:none" action="" ><input name="geojson" type="hidden" value="" id="oskari_geojson"/><input name="tiles" type="hidden" value="" id="oskari_tiles"/><input name="tabledata" type="hidden" value="" id="oskari_print_tabledata"/><input name="customStyles" type="hidden" value=""/></form>' + '</div>',
+            main: '<div class="basic_printout">' + '<div class="header">' + '<div class="icon-close">' + '</div>' + '<h3></h3>' + '</div>' + '<div class="content">' + '</div></div>',
             format: '<div class="printout_format_cont printout_settings_cont"><div class="printout_format_label"></div></div>',
             mapTitleInput: '<div class="printout_option_cont printout_settings_cont"><input class="printout_title_field" type="text"></div>',
             optionPage: '<div class="printout_option_cont printout_settings_cont">' + '<input type="checkbox" />' + '<label></label></div>',
@@ -598,36 +598,43 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
         },
 
         /**
-         * @private @method openPostURLinWindow
+         * @private @method openPostPrint
          * Sends the gathered map data to the server to save them/publish the map.
          *
-         * @param {String} printUrl Url to print service action route GetPrint
-         * @param {String} geoJson Stringified GeoJSON
-         * @param {String} tileData Stringified tile data
-         * @param {String} customStyles Stringified styles
+         * @param {String} printUrl
+         * @param {Object} params
+         * @param {Object} customStyles
          *
          */
-        openPostURLinWindow: function (printUrl, geoJson, tileData, tableData, customStyles) {
-            var me = this;
-            var wopParm = this._getWindowSpecs();
-            me.mainPanel.find('#oskari_print_formID').attr('action', printUrl);
-            me.mainPanel.find('input[name=customStyles]').val(customStyles);
-            // Are these used anymore??
-            if (geoJson) {
-                // UTF-8 Base64 encoding
-                var textu8 = unescape(encodeURIComponent(geoJson));
-                me.mainPanel.find('input[name=geojson]').val(jQuery.base64.encode(textu8));
+        getPostPrint: function (printUrl, params, customStyles) {
+            const payload = { customStyles };
+            let fileName = params.pageTitle || 'print';
+            const format = FORMAT_OPTIONS.find(format => format.mime === params.format);
+            if (format) {
+                fileName += '.' + format.name;
             }
-            if (tileData) {
-                me.mainPanel.find('input[name=tiles]').val(tileData);
-            }
-            if (tableData) {
-                me.mainPanel.find('input[name=tabledata]').val(tableData);
-            }
-
-            window.open('about:blank', 'map_popup_111', wopParm);
-
-            me.mainPanel.find('#oskari_print_formID').submit();
+            const showSpinner = visible => this.instance.getSandbox().postRequestByName('ShowProgressSpinnerRequest', [visible]);
+            showSpinner(true);
+            const successCb = blob => {
+                if (navigator.msSaveOrOpenBlob) {
+                    navigator.msSaveOrOpenBlob(blob, fileName);
+                } else {
+                    const url = window.URL.createObjectURL(blob);
+                    const elem = document.createElement('a');
+                    elem.href = url;
+                    elem.download = fileName;
+                    document.body.appendChild(elem);
+                    elem.click();
+                    document.body.removeChild(elem);
+                    window.URL.revokeObjectURL(url);
+                }
+                showSpinner(false);
+            };
+            const errorCb = error => {
+                Oskari.log('BasicPrintout').error(error);
+                showSpinner(false);
+            };
+            this.instance.getService().fetchPrint(printUrl, payload, successCb, errorCb);
         },
         /**
          * @method printMap
@@ -646,20 +653,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
                 }
             }
             const paramsList = Object.keys(params).map(key => '&' + key + '=' + params[key]);
-            let url = Oskari.urls.getRoute('GetPrint') + '&' + maplinkArgs + paramsList.join('');
-
-            // additional layout params for PDF? is needed??
-            url = url + this._getLayoutParams(params.pageSize);
+            const url = Oskari.urls.getRoute('GetPrint') + '&' + maplinkArgs + paramsList.join('');
             const hasCustomStyles = Object.keys(customStyles).length > 0;
-            const hasTileData = Object.keys(this.instance.tileData).length > 0;
-            // We need to use the POST method if there's GeoJSON or tile data.
-            if (hasTileData || hasCustomStyles || this.instance.tableJson) {
-                var stringifiedJson = this._stringifyGeoJson(null);
-                var stringifiedTileData = this._stringifyTileData(this.instance.tileData);
-                var stringifiedTableData = this._stringifyTableData(this.instance.tableJson);
-                const stringifiedCustomStyles = JSON.stringify(customStyles);
+            // We need to use the POST method if there's custom styles.
+            if (hasCustomStyles) {
                 Oskari.log('BasicPrintout').debug('PRINT POST URL ' + url);
-                this.openPostURLinWindow(url, stringifiedJson, stringifiedTileData, stringifiedTableData, stringifiedCustomStyles);
+                this.getPostPrint(url, params, customStyles);
             } else {
                 // Otherwise GET is satisfiable.
                 Oskari.log('BasicPrintout').debug('PRINT URL ' + url);


### PR DESCRIPTION
Load file with post request instead of opening preview window. If pdf has title then use it for filename otherwise print.pdf (before this: action.pdf). 

Post method is used when WFS layer has custom style. Fixes the issue with Chrome pdf viewer which tries to download file from url (before this used form with post method). 

Removed layout params, tile and table data and geojson from request because server doesn't use them. Didn't remove methods (e.g. _stringifyTileData())

"Chrome's built in PDF viewer will download the pdf file through the PDF's origin URL. So if the PDF is generated at server runtime and if it's not stored in the sever, the download could fail"