### PR TITLE
Vectortilelayer skip adding unsupported layer to map

### DIFF
--- a/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
@@ -169,6 +169,9 @@ class VectorTileLayerPlugin extends AbstractMapLayerPlugin {
      * @param {Boolean} isBaseMap
      */
     addMapLayerToMap (layer, keepLayerOnTop, isBaseMap) {
+        if (!this.getSandbox().getMap().isLayerSupported(layer)) {
+            return;
+        }
         let url = layer.getLayerUrl().replace('{epsg}', this.mapModule.getProjection());
         const urlParams = this.getUrlParams(layer);
         if (urlParams) {
@@ -197,11 +200,6 @@ class VectorTileLayerPlugin extends AbstractMapLayerPlugin {
         vectorTileLayer.set(LAYER_ID, layer.getId(), silent);
         vectorTileLayer.set(LAYER_TYPE, layer.getLayerType(), silent);
         vectorTileLayer.set(LAYER_HOVER, layer.getHoverOptions(), silent);
-
-        if (!this.getSandbox().getMap().isLayerSupported(layer)) {
-            layer.setVisible(false);
-            vectorTileLayer.setVisible(false);
-        }
 
         const zoomLevelHelper = getZoomLevelHelper(this.getMapModule().getScaleArray());
         // Set min max zoom levels that layer should be visible in


### PR DESCRIPTION
Don't add ol layer to map if layer isn't supported. Now layer is added to selected layers as visible layer with unsupported reason but not to ol map. So layer is added to link (dimension-change) and tiles aren't requested if layer isn't supported.

Works like tiles3dlayer: https://github.com/oskariorg/oskari-frontend/blob/develop/bundles/mapping/tiles3d/plugin/Tiles3DLayerPlugin.js#L181