### PR TITLE
Admin layer editor capabilities fix

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/AdditionalTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/AdditionalTabPane.jsx
@@ -28,8 +28,8 @@ const {
     ATTRIBUTES
 } = LayerComposingModel;
 
-export const AdditionalTabPane = ({ layer, capabilities = {}, propertyFields, controller }) => {
-    const { isQueryable } = capabilities;
+export const AdditionalTabPane = ({ layer, propertyFields, controller }) => {
+    const isQueryable = layer.attributes.isQueryable || layer.capabilities.isQueryable;
     return (
         <Fragment>
             { propertyFields.includes(CAPABILITIES) &&
@@ -39,7 +39,7 @@ export const AdditionalTabPane = ({ layer, capabilities = {}, propertyFields, co
                 <Attributions layer={layer} controller={controller} />
             }
             { propertyFields.includes(SELECTED_TIME) &&
-                <SelectedTime layer={layer} capabilities={capabilities} controller={controller} />
+                <SelectedTime layer={layer} controller={controller} />
             }
             { propertyFields.includes(METADATAID) &&
                 <MetadataId layer={layer} controller={controller} />
@@ -57,7 +57,7 @@ export const AdditionalTabPane = ({ layer, capabilities = {}, propertyFields, co
                 <GfiContent layer={layer} controller={controller} />
             }
             { isQueryable && propertyFields.includes(GFI_TYPE) &&
-                <GfiType layer={layer} />
+                <GfiType layer={layer} controller={controller}/>
             }
             { isQueryable && propertyFields.includes(GFI_XSLT) &&
                 <GfiStyle layer={layer} controller={controller} />
@@ -70,7 +70,6 @@ export const AdditionalTabPane = ({ layer, capabilities = {}, propertyFields, co
 };
 AdditionalTabPane.propTypes = {
     layer: PropTypes.object.isRequired,
-    capabilities: PropTypes.object,
     propertyFields: PropTypes.arrayOf(PropTypes.string).isRequired,
     controller: PropTypes.instanceOf(Controller).isRequired
 };

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/GfiType.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/GfiType.jsx
@@ -1,23 +1,38 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Message } from 'oskari-ui';
-import { InlineFlex } from '../InlineFlex';
+import { Message, Select, Option } from 'oskari-ui';
+import { Controller } from 'oskari-ui/util';
 import { InfoTooltip } from '../InfoTooltip';
+import { StyledFormField } from '../styled';
 
-export const GfiType = ({ layer }) => {
-    if (!layer.gfiType) {
+export const GfiType = ({ layer, controller }) => {
+    const { capabilities, gfiType } = layer;
+    const { formats = {} } = capabilities;
+    const options = formats.available || [];
+    const value = gfiType || formats.value || '';
+    if (options.length === 0) {
         return null;
     }
     return (
-        <InlineFlex>
-            <div>
-                <Message messageKey='fields.gfiType'/>
-                <InfoTooltip messageKeys='gfiTypeDesc'/>
-            </div>
-            <div>{ layer.gfiType }</div>
-        </InlineFlex>
+        <Fragment>
+            <Message messageKey='fields.gfiType'/>
+            <InfoTooltip messageKeys='gfiTypeDesc'/>
+            <StyledFormField>
+                <Select
+                    defaultValue={value}
+                    onChange={value => controller.setGfiType(value)}
+                >
+                    { options.map(option => (
+                        <Option key={option} value={option}>
+                            {option}
+                        </Option>
+                    )) }
+                </Select>
+            </StyledFormField>
+        </Fragment>
     );
 };
 GfiType.propTypes = {
-    layer: PropTypes.object.isRequired
+    layer: PropTypes.object.isRequired,
+    controller: PropTypes.instanceOf(Controller).isRequired
 };

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/SelectedTime.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/SelectedTime.jsx
@@ -4,8 +4,9 @@ import { Message, Select, Option } from 'oskari-ui';
 import { Controller } from 'oskari-ui/util';
 import { StyledFormField } from '../styled';
 
-export const SelectedTime = ({ layer, capabilities, controller }) => {
+export const SelectedTime = ({ layer, controller }) => {
     const value = layer.params ? layer.params.selectedTime : '';
+    const { capabilities } = layer;
     if (!capabilities.times) {
         return null;
     }
@@ -26,6 +27,5 @@ export const SelectedTime = ({ layer, capabilities, controller }) => {
 };
 SelectedTime.propTypes = {
     layer: PropTypes.object.isRequired,
-    capabilities: PropTypes.object.isRequired,
     controller: PropTypes.instanceOf(Controller).isRequired
 };

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
@@ -45,7 +45,6 @@ const AdminLayerForm = ({
     dataProviders,
     versions,
     layer,
-    capabilities,
     propertyFields,
     messages = [],
     tab,
@@ -80,13 +79,11 @@ const AdminLayerForm = ({
                     dataProviders={dataProviders}
                     mapLayerGroups={mapLayerGroups}
                     versions={versions}
-                    validators={validators}
-                    capabilities={capabilities} />
+                    validators={validators} />
             </TabPane>
             <TabPane key='visualization' tab={<Message messageKey='visualizationTabTitle'/>}>
                 <VisualizationTabPane
                     layer={layer}
-                    capabilities={capabilities}
                     scales={scales}
                     propertyFields={propertyFields}
                     controller={controller}/>
@@ -95,8 +92,7 @@ const AdminLayerForm = ({
                 <AdditionalTabPane
                     layer={layer}
                     propertyFields={propertyFields}
-                    controller={controller}
-                    capabilities={capabilities} />
+                    controller={controller} />
             </TabPane>
             <TabPane key='permissions' tab={<Mandatory isValid={validPermissions}><Message messageKey='permissionsTabTitle'/>&nbsp;<MandatoryIcon /></Mandatory>}>
                 <PermissionsTabPane
@@ -140,7 +136,6 @@ AdminLayerForm.propTypes = {
     dataProviders: PropTypes.array.isRequired,
     versions: PropTypes.array.isRequired,
     layer: PropTypes.object.isRequired,
-    capabilities: PropTypes.object,
     propertyFields: PropTypes.arrayOf(PropTypes.string).isRequired,
     messages: PropTypes.array,
     onCancel: PropTypes.func,

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/GeneralTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/GeneralTabPane.jsx
@@ -24,11 +24,11 @@ const {
     VERSION
 } = Oskari.clazz.get('Oskari.mapframework.domain.LayerComposingModel');
 
-const GeneralTabPane = ({ validators, mapLayerGroups, dataProviders, versions, layer, capabilities, propertyFields, controller }) => (
+const GeneralTabPane = ({ validators, mapLayerGroups, dataProviders, versions, layer, propertyFields, controller }) => (
     <Fragment>
         { wrapMandatory(validators, layer, 'url', getEndpointField(layer, propertyFields, controller)) }
         { wrapMandatory(validators, layer, 'version', getVersionField(layer, propertyFields, controller, versions)) }
-        { wrapMandatory(validators, layer, 'srs', getSRSField(layer, propertyFields, controller, capabilities)) }
+        { wrapMandatory(validators, layer, 'srs', getSRSField(layer, propertyFields, controller)) }
         { wrapMandatory(validators, layer, 'options.tileGrid', getTileGridField(layer, propertyFields, controller)) }
         { wrapMandatory(validators, layer, 'name', getNameField(layer, propertyFields, controller)) }
         { wrapMandatory(validators, layer, `locale.${Oskari.getSupportedLanguages()[0]}.name`, getLocaleField(layer, propertyFields, controller)) }
@@ -113,7 +113,6 @@ GeneralTabPane.propTypes = {
     versions: PropTypes.array.isRequired,
     propertyFields: PropTypes.arrayOf(PropTypes.string).isRequired,
     layer: PropTypes.object.isRequired,
-    capabilities: PropTypes.object,
     bundleKey: PropTypes.string.isRequired,
     controller: PropTypes.instanceOf(Controller).isRequired
 };

--- a/bundles/admin/admin-layereditor/view/styled.jsx
+++ b/bundles/admin/admin-layereditor/view/styled.jsx
@@ -1,7 +1,7 @@
 import { Select, Alert, Button } from 'oskari-ui';
 import styled from 'styled-components';
 
-export const StyledAlert = styled(Alert)`;
+export const StyledAlert = styled(Alert)`
     margin-bottom: 5px;
 `;
 

--- a/src/react/components/UrlInput.jsx
+++ b/src/react/components/UrlInput.jsx
@@ -64,7 +64,7 @@ export class UrlInput extends React.Component {
         });
     }
     render () {
-        const { credentials, ...other } = this.props;
+        const { credentials = {}, ...other } = this.props;
         const protocolSelect = (
             <Select
                 value={this.state.protocol}
@@ -83,7 +83,7 @@ export class UrlInput extends React.Component {
 
         let collapseProps = {}
 
-        if (this.props.credentials && this.props.credentials.defaultOpen) {
+        if (credentials.defaultOpen) {
             // Panel with this key is open as default
             collapseProps.activeKey = 'usernameAndPassword';
         }


### PR DESCRIPTION
Capabilities object is used for layer wizard. Layer form has to use layer.capabilities. Fix capabilities handling and add possibility to change GFI type (dropdown).

Fix Url input optional credentials:
https://github.com/oskariorg/oskari-frontend/blob/master/src/react/components/UrlInput.jsx#L94