### PR TITLE
Responsive range slider

### DIFF
--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
@@ -1,6 +1,6 @@
 import { Controller } from 'oskari-ui/util';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React from 'react';
 import { Background } from './styled';
 import { TimeSeriesHeader } from './TimeSeriesHeader';
 import { TimeSeriesRange } from './TimeSeriesRange';
@@ -41,6 +41,7 @@ export const TimeSeriesRangeControl = ({
                     end={end}
                     value={value}
                     dataYears={dataYears}
+                    isMobile={isMobile}
                 />
             )}
             {mode === 'range' && (

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesYear.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesYear.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { Col, ColFixed, Row } from './styled';
 import { YearRangeSlider } from './YearRangeSlider';
 
-export const TimeSeriesYear = ({ onChange, start, end, value, dataYears }) => {
+export const TimeSeriesYear = ({ onChange, start, end, value, dataYears, isMobile }) => {
     // when current value is after last data layer
     let prevDataYear = dataYears[dataYears.length - 1] || null;
     let nextDataYear = null;
@@ -37,6 +37,7 @@ export const TimeSeriesYear = ({ onChange, start, end, value, dataYears }) => {
             </Col>
             <ColFixed>
                 <YearRangeSlider
+                    isMobile={isMobile}
                     included={false}
                     step={1}
                     start={start}
@@ -65,5 +66,6 @@ TimeSeriesYear.propTypes = {
     start: PropTypes.number.isRequired,
     end: PropTypes.number.isRequired,
     value: PropTypes.number.isRequired,
-    dataYears: PropTypes.arrayOf(PropTypes.number).isRequired
+    dataYears: PropTypes.arrayOf(PropTypes.number).isRequired,
+    isMobile: PropTypes.bool.isRequired
 };

--- a/bundles/framework/timeseries/view/TimeSeriesRange/YearRangeSlider.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/YearRangeSlider.jsx
@@ -3,14 +3,19 @@ import React from 'react';
 import { StyledRangeSlider } from './styled';
 
 export const YearRangeSlider = (props) => {
-    const { start, end, dataYears } = props;
+    const { start, end, dataYears, isMobile } = props;
     const marks = {
         [start]: start,
         [end]: end
     };
-    for (let i = start + 1; i < end; i++) {
-        if (i % 10 === 0 && i - start >= 5 && end - i >= 5) {
-            marks[i] = i;
+    if (isMobile) {
+        const middle = Math.round((start + end) / 2);
+        marks[middle] = middle;
+    } else {
+        for (let i = start + 1; i < end; i++) {
+            if (i % 10 === 0 && i - start >= 5 && end - i >= 5) {
+                marks[i] = i;
+            }
         }
     }
 
@@ -24,5 +29,6 @@ export const YearRangeSlider = (props) => {
 YearRangeSlider.propTypes = {
     start: PropTypes.number.isRequired,
     end: PropTypes.number.isRequired,
-    dataYears: PropTypes.arrayOf(PropTypes.number).isRequired
+    dataYears: PropTypes.arrayOf(PropTypes.number).isRequired,
+    isMobile: PropTypes.bool.isRequired
 };

--- a/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
@@ -77,8 +77,6 @@ export const ColFixed = styled.div`
 `;
 
 export const YearInput = styled(NumberInput)`
-    margin-left: 18px;
-
     .ant-input-number-handler-wrap {
         opacity: 1;
     }

--- a/bundles/framework/timeseries/view/TimeSeriesRangeControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeSeriesRangeControlPlugin.js
@@ -129,8 +129,24 @@ class TimeSeriesRangeControlPlugin extends BasicMapModulePlugin {
 
     _createEventHandlers () {
         return {
-            AfterMapMoveEvent: () => this._updateCurrentViewportBbox()
+            AfterMapMoveEvent: () => this._updateCurrentViewportBbox(),
+            MapSizeChangedEvent: () => {
+                const isMobileCurrent = Oskari.util.isMobile();
+                const isMobilePrevious = this._getMobileMode();
+                if (isMobilePrevious !== isMobileCurrent) {
+                    this._setMobileMode(isMobileCurrent);
+                    this.redrawUI(isMobileCurrent, true);
+                }
+            }
         };
+    }
+
+    _getMobileMode () {
+        return this._isMobile;
+    }
+
+    _setMobileMode (isMobile) {
+        this._isMobile = isMobile;
     }
 
     _updateCurrentViewportBbox () {


### PR DESCRIPTION
This PR includes following changes:

- Make the timeseries range UI reacts to map size change dynamically
- Make the timeseries year mode more mobile friend (show labels for middle and both ends only)
- Adjust the margin between YearInput and Slider so that the slider end year label is not covered

Year mode mobile view:
![image](https://user-images.githubusercontent.com/1997039/114718700-ed516600-9d3e-11eb-861c-1fa1e6bd37fb.png)

Adjusted the YearInput margin:
![image](https://user-images.githubusercontent.com/1997039/114718614-d4e14b80-9d3e-11eb-9e4a-1c1562a573b2.png)
