### PR TITLE
Support custom formatters for GFI responses

### DIFF
--- a/api/mapping/timeseries/bundle.md
+++ b/api/mapping/timeseries/bundle.md
@@ -14,6 +14,24 @@ Bundles that handle timeseries data/functionality can register with TimeseriesSe
 
 Bundles that define a new layer type, and which want to support animation, must register a class that will be instantiated for each timeseries enabled layer to implement the animation. This bundle itself registers a animator for "WMS" layers.
 
+Admin can choose different control UI for timeseries enabled layers, and it's saved in layer options under `timeseries` entry as:
+
+```json
+{
+  "timeseries": {
+    "ui": "player|range|none",
+    "metadata": {
+      "layer": "<metadata layer id>",
+      "attribute": "<time attribute used to filter metadata layer>",
+      "toggleLevel": "<map toggle level at which the metadata layer will be shown>"
+    }
+  }
+}
+
+```
+
+The metadata is in use when `range` ui is selected
+
 ## Example - general case
 
 Bundle that wants to show timeseries control UI can register with TimeseriesService:
@@ -61,6 +79,14 @@ After registering the new type, TimeseriesLayerService will create delegates aut
 
 No configuration is required.
 
+
+## Bundle state
+
+```json
+{"time": ["start time", "end time"] }
+```
+
+Currently the bundle state is only recognized by range UI.
 
 ## Requests the bundle sends out
 


### PR DESCRIPTION
Example changes needed in sample application:

```javascript
class TimeSeriesLatestPhotoYearFormatter {

    static identifier = "latestPhotoYear";

    enabled(data) {
        const layer = Oskari.getSandbox().getService('Oskari.mapframework.service.MapLayerService').findMapLayer(data.layerId);
        return layer.getAttributes().formatter === TimeSeriesLatestPhotoYearFormatter.identifier;
    }

    format(data) {
        const geojson = JSON.parse(data.content);
        const photoYearAttr = 'kuvausvuosi';
        const years = geojson.features.map(feature => parseInt(feature.properties[photoYearAttr], 10));
        return `<b>${photoYearAttr}:</b> ${Math.max(...years)}`;
    }
};


jQuery(document).ready(function() {
    function onSuccess () {
        var service = Oskari.getSandbox().getService('Oskari.map.DataProviderInfoService');
        if (service) {
            service.addGroup('osm.nominatim', 'Search', [
                { 'id': 'nominatim.attribution', 'name': 'The search functionality uses OpenStreetMap Nominatim, licensed under ODbL <a href="https://www.openstreetmap.org/copyright" target="_blank" ref="noopener">© OpenStreetMap contributors</a>' }
            ]);
        }
        const formatter = new TimeSeriesLatestPhotoYearFormatter();
        Oskari.getSandbox().findRegisteredModuleInstance('MainMapModuleGetInfoPlugin').addLayerFormatter(formatter);
    }
    function onError () {
        jQuery('#mapdiv').append('Unable to start');
    }
    Oskari.app.loadAppSetup(ajaxUrl + 'action_route=GetAppSetup', window.controlParams, onError, onSuccess);
});

```

![image](https://user-images.githubusercontent.com/1997039/112844317-4321df00-90ac-11eb-8aea-54630c8212d0.png)
