### PR TITLE
Prevent JS-errors on tooltips for styled components

### DIFF
--- a/src/react/components/Tooltip.jsx
+++ b/src/react/components/Tooltip.jsx
@@ -2,4 +2,8 @@ import React from 'react';
 import { Tooltip as AntTooltip } from 'antd';
 import 'antd/es/tooltip/style/index.js';
 
-export const Tooltip = (props) => <AntTooltip {...props} />;
+export const Tooltip = ({children, ...restOfProps}) => {
+    return (<AntTooltip {...restOfProps}>
+        <span>{children}</span>
+    </AntTooltip>);
+};

--- a/src/react/components/Tooltip.jsx
+++ b/src/react/components/Tooltip.jsx
@@ -2,6 +2,22 @@ import React from 'react';
 import { Tooltip as AntTooltip } from 'antd';
 import 'antd/es/tooltip/style/index.js';
 
+/*
+The children of Tooltip are wrapped in a `span` to prevent JS-errors like this:
+
+Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?
+
+Check the render method of `styled__IconButton`.
+    in Button (created by styled__IconButton)
+    in styled__IconButton (created by Trigger)
+    in Trigger (created by ForwardRef(Tooltip))
+    in ForwardRef(Tooltip) (created by Tooltip)
+    in Tooltip (created by Tooltip)
+```
+
+There seems to be a problem with tooltips with styled-components as direct children:
+https://stackoverflow.com/questions/61450739/understanding-warning-function-components-cannot-be-given-refs
+*/
 export const Tooltip = ({children, ...restOfProps}) => {
     return (<AntTooltip {...restOfProps}>
         <span>{children}</span>


### PR DESCRIPTION
Wrap tooltip children with a `span` to prevent errors of type:

```
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

Check the render method of `styled__IconButton`.
    in Button (created by styled__IconButton)
    in styled__IconButton (created by Trigger)
    in Trigger (created by ForwardRef(Tooltip))
    in ForwardRef(Tooltip) (created by Tooltip)
    in Tooltip (created by Tooltip)
```

There seems to be a problem with tooltips where styled-components are direct children: https://stackoverflow.com/questions/61450739/understanding-warning-function-components-cannot-be-given-refs

Looks like wrapping the content to something like `span` fixes it.