### PR TITLE
Layerlist fix stashed state

### DIFF
--- a/bundles/framework/layerlist/Flyout.js
+++ b/bundles/framework/layerlist/Flyout.js
@@ -83,7 +83,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerlist.Flyout',
          */
         setActiveFilter: function (activeFilterId) {
             const filterHandler = this.tabsHandler.getLayerListHandler().getFilterHandler();
-            this.tabsHandler.stashCurrentState();
             filterHandler.stashCurrentState();
             filterHandler.updateState({
                 activeFilterId,

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerViewTabsHandler.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerViewTabsHandler.js
@@ -93,9 +93,11 @@ class ViewHandler extends StateHandler {
                     this.updateState({ autoFocusSearch: true });
                     return;
                 }
-                if (event.getViewState() === 'close' && this.hasStashedState()) {
-                    this.useStashedState();
-                    this.getLayerListHandler().getFilterHandler().useStashedState();
+                if (event.getViewState() === 'close') {
+                    const filterHandler = this.getLayerListHandler().getFilterHandler();
+                    if (filterHandler.hasStashedState()) {
+                        filterHandler.useStashedState();
+                    }
                 }
             },
             'MapLayerEvent': event => {


### PR DESCRIPTION
LayerVewTabsHandler's state contains also selected layers and using stashed state with request + filter (analysis, publisher) caused that SelectedLayersHandler.layers !== Oskari.getSandbox().findAllSelectedMapLayers() if layer is added after stash (stashed when publisher/analysis is activated) and flyout is closed.

setActiveFilter changes tab and filter but I think that filter only may confuse user if isn't returned. Returning other states from stash may confuse user more and create weird bugs. Changed to stash only filter handler state. Another solution is to override useStashedState in LayerViewTabsHandler and set only tab from stashed state.