### PR TITLE
Gfi formatting

### DIFF
--- a/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.js
@@ -448,11 +448,10 @@ Oskari.clazz.category('Oskari.mapframework.mapmodule.GetInfoPlugin', 'formatter'
             even = !even;
 
             row = this.template.tableRow.clone();
-            // FIXME this is unnecessary, we can do this with a css selector.
-            if (!even) {
+            const skipLabel = key.startsWith(ID_SKIP_LABEL);
+            if (!skipLabel && !even) {
                 row.addClass('odd');
             }
-            const skipLabel = key.startsWith(ID_SKIP_LABEL);
             if (!skipLabel) {
                 keyColumn = this.template.tableCell.clone();
                 keyColumn.append(key);

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.js
@@ -9,10 +9,6 @@ Oskari.clazz.category('Oskari.mapframework.mapmodule.GetInfoPlugin', 'formatter'
         tableCell: '<td></td>',
         header: '<div class="getinforesult_header"><div class="icon-bubble-left"></div>',
         headerTitle: '<div class="getinforesult_header_title"></div>',
-        myPlacesWrapper: '<div class="myplaces_place">' +
-            '<div class="getinforesult_header"><div class="icon-bubble-left"></div><div class="getinforesult_header_title myplaces_header"></div></div>' +
-            '<p class="myplaces_desc"></p>' +
-            '<a class="myplaces_imglink" target="_blank" rel="noopener"><img class="myplaces_img"></img></a>' + '<br><a class="myplaces_link" target="_blank" rel="noopener"></a>' + '</div>',
         linkOutside: '<a target="_blank" rel="noopener"></a>'
     },
     formatters: {
@@ -27,60 +23,6 @@ Oskari.clazz.category('Oskari.mapframework.mapmodule.GetInfoPlugin', 'formatter'
             parsedHTML.find('tr').removeClass('odd');
             parsedHTML.find('tr:even').addClass('odd');
             return parsedHTML;
-        },
-        /**
-         * Formats the html to show for my places layers' gfi dialog.
-         *
-         * @method myplace
-         * @param {Object} place response data to format
-         * @return {jQuery} formatted html
-         */
-        myplace: function (place) {
-            var content = jQuery('<div class="myplaces_place">' +
-                '<h3 class="myplaces_header"></h3>' +
-                    '<p class="myplaces_desc"></p>' +
-                    '<a class="myplaces_imglink" target="_blank"><img class="myplaces_img"></img></a>' +
-                    '<br><a class="myplaces_link" target="_blank" rel="noopener"></a>' +
-                '</div>');
-            var desc = content.find('p.myplaces_desc');
-            var img = content.find('a.myplaces_imglink');
-            var link = content.find('a.myplaces_link');
-
-            content.find('h3.myplaces_header').html(place.name);
-
-            if (place.place_desc) {
-                desc.html(place.place_desc);
-            } else if (place.description) {
-                desc.html(place.description);
-            } else {
-                desc.remove();
-            }
-
-            if (place.image_url && typeof place.image_url === 'string') {
-                img.attr({
-                    'href': place.image_url
-                }).find('img.myplaces_img').attr({
-                    'src': place.image_url
-                });
-            } else if (place.imageUrl && typeof place.imageUrl === 'string') {
-                img.attr({
-                    'href': place.imageUrl
-                }).find('img.myplaces_img').attr({
-                    'src': place.imageUrl
-                });
-            } else {
-                img.remove();
-            }
-
-            if (place.link) {
-                link.attr({
-                    'href': place.link
-                }).html(place.link);
-            } else {
-                link.remove();
-            }
-
-            return content;
         },
         /**
          * @method json
@@ -165,12 +107,6 @@ Oskari.clazz.category('Oskari.mapframework.mapmodule.GetInfoPlugin', 'formatter'
             .map(fragment => {
                 var fragmentTitle = fragment.layerName;
                 var fragmentMarkup = fragment.markup;
-                if (fragment.isMyPlace) {
-                    if (fragmentMarkup) {
-                        return fragmentMarkup;
-                    }
-                    return;
-                }
                 const contentWrapper = me.template.wrapper.clone();
                 var headerWrapper = me.template.header.clone();
                 var titleWrapper = me.template.headerTitle.clone();
@@ -248,15 +184,6 @@ Oskari.clazz.category('Oskari.mapframework.mapmodule.GetInfoPlugin', 'formatter'
             response = me.template.wrapper.clone();
 
         if (datum.presentationType === 'JSON' || (datum.content && datum.content.parsed)) {
-            // This is for my places info popup
-            if (datum.layerId && typeof datum.layerId === 'string' && datum.layerId.match('myplaces_')) {
-                const baseDiv = jQuery('<div></div>');
-                datum.content.parsed.places
-                    .map(place => me.formatters.myplace(place))
-                    .forEach(place => baseDiv.append(place));
-                return baseDiv;
-            }
-
             var even = false,
                 rawJsonData = datum.content.parsed,
                 dataArray = [],

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.test.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.test.js
@@ -97,9 +97,10 @@ describe('GetInfoPlugin', () => {
         });
         test('myplaces', () => {
             // [{"isMyPlace": true, "layerId": "myplaces_test", "layerName": "testing_myplaces", "markup": {"0": <div class="myplaces_place"><h3 class="myplaces_header">TESTING</h3><br></div>, "length": 1}, "type": "wfslayer"}]
+            const imageLink = 'http://my.domain/test.png';
             const result = plugin._formatWFSFeaturesForInfoBox({
                 layerId: 'myplaces_test',
-                features: [[234, 'TESTING', 'Lorem ipsum', 'http://my.domain/test.png']]
+                features: [[234, 'TESTING', 'Lorem ipsum', imageLink]]
             });
             expect(result.length).toEqual(1);
             expect(result[0].isMyPlace).toEqual(true);
@@ -108,7 +109,7 @@ describe('GetInfoPlugin', () => {
             expect(result[0].type).toEqual('wfslayer');
             expect(result[0].markup instanceof jQuery).toEqual(true);
             const html = result[0].markup.outerHTML();
-            expect(html).toEqual(`<table class="getinforesult_table"><tr class="odd"><td colspan="2"><h3>TESTING</h3></td></tr><tr><td colspan="2"><p>Lorem ipsum</p></td></tr><tr class="odd"><td colspan="2"><a href="http://my.domain/test.png" rel="noreferrer noopener" target="_blank"><img class="oskari_gfi_img" src="http://my.domain/test.png"></a></td></tr></table>`);
+            expect(html).toEqual(`<table class="getinforesult_table"><tr><td colspan="2"><h3>TESTING</h3></td></tr><tr><td colspan="2"><p>Lorem ipsum</p></td></tr><tr><td colspan="2"><a href="${imageLink}" rel="noreferrer noopener" target="_blank" title="${imageLink}"><img class="oskari_gfi_img" src="${imageLink}"></a></td></tr></table>`);
         });
 
         test('wfslayer without values', () => {

--- a/bundles/mapping/mapmodule/plugin/getinfo/ValueFormatters.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/ValueFormatters.js
@@ -1,4 +1,4 @@
-
+import { shortenUrl } from './ValueFormattersUrlHelpers';
 // ----------------------------------------------------------------------
 // Built-in formatters
 // TODO: add params handling for formatters
@@ -14,55 +14,6 @@ const linkFormatter = (value, params = {}) => {
         }
     }
     return `<a href="${value}" rel="noreferrer noopener" target="_blank" title="${value}">${label}</a>`;
-};
-
-const WELL_KNOWN_PROTO = ['http://', 'https://'];
-const removeWellknownProtocolFromUrl = (url = '') => {
-    // this function is just to handle url in case-insensitive way
-    if (!url) {
-        return url;
-    }
-    const input = url.toLowerCase();
-    const foundProto = WELL_KNOWN_PROTO.findIndex(proto => input.startsWith(proto));
-    if (foundProto === -1) {
-        return url;
-    }
-    return url.substring(WELL_KNOWN_PROTO[foundProto].length);
-};
-
-const shortenUrl = (url = '', maxLength = 50) => {
-    if (url.length <= maxLength) {
-        return url;
-    }
-    const urlValue = removeWellknownProtocolFromUrl(url);
-    if (urlValue.length <= maxLength) {
-        return urlValue;
-    }
-    const partLength = maxLength / 2;
-    const start = shortenString(urlValue, partLength);
-    const end = reverseString(shortenString(reverseString(urlValue), partLength));
-    return start + '...' + end;
-};
-
-const reverseString = (input = '') => input.split('').reverse().join('');
-
-const SHORTEN_STOP_CHARS = [' ', '/', '&', '?'];
-const shortenString = (input = '', maxLength = 25) => {
-    if (input.length < maxLength) {
-        return input;
-    }
-    const threshold = maxLength * 0.8;
-    let candidate = input.substring(0, threshold);
-    let restOfInput = input.substring(threshold).split('');
-    while (restOfInput.length && candidate.length < maxLength) {
-        const character = restOfInput.shift();
-        if (SHORTEN_STOP_CHARS.includes(character)) {
-            // encountered char that is natural shorten point
-            break;
-        }
-        candidate += character;
-    }
-    return candidate;
 };
 
 const imgFormatter = (value, params = {}) => {

--- a/bundles/mapping/mapmodule/plugin/getinfo/ValueFormatters.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/ValueFormatters.js
@@ -16,17 +16,31 @@ const linkFormatter = (value, params = {}) => {
     return `<a href="${value}" rel="noreferrer noopener" target="_blank" title="${value}">${label}</a>`;
 };
 
+const WELL_KNOWN_PROTO = ['http://', 'https://'];
+const removeWellknownProtocolFromUrl = (url = '') => {
+    // this function is just to handle url in case-insensitive way
+    if (!url) {
+        return url;
+    }
+    const input = url.toLowerCase();
+    const foundProto = WELL_KNOWN_PROTO.findIndex(proto => input.startsWith(proto));
+    if (foundProto === -1) {
+        return url;
+    }
+    return url.substring(WELL_KNOWN_PROTO[foundProto].length);
+};
+
 const shortenUrl = (url = '', maxLength = 50) => {
     if (url.length <= maxLength) {
         return url;
     }
-    const urlWithoutProto = url.replace('http://', '').replace('https://', '');
-    if (urlWithoutProto.length <= maxLength) {
-        return urlWithoutProto;
+    const urlValue = removeWellknownProtocolFromUrl(url);
+    if (urlValue.length <= maxLength) {
+        return urlValue;
     }
     const partLength = maxLength / 2;
-    const start = shortenString(urlWithoutProto, partLength);
-    const end = reverseString(shortenString(reverseString(urlWithoutProto), partLength));
+    const start = shortenString(urlValue, partLength);
+    const end = reverseString(shortenString(reverseString(urlValue), partLength));
     return start + '...' + end;
 };
 

--- a/bundles/mapping/mapmodule/plugin/getinfo/ValueFormatters.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/ValueFormatters.js
@@ -4,10 +4,55 @@
 // TODO: add params handling for formatters
 // ----------------------------------------------------------------------
 const linkFormatter = (value, params = {}) => {
-    return `<a href="${value}" rel="noreferrer noopener" target="_blank">${params.label || value}</a>`;
+    let label = params.label;
+    if (!label) {
+        if (params.fullUrl === true) {
+            label = value;
+        } else {
+            // defaults to shortened url (max 50 chars for default)
+            label = shortenUrl(value);
+        }
+    }
+    return `<a href="${value}" rel="noreferrer noopener" target="_blank" title="${value}">${label}</a>`;
+};
+
+const shortenUrl = (url = '', maxLength = 50) => {
+    if (url.length <= maxLength) {
+        return url;
+    }
+    const urlWithoutProto = url.replace('http://', '').replace('https://', '');
+    if (urlWithoutProto.length <= maxLength) {
+        return urlWithoutProto;
+    }
+    const partLength = maxLength / 2;
+    const start = shortenString(urlWithoutProto, partLength);
+    const end = reverseString(shortenString(reverseString(urlWithoutProto), partLength));
+    return start + '...' + end;
+};
+
+const reverseString = (input = '') => input.split('').reverse().join('');
+
+const SHORTEN_STOP_CHARS = [' ', '/', '&', '?'];
+const shortenString = (input = '', maxLength = 25) => {
+    if (input.length < maxLength) {
+        return input;
+    }
+    const threshold = maxLength * 0.8;
+    let candidate = input.substring(0, threshold);
+    let restOfInput = input.substring(threshold).split('');
+    while (restOfInput.length && candidate.length < maxLength) {
+        const character = restOfInput.shift();
+        if (SHORTEN_STOP_CHARS.includes(character)) {
+            // encountered char that is natural shorten point
+            break;
+        }
+        candidate += character;
+    }
+    return candidate;
 };
 
 const imgFormatter = (value, params = {}) => {
+    // TODO: onError=replace with nicer placeholder? Maybe when refactoring to React?
     const img = `<img class="oskari_gfi_img" src="${value}"></img>`;
     if (params.link === true) {
         return linkFormatter(value, { label: img });

--- a/bundles/mapping/mapmodule/plugin/getinfo/ValueFormatters.test.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/ValueFormatters.test.js
@@ -23,13 +23,32 @@ describe('GetInfoPlugin', () => {
             });
             test('formats link value', () => {
                 const formatter = getFormatter('link');
-                const result = formatter('https://my.domain');
-                expect(result).toEqual('<a href="https://my.domain" rel="noreferrer noopener" target="_blank">https://my.domain</a>');
+                const link = 'https://my.domain';
+                const result = formatter(link);
+                expect(result).toEqual(`<a href="${link}" rel="noreferrer noopener" target="_blank" title="${link}">${link}</a>`);
+            });
+            test('formats link with label', () => {
+                const formatter = getFormatter('link');
+                const link = 'https://my.domain';
+                const expectedLabel = 'Configured label';
+                const result = formatter(link, {
+                    label: expectedLabel
+                });
+                expect(result).toEqual(`<a href="${link}" rel="noreferrer noopener" target="_blank" title="${link}">${expectedLabel}</a>`);
+            });
+            test('formats long link value', () => {
+                const formatter = getFormatter('link');
+                const link = 'http://thelongestdomainnameintheworldandthensomeandthensomemoreandmore.com/testing/a very long link?with=params&other=stuff';
+                const expectedLabel = 'thelongestdomainnameinthe...with=params&other=stuff';
+                const result = formatter(link);
+                expect(result).toEqual(`<a href="${link}" rel="noreferrer noopener" target="_blank" title="${link}">${expectedLabel}</a>`);
             });
             test('detects link from value and formats as link', () => {
+                // NOTE! We don't give parameter to formatter -> detection
                 const formatter = getFormatter();
-                const result = formatter('https://my.domain');
-                expect(result).toEqual('<a href="https://my.domain" rel="noreferrer noopener" target="_blank">https://my.domain</a>');
+                const link = 'https://my.domain';
+                const result = formatter(link);
+                expect(result).toEqual(`<a href="${link}" rel="noreferrer noopener" target="_blank" title="${link}">${link}</a>`);
             });
             test('formats image value', () => {
                 const formatter = getFormatter('image');
@@ -38,10 +57,11 @@ describe('GetInfoPlugin', () => {
             });
             test('formats image with link value', () => {
                 const formatter = getFormatter('image');
-                const result = formatter('https://my.domain', {
+                const url = 'https://my.domain';
+                const result = formatter(url, {
                     link: true
                 });
-                expect(result).toEqual('<a href="https://my.domain" rel="noreferrer noopener" target="_blank"><img class="oskari_gfi_img" src="https://my.domain"></img></a>');
+                expect(result).toEqual(`<a href="${url}" rel="noreferrer noopener" target="_blank" title="${url}"><img class="oskari_gfi_img" src="${url}"></img></a>`);
             });
         });
     });

--- a/bundles/mapping/mapmodule/plugin/getinfo/ValueFormattersUrlHelpers.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/ValueFormattersUrlHelpers.js
@@ -1,0 +1,71 @@
+
+// protocols that can be removed from url labels
+const WELL_KNOWN_PROTO = ['http://', 'https://'];
+// for reasonable breakpoint
+const SHORTEN_STOP_CHARS = [' ', '/', '&', '?'];
+// so we can find a shorten string from the end of the string
+const reverseString = (input = '') => input.split('').reverse().join('');
+
+/**
+ * The returned string can be a little shorter than preferredLength
+ * or in worst case it can be one character over with added '...' in the middle.
+ * @param {String} url
+ * @param {Number} preferredLength defaults to 50.
+ */
+export const shortenUrl = (url = '', preferredLength = 50) => {
+    if (url.length <= preferredLength) {
+        return url;
+    }
+    const urlValue = removeWellknownProtocolFromUrl(url);
+    if (urlValue.length <= preferredLength) {
+        return urlValue;
+    }
+    const partLength = preferredLength / 2;
+    const start = shortenString(urlValue, partLength);
+    const end = reverseString(shortenString(reverseString(urlValue), partLength));
+    return start + '...' + end;
+};
+
+/**
+ * Removes http:// or https:// from the start of the input url
+ * Case-insensitive
+ * @see WELL_KNOWN_PROTO for protocols that are removed
+ * @param {String} url
+ */
+const removeWellknownProtocolFromUrl = (url = '') => {
+    // this function is just to handle url in case-insensitive way
+    if (!url) {
+        return url;
+    }
+    const input = url.toLowerCase();
+    const foundProto = WELL_KNOWN_PROTO.findIndex(proto => input.startsWith(proto));
+    if (foundProto === -1) {
+        return url;
+    }
+    return url.substring(WELL_KNOWN_PROTO[foundProto].length);
+};
+
+/**
+ * Shortens given string to maxLength or a bit less if it can find a reasonable
+ * character to cut from.
+ * @see SHORTEN_STOP_CHARS
+ * @param {String} input
+ * @param {Number} maxLength defaults to 25
+ */
+const shortenString = (input = '', maxLength = 25) => {
+    if (input.length < maxLength) {
+        return input;
+    }
+    const threshold = maxLength * 0.8;
+    let candidate = input.substring(0, threshold);
+    let restOfInput = input.substring(threshold).split('');
+    while (restOfInput.length && candidate.length < maxLength) {
+        const character = restOfInput.shift();
+        if (SHORTEN_STOP_CHARS.includes(character)) {
+            // encountered char that is natural shorten point
+            break;
+        }
+        candidate += character;
+    }
+    return candidate;
+};

--- a/bundles/mapping/mapmodule/resources/scss/getinfo.scss
+++ b/bundles/mapping/mapmodule/resources/scss/getinfo.scss
@@ -2,23 +2,22 @@
 
 	tr {
 		padding: 5px;
-		
+
 		&.odd {
 			background-color: #EEEEEE;
 		}
-
 	}
-	
+
 	td {
-		padding: 2px;
+		padding: 3px;
+		/* Overriding global styling for "table td"... */
+		border-bottom: 0px;
 
 		.oskari_gfi_img {
-			padding-bottom: 15px;
 			max-height: 350px;
 			max-width: 350px;
 		}
 	}
-
 }
 
 .getinforesult_header {


### PR DESCRIPTION
- Removed unused/deprecated "transport" era myplaces formatting code.
- Added layer info for myplaces GFI (like all the other layers have).
- Minor increase in padding for GFI table cells (2px -> 3px).
- Link formatting now adds tooltip and shortens long urls (for display purposes) so they don't stretch the popup unnecessarily.
- Removed background color from GFI result rows without columns (so rows with heading/paragraph/image looks better).
