### PR TITLE
Add an initial version of timeseries range widget

### DIFF
--- a/bundles/framework/timeseries/WMSAnimator.js
+++ b/bundles/framework/timeseries/WMSAnimator.js
@@ -66,6 +66,17 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.WMSAnimator',
             }
             return times;
         },
+        /**
+         * @method getYearRange
+         * Returns the start and end year of timeseries times
+         * @return {number[]} Start and end year of timeseries times
+         */
+        getYearRange: function () {
+            const times = this._layer.getAttributes().times;
+            const start = moment(times[0]).year();
+            const end = moment(times[times.length - 1]).year();
+            return [start, end];
+        },
         init: function () { },
         /**
          * @method getLayer

--- a/bundles/framework/timeseries/instance.js
+++ b/bundles/framework/timeseries/instance.js
@@ -1,3 +1,5 @@
+import './view/TimeSeriesRangeControlPlugin';
+
 /**
  * @class Oskari.mapframework.bundle.timeseries.TimeseriesToolBundleInstance
  *
@@ -129,8 +131,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesToolBundleI
             case 'player':
                 return 'Oskari.mapframework.bundle.timeseries.TimeseriesControlPlugin';
             case 'range':
-                // TODO: implement range UI control plugin
-                throw new Error('Not implemented');
+                return 'Oskari.mapframework.bundle.timeseries.TimeSeriesRangeControlPlugin';
             case 'none':
                 return null;
             default:

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
@@ -1,25 +1,11 @@
 import { Controller } from 'oskari-ui/util';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Background, Header, Col, ColFixed, Row, YearInput, YearRangeSlider } from './styled';
+import { Background, Header, Col, ColFixed, Row, YearInput } from './styled';
+import { YearRangeSlider } from './YearRangeSlider';
 
 export const TimeSeriesRangeControl = ({ controller, title, start, end, value, dataYears, isMobile }) => {
     const [startValue, endValue] = value;
-    const marks = {
-        [start]: start,
-        [end]: end,
-    };
-    for (let i = start + 1; i < end; i++) {
-        if (i % 10 === 0) {
-            marks[i] = i;
-        }
-    }
-
-    // data years are those years that has timeseries photos in current map view
-    // data years are also marks on the range slider but they are represented
-    // as small circles on the timeline (via css styling)
-    dataYears.filter((year) => !marks[year]).forEach((year) => (marks[year] = ''));
-
     return (
         <Background isMobile={isMobile}>
             <Header className="timeseries-range-drag-handle">{title}</Header>
@@ -35,9 +21,8 @@ export const TimeSeriesRangeControl = ({ controller, title, start, end, value, d
                         <YearRangeSlider
                             range
                             step={1}
-                            min={start}
-                            max={end}
-                            marks={marks}
+                            start={start}
+                            end={end}
                             dataYears={dataYears}
                             value={value}
                             onChange={(val) => controller.updateValue(val)}

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
@@ -1,0 +1,66 @@
+import { Controller } from 'oskari-ui/util';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Background, Header, Col, ColFixed, Row, YearInput, YearRangeSlider } from './styled';
+
+export const TimeSeriesRangeControl = ({ controller, title, start, end, value, dataYears, isMobile }) => {
+    const [startValue, endValue] = value;
+    const marks = {
+        [start]: start,
+        [end]: end,
+    };
+    for (let i = start + 1; i < end; i++) {
+        if (i % 10 === 0) {
+            marks[i] = i;
+        }
+    }
+
+    // data years are those years that has timeseries photos in current map view
+    // data years are also marks on the range slider but they are represented
+    // as small circles on the timeline (via css styling)
+    dataYears.filter((year) => !marks[year]).forEach((year) => (marks[year] = ''));
+
+    return (
+        <Background isMobile={isMobile}>
+            <Header className="timeseries-range-drag-handle">{title}</Header>
+            <Row>
+                <Col>
+                    <YearInput
+                        value={startValue}
+                        onChange={(val) => controller.updateValue([val, endValue])}
+                    ></YearInput>
+                </Col>
+                {!isMobile && (
+                    <ColFixed>
+                        <YearRangeSlider
+                            range
+                            step={1}
+                            min={start}
+                            max={end}
+                            marks={marks}
+                            dataYears={dataYears}
+                            value={value}
+                            onChange={(val) => controller.updateValue(val)}
+                        />
+                    </ColFixed>
+                )}
+                <Col>
+                    <YearInput
+                        value={endValue}
+                        onChange={(val) => controller.updateValue([startValue, val])}
+                    ></YearInput>
+                </Col>
+            </Row>
+        </Background>
+    );
+};
+
+TimeSeriesRangeControl.propTypes = {
+    controller: PropTypes.instanceOf(Controller).isRequired,
+    title: PropTypes.string.isRequired,
+    start: PropTypes.number.isRequired,
+    end: PropTypes.number.isRequired,
+    value: PropTypes.arrayOf(PropTypes.number).isRequired,
+    dataYears: PropTypes.arrayOf(PropTypes.number).isRequired,
+    isMobile: PropTypes.bool.isRequired,
+};

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControlHandler.js
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControlHandler.js
@@ -1,0 +1,26 @@
+import { StateHandler, controllerMixin } from 'oskari-ui/util';
+
+class UIHandler extends StateHandler {
+    constructor (delegate, stateListener) {
+        super();
+        this._delegate = delegate;
+        this._layer = delegate.getLayer();
+        const [start, end] = delegate.getYearRange();
+        this.state = {
+            title: this._layer.getName(),
+            start,
+            end,
+            value: [start, end],
+            dataYears: [1950, 1990, 1996, 2010]
+        };
+        this.addStateListener(stateListener);
+    }
+
+    updateValue (value) {
+        this.updateState({ value });
+    }
+}
+
+export const TimeSeriesRangeControlHandler = controllerMixin(UIHandler, [
+    'updateValue'
+]);

--- a/bundles/framework/timeseries/view/TimeSeriesRange/YearRangeSlider.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/YearRangeSlider.jsx
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { StyledRangeSlider } from './styled';
+
+export const YearRangeSlider = (props) => {
+    const { start, end, dataYears } = props;
+    const marks = {
+        [start]: start,
+        [end]: end,
+    };
+    for (let i = start + 1; i < end; i++) {
+        if (i % 10 === 0) {
+            marks[i] = i;
+        }
+    }
+
+    // data years are those years that has timeseries photos in current map view
+    // data years are also marks on the range slider but they are represented
+    // as small circles on the timeline (via css styling)
+    dataYears.filter((year) => !marks[year]).forEach((year) => (marks[year] = ''));
+    return <StyledRangeSlider {...props} marks={marks} min={start} max={end} />;
+};
+
+YearRangeSlider.propTypes = {
+    start: PropTypes.number.isRequired,
+    end: PropTypes.number.isRequired,
+    dataYears: PropTypes.arrayOf(PropTypes.number).isRequired,
+};

--- a/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
@@ -68,7 +68,7 @@ const getDataYearStyles = (props) => {
     return styles;
 };
 
-export const YearRangeSlider = styled(Slider)`
+export const StyledRangeSlider = styled(Slider)`
     &&& {
         height: 16px;
     }

--- a/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
@@ -1,0 +1,125 @@
+import { Slider, NumberInput } from 'oskari-ui';
+import styled from 'styled-components';
+
+const primaryColor = '#ecb900';
+const backgroundColor = '#3c3c3c';
+const borderColor = '#3c3c3c';
+
+export const Background = styled.div(({ isMobile }) => ({
+    minHeight: isMobile ? '120px !important' : '90px !imoprtant',
+    width: isMobile ? '260px !important' : '720px !important',
+    color: '#ffffff',
+    backgroundColor: backgroundColor
+}));
+
+export const Header = styled.h3`
+    padding: 10px 20px;
+    cursor: grab;
+    cursor: move;
+`;
+
+export const Row = styled.div`
+    margin-top: 10px;
+    padding: 0 20px;
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-around;
+    flex-wrap: wrap;
+`;
+
+export const Col = styled.div`
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%;
+    position: relative;
+`;
+
+export const ColFixed = styled.div`
+    flex: 0 0 65%;
+    width: auto;
+    max-width: 100%;
+    position: relative;
+`;
+
+export const YearInput = styled(NumberInput)`
+    margin-left: 18px;
+`;
+
+const getDataYearStyles = (props) => {
+    const { dataYears, marks } = props;
+    if (dataYears.length === 0) {
+        return '';
+    }
+    const markYears = Object.keys(marks).map(year => parseInt(year, 10)).sort((a, b) => a - b);
+    const dataYearIndices = dataYears.map(year => markYears.indexOf(year) + 1);
+    const selectors = dataYearIndices.map(index => `&:nth-child(${index})`).join(",");
+    const styles = `
+        ${selectors} {
+            border-radius: 50%;
+            border: 2px solid #ffffff;
+            width: 8px;
+            height: 8px;
+            top: -2px;
+            &.ant-slider-dot-active {
+                border: 2px solid ${primaryColor};
+            }
+        }
+    `;
+    return styles;
+};
+
+export const YearRangeSlider = styled(Slider)`
+    &&& {
+        height: 16px;
+    }
+    .ant-slider-mark {
+        top: -21px;
+    }
+    .ant-slider-mark-text {
+        color: #ffffff;
+    }
+    .ant-slider-dot {
+        background-color: ${backgroundColor};
+        border-radius: 0%;
+        border: 0;
+        margin-left: 0px;
+        width: 2px;
+        top: 0px;
+        height: 4px;
+        ${props => getDataYearStyles(props)}
+    }
+    .ant-slider-dot:last-child {
+        margin-left: 0px;
+    }
+    .ant-slider-rail {
+        background-color: #ffffff;
+    }
+    .ant-slider-track {
+        background-color: ${primaryColor};
+    }
+    .ant-slider-handle {
+        width: 8px;
+        height: 16px;
+        border-radius: 6px;
+        border: solid 1px ${borderColor};
+        background-color: ${primaryColor};
+        &:focus,
+        &:active,
+        &:hover {
+            border: solid 1px ${borderColor} !important;
+            background-color: ${primaryColor} !important;
+        }
+        &:focus .ant-slider-track,
+        &:active .ant-slider-track,
+        &:hover .ant-slider-track {
+            background-color: ${primaryColor} !important;
+        }
+    }
+    &:hover .ant-slider-track {
+        background-color: ${primaryColor} !important;
+    }
+    &:hover .ant-slider-handle {
+        border: solid 1px ${borderColor} !important;
+        background-color: ${primaryColor} !important;
+    }
+`;

--- a/bundles/framework/timeseries/view/TimeSeriesRangeControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeSeriesRangeControlPlugin.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { LocaleProvider } from 'oskari-ui/util';
+import { TimeSeriesRangeControl } from './TimeSeriesRange/TimeSeriesRangeControl';
+import { TimeSeriesRangeControlHandler } from './TimeSeriesRange/TimeSeriesRangeControlHandler';
+
+const BasicMapModulePlugin = Oskari.clazz.get('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin');
+/**
+ * @class Oskari.mapframework.bundle.timeseries.TimeSeriesRangeControlPlugin
+ */
+class TimeSeriesRangeControlPlugin extends BasicMapModulePlugin {
+    constructor (delegate, conf) {
+        super(conf);
+        this._clazz = 'Oskari.mapframework.bundle.timeseries.TimeSeriesRangeControlPlugin';
+        this._name = 'TimeSeriesRangeControlPlugin';
+        this._defaultLocation = 'top left';
+        this._log = Oskari.log(this._name);
+        this._toolOpen = false;
+        this._element = null;
+        this._isMobile = Oskari.util.isMobile();
+        this._delegate = delegate;
+        this.stateHandler = new TimeSeriesRangeControlHandler(delegate, () => this.updateUI());
+    }
+
+    getName () {
+        return this._name;
+    }
+
+    updateUI () {
+        const mountElement = this.getReactMountElement();
+        if (!mountElement) {
+            return;
+        }
+        ReactDOM.render(
+            <LocaleProvider value={{ bundleKey: 'timeseries' }}>
+                <TimeSeriesRangeControl
+                    {...this.stateHandler.getState()}
+                    controller={this.stateHandler.getController()}
+                    isMobile={this._isMobile}
+                />
+            </LocaleProvider>,
+            mountElement
+        );
+    }
+
+    getReactMountElement () {
+        const element = this.getElement();
+        return element && element.get(0);
+    }
+
+    redrawUI (mapInMobileMode, forced) {
+        super.redrawUI(mapInMobileMode, forced);
+        this.updateUI();
+        this.makeDraggable();
+    }
+
+    makeDraggable () {
+        const element = this.getElement();
+        if (!element) {
+            return;
+        }
+        element.draggable({
+            scroll: false,
+            handle: '.timeseries-range-drag-handle' // the drag handle class is defined in react component
+        });
+    }
+
+    _createControlElement () {
+        return jQuery('<div class="mapplugin timeseriesrangecontrolplugin"></div>');
+    }
+}
+
+Oskari.clazz.defineES(
+    'Oskari.mapframework.bundle.timeseries.TimeSeriesRangeControlPlugin',
+    TimeSeriesRangeControlPlugin,
+    {
+        protocol: ['Oskari.mapframework.module.Module', 'Oskari.mapframework.ui.module.common.mapmodule.Plugin']
+    }
+);


### PR DESCRIPTION
The widget gets the year range from the timeseries layer, but currently does not get the timeseries photo available years from metadata layer.

![time-range-widget](https://user-images.githubusercontent.com/1997039/102891881-ab3aa680-4467-11eb-9512-33d263326e2c.gif)
