### PR TITLE
Fix empty opts object to return all layers instead of empty array

### DIFF
--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -1129,7 +1129,7 @@ Oskari.clazz.define(
          * @param {Object} featureFilter
          */
         zoomToFeatures: function (opts = {}, featureFilter) {
-            const layers = this.getLayerIds(opts);
+            const layers = this._getLayerIds(opts.layer);
             const features = this.getFeaturesMatchingQuery(layers, featureFilter);
             if (features.length > 0) {
                 const tmpLayer = new olSourceVector({
@@ -1141,22 +1141,20 @@ Oskari.clazz.define(
             this.sendZoomFeatureEvent(features);
         },
         /**
-         * @method getLayerIds
-         *  -
-         * @param {Object} optional object with key layer that has an array of layer ids
-         * @return {Array} array of layer ids
+         * @method _getLayerIds
+         * @private
+         * @param {Array|String|Number} layer id or array of layer ids (optional)
+         * @return {Array} array of layer ids that was requested and we recognized
          */
-        getLayerIds: function (opts = {}) {
-            let { layer } = opts;
-            const allLayers = Object.keys(this._olLayers);
-            if (!layer) {
-                // return all layers we know of if layer is not specified
-                return allLayers;
-            }
-
+        _getLayerIds: function (layer = []) {
             if (!Array.isArray(layer)) {
                 // the value for "layer" needs to be an array so wrap it in one if it isn't
                 layer = [layer];
+            }
+            const allLayers = Object.keys(this._olLayers);
+            if (!layer.length) {
+                // return all layers we know of if layer is not specified
+                return allLayers;
             }
 
             // filtering the requested layers by checking that we know of them

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -1147,7 +1147,7 @@ Oskari.clazz.define(
          * @return {Array} array of layer ids
          */
         getLayerIds: function (opts = {}) {
-            const {layer} = opts;
+            const { layer } = opts;
             const allLayers = Object.keys(this._olLayers);
             if (!layer || typeof layer.filter !== 'function') {
                 // return all layers we know of

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -1147,14 +1147,18 @@ Oskari.clazz.define(
          * @return {Array} array of layer ids
          */
         getLayerIds: function (opts = {}) {
-            const { layer } = opts;
+            let { layer } = opts;
             const allLayers = Object.keys(this._olLayers);
-            if (!layer || typeof layer.filter !== 'function') {
-                // return all layers we know of
+            if (!layer) {
+                // return all layers we know of if layer is not specified
                 return allLayers;
             }
 
-            // the value for "layer" needs to be an array
+            if (!Array.isArray(layer)) {
+                // the value for "layer" needs to be an array so wrap it in one if it isn't
+                layer = [layer];
+            }
+
             // filtering the requested layers by checking that we know of them
             return layer.filter(id => allLayers.includes(id));
         },

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -1146,16 +1146,17 @@ Oskari.clazz.define(
          * @param {Object} optional object with key layer that has an array of layer ids
          * @return {Array} array of layer ids
          */
-        getLayerIds: function (opts) {
-            if (typeof opts !== 'object' || !Object.keys(opts).length) {
+        getLayerIds: function (opts = {}) {
+            const {layer} = opts;
+            const allLayers = Object.keys(this._olLayers);
+            if (!layer || typeof layer.filter !== 'function') {
                 // return all layers we know of
-                return Object.keys(this._olLayers);
+                return allLayers;
             }
-            if (opts.layer && typeof opts.layer.slice === 'function') {
-                // the value for "layer" needs to be an array or we return an empty array
-                return opts.layer.slice(0);
-            }
-            return [];
+
+            // the value for "layer" needs to be an array
+            // filtering the requested layers by checking that we know of them
+            return layer.filter(id => allLayers.includes(id));
         },
         /**
          * @method getBufferedExtent

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.test.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.test.js
@@ -54,21 +54,24 @@ describe('VectorLayerPlugin', () => {
     plugin._olLayers['test_1'] = createFakeLayer();
     plugin._olLayers['test_2'] = createFakeLayer();
 
-    describe('getLayerIds', () => {
-        test('without param returns 2 faked layers', () => {
-            expect(plugin.getLayerIds().length).toEqual(2);
+    describe('_getLayerIds', () => {
+        test('without param returns all layers (2)', () => {
+            expect(plugin._getLayerIds().length).toEqual(2);
         });
-        test('with valid and recognized layer key returns 1', () => {
-            expect(plugin.getLayerIds({ layer: ['test_2'] }).length).toEqual(1);
+        test('with valid and recognized layer id in array returns 1', () => {
+            expect(plugin._getLayerIds(['test_2']).length).toEqual(1);
         });
-        test('with layer key referencing unrecognized layer ids returns 0', () => {
-            expect(plugin.getLayerIds({ layer: [1, 2, 3] }).length).toEqual(0);
+        test('with valid and recognized layer id returns 1', () => {
+            expect(plugin._getLayerIds('test_2').length).toEqual(1);
         });
-        test('with invalid param returns 0', () => {
-            expect(plugin.getLayerIds({ layer: 12 }).length).toEqual(0);
+        test('with referencing some unrecognized layer ids returns one that matches', () => {
+            expect(plugin._getLayerIds([1, 2, 'test_1']).length).toEqual(1);
         });
-        test('without layer key returns all layers', () => {
-            expect(plugin.getLayerIds({ testing: true }).length).toEqual(2);
+        test('with referencing unrecognized layer id returns 0', () => {
+            expect(plugin._getLayerIds(12).length).toEqual(0);
+        });
+        test('without random input returns 0', () => {
+            expect(plugin._getLayerIds({ testing: true }).length).toEqual(0);
         });
     });
 
@@ -76,7 +79,7 @@ describe('VectorLayerPlugin', () => {
         test('add geojson', () => {
             const geojson = generateGeoJSON(1, 2);
             plugin.addFeaturesToMap(geojson);
-            expect(plugin.getLayerIds().length).toEqual(3);
+            expect(plugin._getLayerIds().length).toEqual(3);
         });
     });
     describe('getFeaturesMatchingQuery', () => {

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.test.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.test.js
@@ -58,17 +58,17 @@ describe('VectorLayerPlugin', () => {
         test('without param returns 2 faked layers', () => {
             expect(plugin.getLayerIds().length).toEqual(2);
         });
-        test('with valid param returns 1', () => {
-            expect(plugin.getLayerIds({ layer: [12] }).length).toEqual(1);
+        test('with valid and recognized layer key returns 1', () => {
+            expect(plugin.getLayerIds({ layer: ['test_2'] }).length).toEqual(1);
         });
-        test('with valid param returns 3', () => {
-            expect(plugin.getLayerIds({ layer: [1, 2, 3] }).length).toEqual(3);
+        test('with layer key referencing unrecognized layer ids returns 0', () => {
+            expect(plugin.getLayerIds({ layer: [1, 2, 3] }).length).toEqual(0);
         });
         test('with invalid param returns 0', () => {
             expect(plugin.getLayerIds({ layer: 12 }).length).toEqual(0);
         });
-        test('with invalid param 2 returns 0', () => {
-            expect(plugin.getLayerIds({ testing: true }).length).toEqual(0);
+        test('without layer key returns all layers', () => {
+            expect(plugin.getLayerIds({ testing: true }).length).toEqual(2);
         });
     });
 


### PR DESCRIPTION
Improves on #1341 so we can pass maxZoomLevel WITHOUT specifying layers filter for ZoomToFeaturesRequest. Also adds a check that requested layers need to exist before we start filtering features.