### PR TITLE
Improve API docs for AddFeaturesToMap and VectorLayerRequest

### DIFF
--- a/api/mapping/mapmodule/request/addfeaturestomaprequest.md
+++ b/api/mapping/mapmodule/request/addfeaturestomaprequest.md
@@ -89,7 +89,7 @@ The second parameter is options.
 | animationDuration | number | On update requests it's possible to animate fill color change. Specify animation duration in ms.|
 | attributes | object | Feature's attributes, especially handy when the geometry is a WKT-string.|
 | clearPrevious | boolean | when true, the previous features will be cleared|
-| centerTo | boolean | Whether to zoom to the added features.|
+| centerTo | boolean | Whether to zoom to the added features. When using this you can define minScale or maxZoomLevel to limit how "close" you want to zoom. This is useful with for example single point feature the map is usually zoomed "too close" without any restriction. |
 | cursor | string | Mouse cursor when cursor is over the feature.|
 | prio | number | Feature prio. The lowest number is the must important feature (top on the layer). The highest number is the least important.|
 | featureStyle | object | Defines a generic style used for all the features.|

--- a/api/mapping/mapmodule/request/addfeaturestomaprequest.md
+++ b/api/mapping/mapmodule/request/addfeaturestomaprequest.md
@@ -90,9 +90,8 @@ The second parameter is options.
 | attributes | object | Feature's attributes, especially handy when the geometry is a WKT-string.|
 | clearPrevious | boolean | when true, the previous features will be cleared|
 | centerTo | boolean | Whether to zoom to the added features. |
-| maxZoomLevel | number | Limits the amount of zoom when using "centerTo" (only functions with centerTo). This is useful with for example zooming to a single point the map is usually zoomed "too close" without any restriction. |
-| minScale | number | Limits the zoom levels the features on this layer will be shown. |
-| maxScale | number | Limits the zoom levels the features on this layer will be shown. |
+| maxZoomLevel | number | Limits zooming when using "centerTo" (only functions with centerTo). This is useful with for example zooming to a single point the map is usually zoomed "too close" without any restriction. |
+| minScale | number | Same as maxZoomLevel, but instead of zoom level this restricts by scale. |
 | cursor | string | Mouse cursor when cursor is over the feature.|
 | prio | number | Feature prio. The lowest number is the must important feature (top on the layer). The highest number is the least important.|
 | featureStyle | object | Defines a generic style used for all the features.|

--- a/api/mapping/mapmodule/request/addfeaturestomaprequest.md
+++ b/api/mapping/mapmodule/request/addfeaturestomaprequest.md
@@ -89,7 +89,10 @@ The second parameter is options.
 | animationDuration | number | On update requests it's possible to animate fill color change. Specify animation duration in ms.|
 | attributes | object | Feature's attributes, especially handy when the geometry is a WKT-string.|
 | clearPrevious | boolean | when true, the previous features will be cleared|
-| centerTo | boolean | Whether to zoom to the added features. When using this you can define minScale or maxZoomLevel to limit how "close" you want to zoom. This is useful with for example single point feature the map is usually zoomed "too close" without any restriction. |
+| centerTo | boolean | Whether to zoom to the added features. |
+| maxZoomLevel | number | Limits the amount of zoom when using "centerTo" (only functions with centerTo). This is useful with for example zooming to a single point the map is usually zoomed "too close" without any restriction. |
+| minScale | number | Limits the zoom levels the features on this layer will be shown. |
+| maxScale | number | Limits the zoom levels the features on this layer will be shown. |
 | cursor | string | Mouse cursor when cursor is over the feature.|
 | prio | number | Feature prio. The lowest number is the must important feature (top on the layer). The highest number is the least important.|
 | featureStyle | object | Defines a generic style used for all the features.|

--- a/api/mapping/mapmodule/request/vectorlayerrequest.md
+++ b/api/mapping/mapmodule/request/vectorlayerrequest.md
@@ -10,7 +10,7 @@ Adds a new feature layer to map or updates an existing layer.
 
 ## Description
 
-Prepares a layer for later use or updates an existing layer. 
+Prepares a layer for later use or updates an existing layer for vector features.
 
 The request takes one parameter, options.
 
@@ -24,10 +24,12 @@ The request takes one parameter, options.
 | layerName | string | Name | `'Layer name'` |
 | layerDescription | string | Description | `'Description text'` | 
 | layerPermissions | object | Permissions | `{ publish: 'publication_permission_ok' }` |
-| minScale | number | Feature min scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. | `1451336` |
-| maxScale | number | Feature max scale when zoomTo option is used. Don't let map scale to go below the defined scale when zoomed to features. | `1` |
+| minResolution | number | Features are not shown if map resolution isn't below this. | `128` |
+| maxResolution | number | Features are not shown if map resolution isn't above this. | `0.25` |
 | hover | object | Describes how to visualize features on hover and what kind of tooltip should be shown. | See Hover Settings below |
 | remove | boolean | If the key is present with "truthy" value the layer referenced with layerId is removed from the map. Defaults to undefined. | `true` |
+
+Note! You can use minZoomLevel / maxZoomLevel or minScale / maxScale instead of minResolution / maxResolution.
 
 ### Hover Settings
 

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -682,7 +682,12 @@ Oskari.clazz.define(
             if (!me._features[layerId]) {
                 me._features[layerId] = [];
             }
-            const { centerTo, minScale, maxZoomLevel, ...layerOptions } = options;
+            // Remove scale limit options that are only meant to be used to limit zooming with AddFeaturesToMapRequest
+            // but if they are passed to prepareVectorLayer() they also limit visibility of layers.  
+            // The same prepareVectorLayer() function is used for VectorLayerRequest where we DO want to limit visibility
+            // Note! Only centerTo, minScale and maxZoomLevel are used. The others are just removed from layerOptions
+            // so we don't accidentally limit visibility when passing them in AddFeaturesToMapRequest
+            const { centerTo, minScale, maxScale, maxZoomLevel, minZoomLevel, minResolution, maxResolution, ...layerOptions } = options;
 
             layer = me.prepareVectorLayer(layerOptions);
             olLayer = me._getOlLayer(layer);

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -682,8 +682,9 @@ Oskari.clazz.define(
             if (!me._features[layerId]) {
                 me._features[layerId] = [];
             }
+            const { centerTo, minScale, maxZoomLevel, ...layerOptions } = options;
 
-            layer = me.prepareVectorLayer(options);
+            layer = me.prepareVectorLayer(layerOptions);
             olLayer = me._getOlLayer(layer);
             vectorSource = olLayer.getSource();
 
@@ -693,10 +694,10 @@ Oskari.clazz.define(
                 me.getMapModule().loadingState(layerId, true);
                 for (var key in geometry) {
                     me.getMapModule().loadingState(layerId, true);
-                    me._updateFeature(options, key, geometry[key]);
+                    me._updateFeature(layerOptions, key, geometry[key]);
                     me.getMapModule().loadingState(layerId, false);
                 }
-                me._applyPrioOnSource(options.layerId, vectorSource, options.prio);
+                me._applyPrioOnSource(layerOptions.layerId, vectorSource, layerOptions.prio);
                 me.getMapModule().loadingState(layerId, false);
                 return;
             }
@@ -712,13 +713,13 @@ Oskari.clazz.define(
             this.getMapModule().loadingState(layerId, true);
             var features = format.readFeatures(geometry);
             // add cursor if defined so
-            if (options.cursor) {
-                options.attributes['oskari-cursor'] = options.cursor;
+            if (layerOptions.cursor) {
+                layerOptions.attributes['oskari-cursor'] = layerOptions.cursor;
             }
 
-            if (options.attributes && options.attributes !== null && features instanceof Array && features.length) {
+            if (layerOptions.attributes !== null && features instanceof Array && features.length) {
                 features.forEach(function (ftr) {
-                    ftr.setProperties(options.attributes);
+                    ftr.setProperties(layerOptions.attributes);
                 });
             }
             features.forEach(function (feature) {
@@ -730,21 +731,21 @@ Oskari.clazz.define(
                     // setting id using set(key, value) to make id-property asking by get('id') possible
                     feature.set(FTR_PROPERTY_ID, id);
                 }
-                me.setFeatureStyle(options, feature, false);
+                me.setFeatureStyle(layerOptions, feature, false);
             });
             // clear old features if defined so
-            if (options.clearPrevious === true) {
+            if (layerOptions.clearPrevious === true) {
                 vectorSource.clear();
                 me._features[layerId] = [];
             }
             // prio handling
-            var prio = options.prio || 0;
+            var prio = layerOptions.prio || 0;
             me._features[layerId].push({
                 data: features,
                 prio: prio
             });
 
-            me._applyPrioOnSource(layerId, vectorSource, options.prio);
+            me._applyPrioOnSource(layerId, vectorSource, layerOptions.prio);
             vectorSource.addFeatures(features);
 
             // notify other components that features have been added
@@ -773,22 +774,22 @@ Oskari.clazz.define(
                 sandbox.notifyAll(addEvent);
             }
             // re-position map when opted
-            if (options.centerTo === true) {
+            if (centerTo === true) {
                 var extent = vectorSource.getExtent();
                 me.getMapModule().zoomToExtent(extent);
 
                 // Check scale if defined so. Scale decreases when the map is zoomed in. Scale increases when the map is zoomed out.
-                if (typeof options.minScale === 'number') {
+                if (typeof minScale === 'number') {
                     var currentScale = this.getMapModule().getMapScale();
-                    if (currentScale < options.minScale) {
-                        this.getMapModule().zoomToScale(options.minScale, true);
+                    if (currentScale < minScale) {
+                        this.getMapModule().zoomToScale(minScale, true);
                     }
                 }
                 // Check max zoom if defined so. Zoom increases when the map is zoomed in. Zoom decreases when the map is zoomed out.
-                if (typeof options.maxZoomLevel === 'number') {
+                if (typeof maxZoomLevel === 'number') {
                     var currentZoom = this.getMapModule().getMapZoom();
-                    if (currentZoom > options.maxZoomLevel) {
-                        this.getMapModule().setZoomLevel(options.maxZoomLevel);
+                    if (currentZoom > maxZoomLevel) {
+                        this.getMapModule().setZoomLevel(maxZoomLevel);
                     }
                 }
             }

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -778,10 +778,17 @@ Oskari.clazz.define(
                 me.getMapModule().zoomToExtent(extent);
 
                 // Check scale if defined so. Scale decreases when the map is zoomed in. Scale increases when the map is zoomed out.
-                if (options.minScale) {
+                if (typeof options.minScale === 'number') {
                     var currentScale = this.getMapModule().getMapScale();
                     if (currentScale < options.minScale) {
                         this.getMapModule().zoomToScale(options.minScale, true);
+                    }
+                }
+                // Check max zoom if defined so. Zoom increases when the map is zoomed in. Zoom decreases when the map is zoomed out.
+                if (typeof options.maxZoomLevel === 'number') {
+                    var currentZoom = this.getMapModule().getMapZoom();
+                    if (currentZoom > options.maxZoomLevel) {
+                        this.getMapModule().setZoomLevel(options.maxZoomLevel);
                     }
                 }
             }

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -683,10 +683,12 @@ Oskari.clazz.define(
                 me._features[layerId] = [];
             }
             // Remove scale limit options that are only meant to be used to limit zooming with AddFeaturesToMapRequest
-            // but if they are passed to prepareVectorLayer() they also limit visibility of layers.  
+            // but if they are passed to prepareVectorLayer() they also limit visibility of layers.
             // The same prepareVectorLayer() function is used for VectorLayerRequest where we DO want to limit visibility
             // Note! Only centerTo, minScale and maxZoomLevel are used. The others are just removed from layerOptions
             // so we don't accidentally limit visibility when passing them in AddFeaturesToMapRequest
+            // Disable ESLint since it otherwise complains about unused vars
+            // eslint-disable-next-line no-unused-vars
             const { centerTo, minScale, maxScale, maxZoomLevel, minZoomLevel, minResolution, maxResolution, ...layerOptions } = options;
 
             layer = me.prepareVectorLayer(layerOptions);


### PR DESCRIPTION
Also add maxZoomLevel for AddFeaturesToMapRequest to restrict zooming too close. Fixes an issue introduced in #1385 where passing minScale (or other zoom level related flag) also limited visibility of the layer.