### PR TITLE
Use triggerNode parent container as timeseries slider tooltip container

### DIFF
--- a/bundles/framework/timeseries/view/TimeSeriesRange/YearRangeSlider.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/YearRangeSlider.jsx
@@ -23,7 +23,16 @@ export const YearRangeSlider = (props) => {
     // data years are also marks on the range slider but they are represented
     // as small circles on the timeline (via css styling)
     dataYears.filter((year) => !marks[year]).forEach((year) => (marks[year] = ''));
-    return <StyledRangeSlider {...props} tooltipVisible marks={marks} min={start} max={end} />;
+    return (
+        <StyledRangeSlider
+            {...props}
+            tooltipVisible
+            getTooltipPopupContainer={(triggerNode) => triggerNode.parentElement}
+            marks={marks}
+            min={start}
+            max={end}
+        />
+    );
 };
 
 YearRangeSlider.propTypes = {


### PR DESCRIPTION
By default it uses the document body as the tooltip container, which
causes the flyout window appears under the timeseries tooltip. And also
the tooltips are not destroyed properly when timeseries ui is closed.

![tooltip-fix](https://user-images.githubusercontent.com/1997039/114982656-67493280-9e98-11eb-9096-44712e3fe5b8.gif)
