### PR TITLE
Don't add a missing layer when requesting removal

### DIFF
--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -511,7 +511,11 @@ Oskari.clazz.define(
                 options.layerId = 'VECTOR';
             }
             var layer = this._findOskariLayer(options.layerId);
-            if (!layer && options.remove !== true) {
+            if (!layer) {
+                if (options.remove === true) {
+                    // removal was requested for unrecognized layer id -> don't need to do anything
+                    return;
+                }
                 layer = Oskari.clazz.create('Oskari.mapframework.domain.VectorLayer');
                 layer.setId(options.layerId);
                 layer.setName(options.layerName || 'VECTOR');

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -511,7 +511,7 @@ Oskari.clazz.define(
                 options.layerId = 'VECTOR';
             }
             var layer = this._findOskariLayer(options.layerId);
-            if (!layer) {
+            if (!layer && options.remove !== true) {
                 layer = Oskari.clazz.create('Oskari.mapframework.domain.VectorLayer');
                 layer.setId(options.layerId);
                 layer.setName(options.layerName || 'VECTOR');


### PR DESCRIPTION
Fixes an issue where sending VectorLayerRequest with an unknown layerId and `remove: true` adds a layer instead of removing one. The purpose is that remove flag can be used for cleanup, but without this change the code initializes a new layer instead (if the layerId wasn't referenced before requesting removal).