### PR TITLE
Make default search description more generic

### DIFF
--- a/bundles/framework/search/resources/locale/en.js
+++ b/bundles/framework/search/resources/locale/en.js
@@ -7,7 +7,7 @@ Oskari.registerLocalization(
         "desc": "",
         "tabTitle": "Location Search",
         "invalid_characters": "The search term contains illegal characters. Allowed characters are letters (a-z, å, ä, ö, A-Z, Å, Ä, Ö), numbers (0-9), a dot (.), a comma (,), a hyphen (-) and an exclamation mark (!). You can also replace one mark with a question mark (?) or an end part with an asterisk (*).",
-        "searchDescription": "Search location by placename, address or real estate unit identifier.",
+        "searchDescription": "Search locations by typing a name of a place.",
         "searchAssistance": "Type search term",
         "searchResultCount": "Your search returned",
         "searchResultCount2": "results.",

--- a/bundles/framework/search/resources/locale/fi.js
+++ b/bundles/framework/search/resources/locale/fi.js
@@ -7,7 +7,7 @@ Oskari.registerLocalization(
         "desc": "",
         "tabTitle": "Paikkahaku",
         "invalid_characters": "Hakusanassa on kiellettyjä merkkejä. Sallittuja merkkejä ovat aakkoset (a-ö, A-Ö), numerot (0-9) sekä piste (.), pilkku (,), yhdysviiva (-) ja huutomerkki (!). Voit myös korvata sanassa yhden merkin kysymysmerkillä (?) tai sana loppuosan jokerimerkillä (*).",
-        "searchDescription": "Hae paikkoja paikannimen, osoitteen tai kiinteistötunnuksen perusteella.",
+        "searchDescription": "Hae paikkoja paikannimen perusteella.",
         "searchAssistance": "Anna hakusana",
         "searchResultCount": "Hakusanalla löytyi",
         "searchResultCount2": "hakutulosta.",

--- a/bundles/framework/search/resources/locale/fr.js
+++ b/bundles/framework/search/resources/locale/fr.js
@@ -7,7 +7,7 @@ Oskari.registerLocalization(
         "desc": "",
         "tabTitle": "Recherche de lieu",
         "invalid_characters": "Les termes de la recherche contiennent des caractères non autorisés. Les caractères autorisés sont les lettres de a à z, ainsi que å, ä, ö, les chiffres, la touche effacement, les points d’interrogation ( ?), les astérisques (*) et les tirets.",
-        "searchDescription": "Rechercher un lieu par nom de lieu, adresse ou « Identifiant d'unité immobilière (ou code REUI).",
+        "searchDescription": "Rechercher un lieu par nom de lieu.",
         "searchAssistance": "Saisissez le terme à rechercher.",
         "searchResultCount": "Votre recherche donne",
         "searchResultCount2": "résultats.",

--- a/bundles/framework/search/resources/locale/sv.js
+++ b/bundles/framework/search/resources/locale/sv.js
@@ -7,7 +7,7 @@ Oskari.registerLocalization(
         "desc": "",
         "tabTitle": "Ortnamnssökning",
         "invalid_characters": "Sökbegrepp innehåller otillåtna tecken. Tillåtna tecken är bokstäverna az samt å, ä och ö, siffror, backsteg, frågetecken, stjärnor (*) och bindestreck (?) (-).",
-        "searchDescription": "Sök ortnamn, adress eller fastighetsbeteckning.",
+        "searchDescription": "Sök ortnamn.",
         "searchAssistance": "Skriv sökordet.",
         "searchResultCount": "Din sökning gav",
         "searchResultCount2": "resultat.",


### PR DESCRIPTION
Remove references to real estate ids etc since it depends on the app and backend integrations. Applications can override this and have been forced to do so as the default is very specific.