### PR TITLE
Remove duplicated messages from admin-layereditor

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
@@ -46,7 +46,6 @@ const AdminLayerForm = ({
     versions,
     layer,
     propertyFields,
-    messages = [],
     tab,
     onCancel,
     onDelete,
@@ -65,11 +64,6 @@ const AdminLayerForm = ({
         validPermissions = permissionValidator(layer);
     }
     return (<StyledRoot>
-        { messages.map(({ key, type, args }) =>
-            <StyledAlert key={key} type={type} message={
-                <Message messageKey={key} messageArgs={args}/>
-            }/>
-        )}
         <Tabs activeKey={tab} onChange={tabKey => controller.setTab(tabKey)}>
             <TabPane key='general' tab={<Message messageKey='generalTabTitle'/>}>
                 <GeneralTabPane
@@ -137,7 +131,6 @@ AdminLayerForm.propTypes = {
     versions: PropTypes.array.isRequired,
     layer: PropTypes.object.isRequired,
     propertyFields: PropTypes.arrayOf(PropTypes.string).isRequired,
-    messages: PropTypes.array,
     onCancel: PropTypes.func,
     onSave: PropTypes.func,
     onDelete: PropTypes.func,

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -27,7 +27,6 @@ class UIHandler extends StateHandler {
             versions: [],
             propertyFields: [],
             capabilities: {},
-            messages: [],
             loading: false,
             tab: DEFAULT_TAB,
             credentialsCollapseOpen: false,
@@ -457,16 +456,6 @@ class UIHandler extends StateHandler {
         this.updateState({ layer });
     }
 
-    setMessage (key, type, args) {
-        this.updateState({
-            messages: [{ key, type, args }]
-        });
-    }
-
-    setMessages (messages) {
-        this.updateState({ messages });
-    }
-
     setTab (tab) {
         this.updateState({ tab });
     }
@@ -536,7 +525,6 @@ class UIHandler extends StateHandler {
 
     // http://localhost:8080/action?action_route=LayerAdmin&id=889
     fetchLayer (id, keepCapabilities = false) {
-        this.clearMessages();
         if (!id) {
             // adding new layer
             this.resetLayer();
@@ -1016,12 +1004,6 @@ class UIHandler extends StateHandler {
         return this.loadingCount > 0;
     }
 
-    clearMessages () {
-        this.updateState({
-            messages: []
-        });
-    }
-
     clearCredentialsCollapse () {
         this.updateState({ credentialsCollapseOpen: false });
     }
@@ -1089,8 +1071,6 @@ const wrapped = controllerMixin(UIHandler, [
     'setLayerUrl',
     'setLegendUrl',
     'setLocalizedNames',
-    'setMessage',
-    'setMessages',
     'setMetadataIdentifier',
     'setMinAndMaxScale',
     'setOpacity',

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -951,9 +951,9 @@ class UIHandler extends StateHandler {
                 const { capabilities } = admin;
                 layer.capabilities = capabilities;
                 this.updateState({
-                    layer,
-                    messages: [{ key: 'capabilities.updatedSuccesfully', type: 'success' }]
+                    layer
                 });
+                Messaging.success(getMessage('capabilities.updatedSuccesfully'));
             } else {
                 if (error) {
                     updateFailed(Object.values(error)[0]);

--- a/bundles/admin/admin-layereditor/view/Flyout.js
+++ b/bundles/admin/admin-layereditor/view/Flyout.js
@@ -99,7 +99,6 @@ export class LayerEditorFlyout extends ExtraFlyout {
                         mapLayerGroups={this.mapLayerGroups}
                         dataProviders={this.dataProviders}
                         versions={versions}
-                        messages={messages}
                         rolesAndPermissionTypes={this.uiHandler.getAdminMetadata()}
                         validators={this.uiHandler.getValidatorFunctions(layer.type)}
                         validationErrors={this.uiHandler.validateUserInputValues(layer)}

--- a/bundles/admin/admin-layereditor/view/Flyout.js
+++ b/bundles/admin/admin-layereditor/view/Flyout.js
@@ -68,7 +68,6 @@ export class LayerEditorFlyout extends ExtraFlyout {
             versions,
             capabilities,
             loading,
-            messages,
             propertyFields,
             credentialsCollapseOpen,
             tab,
@@ -85,10 +84,8 @@ export class LayerEditorFlyout extends ExtraFlyout {
                     loading={loading}
                     layerTypes={layerTypes}
                     versions={versions}
-                    messages={messages}
                     credentialsCollapseOpen={credentialsCollapseOpen}
                     onCancel={() => {
-                        this.uiHandler.clearMessages();
                         this.uiHandler.clearCredentialsCollapse();
                     }}>
                     <AdminLayerForm
@@ -107,7 +104,6 @@ export class LayerEditorFlyout extends ExtraFlyout {
                         onDelete={() => this.uiHandler.deleteLayer()}
                         onSave={() => this.uiHandler.saveLayer()}
                         onCancel={() => {
-                            this.uiHandler.clearMessages();
                             this.hide();
                         }} />
                 </LayerWizard>
@@ -120,6 +116,5 @@ export class LayerEditorFlyout extends ExtraFlyout {
             return;
         }
         ReactDOM.unmountComponentAtNode(el.get(0));
-        this.uiHandler.clearMessages();
     }
 }

--- a/bundles/admin/admin-layereditor/view/LayerWizard/LayerWizard.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard/LayerWizard.jsx
@@ -56,7 +56,6 @@ const LayerWizard = ({
     loading,
     children,
     versions,
-    messages = [],
     credentialsCollapseOpen,
     onCancel
 }) => {
@@ -68,7 +67,6 @@ const LayerWizard = ({
     const isDetailsForOldLayer = !layer.isNew && currentStep === WIZARD_STEP.DETAILS;
     return (
         <Fragment>
-            { messages.map(({ key, type }) => <StyledAlert key={key} message={<Message messageKey={key} />} type={type} />) }
             <LoadingIndicator loading={loading}>
                 { (layer.isNew || currentStep !== WIZARD_STEP.DETAILS) &&
                     <StyledSteps current={currentStep}>
@@ -132,7 +130,6 @@ LayerWizard.propTypes = {
     layerTypes: PropTypes.array,
     children: PropTypes.any,
     versions: PropTypes.array.isRequired,
-    messages: PropTypes.array,
     credentialsCollapseOpen: PropTypes.bool.isRequired,
     onCancel: PropTypes.func.isRequired
 };


### PR DESCRIPTION
And refactor a bit so messages are always shown using the Messaging-component instead of the "messages" variable through layer-editor state.