### PR TITLE
Fix "Update now" for layer admin

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -949,7 +949,7 @@ class UIHandler extends StateHandler {
             if (success.includes(`${layer.id}`)) {
                 const { admin = {} } = layerUpdate;
                 const { capabilities } = admin;
-                layer.capabilities = capabilities
+                layer.capabilities = capabilities;
                 this.updateState({
                     layer,
                     messages: [{ key: 'capabilities.updatedSuccesfully', type: 'success' }]

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -945,10 +945,13 @@ class UIHandler extends StateHandler {
                 return Promise.reject(new Error('Updating capabilities failed'));
             }
         }).then(data => {
-            const { success, error, layerData = {} } = data;
+            const { success, error, layerUpdate = {} } = data;
             if (success.includes(`${layer.id}`)) {
+                const { admin = {} } = layerUpdate;
+                const { capabilities } = admin;
+                layer.capabilities = capabilities
                 this.updateState({
-                    capabilities: layerData.capabilities,
+                    layer,
                     messages: [{ key: 'capabilities.updatedSuccesfully', type: 'success' }]
                 });
             } else {


### PR DESCRIPTION
The button calls action route `UpdateCapabilities` which returns this kind of JSON:
```{
    "layerUpdate": {
        ...,
        "admin": {
            "capabilities": { ... the updated capabilities ... },
            ...
        },
        "type":"wmslayer",
        ...
    },
    "success":["2022"],
    "error":{}
}
```
Where `layerUpdate` contains layer details used by the maplayerservice (not the format used by the admin-layereditor). If we want to update the newly parsed capabilities for the layer we triggered the update we don't get it from `layerData` like it's used here but under the `layerUpdate` key. Also there's no capabilities object directly under it but we have to get if from under `admin`. Also we need to update the state with capabilities under `layer` not the `capabilities` in the state "root".
