### PR TITLE
Publisher select width

### DIFF
--- a/bundles/framework/printout/resources/scss/style.scss
+++ b/bundles/framework/printout/resources/scss/style.scss
@@ -78,7 +78,7 @@ div.basic_printout div.icon-info {
 }
 
 div.basic_printout div.form div.field input,
-div.field select {
+div.basic_printout div.field select {
     width: 80%;
     background-color: white;
 }

--- a/bundles/framework/publisher2/resources/scss/style.scss
+++ b/bundles/framework/publisher2/resources/scss/style.scss
@@ -277,15 +277,8 @@ div.publisher {
 }
 
 div.basic_publisher div.form div.field input,
-div.field select {
-    width: 100%;
-
-    /*
-    This used to have a defunct CSS hack for IE 10 only:
-    width: 80%\0;
-    It was never functional because SASS compiled it into single character.
-    It was removed.
-    */
+div.basic_publisher div.field select {
+    width: 80%;
     background-color: #FFF;
 }
 


### PR DESCRIPTION
Language select was too wide if application didn't have printout bundle. Updated select to 80% and fixed printout css leakage.