### PR TITLE
Stop coverage delimiting on tab change

### DIFF
--- a/bundles/catalogue/metadatacatalogue/instance.js
+++ b/bundles/catalogue/metadatacatalogue/instance.js
@@ -360,44 +360,33 @@ Oskari.clazz.define(
                     return;
                 }
 
-                if (!isShown && me.drawCoverage === false) {
-                    me._stopCoverage();
-                    if (me.coverageButton) {
-                        me.coverageButton.val(me.getLocalization('delimitArea'));
-                    }
-                    me.drawCoverage = true;
-
-                    var input = document.getElementById('oskari_metadatacatalogue_forminput_searchassistance');
-                    if (input) {
-                        input.focus();
-                    }
-
-                    if (me.coverageButton) {
-                        me.coverageButton[0].data = '';
-                    }
-                }
-
-                if (event.getViewState() === 'close') {
-                    me._removeFeaturesFromMap();
+                if ((!isShown && me.drawCoverage === false) || event.getViewState() === 'close') {
+                    this._teardownMetaSearch();
                 }
             },
             'Search.TabChangedEvent': function (event) {
-                const me = this;
-
                 if (event.getNewTabId() !== this.id) {
-                    me._stopCoverage();
-                    if (me.coverageButton) {
-                        me.coverageButton.val(me.getLocalization('delimitArea'));
-                    }
-                    me.drawCoverage = true;
-
-                    if (me.coverageButton) {
-                        me.coverageButton[0].data = '';
-                    }
-
-                    me._removeFeaturesFromMap();
+                    this._teardownMetaSearch();
+                } else {
+                    this._removeFeaturesFromMap(); // unactive show-area-icons when changing to metadata search tab
                 }
             }
+        },
+        /**
+         * @method _teardownMetaSearch
+         * @private
+         * Tears down meta data search when changing tab or closing flyout
+         */
+        _teardownMetaSearch: function () {
+            this._stopCoverage();
+
+            if (this.coverageButton) {
+                this.coverageButton.val(this.getLocalization('delimitArea'));
+                this.coverageButton[0].data = '';
+            }
+
+            this.drawCoverage = true;
+            this._removeFeaturesFromMap();
         },
         /**
          * @method _removeFeaturesFromMap

--- a/bundles/catalogue/metadatacatalogue/instance.js
+++ b/bundles/catalogue/metadatacatalogue/instance.js
@@ -55,6 +55,7 @@ Oskari.clazz.define(
         this.state = this.state || {};
         this.progressSpinner = Oskari.clazz.create('Oskari.userinterface.component.ProgressSpinner');
         this._vectorLayerId = 'METADATACATALOGUE_VECTORLAYER';
+        this.id = 'oskari_metadatacatalogue_tabpanel_header';
     }, {
         /**
          * @static
@@ -379,6 +380,23 @@ Oskari.clazz.define(
                 if (event.getViewState() === 'close') {
                     me._removeFeaturesFromMap();
                 }
+            },
+            'Search.TabChangedEvent': function (event) {
+                const me = this;
+
+                if (event.getNewTabId() !== this.id) {
+                    me._stopCoverage();
+                    if (me.coverageButton) {
+                        me.coverageButton.val(me.getLocalization('delimitArea'));
+                    }
+                    me.drawCoverage = true;
+
+                    if (me.coverageButton) {
+                        me.coverageButton[0].data = '';
+                    }
+
+                    me._removeFeaturesFromMap();
+                }
             }
         },
         /**
@@ -560,9 +578,9 @@ Oskari.clazz.define(
             var title = me.getLocalization('tabTitle'),
                 content = metadataCatalogueContainer,
                 priority = this.tabPriority,
-                id = 'oskari_metadatacatalogue_tabpanel_header',
-                reqBuilder = Oskari.requestBuilder('Search.AddTabRequest'),
-                req = reqBuilder(title, content, priority, id);
+                reqBuilder = Oskari.requestBuilder('Search.AddTabRequest');
+
+            const req = reqBuilder(title, content, priority, this.id);
 
             me.sandbox.request(me, req);
 


### PR DESCRIPTION
When changing tab on search flyout we want to stop coverage delimiting. Added missing event handler that was notified at search bundle but wasn't handled in the metadata_catalogue end-point.

Changing tab could also reset search state completely in my opinion.