### PR TITLE
Add WMS timeseries single year mode

### DIFF
--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesHeader.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesHeader.jsx
@@ -1,0 +1,48 @@
+import { LoginOutlined, LogoutOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import { Message, Tooltip, Spin } from 'oskari-ui';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Header, IconButton } from './styled';
+
+const getHeaderContent = (title, loading = false, error = false) => {
+    let content = title;
+    if (loading) {
+        content = (
+            <span>
+                {content} <Spin />
+            </span>
+        );
+    }
+    if (error) {
+        // TODO: give an icon with tooltip or something cleaner
+        content = <span style={{ color: 'red' }}>{content}</span>;
+    }
+    return content;
+};
+
+export const TimeSeriesHeader = ({ toggleMode, title, mode = 'year', loading = false, error = false }) => {
+    const messageKey = mode === 'year' ? 'timeseriesYearModeHelpMsg' : 'timeseriesRangeModeHelpMsg';
+    const message = <Message messageKey={messageKey} />;
+    return (
+        <Header className="timeseries-range-drag-handle">
+            {getHeaderContent(title, loading, error)}
+            <div className="header-mid-spacer"></div>
+            <Tooltip title={message}>
+                <IconButton type="text" size="large">
+                    <QuestionCircleOutlined />
+                </IconButton>
+            </Tooltip>
+            <IconButton type="text" size="large" onClick={() => toggleMode()}>
+                {mode === 'year' ? <LoginOutlined /> : <LogoutOutlined />}
+            </IconButton>
+        </Header>
+    );
+};
+
+TimeSeriesHeader.propTypes = {
+    toggleMode: PropTypes.func.isRequired,
+    title: PropTypes.string.isRequired,
+    mode: PropTypes.oneOf(['year', 'range']),
+    loading: PropTypes.bool,
+    error: PropTypes.bool
+};

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRange.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRange.jsx
@@ -1,0 +1,40 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Col, ColFixed, Row, YearInput } from './styled';
+import { YearRangeSlider } from './YearRangeSlider';
+
+export const TimeSeriesRange = ({ onChange, start, end, value, dataYears, isMobile }) => {
+    const [startValue, endValue] = value;
+    return (
+        <Row>
+            <Col>
+                <YearInput value={startValue} onChange={(val) => onChange([val, endValue])}></YearInput>
+            </Col>
+            {!isMobile && (
+                <ColFixed>
+                    <YearRangeSlider
+                        range
+                        step={1}
+                        start={start}
+                        end={end}
+                        dataYears={dataYears}
+                        value={value}
+                        onChange={(val) => onChange(val)}
+                    />
+                </ColFixed>
+            )}
+            <Col>
+                <YearInput value={endValue} onChange={(val) => onChange([startValue, val])}></YearInput>
+            </Col>
+        </Row>
+    );
+};
+
+TimeSeriesRange.propTypes = {
+    onChange: PropTypes.func.isRequired,
+    start: PropTypes.number.isRequired,
+    end: PropTypes.number.isRequired,
+    value: PropTypes.arrayOf(PropTypes.number).isRequired,
+    dataYears: PropTypes.arrayOf(PropTypes.number).isRequired,
+    isMobile: PropTypes.bool.isRequired
+};

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
@@ -1,34 +1,49 @@
 import { Controller } from 'oskari-ui/util';
 import PropTypes from 'prop-types';
-import React from 'react';
-import { Spin } from 'oskari-ui';
-import { Background, Header } from './styled';
+import React, { useState } from 'react';
+import { Background } from './styled';
+import { TimeSeriesHeader } from './TimeSeriesHeader';
 import { TimeSeriesRange } from './TimeSeriesRange';
 
-const getHeaderContent = (title, loading = false, error = false) => {
-    let content = title;
-    if (loading) {
-        content = (<span>{content} <Spin /></span>);
-    }
-    if (error) {
-        // TODO: give an icon with tooltip or something cleaner
-        content = (<span style={{ color: 'red' }}>{content}</span>);
-    }
-    return content;
-};
-
-export const TimeSeriesRangeControl = ({ controller, title, start, end, value, dataYears, isMobile, loading, error }) => {
+export const TimeSeriesRangeControl = ({
+    controller,
+    title,
+    start,
+    end,
+    value,
+    dataYears,
+    isMobile,
+    loading,
+    error
+}) => {
+    const [mode, setMode] = useState('year');
+    const toggleMode = () => {
+        if (mode === 'year') {
+            setMode('range');
+        } else {
+            setMode('year');
+        }
+    };
     return (
         <Background isMobile={isMobile}>
-            <Header className="timeseries-range-drag-handle">{ getHeaderContent(title, loading, error) }</Header>
-            <TimeSeriesRange
-                onChange={(val) => controller.updateValue(val)}
-                start={start}
-                end={end}
-                value={value}
-                dataYears={dataYears}
-                isMobile={isMobile}
+            <TimeSeriesHeader
+                toggleMode={() => toggleMode()}
+                title={title}
+                mode={mode}
+                loading={loading}
+                error={error}
             />
+            {mode === 'year' && <div>year placeholder</div>}
+            {mode === 'range' && (
+                <TimeSeriesRange
+                    onChange={(val) => controller.updateValue(val)}
+                    start={start}
+                    end={end}
+                    value={value}
+                    dataYears={dataYears}
+                    isMobile={isMobile}
+                />
+            )}
         </Background>
     );
 };

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { Background } from './styled';
 import { TimeSeriesHeader } from './TimeSeriesHeader';
 import { TimeSeriesRange } from './TimeSeriesRange';
+import { TimeSeriesYear } from './TimeSeriesYear';
 
 export const TimeSeriesRangeControl = ({
     controller,
@@ -20,8 +21,10 @@ export const TimeSeriesRangeControl = ({
     const toggleMode = () => {
         if (mode === 'year') {
             setMode('range');
+            controller.updateValue([value, value]);
         } else {
             setMode('year');
+            controller.updateValue(value[0]);
         }
     };
     return (
@@ -33,7 +36,15 @@ export const TimeSeriesRangeControl = ({
                 loading={loading}
                 error={error}
             />
-            {mode === 'year' && <div>year placeholder</div>}
+            {mode === 'year' && (
+                <TimeSeriesYear
+                    onChange={(val) => controller.updateValue(val)}
+                    start={start}
+                    end={end}
+                    value={value}
+                    dataYears={dataYears}
+                />
+            )}
             {mode === 'range' && (
                 <TimeSeriesRange
                     onChange={(val) => controller.updateValue(val)}

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
@@ -2,8 +2,8 @@ import { Controller } from 'oskari-ui/util';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Spin } from 'oskari-ui';
-import { Background, Header, Col, ColFixed, Row, YearInput } from './styled';
-import { YearRangeSlider } from './YearRangeSlider';
+import { Background, Header } from './styled';
+import { TimeSeriesRange } from './TimeSeriesRange';
 
 const getHeaderContent = (title, loading = false, error = false) => {
     let content = title;
@@ -15,40 +15,20 @@ const getHeaderContent = (title, loading = false, error = false) => {
         content = (<span style={{ color: 'red' }}>{content}</span>);
     }
     return content;
-}
+};
 
 export const TimeSeriesRangeControl = ({ controller, title, start, end, value, dataYears, isMobile, loading, error }) => {
-    const [startValue, endValue] = value;
     return (
         <Background isMobile={isMobile}>
             <Header className="timeseries-range-drag-handle">{ getHeaderContent(title, loading, error) }</Header>
-            <Row>
-                <Col>
-                    <YearInput
-                        value={startValue}
-                        onChange={(val) => controller.updateValue([val, endValue])}
-                    ></YearInput>
-                </Col>
-                {!isMobile && (
-                    <ColFixed>
-                        <YearRangeSlider
-                            range
-                            step={1}
-                            start={start}
-                            end={end}
-                            dataYears={dataYears}
-                            value={value}
-                            onChange={(val) => controller.updateValue(val)}
-                        />
-                    </ColFixed>
-                )}
-                <Col>
-                    <YearInput
-                        value={endValue}
-                        onChange={(val) => controller.updateValue([startValue, val])}
-                    ></YearInput>
-                </Col>
-            </Row>
+            <TimeSeriesRange
+                onChange={(val) => controller.updateValue(val)}
+                start={start}
+                end={end}
+                value={value}
+                dataYears={dataYears}
+                isMobile={isMobile}
+            />
         </Background>
     );
 };

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControlHandler.js
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControlHandler.js
@@ -2,8 +2,12 @@ import moment from 'moment';
 import { StateHandler, controllerMixin } from 'oskari-ui/util';
 import { TimeseriesMetadataService } from './TimeseriesMetadataService';
 
-const _getTimeFromYear = (year) => {
+const _getStartTimeFromYear = (year) => {
     return moment.utc(year.toString()).startOf('year');
+};
+
+const _getEndTimeFromYear = (year) => {
+    return moment.utc(year.toString()).endOf('year');
 };
 
 class UIHandler extends StateHandler {
@@ -20,7 +24,7 @@ class UIHandler extends StateHandler {
             title: this._layer.getName(),
             start,
             end,
-            value: [start, start],
+            value: start,
             dataYears
         };
         this.addStateListener(stateListener);
@@ -89,9 +93,17 @@ class UIHandler extends StateHandler {
     }
 
     _requestNewTime (value) {
-        const [startYear, endYear] = value;
-        const startTime = _getTimeFromYear(startYear);
-        const endTime = _getTimeFromYear(endYear);
+        let startYear = null;
+        let endYear = null;
+        if (value.length === 2) {
+            startYear = value[0];
+            endYear = value[1];
+        } else {
+            startYear = value;
+            endYear = value;
+        }
+        const startTime = _getStartTimeFromYear(startYear);
+        const endTime = _getEndTimeFromYear(endYear);
         const newTime = `${startTime.toISOString()}/${endTime.toISOString()}`;
         this._delegate.requestNewTime(newTime);
         this._updateFeaturesByTime(startTime, endTime);
@@ -106,8 +118,16 @@ class UIHandler extends StateHandler {
 
     _getTimeRange () {
         const { value } = this.getState();
-        const [startYear, endYear] = value;
-        return [_getTimeFromYear(startYear), _getTimeFromYear(endYear)];
+        let startYear = null;
+        let endYear = null;
+        if (value.length === 2) {
+            startYear = value[0];
+            endYear = value[1];
+        } else {
+            startYear = value;
+            endYear = value;
+        }
+        return [_getStartTimeFromYear(startYear), _getEndTimeFromYear(endYear)];
     }
 }
 

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesYear.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesYear.jsx
@@ -1,0 +1,69 @@
+import { StepBackwardOutlined, StepForwardOutlined } from '@ant-design/icons';
+import { Button } from 'oskari-ui';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Col, ColFixed, Row } from './styled';
+import { YearRangeSlider } from './YearRangeSlider';
+
+export const TimeSeriesYear = ({ onChange, start, end, value, dataYears }) => {
+    dataYears.sort();
+    // when current value is after last data layer
+    let prevDataYear = dataYears[dataYears.length - 1] || null;
+    let nextDataYear = null;
+    for (let i = 0; i < dataYears.length; i++) {
+        if (dataYears[i] === value) {
+            // when current value is one of the data years
+            prevDataYear = dataYears[i - 1] || null;
+            nextDataYear = dataYears[i + 1] || null;
+            break;
+        }
+        if (dataYears[i] > value) {
+            // when current value is between two data years or before first data year
+            prevDataYear = dataYears[i - 1] || null;
+            nextDataYear = dataYears[i];
+            break;
+        }
+    }
+    return (
+        <Row>
+            <Col>
+                <Button
+                    type="primary"
+                    shape="circle"
+                    disabled={prevDataYear === null}
+                    onClick={() => onChange(prevDataYear)}
+                >
+                    <StepBackwardOutlined />
+                </Button>
+            </Col>
+            <ColFixed>
+                <YearRangeSlider
+                    step={1}
+                    start={start}
+                    end={end}
+                    dataYears={dataYears}
+                    value={value}
+                    onChange={(val) => onChange(val)}
+                />
+            </ColFixed>
+            <Col>
+                <Button
+                    type="primary"
+                    shape="circle"
+                    disabled={nextDataYear === null}
+                    onClick={() => onChange(nextDataYear)}
+                >
+                    <StepForwardOutlined />
+                </Button>
+            </Col>
+        </Row>
+    );
+};
+
+TimeSeriesYear.propTypes = {
+    onChange: PropTypes.func.isRequired,
+    start: PropTypes.number.isRequired,
+    end: PropTypes.number.isRequired,
+    value: PropTypes.arrayOf(PropTypes.number).isRequired,
+    dataYears: PropTypes.arrayOf(PropTypes.number).isRequired
+};

--- a/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
@@ -45,7 +45,9 @@ export const Row = styled.div`
     display: flex;
     flex-flow: row wrap;
     justify-content: space-around;
+    align-items: flex-start;
     flex-wrap: wrap;
+    text-align: center;
 `;
 
 export const Col = styled.div`
@@ -53,6 +55,18 @@ export const Col = styled.div`
     flex-grow: 1;
     max-width: 100%;
     position: relative;
+
+    button {
+        background-color: ${primaryColor};
+        border-color: ${primaryColor};
+
+        &:hover,
+        &:focus,
+        &:active {
+            background-color: ${primaryColor};
+            border-color: ${primaryColor};
+        }
+    }
 `;
 
 export const ColFixed = styled.div`
@@ -82,6 +96,7 @@ const getDataYearStyles = (props) => {
             border: 2px solid #ffffff;
             width: 8px;
             height: 8px;
+            margin-left: -4px;
             top: -2px;
             &.ant-slider-dot-active {
                 border: 2px solid ${primaryColor};

--- a/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
@@ -1,4 +1,4 @@
-import { Slider, NumberInput } from 'oskari-ui';
+import { Button, NumberInput, Slider } from 'oskari-ui';
 import styled from 'styled-components';
 
 const primaryColor = '#ecb900';
@@ -16,6 +16,27 @@ export const Header = styled.h3`
     padding: 10px 20px;
     cursor: grab;
     cursor: move;
+    display: flex;
+    align-items: center;
+
+    .header-mid-spacer {
+        flex: 1;
+    }
+`;
+
+export const IconButton = styled(Button)`
+    padding: 10px;
+    color: ${primaryColor};
+
+    &:hover,
+    &:focus,
+    &:active {
+        color: ${primaryColor};
+    }
+
+    .anticon {
+        font-size: 20px;
+    }
 `;
 
 export const Row = styled.div`
@@ -50,9 +71,11 @@ const getDataYearStyles = (props) => {
     if (dataYears.length === 0) {
         return '';
     }
-    const markYears = Object.keys(marks).map(year => parseInt(year, 10)).sort((a, b) => a - b);
-    const dataYearIndices = dataYears.map(year => markYears.indexOf(year) + 1);
-    const selectors = dataYearIndices.map(index => `&:nth-child(${index})`).join(",");
+    const markYears = Object.keys(marks)
+        .map((year) => parseInt(year, 10))
+        .sort((a, b) => a - b);
+    const dataYearIndices = dataYears.map((year) => markYears.indexOf(year) + 1);
+    const selectors = dataYearIndices.map((index) => `&:nth-child(${index})`).join(',');
     const styles = `
         ${selectors} {
             border-radius: 50%;
@@ -86,7 +109,7 @@ export const StyledRangeSlider = styled(Slider)`
         width: 2px;
         top: 0px;
         height: 4px;
-        ${props => getDataYearStyles(props)}
+        ${(props) => getDataYearStyles(props)}
     }
     .ant-slider-dot:last-child {
         margin-left: 0px;


### PR DESCRIPTION
This PR introduces the single year mode to WMS timeseries layers. User can toggle between `range` and `single year` modes with the button on top right corner. 

![timeseries-toggle-modes](https://user-images.githubusercontent.com/1997039/110642525-c3df7080-81bb-11eb-88e6-ba8483655eec.gif)
