### PR TITLE
Show layer name as html

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/Layer/Layer.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/Layer/Layer.jsx
@@ -46,6 +46,13 @@ const onToolClick = tool => {
     }
 };
 
+// The layer model has entity-references for < > etc (&gt; &lt;)
+// FIXME: after 2.4.0 when we remove the older layerlisting bundles we can
+//  have the name in the model without encoding and NOT use dangerouslySetInnerHTML
+const LayerName = ({ layer }) => {
+    return (<div dangerouslySetInnerHTML={{__html: layer.getName()}} />);
+};
+
 const Layer = ({ model, even, selected, controller }) => {
     return (
         <LayerDiv even={even} className="layer">
@@ -65,7 +72,7 @@ const Layer = ({ model, even, selected, controller }) => {
                     <Switch size="small" checked={selected}
                         onChange={checked => onSelect(checked, model.getId(), controller)}
                         disabled={model.isSticky()} />
-                    <div>{model.getName()}</div>
+                    <LayerName layer={ model } />
                 </Label>
             </Body>
             <LayerTools model={model} controller={controller}/>

--- a/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/LayerBox.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/LayerBox.jsx
@@ -43,7 +43,10 @@ const LayerBox = ({ layer, index, visibilityInfo, controller }) => {
         controller.removeLayer(layer);
     };
     const getName = () => {
-        const field = <b>{layer.getName()}</b>;
+        // The layer model has entity-references for < > etc (&gt; &lt;)
+        // FIXME: after 2.4.0 when we remove the older layerlisting bundles we can
+        //  have the name in the model without encoding and NOT use dangerouslySetInnerHTML
+        const field = <b dangerouslySetInnerHTML={{__html: layer.getName()}} />;
         const description = layer.getDescription();
         if (!description) {
             return field;


### PR DESCRIPTION
Treat layer name as HTML to allow special characters to show correctly.

The layer name that is shown to user is sanitized here because older jQuery-based layer listing bundles: https://github.com/oskariorg/oskari-frontend/blob/2.2.0/bundles/mapping/mapmodule/domain/AbstractLayer.js#L262-L272

After oskariorg/oskari-docs#245 we can change AbstractLayer to have the "raw value" as name and remove use of `dangerouslySetInnerHTML` added in this PR (in 2.4.0 possibly).