### PR TITLE
Fix year parsing in timeseries

### DIFF
--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControlHandler.js
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControlHandler.js
@@ -3,11 +3,11 @@ import { StateHandler, controllerMixin } from 'oskari-ui/util';
 import { TimeseriesMetadataService } from './TimeseriesMetadataService';
 
 const _getStartTimeFromYear = (year) => {
-    return moment.utc(year.toString()).startOf('year');
+    return moment.utc(year.toString(), 'YYYY').startOf('year');
 };
 
 const _getEndTimeFromYear = (year) => {
-    return moment.utc(year.toString()).endOf('year');
+    return moment.utc(year.toString(), 'YYYY').endOf('year');
 };
 
 class UIHandler extends StateHandler {


### PR DESCRIPTION
Reference moment.js docs:

> Warning: Browser support for parsing strings is inconsistent. Because there is no specification on which formats should be supported, what works in some browsers will not work in other browsers.
> 
> For consistent results parsing anything other than ISO 8601 strings, you should use String + Format.