### PR TITLE
RPC getFeatures fix

### DIFF
--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -1186,7 +1186,7 @@ Oskari.clazz.define(
          * @param {Object} featureFilter
          */
         zoomToFeatures: function (opts = {}, featureFilter) {
-            const layers = this._getLayerIds(opts.layer);
+            const layers = this.getLayerIds(opts.layer);
             const features = this.getFeaturesMatchingQuery(layers, featureFilter);
             if (features.length > 0) {
                 const tmpLayer = new olSourceVector({
@@ -1198,12 +1198,12 @@ Oskari.clazz.define(
             this.sendZoomFeatureEvent(features);
         },
         /**
-         * @method _getLayerIds
-         * @private
+         * @method getLayerIds
          * @param {Array|String|Number} layer id or array of layer ids (optional)
          * @return {Array} array of layer ids that was requested and we recognized
+         * @see RPC getFeatures
          */
-        _getLayerIds: function (layer = []) {
+        getLayerIds: function (layer = []) {
             if (!Array.isArray(layer)) {
                 // the value for "layer" needs to be an array so wrap it in one if it isn't
                 layer = [layer];
@@ -1308,6 +1308,7 @@ Oskari.clazz.define(
          *  - gets layer's features as geojson object
          * @param {String} id
          * @return {Object} geojson
+         * @see RPC getFeatures
          */
         getLayerFeatures: function (id) {
             var me = this;

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.test.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.test.js
@@ -54,24 +54,24 @@ describe('VectorLayerPlugin', () => {
     plugin._olLayers['test_1'] = createFakeLayer();
     plugin._olLayers['test_2'] = createFakeLayer();
 
-    describe('_getLayerIds', () => {
+    describe('getLayerIds', () => {
         test('without param returns all layers (2)', () => {
-            expect(plugin._getLayerIds().length).toEqual(2);
+            expect(plugin.getLayerIds().length).toEqual(2);
         });
         test('with valid and recognized layer id in array returns 1', () => {
-            expect(plugin._getLayerIds(['test_2']).length).toEqual(1);
+            expect(plugin.getLayerIds(['test_2']).length).toEqual(1);
         });
         test('with valid and recognized layer id returns 1', () => {
-            expect(plugin._getLayerIds('test_2').length).toEqual(1);
+            expect(plugin.getLayerIds('test_2').length).toEqual(1);
         });
         test('with referencing some unrecognized layer ids returns one that matches', () => {
-            expect(plugin._getLayerIds([1, 2, 'test_1']).length).toEqual(1);
+            expect(plugin.getLayerIds([1, 2, 'test_1']).length).toEqual(1);
         });
         test('with referencing unrecognized layer id returns 0', () => {
-            expect(plugin._getLayerIds(12).length).toEqual(0);
+            expect(plugin.getLayerIds(12).length).toEqual(0);
         });
         test('without random input returns 0', () => {
-            expect(plugin._getLayerIds({ testing: true }).length).toEqual(0);
+            expect(plugin.getLayerIds({ testing: true }).length).toEqual(0);
         });
     });
 
@@ -79,7 +79,7 @@ describe('VectorLayerPlugin', () => {
         test('add geojson', () => {
             const geojson = generateGeoJSON(1, 2);
             plugin.addFeaturesToMap(geojson);
-            expect(plugin._getLayerIds().length).toEqual(3);
+            expect(plugin.getLayerIds().length).toEqual(3);
         });
     });
     describe('getFeaturesMatchingQuery', () => {


### PR DESCRIPTION
Define getLayerIds as public method because RPC getFeatures uses it directly.

https://github.com/oskariorg/oskari-frontend/blob/master/bundles/framework/rpc/instance.js#L373