### PR TITLE
Stateful bundle handling for links

### DIFF
--- a/bundles/framework/mapfull/instance.js
+++ b/bundles/framework/mapfull/instance.js
@@ -551,7 +551,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
                 const json = {
                     id: layer.getId(),
                     opacity: layer.getOpacity()
-                }
+                };
                 if (!layer.isVisible()) {
                     json.hidden = true;
                 }
@@ -589,26 +589,31 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
                 coord: state.east + '_' + state.north
             };
             // add maplayers
-            params.mapLayers = state.selectedLayers.map(layer => {
-                if (layer.hidden) {
-                    return;
-                }
-                if (optimized) {
-                    if (layer.opacity === 0) {
-                        // leave out layers that are not visible
+            params.mapLayers = state.selectedLayers
+                .map(layer => {
+                    if (layer.hidden) {
                         return;
                     }
-                    // TODO: also leave out layers that are not inside zoom-limits
-                }
-                return layer.id + '+' + layer.opacity + '+' + (layer.style || '');
-            })
-            // filter out hidden == undefined from map-function
-            .filter(layer => typeof layer !== 'undefined')
-            // separate with comma
-            .join(',');
+                    if (optimized) {
+                        if (layer.opacity === 0) {
+                            // leave out layers that are not visible
+                            return;
+                        }
+                        // also leave out layers that are not inside zoom-limits, are outside of extent
+                        //  or are otherwise not shown to user
+                        if (!this.getMapModule().isLayerVisible(layer.id)) {
+                            return;
+                        }
+                    }
+                    return layer.id + '+' + layer.opacity + '+' + (layer.style || '');
+                })
+                // filter out hidden == undefined from map-function
+                .filter(layer => typeof layer !== 'undefined')
+                // separate with comma
+                .join(',');
 
             const link = Object.keys(params).map(key => `${key}=${params[key]}`).join('&');
-            return link + layers + this.getMapModule().getStateParameters();
+            return link + this.getMapModule().getStateParameters();
         },
         _getConfiguredLinkParams: function () {
             if (!this.conf || typeof this.conf.link !== 'object') {

--- a/bundles/framework/mapfull/instance.js
+++ b/bundles/framework/mapfull/instance.js
@@ -538,41 +538,37 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
          */
         getState: function () {
             // get applications current state
-            var map = this.getSandbox().getMap(),
-                selectedLayers = this.getSandbox().findAllSelectedMapLayers(),
-                mapmodule = this.getMapModule(),
-                i,
-                layer,
-                layerJson,
-                state = jQuery.extend(
-                    {
-                        north: map.getY(),
-                        east: map.getX(),
-                        zoom: map.getZoom(),
-                        srs: map.getSrsName(),
-                        selectedLayers: []
-                    },
-                    mapmodule.getState()
-                );
-
-            for (i = 0; i < selectedLayers.length; i += 1) {
-                layer = selectedLayers[i];
-                layerJson = {
+            var map = this.getSandbox().getMap();
+            const state = {
+                north: map.getY(),
+                east: map.getX(),
+                zoom: map.getZoom(),
+                srs: map.getSrsName(),
+                selectedLayers: [],
+                ...this.getMapModule().getState()
+            };
+            state.selectedLayers = map.getLayers().map(layer => {
+                const json = {
                     id: layer.getId(),
                     opacity: layer.getOpacity()
-                };
+                }
                 if (!layer.isVisible()) {
-                    layerJson.hidden = true;
+                    json.hidden = true;
                 }
                 // check if we have a style selected and doesn't have THE magic string
-                if (layer.getCurrentStyle &&
-                    layer.getCurrentStyle() &&
-                    layer.getCurrentStyle().getName() &&
-                    layer.getCurrentStyle().getName() !== '!default!') {
-                    layerJson.style = layer.getCurrentStyle().getName();
+                if (typeof layer.getCurrentStyle !== 'function') {
+                    return json;
                 }
-                state.selectedLayers.push(layerJson);
-            }
+                const currentStyle = layer.getCurrentStyle();
+                if (!currentStyle) {
+                    return json;
+                }
+                const styleName = currentStyle.getName();
+                if (styleName && styleName !== '!default!') {
+                    json.style = styleName;
+                }
+                return json;
+            });
 
             return state;
         },
@@ -585,40 +581,40 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
          *
          * @return {String} layers separated with ',' and layer values separated with '+'
          */
-        getStateParameters: function () {
-            var state = this.getState(),
-                link = 'zoomLevel=' + state.zoom + '&coord=' + state.east + '_' + state.north + '&mapLayers=',
-                selectedLayers = state.selectedLayers,
-                mapmodule = this.getMapModule(),
-                layers = '',
-                layer = null,
-                i = 0,
-                ilen = 0,
-                key;
+        getStateParameters: function (optimized = false) {
+            const state = this.getState();
+            const params = {
+                ...this._getConfiguredLinkParams(),
+                zoomLevel: state.zoom,
+                coord: state.east + '_' + state.north
+            };
+            // add maplayers
+            params.mapLayers = state.selectedLayers.map(layer => {
+                if (layer.hidden) {
+                    return;
+                }
+                if (optimized) {
+                    if (layer.opacity === 0) {
+                        // leave out layers that are not visible
+                        return;
+                    }
+                    // TODO: also leave out layers that are not inside zoom-limits
+                }
+                return layer.id + '+' + layer.opacity + '+' + (layer.style || '');
+            })
+            // filter out hidden == undefined from map-function
+            .filter(layer => typeof layer !== 'undefined')
+            // separate with comma
+            .join(',');
 
-            if (this.conf && this.conf.link) {
-                // add additional link params (version etc)
-                for (key in this.conf.link) {
-                    if (this.conf.link.hasOwnProperty(key)) {
-                        link = key + '=' + this.conf.link[key] + '&' + link;
-                    }
-                }
+            const link = Object.keys(params).map(key => `${key}=${params[key]}`).join('&');
+            return link + layers + this.getMapModule().getStateParameters();
+        },
+        _getConfiguredLinkParams: function () {
+            if (!this.conf || typeof this.conf.link !== 'object') {
+                return {};
             }
-            for (i = 0, ilen = selectedLayers.length; i < ilen; i += 1) {
-                layer = selectedLayers[i];
-                if (!layer.hidden) {
-                    if (layers !== '') {
-                        layers += ',';
-                    }
-                    layers += layer.id + '+' + layer.opacity;
-                    if (layer.style) {
-                        layers += '+' + layer.style;
-                    } else {
-                        layers += '+';
-                    }
-                }
-            }
-            return link + layers + mapmodule.getStateParameters();
+            return this.conf.link || {};
         },
 
         /**

--- a/bundles/framework/printout/view/BasicPrintout.js
+++ b/bundles/framework/printout/view/BasicPrintout.js
@@ -529,7 +529,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
             const srs = sandbox.getMap().getSrsName();
             const customStyles = this._getSelectedCustomStyles();
             // printMap has been called outside so keep this separation for mapLinkArgs and selections
-            var maplinkArgs = sandbox.generateMapLinkParameters({ srs, resolution, scaleText });
+            // ask for optimized link with non-visible layers excluded
+            const optimized = true;
+            var maplinkArgs = sandbox.generateMapLinkParameters({ srs, resolution, scaleText }, optimized);
             var selections = {};
 
             container.find('.printout_option_cont input').each(function () {

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -1146,6 +1146,19 @@ export class MapModule extends AbstractMapModule {
         return -1;
     }
 
+    isLayerVisible (layer) {
+        if (typeof layer === 'undefined') {
+            return false;
+        }
+        if (typeof layer === 'object') {
+            // probably passed the layer impl directly
+            return layer.getVisible();
+        }
+        // layer is probably id
+        const layerImpl = this.getOLMapLayers(layer);
+        this.isLayerVisible(layerImpl);
+    }
+
     /**
      * @param {ol/control/Control} layer ol3 specific!
      */

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -1151,8 +1151,9 @@ export class MapModule extends AbstractMapModule {
             return false;
         }
         if (Array.isArray(layer)) {
-            // getOLMapLayers() returns an array
-            return (layer.filter(l => this.isLayerVisible(l)).length === layer.length);
+            // getOLMapLayers() returns an array -> check that atleast one of them is visible
+            // group layers can have multiple layers with only some visible
+            return layer.some(l => this.isLayerVisible(l));
         }
         if (typeof layer === 'object') {
             // probably passed the layer impl directly

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -1150,13 +1150,17 @@ export class MapModule extends AbstractMapModule {
         if (typeof layer === 'undefined') {
             return false;
         }
+        if (Array.isArray(layer)) {
+            // getOLMapLayers() returns an array
+            return (layer.filter(l => this.isLayerVisible(l)).length === layer.length);
+        }
         if (typeof layer === 'object') {
             // probably passed the layer impl directly
             return layer.getVisible();
         }
         // layer is probably id
         const layerImpl = this.getOLMapLayers(layer);
-        this.isLayerVisible(layerImpl);
+        return this.isLayerVisible(layerImpl);
     }
 
     /**

--- a/bundles/mapping/mapmodule/mapmodule.olcs.js
+++ b/bundles/mapping/mapmodule/mapmodule.olcs.js
@@ -455,6 +455,10 @@ class MapModuleOlCesium extends MapModuleOl {
             // probably passed the layer impl directly
             return layer.show || false;
         }
+        if (Array.isArray(layer)) {
+            // getOLMapLayers() returns an array
+            return (layer.filter(l => this.isLayerVisible(l)).length === layer.length);
+        }
         if (typeof layer === 'object') {
             // probably passed the ol layer impl directly
             return super.isLayerVisible(layer);

--- a/bundles/mapping/mapmodule/mapmodule.olcs.js
+++ b/bundles/mapping/mapmodule/mapmodule.olcs.js
@@ -444,6 +444,26 @@ class MapModuleOlCesium extends MapModuleOl {
     }
 
     /**
+     * Returns if the layer is currently being shown to the user
+     * @param {String|Number|Cesium.Cesium3DTileset|ol.layer} layer id in Oskari or the layer implementation
+     */
+    isLayerVisible (layer) {
+        if (typeof layer === 'undefined') {
+            return false;
+        }
+        if (layer instanceof Cesium.Cesium3DTileset) {
+            // probably passed the layer impl directly
+            return layer.show || false;
+        }
+        if (typeof layer === 'object') {
+            // probably passed the ol layer impl directly
+            return super.isLayerVisible(layer);
+        }
+        // layer is probably id
+        const layerImpl = this.getOLMapLayers(layer);
+        return this.isLayerVisible(layerImpl);
+    }
+    /**
      * @param {Object} layerImpl ol/layer/Layer or Cesium.Cesium3DTileset, olcs specific!
      */
     removeLayer (layerImpl) {

--- a/bundles/mapping/mapmodule/mapmodule.olcs.js
+++ b/bundles/mapping/mapmodule/mapmodule.olcs.js
@@ -456,8 +456,9 @@ class MapModuleOlCesium extends MapModuleOl {
             return layer.show || false;
         }
         if (Array.isArray(layer)) {
-            // getOLMapLayers() returns an array
-            return (layer.filter(l => this.isLayerVisible(l)).length === layer.length);
+            // getOLMapLayers() returns an array -> check that atleast one of them is visible
+            // group layers can have multiple layers with only some visible
+            return layer.some(l => this.isLayerVisible(l));
         }
         if (typeof layer === 'object') {
             // probably passed the ol layer impl directly

--- a/bundles/mapping/mapmodule/plugin/layers/LayersPlugin.olcs.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayersPlugin.olcs.js
@@ -6,6 +6,8 @@ class LayersPluginOlcs extends LayersPlugin {
      * @param {Cesium.Cesium3DTileset | olLayer} layer
      */
     _isLayerImplVisible (layer) {
+        // NOTE! mapmodule has isLayerVisible() that is the same thing but uses layer id as param
+        // OL version doesn't have this method at all
         if (layer instanceof Cesium.Cesium3DTileset) {
             return layer.show;
         } else {

--- a/src/sandbox/sandbox-map-methods.js
+++ b/src/sandbox/sandbox-map-methods.js
@@ -53,9 +53,10 @@ Oskari.clazz.category('Oskari.Sandbox', 'map-methods', {
      * Generates query string for an URL that has the maps state with coordinates, zoom and selected map layers
      *
      * @param {Object} extraParams - object with parameters to add {param: value}
+     * @param {Boolean} optimized - hint for stateful components to leavy some params out (like hidden layers etc when we want to get the state for printing etc)
      * @return {String}
      */
-    generateMapLinkParameters: function (extraParams = {}) {
+    generateMapLinkParameters: function (extraParams = {}, optimized = false) {
         if (typeof extraParams !== 'object') {
             this.getLog().warn('Extra params for map links is not an object (ignoring)', extraParams);
             extraParams = {};
@@ -67,7 +68,7 @@ Oskari.clazz.category('Oskari.Sandbox', 'map-methods', {
                     // invalid bundle or getStateParameters() is not implemented for stateful bundle
                     return;
                 }
-                return bundle.getStateParameters();
+                return bundle.getStateParameters(optimized);
             })
             .filter(value => typeof value !== 'undefined');
 

--- a/src/sandbox/sandbox-map-methods.js
+++ b/src/sandbox/sandbox-map-methods.js
@@ -55,33 +55,27 @@ Oskari.clazz.category('Oskari.Sandbox', 'map-methods', {
      * @param {Object} extraParams - object with parameters to add {param: value}
      * @return {String}
      */
-    generateMapLinkParameters: function (extraParams) {
-        // get stateful component parameters
-        // Note! These parameters must be passed to the server in index.js to be used
-        var components = this.getStatefulComponents();
-        var iterator = null;
-        var component = null;
-        var optionsLinkParameterArray = [];
-        var componentLinkParameterArray = [];
-        for (iterator in components) {
-            if (components.hasOwnProperty(iterator)) {
-                component = components[iterator];
-
-                // Make sure the function exists and is a function
-                if (component.getStateParameters && typeof component.getStateParameters === 'function') {
-                    var params = component.getStateParameters();
-                    if (params) {
-                        componentLinkParameterArray.push(params);
-                    }
-                }
-            }
+    generateMapLinkParameters: function (extraParams = {}) {
+        if (typeof extraParams !== 'object') {
+            this.getLog().warn('Extra params for map links is not an object (ignoring)', extraParams);
+            extraParams = {};
         }
+        // get stateful component parameters
+        const bundleStates = Object.values(this.getStatefulComponents())
+            .map(bundle => {
+                if (!bundle || typeof bundle.getStateParameters !== 'function') {
+                    // invalid bundle or getStateParameters() is not implemented for stateful bundle
+                    return;
+                }
+                return bundle.getStateParameters();
+            })
+            .filter(value => typeof value !== 'undefined');
 
-        Object.keys(extraParams || {}).forEach(function (param) {
-            optionsLinkParameterArray.push(param + '=' + extraParams[param]);
+        const additionalParams = Object.keys(extraParams).map(function (param) {
+            return param + '=' + extraParams[param];
         });
 
         // Use array join to make sure the values are always separated with '&', but not the first or last
-        return componentLinkParameterArray.concat(optionsLinkParameterArray).join('&') || null;
+        return bundleStates.concat(additionalParams).join('&') || null;
     }
 });

--- a/src/sandbox/sandbox-state-methods.js
+++ b/src/sandbox/sandbox-state-methods.js
@@ -16,6 +16,15 @@ Oskari.clazz.category('Oskari.Sandbox', 'state-methods', {
      *            pInstance reference to actual bundle instance
      */
     registerAsStateful: function (pBundleId, pInstance) {
+        if (typeof pBundleId !== 'string') {
+            throw new TypeError('Tried registering bundle as stateful without bundleid');
+        }
+
+        if (!pInstance || typeof pInstance.getState !== 'function') {
+            // not a stateful component -> unregister instead
+            this.unregisterStateful(pBundleId);
+            return;
+        }
         this._statefuls[pBundleId] = pInstance;
     },
 
@@ -27,6 +36,9 @@ Oskari.clazz.category('Oskari.Sandbox', 'state-methods', {
      *            pBundleId bundle instance id which to unregister
      */
     unregisterStateful: function (pBundleId) {
+        if (typeof pBundleId !== 'string') {
+            throw new TypeError('Tried unregistering stateful without bundleid');
+        }
         this._statefuls[pBundleId] = null;
         delete this._statefuls[pBundleId];
     },
@@ -40,7 +52,7 @@ Oskari.clazz.category('Oskari.Sandbox', 'state-methods', {
      * @return {Object}
      */
     getStatefulComponents: function () {
-        return this._statefuls;
+        return this._statefuls || {};
     },
 
     /**

--- a/src/sandbox/sandbox-state-methods.js
+++ b/src/sandbox/sandbox-state-methods.js
@@ -23,6 +23,7 @@ Oskari.clazz.category('Oskari.Sandbox', 'state-methods', {
         if (!pInstance || typeof pInstance.getState !== 'function') {
             // not a stateful component -> unregister instead
             this.unregisterStateful(pBundleId);
+            this.getLog().info('Registered without impl param -> unregistering');
             return;
         }
         this._statefuls[pBundleId] = pInstance;

--- a/src/sandbox/sandbox.test.js
+++ b/src/sandbox/sandbox.test.js
@@ -1,0 +1,58 @@
+describe('Sandbox', () => {
+    test('getStatefulComponents()', () => {
+        const sb = Oskari.getSandbox('statefultesting');
+        // initial count is 0
+        expect(Object.keys(sb.getStatefulComponents()).length).toEqual(0);
+
+        sb.registerAsStateful('testbundle');
+        // registering without second param/impl does nothing
+        expect(Object.keys(sb.getStatefulComponents()).length).toEqual(0);
+        
+        // stateful components are required to have getState() function
+        // also for linking purposes they need to implement getStateParameters() but that is not required
+        sb.registerAsStateful('testbundle', {
+            getState: () => {}
+        });
+        sb.registerAsStateful('testbundle2', {
+            getState: () => {}
+        });
+        // after registering 2
+        expect(Object.keys(sb.getStatefulComponents()).length).toEqual(2);
+
+        // unregistering one should still have one
+        sb.unregisterStateful('testbundle');
+        expect(Object.keys(sb.getStatefulComponents()).length).toEqual(1);
+
+        // trying to re-register an existing bundle without impl unregisters it
+        sb.registerAsStateful('testbundle2');
+        expect(Object.keys(sb.getStatefulComponents()).length).toEqual(0);
+    });
+
+    test('generateMapLinkParameters()', () => {
+        const sb = Oskari.getSandbox('linkTesting');
+        // initial value is null
+        expect(sb.generateMapLinkParameters()).toBeNull();
+        // good value is written out
+        expect(sb.generateMapLinkParameters({ test: 'testing'})).toEqual("test=testing");
+        // non-object params should be ignored
+        expect(sb.generateMapLinkParameters('test')).toBeNull();
+        // weird case, just documenting current behavior
+        expect(sb.generateMapLinkParameters(['test'])).toEqual("0=test");
+        
+        // stateful bundles implementing getStateParameters() should be included in link
+        sb.registerAsStateful('testbundle', {
+            getState: () => {},
+            getStateParameters: () => 'testbundle=3'
+        });
+        sb.registerAsStateful('testbundle2', {
+            getState: () => {},
+            getStateParameters: () => 'value=testing'
+        });
+        expect(sb.generateMapLinkParameters()).toEqual("testbundle=3&value=testing");
+        // given params are appended to stateful stuff
+        expect(sb.generateMapLinkParameters({
+            extra: 'additional'
+        })).toEqual("testbundle=3&value=testing&extra=additional");
+    });
+
+});

--- a/src/sandbox/sandbox.test.js
+++ b/src/sandbox/sandbox.test.js
@@ -33,7 +33,7 @@ describe('Sandbox', () => {
         // initial value is null
         expect(sb.generateMapLinkParameters()).toBeNull();
         // good value is written out
-        expect(sb.generateMapLinkParameters({ test: 'testing'})).toEqual("test=testing");
+        expect(sb.generateMapLinkParameters({ test: 'testing' })).toEqual("test=testing");
         // non-object params should be ignored
         expect(sb.generateMapLinkParameters('test')).toBeNull();
         // weird case, just documenting current behavior


### PR DESCRIPTION
Modernized code, added some unit-tests, added a new flag for `sandbox.generateMapLinkParameters()` `[statefulBundle].getStateParameters()` to generate an "optimized" link parameter. The intent is to allow bundles to drop things from the state parameters that does not affect the view. Like leaving out layers that have been set as full transparency (opacity = 0) or layers that are outside their scale limits. We use generateMapLinkParameters() to give the printing functionality info about layers that are on the map and we don't really need to send references to layers that are not shown to the enduser. Currently it only results in unnecessary requests made by the backend.

TODO: 

- [x] optimization for leaving out layers with scale limits/outside coverage area etc -> now checks with the map library if the layer is shown
- [ ] more testing