### PR TITLE
Switch between wms/wfs for wms timeseries layer

### DIFF
--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControlHandler.js
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControlHandler.js
@@ -2,12 +2,13 @@ import moment from 'moment';
 import { StateHandler, controllerMixin } from 'oskari-ui/util';
 
 class UIHandler extends StateHandler {
-    constructor (delegate, stateListener) {
+    constructor (delegate, stateListener, onChange) {
         super();
         this._delegate = delegate;
         this._layer = delegate.getLayer();
         this._timer = null;
         this._debounceTime = 300;
+        this._onChange = onChange;
         const [start, end] = delegate.getYearRange();
         const dataYears = this._getDataYears();
         this.state = {
@@ -30,15 +31,7 @@ class UIHandler extends StateHandler {
         if (this._timer) {
             clearTimeout(this._timer);
         }
-        this._timer = setTimeout(() => this._requestNewTime(value), this._debounceTime);
-    }
-
-    _requestNewTime (value) {
-        const [startYear, endYear] = value;
-        const startTime = moment.utc(startYear.toString()).startOf('year').toISOString();
-        const endTime = moment.utc(endYear.toString()).endOf('year').toISOString();
-        const newTime = `${startTime}/${endTime}`;
-        this._delegate.requestNewTime(newTime);
+        this._timer = setTimeout(() => this._onChange(value), this._debounceTime);
     }
 
     updateDataYears (dataYears) {

--- a/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol.js
@@ -21,6 +21,16 @@ Oskari.clazz.define(
      */
     function () {
         this._log = Oskari.log(this.getName());
+        this._timeSeriesMetadataLayer = null;
+        this._timeSeriesMetadataLayerStyleName = 'timeseriesStyle';
+        this._defaultMetadataLayerStyleDef = {
+            stroke: {
+                width: 1
+            },
+            fill: {
+                color: 'rgba(24, 219, 218, 0.5)'
+            }
+        };
     },
     {
         __name: 'WmsLayerPlugin',
@@ -34,24 +44,27 @@ Oskari.clazz.define(
         _initImpl () {
             const mapLayerService = Oskari.getSandbox().getService('Oskari.mapframework.service.MapLayerService');
             const layerClass = 'Oskari.mapframework.domain.WmsLayer';
-            const composingModel = new LayerComposingModel([
-                LayerComposingModel.CAPABILITIES,
-                LayerComposingModel.CAPABILITIES_STYLES,
-                LayerComposingModel.CREDENTIALS,
-                LayerComposingModel.GFI_CONTENT,
-                LayerComposingModel.GFI_TYPE,
-                LayerComposingModel.GFI_XSLT,
-                LayerComposingModel.LEGEND_IMAGE,
-                LayerComposingModel.REALTIME,
-                LayerComposingModel.REFRESH_RATE,
-                LayerComposingModel.SINGLE_TILE,
-                LayerComposingModel.SELECTED_TIME,
-                LayerComposingModel.SRS,
-                LayerComposingModel.STYLE,
-                LayerComposingModel.TIMES,
-                LayerComposingModel.URL,
-                LayerComposingModel.VERSION
-            ], ['1.1.1', '1.3.0']);
+            const composingModel = new LayerComposingModel(
+                [
+                    LayerComposingModel.CAPABILITIES,
+                    LayerComposingModel.CAPABILITIES_STYLES,
+                    LayerComposingModel.CREDENTIALS,
+                    LayerComposingModel.GFI_CONTENT,
+                    LayerComposingModel.GFI_TYPE,
+                    LayerComposingModel.GFI_XSLT,
+                    LayerComposingModel.LEGEND_IMAGE,
+                    LayerComposingModel.REALTIME,
+                    LayerComposingModel.REFRESH_RATE,
+                    LayerComposingModel.SINGLE_TILE,
+                    LayerComposingModel.SELECTED_TIME,
+                    LayerComposingModel.SRS,
+                    LayerComposingModel.STYLE,
+                    LayerComposingModel.TIMES,
+                    LayerComposingModel.URL,
+                    LayerComposingModel.VERSION
+                ],
+                ['1.1.1', '1.3.0']
+            );
             const type = this.getLayerTypeSelector().toLowerCase() + 'layer';
             mapLayerService.registerLayerModel(type, layerClass, composingModel);
         },
@@ -80,7 +93,10 @@ Oskari.clazz.define(
             var layers = [],
                 olLayers = [];
             // insert layer or sublayers into array to handle them identically
-            if ((layer.isGroupLayer() || layer.isBaseLayer() || isBaseMap === true) && (layer.getSubLayers().length > 0)) {
+            if (
+                (layer.isGroupLayer() || layer.isBaseLayer() || isBaseMap === true) &&
+                layer.getSubLayers().length > 0
+            ) {
                 // replace layers with sublayers
                 layers = layer.getSubLayers();
             } else {
@@ -92,12 +108,12 @@ Oskari.clazz.define(
             for (var i = 0, ilen = layers.length; i < ilen; i++) {
                 var _layer = layers[i];
                 var defaultParams = {
-                        'LAYERS': _layer.getLayerName(),
-                        'TRANSPARENT': true,
-                        'ID': _layer.getId(),
-                        'STYLES': _layer.getCurrentStyle().getName(),
-                        'FORMAT': 'image/png',
-                        'VERSION': _layer.getVersion() || '1.3.0'
+                        LAYERS: _layer.getLayerName(),
+                        TRANSPARENT: true,
+                        ID: _layer.getId(),
+                        STYLES: _layer.getCurrentStyle().getName(),
+                        FORMAT: 'image/png',
+                        VERSION: _layer.getVersion() || '1.3.0'
                     },
                     layerParams = _layer.getParams() || {},
                     layerOptions = _layer.getOptions() || {},
@@ -120,7 +136,7 @@ Oskari.clazz.define(
                 var layerImpl = null;
 
                 var reverseProjection;
-                if (layerAttributes && layerAttributes.reverseXY && (typeof layerAttributes.reverseXY === 'object')) {
+                if (layerAttributes && layerAttributes.reverseXY && typeof layerAttributes.reverseXY === 'object') {
                     var projectionCode = this.getMapModule().getProjection();
                     // use reverse coordinate order for this layer!
                     if (layerAttributes.reverseXY[projectionCode]) {
@@ -153,6 +169,11 @@ Oskari.clazz.define(
                 }
                 // Set min max zoom levels that layer should be visible in
                 zoomLevelHelper.setOLZoomLimits(layerImpl, _layer.getMinScale(), _layer.getMaxScale());
+                // Adjust min zoom level based on timeseries metadata toggle level
+                const metadata = this._getTimeSeriesMetadata(layer);
+                if (metadata.toggleLevel > -1) {
+                    layerImpl.setMinZoom(metadata.toggleLevel);
+                }
                 this.mapModule.addLayer(layerImpl, !keepLayerOnTop);
                 // gather references to layers
                 olLayers.push(layerImpl);
@@ -161,6 +182,12 @@ Oskari.clazz.define(
             }
             // store reference to layers
             this.setOLMapLayers(layer.getId(), olLayers);
+        },
+
+        _getTimeSeriesMetadata: function (layer) {
+            const options = layer.getOptions();
+            const timeseries = options.timeseries || {};
+            return timeseries.metadata || {};
         },
 
         _registerLayerEvents: function (layer, oskariLayer, prefix) {
@@ -192,14 +219,14 @@ Oskari.clazz.define(
             }
 
             var reverseProjection = new olProjProjection({
-                'code': projectionCode,
-                'units': originalProjection.getUnits(),
-                'extent': originalProjection.getExtent(),
-                'axisOrientation': 'neu',
-                'global': originalProjection.isGlobal(),
-                'metersPerUnit': originalProjection.getMetersPerUnit(),
-                'worldExtent': originalProjection.getWorldExtent(),
-                'getPointResolution': originalProjection.getPointResolution
+                code: projectionCode,
+                units: originalProjection.getUnits(),
+                extent: originalProjection.getExtent(),
+                axisOrientation: 'neu',
+                global: originalProjection.isGlobal(),
+                metersPerUnit: originalProjection.getMetersPerUnit(),
+                worldExtent: originalProjection.getWorldExtent(),
+                getPointResolution: originalProjection.getPointResolution
             });
             return reverseProjection;
         },
@@ -230,7 +257,7 @@ Oskari.clazz.define(
             var olLayerList = this.mapModule.getOLMapLayers(layer.getId()) || [];
             const proxyUrl = Oskari.urls.getRoute('GetLayerTile', { id: layer.getId() });
 
-            olLayerList.forEach(olLayer => {
+            olLayerList.forEach((olLayer) => {
                 var layerSource = olLayer.getSource();
                 // TileWMS -> original is olSourceTileWMS.getTileLoadFunction
                 if (typeof layerSource.getTileLoadFunction === 'function') {
@@ -308,17 +335,18 @@ Oskari.clazz.define(
             }
             const zoomLevelHelper = getZoomLevelHelper(this.getMapModule().getScaleArray());
             const layersImpls = this.getOLMapLayers(layer.getId()) || [];
-            layersImpls.forEach(olLayer => {
+            layersImpls.forEach((olLayer) => {
                 // Update min max Resolutions
                 zoomLevelHelper.setOLZoomLimits(olLayer, layer.getMinScale(), layer.getMaxScale());
             });
         }
-    }, {
+    },
+    {
         /**
          * @property {String[]} protocol array of superclasses as {String}
          * @static
          */
-        'protocol': ['Oskari.mapframework.module.Module', 'Oskari.mapframework.ui.module.common.mapmodule.Plugin'],
-        'extend': ['Oskari.mapping.mapmodule.AbstractMapLayerPlugin']
+        protocol: ['Oskari.mapframework.module.Module', 'Oskari.mapframework.ui.module.common.mapmodule.Plugin'],
+        extend: ['Oskari.mapping.mapmodule.AbstractMapLayerPlugin']
     }
 );


### PR DESCRIPTION
This commit adds the functionality to toggle between wms and wfs layer
if a WFS metadata layer and toggle level is configured for timeseries
layer. The styles for the WFS features can be configured in WFS layer
style json under `timeseriesStyle`

![wms-wfs-switch](https://user-images.githubusercontent.com/1997039/103349100-a21f8a00-4aa4-11eb-98cf-b509af09b8f5.gif)

With custom styles:

```
{
  "timeseriesStyle": {
    "stroke": {
      "color": "rgba(0, 0, 255, 1)",
      "width": 5
    },
    "fill": {
      "color": "rgba(255, 0, 0, 0.5)"
    }
  }
}
```

![wms-wfs-switch-style](https://user-images.githubusercontent.com/1997039/103349124-b2376980-4aa4-11eb-8f6e-d478c9a4aec4.png)



