### PR TITLE
Remove generic default style selector from mvt/wfs

### DIFF
--- a/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
@@ -43,7 +43,6 @@ class VectorTileLayerPlugin extends AbstractMapLayerPlugin {
                 LayerComposingModel.EXTERNAL_STYLES_JSON,
                 LayerComposingModel.HOVER,
                 LayerComposingModel.SRS,
-                LayerComposingModel.STYLE,
                 LayerComposingModel.STYLES_JSON,
                 LayerComposingModel.TILE_GRID,
                 LayerComposingModel.URL

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
@@ -95,7 +95,6 @@ export class WfsVectorLayerPlugin extends AbstractMapLayerPlugin {
             LayerComposingModel.CREDENTIALS,
             LayerComposingModel.HOVER,
             LayerComposingModel.SRS,
-            LayerComposingModel.STYLE,
             LayerComposingModel.STYLES_JSON,
             LayerComposingModel.URL,
             LayerComposingModel.VERSION,

--- a/bundles/mapping/tiles3d/plugin/Tiles3DLayerPlugin.js
+++ b/bundles/mapping/tiles3d/plugin/Tiles3DLayerPlugin.js
@@ -58,6 +58,8 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.Tiles3DLayerPlugin',
                 const composingModel = new LayerComposingModel([
                     LayerComposingModel.CESIUM_ION,
                     LayerComposingModel.SRS,
+                    // STYLE combines a list from STYLES_JSON and EXTERNAL_STYLES_JSON
+                    // so it's required for selecting defaults style for 3D...
                     LayerComposingModel.STYLE,
                     LayerComposingModel.STYLES_JSON,
                     LayerComposingModel.EXTERNAL_STYLES_JSON,


### PR DESCRIPTION
LayerComposingModel.STYLE provides default style selection for vector´ish type layers. LayerComposingModel.STYLES_JSON also includes default style selection for same type of layers. Style could be removed completely but it's still needed to select default styles when the layer type supports external styles like https://github.com/oskariorg/oskari-frontend/blob/2.1.0/bundles/mapping/tiles3d/plugin/Tiles3DLayerPlugin.js#L63

If we remove STYLE completely there is no way of selecting an external style as default for 3d-layers.