### PR TITLE
Tuning the progress bar

### DIFF
--- a/bundles/framework/divmanazer/component/ProgressBar.js
+++ b/bundles/framework/divmanazer/component/ProgressBar.js
@@ -21,7 +21,8 @@ Oskari.clazz.define('Oskari.userinterface.component.ProgressBar',
                 position: 'absolute',
                 top: 0,
                 left: 0,
-                height: '0.5%',
+                height: '7px',
+                opacity: 0.75,
                 background: this.defaultColor,
                 width: 0,
                 transition: 'width 250ms',
@@ -31,27 +32,29 @@ Oskari.clazz.define('Oskari.userinterface.component.ProgressBar',
             content.append(this._element);
             return this._element;
         },
-        updateProgressBar: function (goal, current) {
+        updateProgressBar: function (goal, current, containsErrors = false) {
             if (goal === 0) {
                 return;
             }
-            var width = (current / goal * 100).toFixed(1);
-            this._element.css({ width: width + '%' });
+            // 20% + actual progress to make progress more visible to user
+            var width = 20 + (current / goal * 80);
+            this._element.css({ width: width.toFixed(1) + '%' });
             if (width >= 100.0) {
-                this.hide();
+                this.hide(containsErrors ? 2500: 400);
             }
+            return width;
         },
         setColor: function (color) {
             this._element.css({ background: color });
         },
         show: function () {
-            this._element.css({ visibility: 'visible' });
+            this._element.css({ visibility: 'visible', width: '20%' });
         },
-        hide: function () {
+        hide: function (delay = 400) {
             var me = this;
             setTimeout(function () {
                 me._element.css({ visibility: 'hidden', width: 0, background: me.defaultColor });
-            }, 400);
+            }, delay);
         }
 
     });

--- a/bundles/framework/divmanazer/component/ProgressBar.js
+++ b/bundles/framework/divmanazer/component/ProgressBar.js
@@ -40,7 +40,7 @@ Oskari.clazz.define('Oskari.userinterface.component.ProgressBar',
             var width = 20 + (current / goal * 80);
             this._element.css({ width: width.toFixed(1) + '%' });
             if (width >= 100.0) {
-                this.hide(containsErrors ? 2500: 400);
+                this.hide(containsErrors ? 2500 : 400);
             }
             return width;
         },

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1059,12 +1059,12 @@ Oskari.clazz.define(
                 layers.forEach(function (layer) {
                     tilesLoaded += layer.loaded;
                     pendingTiles += layer.tilesToLoad;
-                    errorCount += layer.errors
+                    errorCount += layer.errors;
                 });
                 const progressPercentage = this.progBar.updateProgressBar(pendingTiles, tilesLoaded, errorCount > 0);
                 if (this.__PROGRESS_DEBUGGING === true) {
                     // for debugging purposes
-                    console.log(`${tilesLoaded} / ${pendingTiles} = ${progressPercentage}`)
+                    console.log(`${tilesLoaded} / ${pendingTiles} = ${progressPercentage}`);
                 }
             }
             this.loadtimer = setTimeout(function () {

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -191,6 +191,8 @@ Oskari.clazz.define(
                     '<div class="oskari-crosshair-horizontal-bar"></div>' +
                 '</div>')
         };
+        // adds on/off/trigger functions for internal eventing
+        Oskari.makeObservable(this);
     }, {
         /**
          * Moved from core, to be removed
@@ -989,39 +991,25 @@ Oskari.clazz.define(
          * offer that).
          */
         updateCurrentState: function () {
-            var me = this,
-                sandbox = me._sandbox,
-                layers = sandbox.findAllSelectedMapLayers(),
-                lps = this.getLayerPlugins(),
-                layersPlugin,
-                p;
-
-            for (p in lps) {
-                if (lps.hasOwnProperty(p)) {
-                    layersPlugin = lps[p];
-                    if (typeof layersPlugin.preselectLayers !== 'function') {
-                        continue;
-                    }
-                    this.log.debug('preselecting ' + p);
-                    layersPlugin.preselectLayers(layers);
+            const sandbox = this.getSandbox();
+            const layers = sandbox.findAllSelectedMapLayers();
+            const layerPlugins = this.getLayerPlugins();
+            Object.keys(layerPlugins).forEach(pluginName => {
+                const plugin = layerPlugins[pluginName];
+                if (typeof plugin.preselectLayers !== 'function') {
+                    return;
                 }
-            }
+                this.log.debug('preselecting ' + pluginName);
+                plugin.preselectLayers(layers);
+            });
         },
         isLoading: function (id) {
-            var loading = false;
-            if (typeof id === 'undefined') {
-                var oskariLayers = this.getSandbox().getMap().getLayers();
-                oskariLayers.forEach(function (layer) {
-                    if (loading) {
-                        return;
-                    }
-                    loading = layer.getLoadingState().loading > 0;
-                });
-            } else {
-                var oskariLayer = this.getSandbox().getMap().getSelectedLayer(id);
-                loading = oskariLayer.getLoadingState().loading > 0;
+            if (typeof id !== 'undefined') {
+                const oskariLayer = this.getSandbox().getMap().getSelectedLayer(id);
+                return oskariLayer.getLoadingState().loading > 0;
             }
-            return loading;
+            const oskariLayers = this.getSandbox().getMap().getLayers();
+            return oskariLayers.some((layer) => layer.getLoadingState().loading > 0);
         },
         /**
          * @method loadingState
@@ -1029,15 +1017,11 @@ Oskari.clazz.define(
          * @param {Number} layerid, the id number of the abstract layer in loading
          * @param {boolean} started is true if tileloadstart has been called, false if tileloadend
          */
-        loadingState: function (layerId, started, errors) {
-            if (typeof errors === 'undefined') {
-                errors = false;
-            }
-            var done = false;
-            var me = this;
-            var layers = this.getSandbox().findAllSelectedMapLayers();
-            var oskariLayer = this.getSandbox().getMap().getSelectedLayer(layerId);
+        loadingState: function (layerId, started, errors = false) {
+            const sandbox = this.getSandbox();
+            const oskariLayer = sandbox.getMap().getSelectedLayer(layerId);
             if (!oskariLayer) {
+                // layer not on map, this should only be caused by some timing issue
                 return;
             }
 
@@ -1050,41 +1034,49 @@ Oskari.clazz.define(
                 clearTimeout(this.loadtimer);
             }
 
+            let done = false;
             if (started) {
-                var wasFirstTile = oskariLayer.loadingStarted();
-                if (wasFirstTile) {
+                // loading (a tile etc)  started for layer
+                const firstTile = oskariLayer.loadingStarted();
+                if (firstTile) {
+                    // on first tile show progress bar
                     this.progBar.show();
+                    // resets any previous error states etc
                     oskariLayer.resetLoadingState(1);
                 }
             } else {
-                var tilesLoaded = 0;
-                var pendingTiles = 0;
-                if (!errors) {
-                    done = oskariLayer.loadingDone();
-                    layers.forEach(function (layer) {
-                        tilesLoaded += layer.loaded;
-                        pendingTiles += layer.tilesToLoad;
-                    });
-                    this.progBar.updateProgressBar(pendingTiles, tilesLoaded);
-                } else {
+                // loading (a tile etc) ended for layer
+                let tilesLoaded = 0;
+                let pendingTiles = 0;
+                let errorCount = 0;
+                if (errors) {
+                    oskariLayer.loadingError();
                     this.progBar.setColor('rgba( 190, 0, 10, 0.4 )');
-                    oskariLayer.loadingError(oskariLayer.getLoadingState().loading);
-                    errors = oskariLayer.getLoadingState().errors;
-                    oskariLayer.loadingDone(0);
-
-                    setTimeout(function () {
-                        me.progBar.hide();
-                    }, 2000);
-                    tilesLoaded = 0;
-                    pendingTiles = 0;
-                    this.notifyErrors(errors, oskariLayer);
+                    this.notifyErrors(oskariLayer.getLoadingState().errors, oskariLayer);
+                }
+                done = oskariLayer.loadingDone();
+                const layers = sandbox.findAllSelectedMapLayers();
+                layers.forEach(function (layer) {
+                    tilesLoaded += layer.loaded;
+                    pendingTiles += layer.tilesToLoad;
+                    errorCount += layer.errors
+                });
+                const progressPercentage = this.progBar.updateProgressBar(pendingTiles, tilesLoaded, errorCount > 0);
+                if (this.__PROGRESS_DEBUGGING === true) {
+                    // for debugging purposes
+                    console.log(`${tilesLoaded} / ${pendingTiles} = ${progressPercentage}`)
                 }
             }
             this.loadtimer = setTimeout(function () {
                 var eventBuilder = Oskari.eventBuilder('ProgressEvent');
                 var event = eventBuilder(done, layerId);
-                me._sandbox.notifyAll(event);
+                sandbox.notifyAll(event);
             }, 50);
+            this.trigger('layer.loading', {
+                layer: layerId,
+                started: started,
+                errored: errors
+            });
         },
         notifyErrors: function (errors, oskariLayer) {
             Oskari.log(this.getName()).warn('error loading layer: ' + oskariLayer.getName());

--- a/bundles/mapping/mapmodule/domain/AbstractLayer.js
+++ b/bundles/mapping/mapmodule/domain/AbstractLayer.js
@@ -488,6 +488,7 @@ Oskari.clazz.define(
             var toBeLoaded = tilesToLoad || 0;
             this.loaded = 0;
             this.errors = 0;
+            this.loading = toBeLoaded;
             this.tilesToLoad = toBeLoaded;
         },
         /**

--- a/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol.js
@@ -177,19 +177,20 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.WmsLayerPlugin',
         },
 
         _registerLayerEvents: function (layer, oskariLayer, prefix) {
-            var me = this;
-            var source = layer.getSource();
+            const me = this;
+            const source = layer.getSource();
+            const layerId = oskariLayer.getId();
 
             source.on(prefix + 'loadstart', function () {
-                me.getMapModule().loadingState(oskariLayer._id, true);
+                me.getMapModule().loadingState(layerId, true);
             });
 
             source.on(prefix + 'loadend', function () {
-                me.getMapModule().loadingState(oskariLayer._id, false);
+                me.getMapModule().loadingState(layerId, false);
             });
 
             source.on(prefix + 'loaderror', function () {
-                me.getMapModule().loadingState(oskariLayer.getId(), null, true);
+                me.getMapModule().loadingState(layerId, null, true);
             });
         },
         /**


### PR DESCRIPTION
Tuning the maps progress bar to init at 20% and some visual improvements so it's easier to see.
Also add internal eventing for layer loading status so problems can be tracked in an app.

Loading progress can be monitored by running this code:
```
const map = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule');
map.on('layer.loading', (event) => console.log(event));
```
Also for getting progress bar status printed out to dev-console you can do:
```
map.__PROGRESS_DEBUGGING = true;
```