### PR TITLE
Add admin time series fields to layer editor admin UI

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -134,6 +134,16 @@ Oskari.registerLocalization(
                 "geojson": "Big objects",
                 "info": "Viewing of small objects has been optimized. This restricts the scale on which the objects are viewed."
             },
+            "timeSeries": {
+                "metadataLayer": "Metadata layer",
+                "metadataAttribute": "Timeline attribute",
+                "metadataToggleLevel": "Zoom level to toggle between WMS and WFS layers",
+                "noToggle": "No toggle",
+                "ui": "Time series UI",
+                "player": "Player",
+                "range": "Range slider",
+                "none": "None"
+            },
             "validation": {
                 "mandatoryMsg": "Mandatory fields missing:",
                 "styles" : "Invalid JSON syntax in Style definitions.",

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -180,6 +180,36 @@ class UIHandler extends StateHandler {
         }
         this.updateState({ layer });
     }
+    setTimeSeriesUI (ui) {
+        const layer = { ...this.getState().layer };
+        const timeseries = { ...layer.options.timeseries, ui };
+        layer.options.timeseries = timeseries;
+        this.updateState({ layer });
+    }
+    setTimeSeriesMetadataLayer (layerId) {
+        const layer = { ...this.getState().layer };
+        const timeseries = { ...layer.options.timeseries };
+        const metadata = { ...timeseries.metadata, layer: layerId };
+        timeseries.metadata = metadata;
+        layer.options.timeseries = timeseries;
+        this.updateState({ layer });
+    }
+    setTimeSeriesMetadataAttribute (attribute) {
+        const layer = { ...this.getState().layer };
+        const timeseries = { ...layer.options.timeseries };
+        const metadata = { ...timeseries.metadata, attribute };
+        timeseries.metadata = metadata;
+        layer.options.timeseries = timeseries;
+        this.updateState({ layer });
+    }
+    setTimeSeriesMetadataToggleLevel (toggleLevel) {
+        const layer = { ...this.getState().layer };
+        const timeseries = { ...layer.options.timeseries };
+        const metadata = { ...timeseries.metadata, toggleLevel };
+        timeseries.metadata = metadata;
+        layer.options.timeseries = timeseries;
+        this.updateState({ layer });
+    }
     setRefreshRate (refreshRate) {
         this.updateState({
             layer: { ...this.getState().layer, refreshRate }
@@ -889,6 +919,10 @@ const wrapped = controllerMixin(UIHandler, [
     'setPassword',
     'setPermissionForAll',
     'setSingleTile',
+    'setTimeSeriesUI',
+    'setTimeSeriesMetadataLayer',
+    'setTimeSeriesMetadataAttribute',
+    'setTimeSeriesMetadataToggleLevel',
     'setRealtime',
     'setRefreshRate',
     'setRenderMode',

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/TimeSeries.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/TimeSeries.jsx
@@ -1,0 +1,76 @@
+import { Message, Radio } from 'oskari-ui';
+import { Controller } from 'oskari-ui/util';
+import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
+import styled from 'styled-components';
+import { StyledFormField } from './styled';
+import { TimeSeriesMetadataAttribute } from './TimeSeriesMetadataAttribute';
+import { TimeSeriesMetadataLayerSelect } from './TimeSeriesMetadataLayerSelect';
+import { TimeSeriesMetadataToggleLevel } from './TimeSeriesMetadataToggleLevel';
+
+const TIME_SERIES_UI = {
+    PLAYER: 'player',
+    RANGE: 'range',
+    NONE: 'none',
+};
+
+const TimeSeriesContainer = styled('div')`
+    border: 1px solid #d9d9d9;
+    padding: 10px;
+    margin-top: 5px;
+    margin-bottom: 10px;
+`;
+
+export const TimeSeries = ({ layer, scales, controller }) => {
+    const options = layer.options || {};
+    const timeseries = options.timeseries || { ui: TIME_SERIES_UI.PLAYER };
+    const metadata = timeseries.metadata || { layer: '' };
+    return (
+        <TimeSeriesContainer>
+            <Message messageKey="timeSeries.ui" />
+            <StyledFormField>
+                <Radio.Group
+                    value={timeseries.ui}
+                    buttonStyle="solid"
+                    onChange={(evt) => controller.setTimeSeriesUI(evt.target.value)}
+                >
+                    <Radio.Button value={TIME_SERIES_UI.PLAYER}>
+                        <Message messageKey="timeSeries.player" />
+                    </Radio.Button>
+                    <Radio.Button value={TIME_SERIES_UI.RANGE}>
+                        <Message messageKey="timeSeries.range" />
+                    </Radio.Button>
+                    <Radio.Button value={TIME_SERIES_UI.NONE}>
+                        <Message messageKey="timeSeries.none" />
+                    </Radio.Button>
+                </Radio.Group>
+            </StyledFormField>
+            {timeseries.ui === TIME_SERIES_UI.RANGE && (
+                <Fragment>
+                    <TimeSeriesMetadataLayerSelect
+                        layer={layer}
+                        value={metadata.layer}
+                        controller={controller}
+                    ></TimeSeriesMetadataLayerSelect>
+                    <TimeSeriesMetadataAttribute
+                        layer={layer}
+                        disabled={metadata.layer === ''}
+                        controller={controller}
+                    ></TimeSeriesMetadataAttribute>
+                    <TimeSeriesMetadataToggleLevel
+                        layer={layer}
+                        disabled={metadata.layer === ''}
+                        scales={scales}
+                        controller={controller}
+                    ></TimeSeriesMetadataToggleLevel>
+                </Fragment>
+            )}
+        </TimeSeriesContainer>
+    );
+};
+
+TimeSeries.propTypes = {
+    layer: PropTypes.object.isRequired,
+    scales: PropTypes.array.isRequired,
+    controller: PropTypes.instanceOf(Controller).isRequired,
+};

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/TimeSeriesMetadataAttribute.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/TimeSeriesMetadataAttribute.jsx
@@ -1,0 +1,30 @@
+import { Message, TextInput } from 'oskari-ui';
+import { Controller } from 'oskari-ui/util';
+import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
+import { StyledFormField } from './styled';
+
+export const TimeSeriesMetadataAttribute = ({ layer, disabled, controller }) => {
+    const options = layer.options || {};
+    const timeseries = options.timeseries || {};
+    const metadata = timeseries.metadata || { attribute: '' };
+    return (
+        <Fragment>
+            <Message messageKey="timeSeries.metadataAttribute" />
+            <StyledFormField>
+                <TextInput
+                    value={metadata.attribute}
+                    disabled={disabled}
+                    type="text"
+                    onChange={(evt) => controller.setTimeSeriesMetadataAttribute(evt.target.value)}
+                />
+            </StyledFormField>
+        </Fragment>
+    );
+};
+
+TimeSeriesMetadataAttribute.propTypes = {
+    layer: PropTypes.object.isRequired,
+    disabled: PropTypes.bool.isRequired,
+    controller: PropTypes.instanceOf(Controller).isRequired,
+};

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/TimeSeriesMetadataLayerSelect.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/TimeSeriesMetadataLayerSelect.jsx
@@ -1,0 +1,39 @@
+import { Message, Option, Select } from 'oskari-ui';
+import { Controller } from 'oskari-ui/util';
+import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
+import { StyledFormField } from './styled';
+
+export const TimeSeriesMetadataLayerSelect = ({ layer, controller }) => {
+    const options = layer.options || {};
+    const timeseries = options.timeseries || {};
+    const metadata = timeseries.metadata || { layer: '' };
+    const mapLayerService = Oskari.getSandbox().getService('Oskari.mapframework.service.MapLayerService');
+    const wfsLayers = mapLayerService.getAllLayers().filter((l) => l.isLayerOfType('WFS'));
+    // add an empty option to make it possible to unlink metadata layer (by selecting the empty option)
+    const metadataOptions = [
+        {
+            value: '',
+            name: '--------',
+        },
+    ].concat(wfsLayers.map((layer) => ({ value: layer.getId(), name: layer.getName() })));
+    return (
+        <Fragment>
+            <Message messageKey="timeSeries.metadataLayer" />
+            <StyledFormField>
+                <Select value={metadata.layer} onChange={(value) => controller.setTimeSeriesMetadataLayer(value)}>
+                    {metadataOptions.map((option) => (
+                        <Option key={option.value} value={option.value}>
+                            {option.name}
+                        </Option>
+                    ))}
+                </Select>
+            </StyledFormField>
+        </Fragment>
+    );
+};
+
+TimeSeriesMetadataLayerSelect.propTypes = {
+    layer: PropTypes.object.isRequired,
+    controller: PropTypes.instanceOf(Controller).isRequired,
+};

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/TimeSeriesMetadataToggleLevel.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/TimeSeriesMetadataToggleLevel.jsx
@@ -1,0 +1,56 @@
+import { Message, Slider } from 'oskari-ui';
+import { Controller } from 'oskari-ui/util';
+import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
+import styled from 'styled-components';
+
+const SliderContainer = styled('div')`
+    padding-left: 15px;
+    padding-right: 15px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+
+    .ant-slider-mark-text {
+        font-size: 11px;
+    }
+`;
+
+export const TimeSeriesMetadataToggleLevel = ({ layer, disabled, scales, controller }) => {
+    const options = layer.options || {};
+    const timeseries = options.timeseries || {};
+    const metadata = timeseries.metadata || { toggleLevel: 8};
+    const minZoomLevel = -1;
+    const maxZoomLevel = scales.length - 1;
+    const marks = {
+        [minZoomLevel]: <Message messageKey="timeSeries.noToggle" />,
+        [maxZoomLevel]: String(maxZoomLevel),
+    };
+    scales.forEach((scale, index) => {
+        if (index % 5 === 0) {
+            marks[index] = String(index);
+        }
+    });
+    return (
+        <Fragment>
+            <Message messageKey="timeSeries.metadataToggleLevel" />
+            <SliderContainer>
+                <Slider
+                    disabled={disabled}
+                    step={1}
+                    min={-1}
+                    max={scales.length - 1}
+                    marks={marks}
+                    value={metadata.toggleLevel}
+                    onChange={(value) => controller.setTimeSeriesMetadataToggleLevel(value)}
+                />
+            </SliderContainer>
+        </Fragment>
+    );
+};
+
+TimeSeriesMetadataToggleLevel.propTypes = {
+    layer: PropTypes.object.isRequired,
+    disabled: PropTypes.bool.isRequired,
+    scales: PropTypes.arrayOf(PropTypes.number).isRequired,
+    controller: PropTypes.instanceOf(Controller).isRequired,
+};

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VisualizationTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VisualizationTabPane.jsx
@@ -10,6 +10,7 @@ import { Scale } from './Scale';
 import { ClusteringDistance } from './ClusteringDistance';
 import { WfsRenderMode } from './WfsRenderMode';
 import { StyledColumn } from './styled';
+import { TimeSeries } from './TimeSeries';
 
 const {
     OPACITY,
@@ -19,7 +20,8 @@ const {
     STYLES_JSON,
     EXTERNAL_STYLES_JSON,
     HOVER,
-    SCALE
+    SCALE,
+    TIMES
 } = Oskari.clazz.get('Oskari.mapframework.domain.LayerComposingModel');
 
 export const VisualizationTabPane = ({ layer, capabilities, scales, propertyFields, controller }) => (
@@ -27,6 +29,9 @@ export const VisualizationTabPane = ({ layer, capabilities, scales, propertyFiel
         <StyledColumn.Left>
             { propertyFields.includes(OPACITY) &&
                 <Opacity layer={layer} controller={controller} />
+            }
+            { propertyFields.includes(TIMES) && layer.capabilities.times &&
+                <TimeSeries layer={layer} scales={scales} controller={controller} />
             }
             { propertyFields.includes(CLUSTERING_DISTANCE) &&
                 <ClusteringDistance layer={layer} controller={controller} />

--- a/bundles/mapping/mapmodule/domain/LayerComposingModel.js
+++ b/bundles/mapping/mapmodule/domain/LayerComposingModel.js
@@ -28,6 +28,7 @@ const PROPERTY_FIELDS = [
     'STYLE',
     'STYLES_JSON',
     'TILE_GRID',
+    'TIMES',
     'URL',
     'VERSION',
     'WFS_RENDER_MODE'

--- a/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol.js
@@ -48,6 +48,7 @@ Oskari.clazz.define(
                 LayerComposingModel.SELECTED_TIME,
                 LayerComposingModel.SRS,
                 LayerComposingModel.STYLE,
+                LayerComposingModel.TIMES,
                 LayerComposingModel.URL,
                 LayerComposingModel.VERSION
             ], ['1.1.1', '1.3.0']);


### PR DESCRIPTION
The timeseries fields are used for configuring the ui widget for WMS-T layers.

Available ui options are: player, range and none. When range ui is selected,
admin users can further choose a WFS metadata layer, the timeline attribute
name and the zoom level to toggle between WMS-T/WFS.

![time-series-fields](https://user-images.githubusercontent.com/1997039/100724894-0d097280-33cc-11eb-8b47-b5e332236884.gif)
