### PR TITLE
Confirm reset state

### DIFF
--- a/bundles/framework/divmanazer/component/Popup.js
+++ b/bundles/framework/divmanazer/component/Popup.js
@@ -231,6 +231,19 @@ Oskari.clazz.define('Oskari.userinterface.component.Popup',
             okBtn.setHandler(() => this.close(true));
             return okBtn;
         },
+        createConfirmButtons: function (callback) {
+            const cancelBtn = this.createCloseButton(Oskari.getMsg('DivManazer', 'buttons.no'));
+            const okBtn = Oskari.clazz.create('Oskari.userinterface.component.Button');
+            okBtn.setTitle(Oskari.getMsg('DivManazer', 'buttons.yes'));
+            okBtn.setPrimary(true);
+            if (typeof callback === 'function') {
+                okBtn.setHandler(() => {
+                    this.close(true);
+                    callback();
+                });
+            }
+            return [cancelBtn, okBtn];
+        },
 
         /**
         * @method createCloseIcon

--- a/bundles/framework/divmanazer/resources/locale/en.js
+++ b/bundles/framework/divmanazer/resources/locale/en.js
@@ -16,7 +16,9 @@ Oskari.registerLocalization(
             "exit": "Exit",
             "ok": "OK",
             "save": "Save",
-            "search": "Search"
+            "search": "Search",
+            "yes": "Yes",
+            "no": "No"
         },
         "LanguageSelect": {
             "title": "Language",

--- a/bundles/framework/divmanazer/resources/locale/fi.js
+++ b/bundles/framework/divmanazer/resources/locale/fi.js
@@ -16,7 +16,9 @@ Oskari.registerLocalization(
             "exit": "Poistu",
             "ok": "OK",
             "save": "Tallenna",
-            "search": "Hae"
+            "search": "Hae",
+            "yes": "Kyllä",
+            "no": "Ei"
         },
         "LanguageSelect": {
             "title": "Kieli",

--- a/bundles/framework/divmanazer/resources/locale/fr.js
+++ b/bundles/framework/divmanazer/resources/locale/fr.js
@@ -16,7 +16,9 @@ Oskari.registerLocalization(
             "exit": "Sortir",
             "ok": "OK",
             "save": "Enregistrer",
-            "search": "Rechercher"
+            "search": "Rechercher",
+            "yes": "Oui",
+            "no": "Non"
         },
         "LanguageSelect": {
             "title": "Langue",

--- a/bundles/framework/divmanazer/resources/locale/is.js
+++ b/bundles/framework/divmanazer/resources/locale/is.js
@@ -12,7 +12,9 @@ Oskari.registerLocalization(
             "exit": "Hætta",
             "ok": "Í lagi",
             "save": "Vista",
-            "search": "Leita"
+            "search": "Leita",
+            "yes": "Já",
+            "no": "Nei"
         },
         "LanguageSelect": {
             "title": "tungumál",

--- a/bundles/framework/divmanazer/resources/locale/ru.js
+++ b/bundles/framework/divmanazer/resources/locale/ru.js
@@ -16,7 +16,9 @@ Oskari.registerLocalization(
             "exit": "Выйти",
             "ok": "OK",
             "save": "Сохранить",
-            "search": "Поиск"
+            "search": "Поиск",
+            "yes": "Да",
+            "no": "Нет"
         },
         "LanguageSelect": {
             "title": "Язык",

--- a/bundles/framework/divmanazer/resources/locale/sv.js
+++ b/bundles/framework/divmanazer/resources/locale/sv.js
@@ -16,7 +16,9 @@ Oskari.registerLocalization(
             "exit": "Avsluta",
             "ok": "OK",
             "save": "Spara",
-            "search": "Sök"
+            "search": "Sök",
+            "yes": "Ja",
+            "no": "Nej"
         },
         "LanguageSelect": {
             "title": "Språk",

--- a/bundles/mapping/mapmodule/plugin/panbuttons/PanButtons.js
+++ b/bundles/mapping/mapmodule/plugin/panbuttons/PanButtons.js
@@ -19,6 +19,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
         this._defaultLocation = 'top right';
         this._index = 20;
         this._name = 'PanButtons';
+        this._panPxs = 100;
 
         me._mobileDefs = {
             buttons: {
@@ -27,17 +28,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
                     tooltip: '',
                     sticky: false,
                     show: true,
-                    callback: function (el) {
-                        if (!me.inLayerToolsEditMode()) {
-                            var requestBuilder = Oskari.requestBuilder(
-                                'StateHandler.SetStateRequest'
-                            );
-                            if (requestBuilder) {
-                                me.getSandbox().request(me, requestBuilder());
-                            } else {
-                                me.getSandbox().resetState();
-                            }
-                        }
+                    callback: function () {
+                        me._resetClicked();
                     }
                 }
             },
@@ -87,16 +79,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
                 panbuttonDivImg.removeClass('root');
             });
             center.on('click', function (event) {
-                if (!me.inLayerToolsEditMode()) {
-                    var requestBuilder = Oskari.requestBuilder(
-                        'StateHandler.SetStateRequest'
-                    );
-                    if (requestBuilder) {
-                        me.getSandbox().request(me, requestBuilder());
-                    } else {
-                        me.getSandbox().resetState();
-                    }
-                }
+                me._resetClicked();
             });
 
             left.on('mouseover', function (event) {
@@ -106,9 +89,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
                 panbuttonDivImg.removeClass('left');
             });
             left.on('click', function (event) {
-                if (!me.inLayerToolsEditMode()) {
-                    me.getMapModule().panMapByPixels(-100, 0, true);
-                }
+                me._panClicked(-1, 0);
             });
 
             right.on('mouseover', function (event) {
@@ -118,9 +99,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
                 panbuttonDivImg.removeClass('right');
             });
             right.on('click', function (event) {
-                if (!me.inLayerToolsEditMode()) {
-                    me.getMapModule().panMapByPixels(100, 0, true);
-                }
+                me._panClicked(1, 0);
             });
 
             top.on('mouseover', function (event) {
@@ -129,10 +108,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
             top.on('mouseout', function (event) {
                 panbuttonDivImg.removeClass('up');
             });
-            top.on('click', function (event) {
-                if (!me.inLayerToolsEditMode()) {
-                    me.getMapModule().panMapByPixels(0, -100, true);
-                }
+            top.on('click', function () {
+                me._panClicked(0, -1);
             });
 
             bottom.on('mouseover', function (event) {
@@ -142,9 +119,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
                 panbuttonDivImg.removeClass('down');
             });
             bottom.on('click', function (event) {
-                if (!me.inLayerToolsEditMode()) {
-                    me.getMapModule().panMapByPixels(0, 100, true);
-                }
+                me._panClicked(0, 1);
             });
             el.on('mousedown', function (event) {
                 if (!me.inLayerToolsEditMode()) {
@@ -160,7 +135,32 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
 
             return el;
         },
-
+        _resetClicked: function () {
+            if (this.inLayerToolsEditMode()) {
+                return;
+            }
+            const popup = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+            const cb = () => {
+                const requestBuilder = Oskari.requestBuilder(
+                    'StateHandler.SetStateRequest'
+                );
+                if (requestBuilder) {
+                    this.getSandbox().request(this, requestBuilder());
+                } else {
+                    this.getSandbox().resetState();
+                }
+            };
+            popup.show(null, Oskari.getMsg('MapModule', 'plugin.PanButtonsPlugin.center.confirmReset'), popup.createConfirmButtons(cb));
+            popup.makeModal();
+        },
+        _panClicked: function (x, y) {
+            if (this.inLayerToolsEditMode()) {
+                return;
+            }
+            const pxX = this._panPxs * x;
+            const pxY = this._panPxs * y;
+            this.getMapModule().panMapByPixels(pxX, pxY, true);
+        },
         /**
          * @public  @method _refresh
          * Called after a configuration change.

--- a/bundles/mapping/mapmodule/resources/locale/en.js
+++ b/bundles/mapping/mapmodule/resources/locale/en.js
@@ -122,7 +122,8 @@ Oskari.registerLocalization(
             },
             "PanButtonsPlugin": {
                 "center" : {
-                    "tooltip": "Move to the original map view"
+                    "tooltip": "Move to the original map view",
+                    "confirmReset": "Do you wish to return to the original view?"
                 }
             },
             "Tiles3DLayerPlugin": {

--- a/bundles/mapping/mapmodule/resources/locale/fi.js
+++ b/bundles/mapping/mapmodule/resources/locale/fi.js
@@ -67,15 +67,13 @@ Oskari.registerLocalization(
                 "noAttributeData": "Ei näytettäviä ominaisuustietoja. Avaa kohdetiedot nähdäksesi piilotetut ominaisuustiedot."
             },
             "PublisherToolbarPlugin": {
-                "test": "testi",
                 "history": {
-                    "reset": "Palaa alkutilaan.",
-                    "back": "Siirry edelliseen näkymään.",
-                    "next": "Siirry seuraavaan näkymään."
+                    "back": "Siirry edelliseen näkymään",
+                    "next": "Siirry seuraavaan näkymään"
                 },
                 "measure": {
-                    "line": "Mittaa etäisyys.",
-                    "area": "Mittaa pinta-ala."
+                    "line": "Mittaa etäisyys",
+                    "area": "Mittaa pinta-ala"
                 }
             },
             "MarkersPlugin": {
@@ -122,7 +120,8 @@ Oskari.registerLocalization(
             },
             "PanButtonsPlugin": {
                 "center" : {
-                    "tooltip": "Palaa alkutilaan"
+                    "tooltip": "Palaa alkutilaan",
+                    "confirmReset": "Haluatko palata alkutilaan?"
                 }
             },
             "Tiles3DLayerPlugin": {

--- a/bundles/mapping/mapmodule/resources/locale/sv.js
+++ b/bundles/mapping/mapmodule/resources/locale/sv.js
@@ -122,7 +122,8 @@ Oskari.registerLocalization(
             },
             "PanButtonsPlugin": {
                 "center" : {
-                    "tooltip": "Gå tillbaka till standardvyn för kartvyn"
+                    "tooltip": "Gå tillbaka till standardvyn för kartvyn",
+                    "confirmReset": "Vill du gå tillbaka till standardvyn för kartvyn?"
                 }
             },
             "Tiles3DLayerPlugin": {

--- a/bundles/mapping/toolbar/default-buttons.js
+++ b/bundles/mapping/toolbar/default-buttons.js
@@ -65,15 +65,7 @@ Oskari.clazz.category(
                         iconCls: 'tool-reset',
                         tooltip: loc.history.reset,
                         sticky: false,
-                        callback: function () {
-                            // statehandler reset state
-                            var rb = Oskari.requestBuilder(
-                                'StateHandler.SetStateRequest'
-                            );
-                            if (rb) {
-                                me.getSandbox().request(me, rb());
-                            }
-                        }
+                        callback: () => me._resetClicked()
                     },
                     'history_back': {
                         iconCls: 'tool-history-back',
@@ -193,6 +185,21 @@ Oskari.clazz.category(
                     }
                 }
             }
+        },
+        _resetClicked: function () {
+            const loc = this.getLocalization('buttons');
+            const popup = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+            const cb = () => {
+                // statehandler reset state
+                const rb = Oskari.requestBuilder(
+                    'StateHandler.SetStateRequest'
+                );
+                if (rb) {
+                    this.getSandbox().request(this, rb());
+                }
+            };
+            popup.show(null, loc.history.confirmReset, popup.createConfirmButtons(cb));
+            popup.makeModal();
         },
         _createMapLinkPopup: function () {
             var sandbox = Oskari.getSandbox();

--- a/bundles/mapping/toolbar/resources/locale/en.js
+++ b/bundles/mapping/toolbar/resources/locale/en.js
@@ -5,7 +5,7 @@ Oskari.registerLocalization(
     "value": {
         "buttons": {
             "link": {
-                "tooltip": "Make a link to the map view.",
+                "tooltip": "Make a link to the map view",
                 "ok": "OK",
                 "copy": "Copy the link to the clipboard",
                 "title": "Link to Map View",
@@ -14,15 +14,16 @@ Oskari.registerLocalization(
                 "skipInfo": "Do not show quick guide"
             },
             "history": {
-                "reset": "Move to the original map view.",
-                "back": "Move to the previous map view.",
-                "next": "Move to the next map view."
+                "reset": "Move to the original map view",
+                "confirmReset": "Do you wish to return to the original view?",
+                "back": "Move to the previous map view",
+                "next": "Move to the next map view"
             },
-            "pan": "Pan the map by dragging it with a mouse.",
-            "zoom": "Zoom in the map view.",
+            "pan": "Pan the map by dragging it with a mouse",
+            "zoom": "Zoom in the map view",
             "measure": {
-                "line": "Measure a line on the map.",
-                "area": "Measure an area on the map."
+                "line": "Measure a line on the map",
+                "area": "Measure an area on the map"
             }
         },
         "measure": {

--- a/bundles/mapping/toolbar/resources/locale/fi.js
+++ b/bundles/mapping/toolbar/resources/locale/fi.js
@@ -5,7 +5,7 @@ Oskari.registerLocalization(
     "value": {
         "buttons": {
             "link": {
-                "tooltip": "Tee linkki karttanäkymään.",
+                "tooltip": "Tee linkki karttanäkymään",
                 "ok": "OK",
                 "copy": "Kopioi linkki leikepöydälle",
                 "title": "Linkki karttanäkymään",
@@ -14,15 +14,16 @@ Oskari.registerLocalization(
                 "skipInfo": "Älä näytä pikaopasta"
             },
             "history": {
-                "reset": "Palaa alkutilaan.",
-                "back": "Siirry edelliseen näkymään.",
-                "next": "Siirry seuraavaan näkymään."
+                "reset": "Palaa alkutilaan",
+                "confirmReset": "Haluatko palata alkutilaan?",
+                "back": "Siirry edelliseen näkymään",
+                "next": "Siirry seuraavaan näkymään"
             },
-            "pan": "Siirrä karttaa hiirellä raahaamalla.",
-            "zoom": "Lähennä karttaa.",
+            "pan": "Siirrä karttaa hiirellä raahaamalla",
+            "zoom": "Lähennä karttaa",
             "measure": {
-                "line": "Mittaa etäisyys pisteiden välillä.",
-                "area": "Mittaa alueen pinta-ala."
+                "line": "Mittaa etäisyys pisteiden välillä",
+                "area": "Mittaa alueen pinta-ala"
             }
         },
         "measure": {

--- a/bundles/mapping/toolbar/resources/locale/sv.js
+++ b/bundles/mapping/toolbar/resources/locale/sv.js
@@ -8,21 +8,22 @@ Oskari.registerLocalization(
                 "tooltip": "Länk",
                 "ok": "OK",
                 "copy": "Kopiera länken till klippbordet",
-                "title": "Gör en länk till kartvyn.",
+                "title": "Gör en länk till kartvyn",
                 "cannot": "Denna kartvy kan inte länkas till. Skapa en ny kartvy och försök igen.",
                 "addMarker": "Visa kartans mittmarkör",
                 "skipInfo": "Visa inte snabbguide"
             },
             "history": {
-                "reset": "Gå tillbaka till standardvyn för kartvyn.",
-                "back": "Gå tillbaka till föregående kartvy.",
-                "next": "Flytta till nästa kartvy."
+                "reset": "Gå tillbaka till standardvyn för kartvyn",
+                "confirmReset": "Vill du gå tillbaka till standardvyn för kartvyn?",
+                "back": "Gå tillbaka till föregående kartvy",
+                "next": "Flytta till nästa kartvy"
             },
-            "pan": "Panorera kartvyn genom att dra musen på kartan.",
-            "zoom": "Zooma in kartvyn.",
+            "pan": "Panorera kartvyn genom att dra musen på kartan",
+            "zoom": "Zooma in kartvyn",
             "measure": {
-                "line": "Mät en linje på kartan.",
-                "area": "Mät ett område på kartan."
+                "line": "Mät en linje på kartan",
+                "area": "Mät ett område på kartan"
             }
         },
         "measure": {


### PR DESCRIPTION
Add confirm popup for reset map state buttons. Removed some dots from tools' tooltips (most simple tooltips doesn't have end dot).

Added createConfirmButtons() for Popup. I'm not sure if this is useful for other components and should it be added. At least "yes" and "no" localization is only in divmanazer's localization and PanButtons and default-buttons doesn't have to use other bundles localization or copy-paste them. Also it's shorter/simpler to create confirm popups for PanButtons and default-buttons.