### PR TITLE
Statistics indicator list tools layout fix

### DIFF
--- a/bundles/statistics/statsgrid2016/components/IndicatorList.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorList.js
@@ -15,8 +15,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorList', function (servi
             `<li>
                 <div>
                     <span title="\${full}">\${name}</span>
-                    <div class="indicator-list-info icon-info"/>
-                    <div class="indicator-list-remove icon-close" data-ind-hash="\${indHash}"/>
+                    <div class="indicator-list-info icon-info"></div>
+                    <div class="indicator-list-remove icon-close" data-ind-hash="\${indHash}"></div>
                 </div>
             </li>`),
         empty: _.template('<li>${emptyMsg}</li>')

--- a/bundles/statistics/statsgrid2016/components/MetadataPopup.js
+++ b/bundles/statistics/statsgrid2016/components/MetadataPopup.js
@@ -94,10 +94,10 @@ export class MetadataPopup extends Popup {
             // Open the last panel
             this._accordions[this._accordions.length - 1].getPanels()[0].open();
         }
+        const btn = this.createCloseButton();
+        btn.setPrimary(true);
         const title = this.loc('metadataPopup.title', { indicators: this._accordions.length });
-        const okButton = Oskari.clazz.create('Oskari.userinterface.component.buttons.OkButton');
-        okButton.setHandler(() => this.close());
-        super.show(title, container, [okButton]);
+        super.show(title, container, [btn]);
     }
 
     /**


### PR DESCRIPTION
Remove icon div was placed inside info icon div. Maybe this was broken because of the jQuery update. Changed ok button to close button.