### PR TITLE
Timeseries WMS/WFS visibility change

### DIFF
--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeseriesMetadataService.js
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeseriesMetadataService.js
@@ -102,7 +102,7 @@ export class TimeseriesMetadataService {
         this.clearPreviousFeatures();
         const log = Oskari.log('TimeSeries');
         log.info('Toggle at: ' + this._toggleLevel, 'Current zoom is: ' + sandbox.getMap().getZoom());
-        if (this._toggleLevel === -1 || this._toggleLevel < sandbox.getMap().getZoom()) {
+        if (this._toggleLevel === -1 || this._toggleLevel >= sandbox.getMap().getZoom()) {
             // don't show features but the wms
             log.info('Not showing features, WMS should be shown');
             return;

--- a/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol.js
@@ -157,11 +157,6 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.WmsLayerPlugin',
                 }
                 // Set min max zoom levels that layer should be visible in
                 zoomLevelHelper.setOLZoomLimits(layerImpl, _layer.getMinScale(), _layer.getMaxScale());
-                // Adjust min zoom level based on timeseries metadata toggle level
-                const metadata = this._getTimeSeriesMetadata(layer);
-                if (metadata.toggleLevel > -1) {
-                    layerImpl.setMinZoom(metadata.toggleLevel);
-                }
 
                 this._log.debug('#!#! CREATED ol/layer/TileLayer for ' + _layer.getId());
                 return layerImpl;
@@ -172,12 +167,6 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.WmsLayerPlugin',
             });
             // store reference to layers
             this.setOLMapLayers(layer.getId(), olLayers);
-        },
-
-        _getTimeSeriesMetadata: function (layer) {
-            const options = layer.getOptions();
-            const timeseries = options.timeseries || {};
-            return timeseries.metadata || {};
         },
 
         _registerLayerEvents: function (layer, oskariLayer, prefix) {


### PR DESCRIPTION
This PR changes the way the timeseries WMS and metadata WFS are shown:

- WMS layer is always visible in all zoom levels if there are image available for the selected year(s)
- WFS is only visible in zoom levels that bigger than selected toggle level (zoomed in close enough) if there are features available for selected year(s)



![timeseries-wfs-toggle](https://user-images.githubusercontent.com/1997039/110945354-3e3bfc00-8346-11eb-9e2a-5e91bd758894.gif)
