### PR TITLE
Layerlist raster layer filter

### DIFF
--- a/bundles/framework/layerlist/instance.js
+++ b/bundles/framework/layerlist/instance.js
@@ -101,13 +101,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerlist.LayerListBundleInstanc
                 }
             }
 
-            // Add newest layers filter.
-            const loc = this.getLocalization('filter');
-            layerlistService.registerLayerlistFilterButton(
-                loc.newest.title,
-                loc.newest.tooltip.replace('##', FILTER_NEWEST_COUNT),
-                {},
-                'newest');
+            this._registerFilterButtons(layerlistService);
 
             // Let's extend UI
             const request = Oskari.requestBuilder('userinterface.AddExtensionRequest')(this);
@@ -303,7 +297,21 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerlist.LayerListBundleInstanc
                 return [openLink, closeLink];
             }
         },
-
+        _registerFilterButtons: function (service) {
+            // Add newest layers filter
+            const loc = this.getLocalization('filter');
+            service.registerLayerlistFilterButton(
+                loc.newest.title,
+                loc.newest.tooltip.replace('##', FILTER_NEWEST_COUNT),
+                {},
+                'newest');
+            // Add raster layers filter
+            service.registerLayerlistFilterButton(
+                loc.raster.title,
+                loc.raster.tooltip,
+                {},
+                'raster');
+        },
         /**
          * @method _registerForGuidedTour
          * Registers bundle for guided tour help functionality. Waits for guided tour load if not found

--- a/bundles/framework/layerlist/resources/locale/en.js
+++ b/bundles/framework/layerlist/resources/locale/en.js
@@ -26,6 +26,10 @@ Oskari.registerLocalization(
                 'newest': {
                     'title': 'Newest',
                     'tooltip': 'Show ## newest map layers'
+                },
+                'raster': {
+                    'title': 'Raster layers',
+                    'tooltip': 'Show only raster layers'
                 }
             },
             'grouping': {

--- a/bundles/framework/layerlist/resources/locale/fi.js
+++ b/bundles/framework/layerlist/resources/locale/fi.js
@@ -26,6 +26,10 @@ Oskari.registerLocalization(
                 'newest': {
                     'title': 'Uusimmat',
                     'tooltip': 'Näytä ## uusinta karttatasoa'
+                },
+                'raster': {
+                    'title': 'Rasteritasot',
+                    'tooltip': 'Näytä vain rasteritasot'
                 }
             },
             'grouping': {

--- a/bundles/framework/layerlist/resources/locale/sv.js
+++ b/bundles/framework/layerlist/resources/locale/sv.js
@@ -26,6 +26,10 @@ Oskari.registerLocalization(
                 'newest': {
                     'title': 'Nyaste',
                     'tooltip': 'Visa de ## nyaste kartlager'
+                },
+                'raster': {
+                    'title': 'Rasterlager',
+                    'tooltip': 'Visa endast kartlager med rastergrafik'
                 }
             },
             'grouping': {

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -60,20 +60,22 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
         /*
          * Layer filters
          */
+        const rasterLayerTypes = ['wmts', 'bingmaps', 'arcgis', 'wms', 'arcgis93'];
         this.layerFilters = {
-            'featuredata': function (layer) {
+            featuredata: function (layer) {
                 return layer.hasFeatureData();
             },
-            'newest': function (layer) {
+            newest: function (layer) {
                 // kinda heavy, but get a list of 20 newest layers and check if the requested layer is one them
                 // getNewestLayers() caches the result so in practice it's not as heavy as it looks.
                 return !!me.getNewestLayers(20).find(function (newLayer) {
                     return layer.getId() === newLayer.getId();
                 });
             },
-            'timeseries': function (layer) {
+            timeseries: function (layer) {
                 return layer.hasTimeseries();
-            }
+            },
+            raster: layer => rasterLayerTypes.includes(layer.getLayerType())
         };
 
         Oskari.makeObservable(this);


### PR DESCRIPTION
Add layer filter for raster layers. Raster filter is like newest filter (registered in layerlist and defined in maplayerservice). Now maplayer service contains hard coded list of raster layer types.  Maybe maplayer plugins should push/register layer type/model with raster/vector/timeseries... additional information which could be used for filters (and layer tools). Vector layer filter uses hasFeatureData().