### PR TITLE
Minor fine tuning with timeseries mode change

### DIFF
--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
@@ -21,10 +21,10 @@ export const TimeSeriesRangeControl = ({
     const toggleMode = () => {
         if (mode === 'year') {
             setMode('range');
-            controller.updateValue([value, value]);
+            controller.updateValue([start, value]);
         } else {
             setMode('year');
-            controller.updateValue(value[0]);
+            controller.updateValue(value[1]);
         }
     };
     return (

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesYear.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesYear.jsx
@@ -38,6 +38,7 @@ export const TimeSeriesYear = ({ onChange, start, end, value, dataYears }) => {
             </Col>
             <ColFixed>
                 <YearRangeSlider
+                    included={false}
                     step={1}
                     start={start}
                     end={end}


### PR DESCRIPTION
- Remove the active color from year mode, which makes it more like a "range"
- Use start value and current year value as the new range when switching from year mode to range mode

![timeseries-modes-2](https://user-images.githubusercontent.com/1997039/110755130-47976c80-8251-11eb-96ef-641697b00470.gif)
