### PR TITLE
Wfs handle properties

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -521,8 +521,8 @@ class UIHandler extends StateHandler {
             }
             return response.json();
         }).then(json => {
-            const { attributes, locale } = json;
-            const attributeIdentifiers = Object.keys(attributes);
+            const { types, locale } = json;
+            const attributeIdentifiers = Object.keys(types);
             const currentLocale = Oskari.getLang();
             const labelMapping = locale && locale[currentLocale] ? locale[currentLocale] : {};
             return attributeIdentifiers.reduce((choices, identifier) => {

--- a/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
+++ b/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
@@ -20,9 +20,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmyplaces.domain.MyPlacesLayer
             // call parent parseLayerData
             this.wfsBuilder.parseLayerData(layer, mapLayerJson, maplayerService);
 
-            if (mapLayerJson.fields) {
-                layer.setFields(mapLayerJson.fields);
-            }
             if (loclayer.organization) {
                 layer.setOrganizationName(loclayer.organization);
             }

--- a/bundles/mapping/mapuserlayers/domain/UserLayerModelBuilder.js
+++ b/bundles/mapping/mapuserlayers/domain/UserLayerModelBuilder.js
@@ -25,11 +25,6 @@ Oskari.clazz.define(
             layer.setSource(mapLayerJson.source);
             layer.setRenderingElement(mapLayerJson.renderingElement);
             layer.addLayerUrl(mapLayerJson.renderingUrl);
-            const props = mapLayerJson.propertyNames;
-            if (Array.isArray(props)) {
-                layer.setFields(props.map(p => p.name));
-                layer.setLocales(props.map(p => p.locale));
-            }
         }
     }
 );

--- a/bundles/mapping/mapwfs2/domain/WFSLayer.js
+++ b/bundles/mapping/mapwfs2/domain/WFSLayer.js
@@ -12,8 +12,8 @@ export class WFSLayer extends VectorTileLayer {
         /* Layer Type */
         this._layerType = 'WFS';
         this._featureData = true;
-        this._propertyFilter = []; // filtered/ordered property names
-        this._propertyNames = {};
+        this._propertySelection = []; // names to order and limit visible properties
+        this._propertyLabels = {};
         this._propertyTypes = {};
         this._activeFeatures = []; // features on screen
         this._selectedFeatures = []; // filtered features
@@ -38,16 +38,15 @@ export class WFSLayer extends VectorTileLayer {
      */
     getFields () {
         const id = '__fid';
-        if (this._propertyFilter.length) {
-            return [id, ...this._propertyFilter];
+        if (this._propertySelection.length) {
+            return [id, ...this._propertySelection];
         }
-        const fromNames = Object.keys(this._propertyNames);
-        if (fromNames.length) {
-            return [id, ...fromNames];
+        let names = Object.keys(this._propertyLabels);
+        if (names.length) {
+            names = Object.keys(this._propertyTypes);
         }
-        const fromTypes = Object.keys(this._propertyTypes);
-        if (fromTypes.length) {
-            return [id, ...fromTypes];
+        if (names.length) {
+            return [id, ...names];
         }
         return [];
     }
@@ -67,6 +66,10 @@ export class WFSLayer extends VectorTileLayer {
      * @return {String[]} locales
      */
     getLocales () {
+        if (this._propertySelection.length) {
+            const labels = this._propertySelection.map(p => this._propertyNames[p] || p);
+            return ['ID', ...labels];
+        }
         const locales = Object.values(this._propertyNames);
         return locales.length ? ['ID', ...locales] : locales;
     }
@@ -202,35 +205,35 @@ export class WFSLayer extends VectorTileLayer {
     }
 
     /**
-     * @method setPropertyFilter
-     * @param {String[]} propertyFilter
+     * @method setPropertySelection
+     * @param {String[]} propertySelection
      */
-    setPropertyFilter (propertyFilter) {
-        this._propertyFilter = propertyFilter;
+    setPropertySelection (propertySelection) {
+        this._propertySelection = propertySelection;
     }
 
     /**
-     * @method getPropertyFilter
-     * @return {String[]} propertyFilter
+     * @method getPropertySelection
+     * @return {String[]} propertySelection
      */
-    getPropertyFilter () {
-        return this._propertyFilter;
+    getPropertySelection () {
+        return this._propertySelection;
     }
 
     /**
-     * @method setPropertyNames
-     * @param {json} propertyNames
+     * @method setPropertyLabels
+     * @param {json} propertyLabels
      */
-    setPropertyNames (propertyNames) {
-        this._propertyNames = propertyNames;
+    setPropertyLabels (propertyLabels) {
+        this._propertyLabels = propertyLabels;
     }
 
     /**
-     * @method getPropertyNames
-     * @return {json} propertyNames
+     * @method getPropertyLabels
+     * @return {json} propertyLabels
      */
-    getPropertyNames () {
-        return this._propertyNames;
+    getPropertyLabels () {
+        return this._propertyLabels;
     }
 
     /**

--- a/bundles/mapping/mapwfs2/domain/WFSLayer.js
+++ b/bundles/mapping/mapwfs2/domain/WFSLayer.js
@@ -12,15 +12,14 @@ export class WFSLayer extends VectorTileLayer {
         /* Layer Type */
         this._layerType = 'WFS';
         this._featureData = true;
-        this._fields = []; // property names
-        this._locales = []; // property name locales
+        this._propertyFilter = []; // filtered/ordered property names
+        this._propertyNames = {};
+        this._propertyTypes = {};
         this._activeFeatures = []; // features on screen
         this._selectedFeatures = []; // filtered features
         this._clickedFeatureIds = []; // clicked feature ids (map)
         this._clickedFeatureListIds = []; // clicked feature ids (list)
         this._clickedGeometries = []; // clicked feature geometries [[id  geom]..]
-        this._propertyTypes = {}; // name and describeFeatureType type (hashmap  json) (Analysis populates)
-        this._wpsLayerParams = {}; // wfs/wps analysis layer params (hashmap  json)    (Analysis populates)
         this._styles = []; /* Array of styles that this layer supports */
         this._customStyle = null;
         this._filterJson = null;
@@ -34,34 +33,51 @@ export class WFSLayer extends VectorTileLayer {
 
     /**
      * @method getFields
+     * @deprecated
      * @return {String[]} fields
      */
     getFields () {
-        return this._fields;
+        const id = '__fid';
+        if (this._propertyFilter.length) {
+            return [id, ...this._propertyFilter];
+        }
+        const fromNames = Object.keys(this._propertyNames);
+        if (fromNames.length) {
+            return [id, ...fromNames];
+        }
+        const fromTypes = Object.keys(this._propertyTypes);
+        if (fromTypes.length) {
+            return [id, ...fromTypes];
+        }
+        return [];
     }
 
     /**
      * @method setFields
+     * @deprecated
      * @param {String[]} fields
      */
-    setFields (fields) {
-        this._fields = fields;
+    setFields () {
+        Oskari.log('WFSLayer').deprecated('setFields');
     }
 
     /**
      * @method getLocales
+     * @deprecated
      * @return {String[]} locales
      */
     getLocales () {
-        return this._locales;
+        const locales = Object.values(this._propertyNames);
+        return locales.length ? ['ID', ...locales] : locales;
     }
 
     /**
      * @method setLocales
+     * @deprecated
      * @param {String[]} locales
      */
-    setLocales (locales) {
-        this._locales = locales;
+    setLocales () {
+        Oskari.log('WFSLayer').deprecated('setLocales');
     }
 
     /**
@@ -186,6 +202,38 @@ export class WFSLayer extends VectorTileLayer {
     }
 
     /**
+     * @method setPropertyFilter
+     * @param {String[]} propertyFilter
+     */
+    setPropertyFilter (propertyFilter) {
+        this._propertyFilter = propertyFilter;
+    }
+
+    /**
+     * @method getPropertyFilter
+     * @return {String[]} propertyFilter
+     */
+    getPropertyFilter () {
+        return this._propertyFilter;
+    }
+
+    /**
+     * @method setPropertyNames
+     * @param {json} propertyNames
+     */
+    setPropertyNames (propertyNames) {
+        this._propertyNames = propertyNames;
+    }
+
+    /**
+     * @method getPropertyNames
+     * @return {json} propertyNames
+     */
+    getPropertyNames () {
+        return this._propertyNames;
+    }
+
+    /**
      * @method setPropertyTypes
      * @param {json} propertyTypes
      */
@@ -203,10 +251,11 @@ export class WFSLayer extends VectorTileLayer {
 
     /**
      * @method setWpsLayerParams
+     * @deprecated
      * @param {json} wpsLayerParams
      */
-    setWpsLayerParams (wpsLayerParams) {
-        this._wpsLayerParams = wpsLayerParams;
+    setWpsLayerParams () {
+        Oskari.log('WFSLayer').deprecated('setWpsLayerParams');
     }
 
     /**
@@ -214,7 +263,8 @@ export class WFSLayer extends VectorTileLayer {
      * @return {json} wpsLayerParams
      */
     getWpsLayerParams () {
-        return this._wpsLayerParams;
+        const { wpsParams = {} } = this.getAttributes();
+        return wpsParams;
     }
 
     /**

--- a/bundles/mapping/mapwfs2/domain/WFSLayer.js
+++ b/bundles/mapping/mapwfs2/domain/WFSLayer.js
@@ -42,7 +42,7 @@ export class WFSLayer extends VectorTileLayer {
             return [id, ...this._propertySelection];
         }
         let names = Object.keys(this._propertyLabels);
-        if (names.length) {
+        if (!names.length) {
             names = Object.keys(this._propertyTypes);
         }
         if (names.length) {
@@ -67,10 +67,10 @@ export class WFSLayer extends VectorTileLayer {
      */
     getLocales () {
         if (this._propertySelection.length) {
-            const labels = this._propertySelection.map(p => this._propertyNames[p] || p);
+            const labels = this._propertySelection.map(p => this._propertyLabels[p] || p);
             return ['ID', ...labels];
         }
-        const locales = Object.values(this._propertyNames);
+        const locales = Object.values(this._propertyLabels);
         return locales.length ? ['ID', ...locales] : locales;
     }
 

--- a/bundles/mapping/mapwfs2/domain/WfsLayerModelBuilder.js
+++ b/bundles/mapping/mapwfs2/domain/WfsLayerModelBuilder.js
@@ -109,5 +109,25 @@ Oskari.clazz.define(
             if (mapLayerJson.WMSLayerId) {
                 layer.setWMSLayerId(mapLayerJson.WMSLayerId);
             }
+            this.parseLayerAttributes(layer);
+        },
+        parseLayerAttributes: function (layer) {
+            const { data = {} } = layer.getAttributes();
+            const { filter, locale = {}, types } = data;
+            const lang = Oskari.getLang();
+
+            if (Array.isArray(filter)) {
+                layer.setPropertyFilter(filter);
+            } else if (typeof filter === 'object') {
+                const filterArray = filter[lang] || filter.default || [];
+                layer.setPropertyFilter(filterArray);
+            }
+            const localized = locale[lang];
+            if (localized) {
+                layer.setPropertyNames(localized);
+            }
+            if (types) {
+                layer.setPropertyTypes(types);
+            }
         }
     });

--- a/bundles/mapping/mapwfs2/domain/WfsLayerModelBuilder.js
+++ b/bundles/mapping/mapwfs2/domain/WfsLayerModelBuilder.js
@@ -117,14 +117,14 @@ Oskari.clazz.define(
             const lang = Oskari.getLang();
 
             if (Array.isArray(filter)) {
-                layer.setPropertyFilter(filter);
+                layer.setPropertySelection(filter);
             } else if (typeof filter === 'object') {
                 const filterArray = filter[lang] || filter.default || [];
-                layer.setPropertyFilter(filterArray);
+                layer.setPropertySelection(filterArray);
             }
             const localized = locale[lang];
             if (localized) {
-                layer.setPropertyNames(localized);
+                layer.setPropertyLabels(localized);
             }
             if (types) {
                 layer.setPropertyTypes(types);

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
@@ -364,12 +364,16 @@ export class WfsVectorLayerPlugin extends AbstractMapLayerPlugin {
         }
         const onSuccess = response => {
             const lang = Oskari.getLang();
-            const { attributes = {}, locale = {}, filter = {} } = response;
-            const filterArray = filter[lang] || filter.default || fields;
-            layer.setPropertyFilter(filterArray);
-            const names = locale[lang] || locale.default || {};
-            layer.setPropertyNames(names);
-            layer.setPropertyTypes(attributes);
+            const { types = {}, locale = {}, selection } = response;
+            if (Array.isArray(selection)) {
+                layer.setPropertyFilter(selection);
+            } else if (selection) {
+                const selectionArray = selection[lang] || selection.default || fields;
+                layer.setPropertySelection(selectionArray);
+            }
+            const labels = locale[lang] || locale.default || {};
+            layer.setPropertyLabels(labels);
+            layer.setPropertyTypes(types);
             this.updateLayerProperties(layer);
         };
         jQuery.ajax({

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
@@ -3,7 +3,7 @@ import { MvtLayerHandler } from './WfsVectorLayerPlugin/impl/MvtLayerHandler.ol'
 import { ReqEventHandler } from './WfsVectorLayerPlugin/ReqEventHandler';
 import { HoverHandler } from './WfsVectorLayerPlugin/HoverHandler';
 import { styleGenerator } from './WfsVectorLayerPlugin/util/style';
-import { WFS_ID_KEY, WFS_FTR_ID_KEY, WFS_FTR_ID_LOCALE } from './WfsVectorLayerPlugin/util/props';
+import { WFS_ID_KEY } from './WfsVectorLayerPlugin/util/props';
 import { LAYER_ID, LAYER_HOVER, LAYER_TYPE, RENDER_MODE_MVT, RENDER_MODE_VECTOR } from '../../mapmodule/domain/constants';
 import { UserStyleService } from '../service/UserStyleService';
 

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/AbstractLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/AbstractLayerHandler.ol.js
@@ -76,17 +76,17 @@ export class AbstractLayerHandler {
     refreshLayer (layer) {
         this._log.debug('TODO: refreshLayer() not implemented on LayerHandler');
     }
+
     _updateLayerProperties (layer, source) {
         if (!layer.isVisible()) {
             layer.setActiveFeatures([]);
-            this.plugin.notify('WFSPropertiesEvent', layer, layer.getLocales(), layer.getFields());
             return;
         }
         const { left, bottom, right, top } = this.plugin.getSandbox().getMap().getBbox();
         const propsList = this._getFeaturePropsInExtent(source, [left, bottom, right, top]);
-        const fields = getFieldsArray(propsList);
-        // Update fields and locales only if fields is empty
-        if (!layer.getFields().length) {
+        // Update properties only if fields aren't set and there is features in extent
+        if (!layer.getFields().length && source.getFeatures().length) {
+            const fields = getFieldsArray(propsList);
             this.plugin.setWFSProperties(layer, fields);
             return;
         }
@@ -98,6 +98,7 @@ export class AbstractLayerHandler {
 
         this.plugin.notify('WFSPropertiesEvent', layer, layer.getLocales(), layer.getFields());
     }
+
     _getFeaturePropsInExtent (source, extent) {
         if (typeof source.getFeaturePropsInExtent === 'function') {
             return source.getFeaturePropsInExtent(extent);

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/AbstractLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/AbstractLayerHandler.ol.js
@@ -85,7 +85,7 @@ export class AbstractLayerHandler {
         const { left, bottom, right, top } = this.plugin.getSandbox().getMap().getBbox();
         const propsList = this._getFeaturePropsInExtent(source, [left, bottom, right, top]);
         // Update properties only if fields aren't set and there is features in extent
-        if (!layer.getFields().length && source.getFeatures().length) {
+        if (!layer.getFields().length && propsList.length) {
             const fields = getFieldsArray(propsList);
             this.plugin.setWFSProperties(layer, fields);
             return;


### PR DESCRIPTION
Use GetWFSLayerFields action route instead of GetLocalizedPropertyNames.

WFS layer use:
- propertyLabels {name, localized name/label}
- propertyTypes {name:type}
- propertySelection [name]
instead of locales and fields array. Deprecate fields, locales and wpsLayerParams setters. Next pr will remove getfields and getlocales usage from featuredata2 (table, filter) and gfi popup.

Set names and filter from attributes for wfs layers. Remove fields handling from userlayer and myplaces layer builders because names and locales are stored in attributes.

https://github.com/oskariorg/oskari-server/pull/691