### PR TITLE
Hide overlapping year marks in both ends of year range slider

### DIFF
--- a/bundles/framework/timeseries/view/TimeSeriesRange/YearRangeSlider.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/YearRangeSlider.jsx
@@ -6,10 +6,10 @@ export const YearRangeSlider = (props) => {
     const { start, end, dataYears } = props;
     const marks = {
         [start]: start,
-        [end]: end,
+        [end]: end
     };
     for (let i = start + 1; i < end; i++) {
-        if (i % 10 === 0) {
+        if (i % 10 === 0 && i - start >= 5 && end - i >= 5) {
             marks[i] = i;
         }
     }
@@ -24,5 +24,5 @@ export const YearRangeSlider = (props) => {
 YearRangeSlider.propTypes = {
     start: PropTypes.number.isRequired,
     end: PropTypes.number.isRequired,
-    dataYears: PropTypes.arrayOf(PropTypes.number).isRequired,
+    dataYears: PropTypes.arrayOf(PropTypes.number).isRequired
 };


### PR DESCRIPTION
Hide the year mark that close to the ends (year difference is less than 5 years)

![image](https://user-images.githubusercontent.com/1997039/111144631-f9a3a100-858f-11eb-9385-7d519609fa07.png)
