### PR TITLE
Remove style defaults that actively conflict with selections on StyleEditor

### DIFF
--- a/src/react/components/StyleEditor/OskariDefaultStyle.js
+++ b/src/react/components/StyleEditor/OskariDefaultStyle.js
@@ -35,11 +35,9 @@ export const OSKARI_BLANK_STYLE = {
     image: { // image style
         shape: 5, // 0-6 for default markers. svg or external icon path
         size: 3, // Oskari icon size.
-        sizePx: 20, // Exact icon px size. Used if 'size' not defined.
         offsetX: 0, // image offset x
         offsetY: 0, // image offset y
         opacity: 0.7, // image opacity
-        radius: 2, // image radius
         fill: {
             color: '#ff00ff' // image fill color
         }


### PR DESCRIPTION
Especially sizePx but also radius is not required when StyleEditor only has options for SVG-icons. Fixes an issue where adding a style using the visual editor and selecting point size didn't work because the "hardcoded" sizePx overrides any value that size might have and visual editor only modifies the size key.