### PR TITLE
WFSLayerService click select fix

### DIFF
--- a/bundles/mapping/mapwfs2/service/WFSLayerService.js
+++ b/bundles/mapping/mapwfs2/service/WFSLayerService.js
@@ -139,23 +139,23 @@ Oskari.clazz.define(
          * Handles status of selected features
          */
         setWFSFeaturesSelections: function (layerId, featureIds, makeNewSelection) {
-            let updatedIds;
+            let selectedFeatureIds = featureIds;
             if (makeNewSelection) {
-                updatedIds = featureIds;
+                selectedFeatureIds = featureIds;
             } else {
-                const existingIds = this.getSelectedFeatureIds(layerId);
+                const previousSelectedFeatureIds = this.getSelectedFeatureIds(layerId);
                 // Either add all featureIds or remove all feature Ids from selection. Don't mix.
-                const someSelected = existingIds.some(selected => featureIds.includes(selected));
-                if (someSelected) {
-                    updatedIds = existingIds.filter(id => !featureIds.includes(id));
+                const shouldRemoveFeaturesFromSelection = previousSelectedFeatureIds.some(selected => featureIds.includes(selected));
+                if (shouldRemoveFeaturesFromSelection) {
+                    selectedFeatureIds = previousSelectedFeatureIds.filter(id => !featureIds.includes(id));
                 } else {
-                    updatedIds = [...existingIds, ...featureIds];
+                    selectedFeatureIds = [...previousSelectedFeatureIds, ...featureIds];
                 }
             }
             // clear old selection
             this.__removeFeatureSelectionForLayer(layerId);
             // add the updated selection
-            this.getWFSSelections().push({ layerId, featureIds: updatedIds });
+            this.getWFSSelections().push({ layerId, featureIds: selectedFeatureIds });
         },
 
         /**

--- a/bundles/mapping/mapwfs2/service/WFSLayerService.js
+++ b/bundles/mapping/mapwfs2/service/WFSLayerService.js
@@ -139,35 +139,23 @@ Oskari.clazz.define(
          * Handles status of selected features
          */
         setWFSFeaturesSelections: function (layerId, featureIds, makeNewSelection) {
-            var me = this;
-
+            let updatedIds;
             if (makeNewSelection) {
-                this.__removeFeatureSelectionForLayer(layerId);
-                me.getWFSSelections().push({ 'layerId': layerId, 'featureIds': featureIds });
+                updatedIds = featureIds;
             } else {
-                const existingFeatureSelections = this.getSelectedFeatureIds(layerId);
-                // no existing selections -> add all
-                if (!existingFeatureSelections || existingFeatureSelections.length === 0) {
-                    existingFeatureSelections.push(featureIds);
+                const existingIds = this.getSelectedFeatureIds(layerId);
+                // Either add all featureIds or remove all feature Ids from selection. Don't mix.
+                const someSelected = existingIds.some(selected => featureIds.includes(selected));
+                if (someSelected) {
+                    updatedIds = existingIds.filter(id => !featureIds.includes(id));
                 } else {
-                    // Either add all featureIds or remove all feature Ids from selection. Don't mix.
-                    const selectionArray = existingFeatureSelections[0];
-                    const someSelected = selectionArray.some(selected => featureIds.includes(selected));
-                    if (someSelected) {
-                        featureIds.forEach(id => {
-                            if (selectionArray.includes(id)) {
-                                selectionArray.splice(selectionArray.indexOf(id), 1);
-                            }
-                        });
-                        return;
-                    }
-                    featureIds.forEach(id => selectionArray.push(id));
+                    updatedIds = [...existingIds, ...featureIds];
                 }
-                // clear old selection
-                this.__removeFeatureSelectionForLayer(layerId);
-                // add the updated selection
-                me.getWFSSelections().push({ 'layerId': layerId, 'featureIds': existingFeatureSelections[0] });
             }
+            // clear old selection
+            this.__removeFeatureSelectionForLayer(layerId);
+            // add the updated selection
+            this.getWFSSelections().push({ layerId, featureIds: updatedIds });
         },
 
         /**

--- a/bundles/mapping/mapwfs2/service/WFSLayerService.js
+++ b/bundles/mapping/mapwfs2/service/WFSLayerService.js
@@ -140,9 +140,7 @@ Oskari.clazz.define(
          */
         setWFSFeaturesSelections: function (layerId, featureIds, makeNewSelection) {
             let selectedFeatureIds = featureIds;
-            if (makeNewSelection) {
-                selectedFeatureIds = featureIds;
-            } else {
+            if (!makeNewSelection) {
                 const previousSelectedFeatureIds = this.getSelectedFeatureIds(layerId);
                 // Either add all featureIds or remove all feature Ids from selection. Don't mix.
                 const shouldRemoveFeaturesFromSelection = previousSelectedFeatureIds.some(selected => featureIds.includes(selected));

--- a/bundles/mapping/mapwfs2/service/WFSLayerService.test.js
+++ b/bundles/mapping/mapwfs2/service/WFSLayerService.test.js
@@ -9,8 +9,22 @@ const service = Oskari.clazz.create('Oskari.mapframework.bundle.mapwfs2.service.
 const layerId = 123;
 
 describe('WFSLayerService', () => {
-    test('setWFSFeaturesSelections()', () => {
+    test('click setWFSFeaturesSelections()', () => {
+        service.setWFSFeaturesSelections(layerId, [1, 2], false);
+        expect(service.getSelectedFeatureIds(layerId).length).toBe(2);
+        service.setWFSFeaturesSelections(layerId, [3], false);
+        expect(service.getSelectedFeatureIds(layerId).length).toBe(3);
+        // unselect feature by using existing id
+        service.setWFSFeaturesSelections(layerId, [3], false);
+        const ids = service.getSelectedFeatureIds(layerId);
+        expect(ids.length).toBe(2);
+        expect(ids).toEqual(expect.arrayContaining([1, 2]));
+        expect(ids).not.toContain(3);
+    });
+
+    test('selection tool setWFSFeaturesSelections()', () => {
         expect(service.getSelectedWFSLayerIds().length).toEqual(0);
+        // using true clears old selections and makes new selection
         service.setWFSFeaturesSelections(layerId, [1, 2], true);
         const selections = service.getWFSSelections();
         expect(selections.length).toEqual(1);


### PR DESCRIPTION
existingFeatureSelections[0] was feature id not array so selecting more features or unselecting them caused error on calling .some().
Added test for click select/unselect.

Fixes issues with selecting features by ctrl+click feature on map and featuredata table.