### PR TITLE
Add maxZoomLevel option for ZoomToFeaturesRequest

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -9,6 +9,12 @@ Some extra tags:
 - [rpc] tag indicates that the change affects RPC API
 - [breaking] tag indicates that the change is not backwards compatible
 
+## 2.1.0
+
+### [mod] [rpc] ZoomToFeaturesRequest
+
+Now supports an optional maxZoomLevel flag to restrict the amount of zooming we are willing to make while showing the features. This is useful for point features or features that are close to each other. Without this the map might zoom "all-in" that might not be what we want to do.
+
 ## 1.55.0
 
 ### [add] [rpc] New SetTimeRequest Request

--- a/api/mapping/mapmodule/request/zoomtofeaturesrequest.md
+++ b/api/mapping/mapmodule/request/zoomtofeaturesrequest.md
@@ -1,6 +1,6 @@
 # ZoomToFeaturesRequest [RPC]
 
-Zoom to specific or all features on a map.
+Moves map to show referenced vector features on the viewport.
 
 ## Use cases
 
@@ -8,23 +8,50 @@ Zoom to specific or all features on a map.
 
 ## Description
 
-This request is used to zoom to the extent of all or specific features on the specified layers. If layer(s) not giving, will zoom to all features on the layers, that were created by the VectorLayerPlugin
+This request is used to zoom/move the map so requested features are visible on the map viewport. Requested features can be selected by referencing a vector layer and/or referencing attribute data values. If selection is not made the map is zoomed out to show all vector features that have been programmatically added to the map (features added directly from services/map layers providing vector features are not included).
 
 ## Parameters
 
-(* means the parameter is required)
+All of the parameters for this request are optional.
 
 <table class="table">
 <tr>
   <th> Name</th><th> Type</th><th> Description</th><th> Default value</th>
 </tr>
 <tr>
-  <td> layer</td><td> Array</td><td> Zooming will be applied to the features on the specified layers. </td><td> All layers, that were created by the VectorLayerPlugin</td>
+  <td> options</td><td> Object</td><td> Can be used to select layers to include or max zoom level </td><td> See below</td>
 </tr>
 <tr>
-  <td> features: key - property name, value - list of property's values </td><td> Array</td><td> Zooming will be applied to the specified features. <br> If not giving, will zoom to all features on the specified layers.</td><td> All features on the specified layers.</td>
+  <td> feature filter </td><td> Object </td><td> Features to zoom to can be selected by defining filters with this parameter. If not provided the features are not filtered.</td><td> No filter/all features on the specified layers are shown.</td>
 </tr>
 </table>
+
+### Param: options
+
+<table class="table">
+<tr>
+  <th> Name</th><th> Type</th><th> Description</th><th> Default value</th>
+</tr>
+<tr>
+  <td> layer</td><td> Array</td><td> Features to show are only included from layers matching ids referenced in the array</td><td> All layers that were created for programmatically added features (by VectorLayerPlugin)</td>
+</tr>
+<tr>
+  <td> maxZoomLevel</td><td> Number</td><td> Can be used to restrict how "close" we want to zoom if the features are very close to each other or a single point.</td><td> No restriction</td>
+</tr>
+</table>
+
+### Param: feature filter
+
+The feature filter is an object where keys are feature attribute names. The value for specific key is an array listing the accepted values for that attribute. If a feature has that attribute with any of the listed values it will be included in the set.
+
+For example:
+```
+{
+	"name": ["F1","F2"]
+}
+```
+
+The above filter would only include features where the name attribute has a value of "F1" or "F2".
 
 ## Examples
 

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -584,11 +584,19 @@ export class MapModule extends AbstractMapModule {
      * @param {Boolean} suppressEnd true to NOT send an event about the map move
      *  (other components wont know that the map has moved, only use when chaining moves and
      *     wanting to notify at end of the chain for performance reasons or similar) (optional)
+     * @param {Number} maxZoomLevel restrict to max level so we don't zoom "too close" for point features etc (optional)
      */
-    zoomToExtent (bounds, suppressStart, suppressEnd) {
+    zoomToExtent (bounds, suppressStart, suppressEnd, maxZoomLevel = -1) {
         var extent = this.__boundsToArray(bounds);
         this.getMap().getView().fit(extent);
-        this.updateDomain();
+        if (maxZoomLevel !== -1 && this.getMapZoom() > maxZoomLevel) {
+            // restrict that we don't "overzoom" for point features etc
+            this.setZoomLevel(maxZoomLevel, true);
+        } else {
+            // setZoomLevel updates domain so only do it once
+            this.updateDomain();
+        }
+
         // send note about map change
         if (suppressStart !== true) {
             this.notifyStartMove();

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -1129,8 +1129,8 @@ Oskari.clazz.define(
          * @param {Object} featureFilter
          */
         zoomToFeatures: function (opts = {}, featureFilter) {
-            const layers = me.getLayerIds(opts);
-            const features = me.getFeaturesMatchingQuery(layers, featureFilter);
+            const layers = this.getLayerIds(opts);
+            const features = this.getFeaturesMatchingQuery(layers, featureFilter);
             if (features.length > 0) {
                 const tmpLayer = new olSourceVector({
                     features: features

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -1128,7 +1128,7 @@ Oskari.clazz.define(
          * @param {Object} opts
          * @param {Object} featureFilter
          */
-        zoomToFeatures: function (opts, featureFilter) {
+        zoomToFeatures: function (opts = {}, featureFilter) {
             const layers = me.getLayerIds(opts);
             const features = me.getFeaturesMatchingQuery(layers, featureFilter);
             if (features.length > 0) {
@@ -1136,7 +1136,7 @@ Oskari.clazz.define(
                     features: features
                 });
                 const extent = this.getBufferedExtent(tmpLayer.getExtent(), 35);
-                this.getMapModule().zoomToExtent(extent);
+                this.getMapModule().zoomToExtent(extent, false, false, opts.maxZoomLevel);
             }
             this.sendZoomFeatureEvent(features);
         },

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -1124,23 +1124,38 @@ Oskari.clazz.define(
 
         /**
          * @method zoomToFeatures
-         *  - zooms to features
-         * @param {Object} layer
-         * @param {Object} options
+         *  - moves map to show to features on the viewport
+         * @param {Object} opts
+         * @param {Object} featureFilter
          */
-        zoomToFeatures: function (layer, options) {
-            var me = this;
-            var layers = me.getLayerIds(layer);
-            var features = me.getFeaturesMatchingQuery(layers, options);
+        zoomToFeatures: function (opts, featureFilter) {
+            const layers = me.getLayerIds(opts);
+            const features = me.getFeaturesMatchingQuery(layers, featureFilter);
             if (features.length > 0) {
-                var vector = new olSourceVector({
+                const tmpLayer = new olSourceVector({
                     features: features
                 });
-                var extent = vector.getExtent();
-                extent = me.getBufferedExtent(extent, 35);
-                me.getMapModule().zoomToExtent(extent);
+                const extent = this.getBufferedExtent(tmpLayer.getExtent(), 35);
+                this.getMapModule().zoomToExtent(extent);
             }
-            me.sendZoomFeatureEvent(features);
+            this.sendZoomFeatureEvent(features);
+        },
+        /**
+         * @method getLayerIds
+         *  -
+         * @param {Object} optional object with key layer that has an array of layer ids
+         * @return {Array} array of layer ids
+         */
+        getLayerIds: function (opts) {
+            if (typeof opts !== 'object' || !Object.keys(opts).length) {
+                // return all layers we know of
+                return Object.keys(this._olLayers);
+            }
+            if (opts.layer && typeof opts.layer.slice === 'function') {
+                // the value for "layer" needs to be an array or we return an empty array
+                return opts.layer.slice(0);
+            }
+            return [];
         },
         /**
          * @method getBufferedExtent
@@ -1227,21 +1242,6 @@ Oskari.clazz.define(
                 features = features.concat(filteredAndModified);
             });
             return features;
-        },
-        /**
-         * @method getLayerIds
-         *  -
-         * @param {Object} optional object with key layer that has an array of layer ids
-         * @return {Array} array of layer ids
-         */
-        getLayerIds: function (layerIds) {
-            if (typeof layerIds !== 'object' || !Object.keys(layerIds).length) {
-                return Object.keys(this._olLayers);
-            }
-            if (layerIds.layer && typeof layerIds.layer.slice === 'function') {
-                return layerIds.layer.slice(0);
-            }
-            return [];
         },
         /**
          * @method getLayerFeatures

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/request/ZoomToFeaturesRequest.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/request/ZoomToFeaturesRequest.js
@@ -8,12 +8,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.ZoomToFeatures
      * @method create called automatically on construction
      * @static
      *
-     * @param {Object} layer
-     * @param {Object} options additional options
+     * @param {Object} options object with layer references and/or maxZoomLevel
+     * @param {Object} featureFilter object with attribute names and accepted values
      */
-    function (layer, options) {
-        this._layer = layer;
+    function (options, featureFilter) {
         this._options = options;
+        this._featureFilter = featureFilter;
     }, {
         /** @static @property __name request name */
         __name: 'MapModulePlugin.ZoomToFeaturesRequest',
@@ -25,18 +25,18 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.ZoomToFeatures
             return this.__name;
         },
         /**
-         * @method getLayer
-         * @return {Object} layer
-         */
-        getLayer: function () {
-            return this._layer;
-        },
-        /**
          * @method getOptions
-         * @return {Object} options
+         * @return {Object} options for layer references and/or maxZoomLevel
          */
         getOptions: function () {
             return this._options;
+        },
+        /**
+         * @method getFeatureFilter
+         * @return {Object} object with attribute names and accepted values
+         */
+        getFeatureFilter: function () {
+            return this._featureFilter;
         }
     }, {
         /**

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/request/ZoomToFeaturesRequestHandler.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/request/ZoomToFeaturesRequestHandler.js
@@ -23,7 +23,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.ZoomToFeatures
          */
         handleRequest: function (core, request) {
             this._log.debug('Zoom to Features');
-            this.vectorLayerPlugin.zoomToFeatures(request.getLayer(), request.getOptions());
+            this.vectorLayerPlugin.zoomToFeatures(request.getOptions(), request.getFeatureFilter());
         }
     }, {
         /**


### PR DESCRIPTION
Useful for point features or features that are close to each other. Without this the map might zoom "all-in" and configuring the maxZoomLevel we can now limit how close we are willing to go even for smaller features.