### PR TITLE
Remove the fill color of timeseries metadata boxes

### DIFF
--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeseriesMetadataService.js
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeseriesMetadataService.js
@@ -7,7 +7,7 @@ const DEFAULT_STYLE = {
         color: 'rgba(0, 0, 0, 0.8)'
     },
     fill: {
-        color: 'rgba(24, 219, 218, 0.5)'
+        color: null
     }
 };
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1997039/111767912-f110da80-88af-11eb-8a2f-b3910753b0f8.png)
