### PR TITLE
Fix delegate check for timeseries

### DIFF
--- a/bundles/framework/timeseries/instance.js
+++ b/bundles/framework/timeseries/instance.js
@@ -111,11 +111,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesToolBundleI
                 var conf = jQuery.extend(true, {}, this._controlPluginConf || {}, active.conf);
                 if (typeof conf.showControl === 'undefined' || conf.showControl) {
                     const controlClass = this._getControlPluginClazz(active.delegate);
-                    if (
-                        this._controlPlugin &&
-                        this._controlPlugin.getClazz() === controlClass &&
-                        this._controlPlugin.isControlling(active.delegate)
-                    ) {
+                    if (this._isCurrentlyControlling(controlClass, active.delegate)) {
                         // do not update control ui if there's no changes in ui type and layer
                         return;
                     }
@@ -126,6 +122,19 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesToolBundleI
                 }
             }
             this._removeControlPlugin();
+        },
+        _isCurrentlyControlling: function(controlClass, delegate) {
+            if (!this._controlPlugin) {
+                return false;
+            }
+            if (this._controlPlugin.getClazz() !== controlClass) {
+                return false;
+            }
+            if (typeof this._controlPlugin.isControlling === 'function') {
+                // don't know for sure but isControlling is not implemented on this control
+                return false;
+            }
+            return this._controlPlugin.isControlling(delegate)
         },
         /**
          * @method _getControlPluginClazz

--- a/bundles/framework/timeseries/instance.js
+++ b/bundles/framework/timeseries/instance.js
@@ -114,7 +114,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesToolBundleI
                     if (
                         this._controlPlugin &&
                         this._controlPlugin.getClazz() === controlClass &&
-                        this._controlPlugin.delegate.getLayer().getId() === active.delegate.getLayer().getId()
+                        this._controlPlugin.isControlling(active.delegate)
                     ) {
                         // do not update control ui if there's no changes in ui type and layer
                         return;

--- a/bundles/framework/timeseries/instance.js
+++ b/bundles/framework/timeseries/instance.js
@@ -123,7 +123,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesToolBundleI
             }
             this._removeControlPlugin();
         },
-        _isCurrentlyControlling: function(controlClass, delegate) {
+        _isCurrentlyControlling: function (controlClass, delegate) {
             if (!this._controlPlugin) {
                 return false;
             }
@@ -134,7 +134,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesToolBundleI
                 // don't know for sure but isControlling is not implemented on this control
                 return false;
             }
-            return this._controlPlugin.isControlling(delegate)
+            return this._controlPlugin.isControlling(delegate);
         },
         /**
          * @method _getControlPluginClazz

--- a/bundles/framework/timeseries/view/TimeSeriesRangeControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeSeriesRangeControlPlugin.js
@@ -94,6 +94,35 @@ class TimeSeriesRangeControlPlugin extends BasicMapModulePlugin {
         });
     }
 
+    /**
+     * Compares delegate to controls own delegate to see if it's being controlled by this plugin
+     * @param {Oskari.mapframework.bundle.timeseries.TimeseriesDelegate} delegate for comparison
+     * @returns {Boolean}
+     */
+    isControlling (delegate) {
+        if (!delegate) {
+            return false;
+        }
+        if (!this._delegate) {
+            return false;
+        }
+        if (this._delegate._clazz !== delegate._clazz) {
+            return false;
+        }
+        // we only have the WMSAnimator at this time but check that delegate is it so we can expect to find getLayer()
+        if (this._delegate._clazz !== 'Oskari.mapframework.bundle.timeseries.WMSAnimator') {
+            return false;
+        }
+        // here we can be sure that delegate and this._delegate are both WMSAnimator
+        const myLayer = this._delegate.getLayer();
+        const theirLayer = delegate.getLayer();
+        if (!myLayer || !theirLayer) {
+            return false;
+        }
+
+        return myLayer.getId() === theirLayer.getId();
+    }
+
     _createControlElement () {
         return jQuery('<div class="mapplugin timeseriesrangecontrolplugin"></div>');
     }

--- a/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
@@ -106,6 +106,34 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
             return this._uiState.currentTime;
         },
         /**
+         * Compares delegate to controls own delegate to see if it's being controlled by this plugin
+         * @param {Oskari.mapframework.bundle.timeseries.TimeseriesDelegate} delegate for comparison
+         * @returns {Boolean}
+         */
+        isControlling: function (delegate) {
+            if (!delegate) {
+                return false;
+            }
+            if (!this._delegate) {
+                return false;
+            }
+            if (this._delegate._clazz !== delegate._clazz) {
+                return false;
+            }
+            // we only have the WMSAnimator at this time but check that delegate is it so we can expect to find getLayer()
+            if (this._delegate._clazz !== 'Oskari.mapframework.bundle.timeseries.WMSAnimator') {
+                return false;
+            }
+            // here we can be sure that delegate and this._delegate are both WMSAnimator
+            const myLayer = this._delegate.getLayer();
+            const theirLayer = delegate.getLayer();
+            if (!myLayer || !theirLayer) {
+                return false;
+            }
+
+            return myLayer.getId() === theirLayer.getId();
+        },
+        /**
          * @method _filterSkipOptions Return animation skip options that are longer or as long than the shortest time interval in the series
          * @private
          * @param  {String[]} times time instants in timeseries, ISO-string


### PR DESCRIPTION
Fixes an error from timeseries referencing a wrong variable:
```
Error notifying about activeChanged TypeError: Cannot read property 'getLayer' of undefined
    at Oskari.clazz.define.__name._updateControl (instance.js:88)
    at events.js:59
```