### PR TITLE
Fix function name for RPC

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -2633,7 +2633,7 @@ Oskari.clazz.define(
                 return me.getMapZoom();
             });
 
-            rpcService.addFunction('getPixelMeasuresInScal', function (mmMeasures, scale) {
+            rpcService.addFunction('getPixelMeasuresInScale', function (mmMeasures, scale) {
                 let scalein = scale;
                 let pixelMeasures = [];
                 let zoomLevel = 0;


### PR DESCRIPTION
Add the missing e that caused problems with function name change on RPC clients.

Caused by #1485 