### PR TITLE
Fix confirm placement

### DIFF
--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -494,3 +494,9 @@ select:not([class*="ant-"]) {
 .ant-tooltip {
   z-index: 999999 !important;
 }
+/*
+So confirm doesn't open behind flyouts (in admin for example)
+*/
+.ant-popconfirm {
+  z-index: 999998 !important;
+}

--- a/src/react/components/Confirm.jsx
+++ b/src/react/components/Confirm.jsx
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import { Popconfirm } from 'antd';
 import 'antd/es/popconfirm/style/index.js';
 
+// NOTE! z-index is overridden in resources/css/portal.css
+// Without the override the confirm is shown behind flyouts (for example in admin)
+
 export const Confirm = ({ children, ...other }) => (
     <Popconfirm {...other}>{children}</Popconfirm>
 );


### PR DESCRIPTION
So it's not shown behind flyouts where users can't see them resulting in confusion for end-users.