### PR TITLE
Change to use a Select component fo choosing timeseries metadata attribute

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -190,9 +190,21 @@ class UIHandler extends StateHandler {
         const layer = { ...this.getState().layer };
         const timeseries = { ...layer.options.timeseries };
         const metadata = { ...timeseries.metadata, layer: layerId };
-        timeseries.metadata = metadata;
-        layer.options.timeseries = timeseries;
-        this.updateState({ layer });
+        if (layerId === '') {
+            delete metadata.attribute;
+            delete metadata.layerAttributes;
+            timeseries.metadata = metadata;
+            layer.options.timeseries = timeseries;
+            this.updateState({ layer });
+        } else {
+            this.fetchWFSLayerAttributes(layerId).then(layerAttributes => {
+                delete metadata.attribute;
+                metadata.layerAttributes = layerAttributes;
+                timeseries.metadata = metadata;
+                layer.options.timeseries = timeseries;
+                this.updateState({ layer });
+            });
+        }
     }
     setTimeSeriesMetadataAttribute (attribute) {
         const layer = { ...this.getState().layer };
@@ -433,6 +445,33 @@ class UIHandler extends StateHandler {
         const { type, version } = layer;
         const composingModel = this.mapLayerService.getComposingModelForType(type);
         return composingModel ? composingModel.getPropertyFields(version) : [];
+    }
+
+    // http://localhost:8080/action?action_route=GetWFSLayerFields&layer_id=888
+    fetchWFSLayerAttributes (layerId) {
+        this.ajaxStarted();
+        return fetch(Oskari.urls.getRoute('GetWFSLayerFields', { layer_id: layerId }), {
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json'
+            }
+        }).then(response => {
+            this.ajaxFinished();
+            if (!response.ok) {
+                Messaging.error(getMessage('messages.errorFetchWFSLayerAttributes'));
+            }
+            return response.json();
+        }).then(json => {
+            const { attributes, locale } = json;
+            const attributeIdentifiers = Object.keys(attributes);
+            const currentLocale = Oskari.getLang();
+            const labelMapping = locale && locale[currentLocale] ? locale[currentLocale] : {};
+            return attributeIdentifiers.reduce((choices, identifier) => {
+                // use the attribute identifier as the label if no label is provided for current locale
+                choices[identifier] = labelMapping[identifier] || identifier;
+                return choices;
+            }, {});
+        });
     }
 
     // http://localhost:8080/action?action_route=LayerAdmin&id=889

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/TimeSeriesMetadataAttribute.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/TimeSeriesMetadataAttribute.jsx
@@ -1,4 +1,4 @@
-import { Message, TextInput } from 'oskari-ui';
+import { Message, Option, Select } from 'oskari-ui';
 import { Controller } from 'oskari-ui/util';
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
@@ -7,17 +7,26 @@ import { StyledFormField } from './styled';
 export const TimeSeriesMetadataAttribute = ({ layer, disabled, controller }) => {
     const options = layer.options || {};
     const timeseries = options.timeseries || {};
-    const metadata = timeseries.metadata || { attribute: '' };
+    const metadata = timeseries.metadata || {};
+    const selectedAttribute = metadata.attribute || '';
+    const layerAttributes = metadata.layerAttributes || {};
     return (
         <Fragment>
             <Message messageKey="timeSeries.metadataAttribute" />
             <StyledFormField>
-                <TextInput
-                    value={metadata.attribute}
+                <Select
+                    showSearch
+                    filterOption={(input, option) => option.children.toLowerCase().indexOf(input.toLowerCase()) >= 0}
+                    value={selectedAttribute}
                     disabled={disabled}
-                    type="text"
-                    onChange={(evt) => controller.setTimeSeriesMetadataAttribute(evt.target.value)}
-                />
+                    onChange={(value) => controller.setTimeSeriesMetadataAttribute(value)}
+                >
+                    {Object.entries(layerAttributes).map(([identifier, label]) => (
+                        <Option key={identifier} value={identifier}>
+                            {label}
+                        </Option>
+                    ))}
+                </Select>
             </StyledFormField>
         </Fragment>
     );


### PR DESCRIPTION
The list of available attributes are fetched from backend through GetWFSLayerAttributes
action route.

![time-series-attribute-select](https://user-images.githubusercontent.com/1997039/102089581-1a3f4c00-3e25-11eb-8d8b-052f7b0e9845.gif)
