### PR TITLE
Downgrade OpenLayers to fix point symbol clipping on vectortiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "mobile-detect": "1.4.4",
     "moment": "2.24.0",
     "node-sass": "4.14.1",
-    "ol": "6.5.0",
+    "ol": "6.4.3",
     "ol-mapbox-style": "6.3.1",
     "olcs": "2.12.0",
     "optimize-css-assets-webpack-plugin": "5.0.3",


### PR DESCRIPTION
Fixed on the next version of OpenLayers  but there's no release yet so we'll have to wait a bit for it: https://github.com/openlayers/openlayers/issues/11884