### PR TITLE
Restrict timeseries range mode input number min/max

### DIFF
--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRange.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRange.jsx
@@ -8,7 +8,12 @@ export const TimeSeriesRange = ({ onChange, start, end, value, dataYears, isMobi
     return (
         <Row>
             <Col>
-                <YearInput value={startValue} onChange={(val) => onChange([val, endValue])}></YearInput>
+                <YearInput
+                    value={startValue}
+                    min={start}
+                    max={endValue}
+                    onChange={(val) => onChange([val, endValue])}
+                ></YearInput>
             </Col>
             {!isMobile && (
                 <ColFixed>
@@ -24,7 +29,12 @@ export const TimeSeriesRange = ({ onChange, start, end, value, dataYears, isMobi
                 </ColFixed>
             )}
             <Col>
-                <YearInput value={endValue} onChange={(val) => onChange([startValue, val])}></YearInput>
+                <YearInput
+                    value={endValue}
+                    min={startValue}
+                    max={end}
+                    onChange={(val) => onChange([startValue, val])}
+                ></YearInput>
             </Col>
         </Row>
     );


### PR DESCRIPTION
The low end value should not exceed the high end value

![restrict-timeseries-range-input-number](https://user-images.githubusercontent.com/1997039/111643978-10ecc380-8808-11eb-91df-302ee7359f4a.gif)
