### PR TITLE
Mobile map height fix

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1331,7 +1331,7 @@ Oskari.clazz.define(
             if (Oskari.util.isMobile() && mobileDiv.is(':visible')) {
                 var totalHeight = jQuery('#contentMap').height();
                 if (totalHeight < mapDivHeight + mobileDiv.outerHeight()) {
-                    mapDivHeight -= mobileDiv.outerHeight();
+                    mapDivHeight = totalHeight - mobileDiv.outerHeight();
                 }
                 if ((mobileDiv.attr('data-height')) !== mapDivHeight.toString()) {
                     jQuery('#' + this.getMapElementId()).css('height', mapDivHeight + 'px');

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1332,11 +1332,7 @@ Oskari.clazz.define(
                 var totalHeight = jQuery('#contentMap').height();
                 if (totalHeight < mapDivHeight + mobileDiv.outerHeight()) {
                     mapDivHeight = totalHeight - mobileDiv.outerHeight();
-                }
-                if ((mobileDiv.attr('data-height')) !== mapDivHeight.toString()) {
                     jQuery('#' + this.getMapElementId()).css('height', mapDivHeight + 'px');
-                    this.updateDomain();
-                    mobileDiv.attr('data-height', mapDivHeight);
                 }
             }
             this.updateSize();

--- a/bundles/mapping/mapmodule/resources/scss/indexmap.ol.scss
+++ b/bundles/mapping/mapmodule/resources/scss/indexmap.ol.scss
@@ -108,6 +108,9 @@ div.mapplugin.indexmap {
 div.ol-overviewmap.ol-control {
     /* reset positioning that is set in ol/ol.css so the indexmap isn't opened outside the browser window */ 
     position: inherit;
+    &.ol-collapsed {
+        background: none;
+    }
 }
 .ol-overviewmap .ol-overviewmap-map {
     border: 1px solid #3c3c3c;


### PR DESCRIPTION
Changed to calculate mapdiv height based on contentMap height instead of earlier calculated mapdiv height. Plugins/tools are added lazily so first row decreased mapdiv height by 54px if added plugins/tools are rendered to second row then height was decreased 92px more (totally 146). So mapdiv with two mobile tool rows was 54px too small.

Didn't find any good reason to store mapdiv height to mobiletoolbar data-height attribute. Also updateDomain() doesn't do anything before updateSize because map's size isn't updated. Storing height and comparing it is problematic if resize doesn't change height. For exampe mapdiv size is 300x300 after _adjustMobileMapSize is 300x246 (toolbar 54px) then resized to 350x300 _adjustMobileMapSize calculates that height should be reduced by 54 to 246 but same 246 was stored to data-height and mapdiv size isn't reduced. So removed stored height check and changed to update mapdiv height always when new height is calculated(mapdiv + mobileDiv > contentMap). So ol map size might get updated more often but MapSizeChangedEvent isn't sent if size isn't changed.

I don't know why mapfull's mapdiv size calculation contains #menutoolbar but not .mobileToolbarDiv. 
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/framework/mapfull/instance.js#L60
Maybe the reason is that changing desktop/mobile modes and plugin rendering is handled by mapmodule. However calculating and updating mapdiv size in two places and phases is little confusing.

override ol control background color to avoid rendering gray bar over index map icon (collapsed index map control). Another solution could be to remove padding (2px) from collapsed control.


