### PR TITLE
Maprotator mobile button fix

### DIFF
--- a/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
+++ b/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
@@ -22,7 +22,7 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
                     callback: function () {
                         me.setRotation(0);
                     },
-                    sticky: true,
+                    sticky: false,
                     toggleChangeIcon: false
                 }
             },


### PR DESCRIPTION
Maprotator's mobile button doesn't need to be sticky.