### PR TITLE
Show alert message when swipe layer is not visible in current map view

### DIFF
--- a/bundles/mapping/layerswipe/resources/locale/en.js
+++ b/bundles/mapping/layerswipe/resources/locale/en.js
@@ -6,7 +6,9 @@ Oskari.registerLocalization({
         alert: {
             ok: 'OK',
             swipeNoRasterTitle: 'There is no raster layer selected to use with the map swipe tool',
-            swipeNoRasterMessage: 'Set a raster map layer visible.'
+            swipeNoRasterMessage: 'Set a raster map layer visible.',
+            swipeLayerNotVisibleTitle: 'Topmost layer is not visible in the current view',
+            swipeLayerNotVisibleMessage: 'Swipe feature is not working properly. Move the map view to a location with data visible in the top most layer'
         }
     }
 });

--- a/bundles/mapping/layerswipe/resources/locale/fi.js
+++ b/bundles/mapping/layerswipe/resources/locale/fi.js
@@ -6,7 +6,9 @@ Oskari.registerLocalization({
         alert: {
             ok: 'OK',
             swipeNoRasterTitle: 'Yhtään rasterikarttatasoa ei ole valittuna käytettäväksi vertailutyökalun kanssa',
-            swipeNoRasterMessage: 'Aseta karttatasovalikosta rasteritaso näkyväksi'
+            swipeNoRasterMessage: 'Aseta karttatasovalikosta rasteritaso näkyväksi',
+            swipeLayerNotVisibleTitle: 'Ylin karttataso ei näy tässä näkymässä',
+            swipeLayerNotVisibleMessage: 'Karttatasojen vertailu ei toimi. Siirry näkymässä sijaintiin, jossa ylin karttataso on näkyvissä'
         }
     }
 });


### PR DESCRIPTION
This PR also adds an event listener to update the swipe layer when layers are rearranged

![swipe-not-visible](https://user-images.githubusercontent.com/1997039/114524892-48eff680-9c4e-11eb-9f67-91cbd89aa910.gif)
