### PR TITLE
Add search capability to timeseries metadata layer select

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/TimeSeriesMetadataLayerSelect.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/TimeSeriesMetadataLayerSelect.jsx
@@ -21,7 +21,12 @@ export const TimeSeriesMetadataLayerSelect = ({ layer, controller }) => {
         <Fragment>
             <Message messageKey="timeSeries.metadataLayer" />
             <StyledFormField>
-                <Select value={metadata.layer} onChange={(value) => controller.setTimeSeriesMetadataLayer(value)}>
+                <Select
+                    showSearch
+                    filterOption={(input, option) => option.children.toLowerCase().indexOf(input.toLowerCase()) >= 0}
+                    value={metadata.layer}
+                    onChange={(value) => controller.setTimeSeriesMetadataLayer(value)}
+                >
                     {metadataOptions.map((option) => (
                         <Option key={option.value} value={option.value}>
                             {option.name}


### PR DESCRIPTION
The list of available WFS layers can be quite a long, and adding
the search capability will allow user finding the layer quickly.

![metadata-layer-search](https://user-images.githubusercontent.com/1997039/100870724-c2f5bf00-34a7-11eb-87c2-dd8ad4c895e4.gif)
