### PR TITLE
Myplaces refactor internal places handling

### DIFF
--- a/bundles/framework/myplaces3/CategoryHandler.js
+++ b/bundles/framework/myplaces3/CategoryHandler.js
@@ -76,13 +76,24 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.CategoryHandler',
             }
             return this._parseLayerToCategory(layer);
         },
+        getCategory: function (categoryId) {
+            const layer = this.mapLayerService.findMapLayer(this.getMapLayerId(categoryId));
+            if (!layer) {
+                this.log.error('Could not find layer. Category id: ' + categoryId);
+                return;
+            }
+            return this._parseLayerToCategory(layer);
+        },
         _parseLayerToCategory: function (layer) {
             const layerId = layer.getId();
+            // has only one style default for now
+            const { featureStyle } = layer.getCurrentStyleDef();
             return {
                 categoryId: this.parseCategoryId(layerId),
                 layerId,
                 name: layer.getName(),
-                isDefault: !!layer.getOptions().isDefault
+                isDefault: !!layer.getOptions().isDefault,
+                style: featureStyle || {}
             };
         },
         parseCategoryId: function (layerId) {
@@ -192,23 +203,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.CategoryHandler',
 
         editCategory: function (categoryId) {
             var me = this;
-            this.sandbox.postRequestByName('DisableMapKeyboardMovementRequest');
-            var form = Oskari.clazz.create('Oskari.mapframework.bundle.myplaces3.view.CategoryForm', me.instance);
-            const mapLayerService = this.sandbox.getService('Oskari.mapframework.service.MapLayerService');
-            const layer = mapLayerService.findMapLayer(this.getMapLayerId(categoryId));
-            if (!layer) {
-                this.log.error('Could not find layer for editing. Category id: ' + categoryId);
+            const values = this.getCategory(categoryId);
+            var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+            if (!values) {
+                dialog.show(me.loc('notification.error.title'), me.loc('notification.error.generic'), [dialog.createCloseButton()]);
                 return;
             }
-            // has only one style default for now
-            const { featureStyle } = layer.getCurrentStyleDef();
-            var values = {
-                categoryId,
-                name: layer.getName(),
-                isDefault: !!layer.getOptions().isDefault,
-                style: featureStyle || {}
-            };
-            var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+            var form = Oskari.clazz.create('Oskari.mapframework.bundle.myplaces3.view.CategoryForm', me.instance);
+            this.sandbox.postRequestByName('DisableMapKeyboardMovementRequest');
             var buttons = [];
             var saveBtn = Oskari.clazz.create('Oskari.userinterface.component.Button');
             saveBtn.setTitle(me.loc('buttons.save'));
@@ -313,15 +315,19 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.CategoryHandler',
          * If category is empty -> only has delete and cancel
          * The message will also be different for both cases.
          */
-        confirmDeleteCategory: function (categoryId, name) {
+        confirmDeleteCategory: function (categoryId) {
             var me = this;
             var service = this.instance.getService();
             var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
             var deleteBtn;
-
+            const category = this.getCategory(categoryId);
+            if (!category) {
+                dialog.show(me.loc('notification.error.title'), me.loc('notification.error.deleteCategory'), [dialog.createCloseButton()]);
+                return;
+            }
+            const { name, isDefault } = category;
             dialog.makeModal();
-            const defaultCategory = this.getDefaultCategory();
-            if (defaultCategory.categoryId === categoryId) {
+            if (isDefault) {
                 // cannot delete default category
                 var okBtn = dialog.createCloseButton(me.loc('buttons.ok'));
                 dialog.show(me.loc('notification.error.title'), me.loc('notification.error.deleteDefault'), [okBtn]);
@@ -332,6 +338,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.CategoryHandler',
 
             var content = '';
             if (placesCount > 0) {
+                const defaultCategory = this.getDefaultCategory();
                 deleteBtn = Oskari.clazz.create('Oskari.userinterface.component.Button');
                 deleteBtn.setTitle(me.loc('buttons.deleteCategoryAndPlaces'));
                 deleteBtn.setHandler(function () {

--- a/bundles/framework/myplaces3/MyPlacesTab.js
+++ b/bundles/framework/myplaces3/MyPlacesTab.js
@@ -162,7 +162,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.MyPlacesTab',
          */
         _deletePlace: function (data) {
             var me = this;
-            var sandbox = this.instance.sandbox;
             var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
             var okBtn = Oskari.clazz.create('Oskari.userinterface.component.Button');
             okBtn.setTitle(me.loc('tab.notification.delete.btnDelete'));
@@ -170,21 +169,16 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.MyPlacesTab',
 
             okBtn.setHandler(function () {
                 dialog.close();
-                var service = sandbox.getService('Oskari.mapframework.bundle.myplaces3.service.MyPlacesService');
                 var callback = function (isSuccess) {
-                    var request;
-
+                    const popup = Oskari.clazz.create('Oskari.userinterface.component.Popup');
                     if (isSuccess) {
-                        dialog.show(me.loc('tab.notification.delete.title'), me.loc('tab.notification.delete.success'));
-                        request = Oskari.requestBuilder('MyPlaces.DeletePlaceRequest')(data.categoryId);
-
-                        me.instance.sandbox.request(me.instance, request);
+                        popup.show(me.loc('tab.notification.delete.title'), me.loc('tab.notification.delete.success'));
+                        popup.fadeout();
                     } else {
-                        dialog.show(me.loc('tab.notification.delete.title'), me.loc('tab.notification.delete.error'));
+                        popup.show(me.loc('tab.notification.delete.title'), me.loc('tab.notification.delete.error'), [popup.createCloseButton()]);
                     }
-                    dialog.fadeout();
                 };
-                service.deleteMyPlace(data.id, callback);
+                me.instance.getService().deleteMyPlace(data.id, callback);
             });
             var cancelBtn = dialog.createCloseButton(me.loc('tab.notification.delete.btnCancel'));
             var confirmMsg = me.loc('tab.notification.delete.confirm', { name: data.name });

--- a/bundles/framework/myplaces3/resources/locale/en.js
+++ b/bundles/framework/myplaces3/resources/locale/en.js
@@ -285,7 +285,7 @@ Oskari.registerLocalization(
             },
             "categoryDelete": {
                 "title": "Delete Map Layer",
-                "deleteConfirmMove": "You are deleting the map layer \"{0}\". There {1, plural, one {is # place} other {are # places}} on the map layer. Do you want to: <br/> 1. delete the map layer and its {1, plural, one {place} other {places}} <br/> 2. move the {1, plural, one {place} other {places}} to the default map layer before deleting the map layer?",
+                "deleteConfirmMove": "You are deleting the map layer \"{0}\". There {1, plural, one {is # place} other {are # places}} on the map layer. Do you want to: <br/> 1. delete the map layer and its {1, plural, one {place} other {places}} <br/> 2. move the {1, plural, one {place} other {places}} to the default map layer \"{2}\" before deleting the map layer?",
                 "deleteConfirm": "Do you want to delete the map layer \"{0}\"?",
                 "deleted": "The map layer has been deleted."
             },

--- a/bundles/framework/myplaces3/resources/locale/fi.js
+++ b/bundles/framework/myplaces3/resources/locale/fi.js
@@ -285,7 +285,7 @@ Oskari.registerLocalization(
             },
             "categoryDelete": {
                 "title": "Karttatason poistaminen",
-                "deleteConfirmMove": "Olet poistamassa karttatasoa \"{0}\". Karttatasolla on {1, plural, one {# kohde} other {# kohdetta}}. Haluatko: <br/> 1. poistaa karttatason kohteineen <br/> 2. siirtää {1, plural, one {kohteen} other {kohteet}} oletuskarttatasolle ennen karttatason poistoa?",
+                "deleteConfirmMove": "Olet poistamassa karttatasoa \"{0}\". Karttatasolla on {1, plural, one {# kohde} other {# kohdetta}}. Haluatko: <br/> 1. poistaa karttatason kohteineen <br/> 2. siirtää {1, plural, one {kohteen} other {kohteet}} oletuskarttatasolle \"{2}\" ennen karttatason poistoa?",
                 "deleteConfirm": "Haluatko poistaa karttatason {0}?",
                 "deleted": "Karttataso on poistettu."
             },

--- a/bundles/framework/myplaces3/service/MyPlacesService.js
+++ b/bundles/framework/myplaces3/service/MyPlacesService.js
@@ -154,7 +154,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
                 type: 'DELETE',
                 url: Oskari.urls.getRoute('MyPlacesFeatures') + '&features=' + idList.join(),
                 success: function (response) {
-                    callback(response.success);
+                    const success = response.deleted > 0;
+                    callback(success);
                 },
                 error: function (jqXHR, textStatus) {
                     if (jqXHR.status !== 0) {
@@ -373,7 +374,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
                 }),
                 url: Oskari.urls.getRoute('MyPlacesFeatures') + '&crs=' + this.srsName,
                 success: function (response) {
-                    callback(response.success);
+                    const success = response.totalFeatures > 0;
+                    callback(success);
                 },
                 error: function (jqXHR, textStatus) {
                     if (jqXHR.status !== 0) {

--- a/bundles/framework/myplaces3/service/MyPlacesService.js
+++ b/bundles/framework/myplaces3/service/MyPlacesService.js
@@ -41,46 +41,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
             });
             return count;
         },
-
-        /**
-         * @method _addMyPlace
-         * @private
-         * Adds given place to internal data structure. Called when similar backend function
-         * has returned successfully.
-         * @param {Oskari.mapframework.bundle.myplaces3.model.MyPlace} myplaceModel place to add
-         */
-        _addMyPlace: function (myplaceModel) {
-            var categoryId = myplaceModel.getCategoryId();
-            if (!this._placesList[categoryId]) {
-                this._placesList[categoryId] = [];
-            }
-            this._placesList[categoryId].push(myplaceModel);
+        _updatePlaces: function (categoryId) {
+            this._removePlaces(categoryId);
+            this.loadPlaces(categoryId);
         },
-        /**
-         * @method _removeMyPlace
-         * @private
-         * Removes given place from internal data structure. Called when similar backend function
-         * has returned successfully.
-         * @param {Number} placeId id for place to remove
-         */
-        _removeMyPlace: function (id) {
-            var placesList = this._placesList;
-            Object.keys(placesList).forEach(function (category) {
-                var placesInCategory = placesList[category];
-                var indexInCategory = placesInCategory.findIndex(function (place) {
-                    return place.getId() === id;
-                });
-                if (indexInCategory !== -1) {
-                    placesInCategory.splice(indexInCategory, 1);
-                }
-            });
-        },
-        _removePlacesFromCategory: function (categoryId) {
+        _removePlaces: function (categoryId) {
             delete this._placesList[categoryId];
-        },
-        _removePlaceFromCategory: function (id, categoryId) {
-            this._placesList[categoryId] = this.getPlacesInCategory(categoryId)
-                .filter(place => place.getId() !== id);
         },
         findMyPlaceByLonLat: function (lonlat, zoom) {
             this.log.info('findMyPlaceByLonLat() is not implemented');
@@ -139,23 +105,21 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
          */
         movePlacesToCategory: function (oldCategoryId, newCategoryId, callback) {
             var me = this;
-            var placesInDeleteCategory = me.getPlacesInCategory(oldCategoryId);
-            if (placesInDeleteCategory.length === 0) {
+            var places = me.getPlacesInCategory(oldCategoryId);
+            if (places.length === 0) {
                 // no places to move -> callback right away
                 callback(true);
                 return;
             }
-            for (var i = 0; i < placesInDeleteCategory.length; i++) {
-                placesInDeleteCategory[i].setCategoryId(newCategoryId);
-            }
-            const removeCbWrapper = success => {
+            const cbWrapper = success => {
                 if (success) {
-                    // remove from internal store
-                    this._removePlacesFromCategory(oldCategoryId);
+                    this._removePlaces(oldCategoryId);
+                    this._updatePlaces(newCategoryId);
                 }
                 callback(success);
             };
-            this.commitMyPlaces(placesInDeleteCategory, removeCbWrapper, true);
+            places.forEach(place => place.setCategoryId(newCategoryId));
+            this.commitMyPlaces(places, cbWrapper, true);
         },
 
         /**
@@ -165,25 +129,20 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
          * @param {Number} categoryId category id to delete from
          */
         deletePlacesInCategory: function (categoryId, callback) {
-            var placesInDeleteCategory = this.getPlacesInCategory(categoryId);
-            var idList = placesInDeleteCategory.map(function (place) {
-                return place.getId();
-            });
+            const idList = this.getPlacesInCategory(categoryId).map(place => place.getId());
             if (idList.length === 0) {
-                if (callback) {
-                    callback(true);
-                }
+                // no places to delete -> callback right away
+                this._removePlaces(categoryId);
+                callback(true);
                 return;
             }
-            this.deletePlaces(idList, success => {
+            const cbWrapper = success => {
                 if (success) {
-                    this._removePlacesFromCategory(categoryId);
-                    this._notifyDataChanged();
+                    this._removePlaces(categoryId);
                 }
-                if (callback) {
-                    callback(success);
-                }
-            });
+                callback(success);
+            };
+            this.deletePlaces(idList, cbWrapper);
         },
         /*
          * @method deletePlaces
@@ -195,15 +154,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
                 type: 'DELETE',
                 url: Oskari.urls.getRoute('MyPlacesFeatures') + '&features=' + idList.join(),
                 success: function (response) {
-                    if (response) {
-                        callback(true, idList);
-                    } else {
-                        callback(false, idList);
-                    }
+                    callback(response.success);
                 },
                 error: function (jqXHR, textStatus) {
                     if (jqXHR.status !== 0) {
-                        callback(false, idList);
+                        callback(false);
                     }
                 }
             });
@@ -223,9 +178,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
                     layerId: categoryId,
                     crs: this.srsName
                 },
-                success: response => {
-                    if (response) {
-                        this._handleLoadPlacesResponse(categoryId, response.features);
+                success: ({ features }) => {
+                    if (features) {
+                        this._handleLoadPlacesResponse(categoryId, features);
                     } else {
                         this.log.error('Failed to load myplaces.');
                     }
@@ -279,14 +234,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
          * @param response server response
          */
         _handleLoadPlacesResponse: function (categoryId, features = []) {
-            this._placesList[categoryId] = [];
-            features.forEach(feat => {
-                var place = Oskari.clazz.create('Oskari.mapframework.bundle.myplaces3.model.MyPlace');
-                place.setId(feat.id);
-                place.setUuid(feat.properties.uuid);
-                this._setPlaceProperties(place, feat);
-                this._addMyPlace(place);
-            });
+            this._placesList[categoryId] = features.map(feat => this._createPlace(feat));
             this._notifyDataChanged();
         },
         /**
@@ -334,9 +282,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
                 dataType: 'json',
                 data,
                 url: Oskari.urls.getRoute('MyPlacesLayers'),
-                success: response => {
-                    if (response) {
-                        callback(response.layer);
+                success: ({ layer }) => {
+                    if (layer) {
+                        callback(layer);
                         return;
                     }
                     callback(null);
@@ -359,14 +307,19 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
          * @param {Function} callback function to call when done, receives boolean as argument(true == successful)
          */
         deleteMyPlace: function (placeId, callback) {
-            var me = this;
-            this.deletePlaces([placeId], function (success, list) {
+            const place = this.findMyPlace(placeId);
+            if (!place) {
+                this.log.error('Could not find requested place with id:', placeId);
+                callback(false);
+                return;
+            }
+            const cbWrapper = success => {
                 if (success) {
-                    me._removeMyPlace(list[0]);
-                    me._notifyDataChanged();
+                    this._updatePlaces(place.getCategoryId());
                 }
-                callback(success, list[0]);
-            });
+                callback(success);
+            };
+            this.deletePlaces([placeId], cbWrapper);
         },
         /**
          * @method saveMyPlace
@@ -375,10 +328,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
          * @param {Function} callback function to call when done, receives boolean as
          *      first argument(true == successful), myplaceModel as second parameter and boolean as third parameter (true if the category was new)
          */
-        saveMyPlace: function (myplaceModel, callback) {
-            const id = myplaceModel.getId();
+        saveMyPlace: function (place, callback) {
+            const id = place.getId();
             let oldCategoryId = null;
-            const categoryId = myplaceModel.getCategoryId();
+            const categoryId = place.getCategoryId();
             if (id) {
                 let oldPlace;
                 Object.keys(this._placesList).forEach(cat => {
@@ -394,14 +347,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
                 });
             }
             const callbackWrapper = success => {
-                if (success && oldCategoryId) {
-                    this._removePlaceFromCategory(id, oldCategoryId);
-                    this._addMyPlace(myplaceModel);
-                }
                 callback(success, categoryId, oldCategoryId);
-                this._notifyDataChanged();
+                this._updatePlaces(categoryId);
+                if (oldCategoryId) {
+                    this._updatePlaces(oldCategoryId);
+                }
             };
-            this.commitMyPlaces([myplaceModel], callbackWrapper, !!id);
+            this.commitMyPlaces([place], callbackWrapper, !!id);
         },
 
         /**
@@ -409,47 +361,19 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
          *
          * handles insert & update (NO delete)
          */
-        commitMyPlaces: function (list, callback, isUpdate) {
-            var me = this;
-            var features = [];
-            list.forEach(function (feat) {
-                // backend formatting
-                var id = feat.getId();
-                var geojson = {
-                    'id': id,
-                    'type': feat.getType(),
-                    'geometry': feat.getGeometry(),
-                    'category_id': feat.getCategoryId(),
-                    'properties': {
-                        'name': feat.getName(),
-                        'place_desc': feat.getDescription(),
-                        'attention_text': feat.getAttentionText(),
-                        'link': feat.getLink(),
-                        'image_url': feat.getImageLink()
-                    }
-                };
-                features.push(geojson);
-            });
+        commitMyPlaces: function (places, callback, isUpdate) {
+            var features = places.map(place => this._createFeature(place));
             jQuery.ajax({
                 type: isUpdate ? 'PUT' : 'POST',
                 dataType: 'json',
                 contentType: 'application/json',
                 data: JSON.stringify({
-                    'features': features,
-                    'srsName': this.srsName
+                    features: features,
+                    srsName: this.srsName
                 }),
                 url: Oskari.urls.getRoute('MyPlacesFeatures') + '&crs=' + this.srsName,
                 success: function (response) {
-                    if (response) {
-                        if (me.skipLoading === true) {
-                            callback(true);
-                            return;
-                        }
-                        const success = me._handleCommitMyPlacesResponse(response, isUpdate);
-                        callback(success);
-                    } else {
-                        callback(false);
-                    }
+                    callback(response.success);
                 },
                 error: function (jqXHR, textStatus) {
                     if (jqXHR.status !== 0) {
@@ -458,41 +382,16 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
                 }
             });
         },
-
         /**
-         * @method _handleCommitMyPlacesResponse
-         * processes ajax response from backend
-         * @param response server response
-         * @param cb callback to call with the model list as param
+         * @method _createPlace
+         * Creates MyPlace from GeoJSON feature
+         * @param {Object} feature
          */
-        _handleCommitMyPlacesResponse: function (response, isUpdate) {
-            var features = response.features || [];
-            if (features.length === 0) {
-                return false;
-            }
-            features.forEach(feature => {
-                var id = feature.id;
-                var place;
-                if (isUpdate) {
-                    place = this.findMyPlace(id);
-                    if (!place) {
-                        this.log.error('Cannot find place to update');
-                        return false;
-                    }
-                } else {
-                    place = Oskari.clazz.create('Oskari.mapframework.bundle.myplaces3.model.MyPlace');
-                    place.setId(id);
-                    place.setUuid(feature.uuid);
-                }
-                this._setPlaceProperties(place, feature);
-                if (!isUpdate) {
-                    this._addMyPlace(place);
-                }
-            });
-            return true;
-        },
-        _setPlaceProperties: function (place, feature) {
-            const { properties, geometry } = feature;
+        _createPlace: function (feature) {
+            const place = Oskari.clazz.create('Oskari.mapframework.bundle.myplaces3.model.MyPlace');
+            const { properties, geometry, id } = feature;
+            place.setId(id);
+            place.setUuid(properties.uuid);
             place.setName(Oskari.util.sanitize(properties.name));
             place.setDescription(Oskari.util.sanitize(properties.place_desc));
             place.setAttentionText(Oskari.util.sanitize(properties.attention_text));
@@ -505,6 +404,27 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
             const drawMode = this.getDrawModeFromGeometry(geometry);
             const measurement = this.mapmodule.formatMeasurementResult(this.mapmodule.getMeasurementResult(geometry), drawMode);
             place.setMeasurement(measurement);
+            return place;
+        },
+        /**
+         * @method _createFeature
+         * Creates GeoJSON feature from MyPlace
+         * @param {MyPlace} place
+         */
+        _createFeature: function (place) {
+            return {
+                id: place.getId(),
+                type: place.getType(),
+                geometry: place.getGeometry(),
+                category_id: place.getCategoryId(),
+                properties: {
+                    name: place.getName(),
+                    place_desc: place.getDescription(),
+                    attention_text: place.getAttentionText(),
+                    link: place.getLink(),
+                    image_url: place.getImageLink()
+                }
+            };
         },
         /**
          * @method publishCategory
@@ -523,11 +443,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
                 },
                 url: Oskari.urls.getRoute('PublishMyPlaceLayer'),
                 success: pResp => {
-                    if (pResp) {
-                        callback(true);
-                    } else {
-                        callback(false);
-                    }
+                    callback(pResp);
                 },
                 error: jqXHR => {
                     if (jqXHR.status !== 0) {
@@ -537,5 +453,5 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
             });
         }
     }, {
-        'protocol': ['Oskari.mapframework.service.Service']
+        protocol: ['Oskari.mapframework.service.Service']
     });

--- a/bundles/framework/myplaces3/view/PlaceForm.js
+++ b/bundles/framework/myplaces3/view/PlaceForm.js
@@ -65,7 +65,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.view.PlaceForm',
             // populate category options (only if not in a published map)
             if (categories && !isPublished) {
                 const selection = ui.find('select[data-name=category]');
-                const selectedCategoryId = place ? place.getCategoryId() : categories.find(c => c.isDefault === true).categoryId;
+                const defaultCategory = categories.find(c => c.isDefault === true);
+                let selectedCategoryId;
+                if (place) {
+                    selectedCategoryId = place.getCategoryId();
+                } else if (defaultCategory) {
+                    selectedCategoryId = defaultCategory.categoryId;
+                }
                 categories.forEach(({ categoryId, name }) => {
                     const option = this.templateOption.clone();
                     option.text(name);
@@ -75,7 +81,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.view.PlaceForm',
                     }
                     selection.append(option);
                 });
-                selection.val(selectedCategoryId);
+                if (selectedCategoryId) {
+                    selection.val(selectedCategoryId);
+                }
             }
             if (isPublished) {
                 // remove the layer selections if in a publised map


### PR DESCRIPTION
Load/refresh category's places when place is added, removed or edited. Fixes the issue where frontend didn't load places if place was added to category without opening category from my places tab. New place was stored to internal storage and placesLoaded(categoryId) checked if storage had key for category.

Fixed missing category name in delete category popup. Also added index for default category name in en ja fi localization (sv had already). Fixed popup fade out on success delete place.