### PR TITLE
Various improvements to layer swipe tool

### DIFF
--- a/bundles/mapping/layerswipe/instance.js
+++ b/bundles/mapping/layerswipe/instance.js
@@ -27,7 +27,13 @@ Oskari.clazz.define(
                 iconCls: 'tool-layer-swipe',
                 tooltip: this.loc('toolLayerSwipe'),
                 sticky: true,
-                callback: () => this.setActive(!this.active)
+                callback: () => {
+                    if (this.active) {
+                        this.activateDefaultMapTool();
+                    } else {
+                        this.setActive(true);
+                    }
+                }
             };
             sandbox.request(this, addToolButtonBuilder('LayerSwipe', 'basictools', buttonConf));
         },
@@ -36,6 +42,7 @@ Oskari.clazz.define(
             if (active) {
                 const layer = this.getTopmostLayer();
                 if (layer === null) {
+                    this.activateDefaultMapTool();
                     this.showAlert();
                     return;
                 }
@@ -57,11 +64,16 @@ Oskari.clazz.define(
             this.unregisterEventListeners();
             const layer = this.getTopmostLayer();
             if (layer === null) {
-                this.setActive(false);
+                this.activateDefaultMapTool();
                 this.showAlert();
                 return;
             }
             this.registerEventListeners(layer);
+        },
+
+        activateDefaultMapTool: function () {
+            // reset toolbar to use the default tool
+            Oskari.getSandbox().postRequestByName('Toolbar.SelectToolButtonRequest', []);
         },
 
         showAlert: function () {
@@ -71,7 +83,10 @@ Oskari.clazz.define(
         },
 
         getTopmostLayer: function () {
-            const layers = this.map.getLayers().getArray().filter(layer => layer.getVisible() && !(layer instanceof VectorLayer));
+            const layers = this.map
+                .getLayers()
+                .getArray()
+                .filter((layer) => layer.getVisible() && !(layer instanceof VectorLayer));
             return layers.length !== 0 ? layers[layers.length - 1] : null;
         },
 
@@ -106,7 +121,7 @@ Oskari.clazz.define(
         },
 
         unregisterEventListeners: function () {
-            this.eventListenerKeys.forEach(key => unByKey(key));
+            this.eventListenerKeys.forEach((key) => unByKey(key));
             this.eventListenerKeys = [];
         },
 
@@ -148,12 +163,12 @@ Oskari.clazz.define(
                     this.setActive(false);
                 }
             },
-            'AfterMapLayerAddEvent': function (event) {
+            AfterMapLayerAddEvent: function (event) {
                 if (this.active) {
                     this.updateSwipeLayer();
                 }
             },
-            'AfterMapLayerRemoveEvent': function (event) {
+            AfterMapLayerRemoveEvent: function (event) {
                 if (this.active) {
                     this.updateSwipeLayer();
                 }

--- a/bundles/mapping/layerswipe/instance.js
+++ b/bundles/mapping/layerswipe/instance.js
@@ -117,14 +117,21 @@ Oskari.clazz.define(
                     containment: '#mapdiv',
                     axis: 'x',
                     drag: () => {
-                        const mapOffset = jQuery('#mapdiv').offset();
-                        const splitterOffset = jQuery('.layer-swipe-splitter').offset();
-                        this.cropSize = splitterOffset.left - mapOffset.left + this.splitterWidth / 2;
-                        this.map.render();
+                        this.updateMapCropping();
+                    },
+                    stop: () => {
+                        this.updateMapCropping();
                     }
                 });
             }
             return this.splitter;
+        },
+
+        updateMapCropping: function () {
+            const mapOffset = jQuery('#mapdiv').offset();
+            const splitterOffset = jQuery('.layer-swipe-splitter').offset();
+            this.cropSize = splitterOffset.left - mapOffset.left + this.splitterWidth / 2;
+            this.map.render();
         },
 
         showSplitter: function () {

--- a/bundles/mapping/layerswipe/resources/locale/en.js
+++ b/bundles/mapping/layerswipe/resources/locale/en.js
@@ -2,6 +2,11 @@ Oskari.registerLocalization({
     lang: 'en',
     key: 'LayerSwipe',
     value: {
-        toolLayerSwipe: 'Swipe: Compare the topmost map layer with other map layers'
+        toolLayerSwipe: 'Swipe: Compare the topmost map layer with other map layers',
+        alert: {
+            ok: 'OK',
+            swipeNoRasterTitle: 'There is no raster layer selected to use with the map swipe tool',
+            swipeNoRasterMessage: 'Set a raster map layer visible.'
+        }
     }
 });

--- a/bundles/mapping/layerswipe/resources/locale/fi.js
+++ b/bundles/mapping/layerswipe/resources/locale/fi.js
@@ -2,6 +2,11 @@ Oskari.registerLocalization({
     lang: 'fi',
     key: 'LayerSwipe',
     value: {
-        toolLayerSwipe: 'Vertaa ylintä karttatasoa alempiin karttatasoihin'
+        toolLayerSwipe: 'Vertaa ylintä karttatasoa alempiin karttatasoihin',
+        alert: {
+            ok: 'OK',
+            swipeNoRasterTitle: 'Yhtään rasterikarttatasoa ei ole valittuna käytettäväksi vertailutyökalun kanssa',
+            swipeNoRasterMessage: 'Aseta karttatasovalikosta rasteritaso näkyväksi'
+        }
     }
 });

--- a/bundles/mapping/layerswipe/resources/locale/sv.js
+++ b/bundles/mapping/layerswipe/resources/locale/sv.js
@@ -2,6 +2,11 @@ Oskari.registerLocalization({
     lang: 'sv',
     key: 'LayerSwipe',
     value: {
-        toolLayerSwipe: 'Jämför kartlagret högst uppe med nedanstående kartlager'
+        toolLayerSwipe: 'Jämför kartlagret högst uppe med nedanstående kartlager',
+        alert: {
+            ok: 'OK',
+            swipeNoRasterTitle: 'Inget kartlager i rasterformat har valts för jämföring',
+            swipeNoRasterMessage: 'Lägg till raster kartlager i kartvyn.'
+        }
     }
 });


### PR DESCRIPTION
This PR includes several improvements to the layer swipe tool:

- Show a popup when there's no raster layer available and deactivate the tool immediately
- Fix the gap issue between the swipe splitter and map boundary when dragging the splitter too fast
- Reset to default map tool when layer swipe is deactivated

![temp](https://user-images.githubusercontent.com/1997039/114388012-cf97cb80-9b9b-11eb-846f-aecc7d6c36dc.gif)
