### PR TITLE
Get data years from timeseries times

### DIFF
--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControlHandler.js
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControlHandler.js
@@ -9,14 +9,20 @@ class UIHandler extends StateHandler {
         this._timer = null;
         this._debounceTime = 300;
         const [start, end] = delegate.getYearRange();
+        const dataYears = this._getDataYears();
         this.state = {
             title: this._layer.getName(),
             start,
             end,
             value: [start, end],
-            dataYears: [1950, 1990, 1996, 2010]
+            dataYears
         };
         this.addStateListener(stateListener);
+    }
+
+    _getDataYears () {
+        const times = this._layer.getAttributes().times;
+        return times.map(time => moment(time).year());
     }
 
     updateValue (value) {


### PR DESCRIPTION
This is a temporary solution to get rid of mock data. We'll need to dynamically get the data years from metadata layer for current map view.

![image](https://user-images.githubusercontent.com/1997039/102987564-32952200-451b-11eb-98cd-3e28deae951a.png)
