### PR TITLE
Layerswipe visible layers

### DIFF
--- a/bundles/mapping/layerswipe/instance.js
+++ b/bundles/mapping/layerswipe/instance.js
@@ -118,10 +118,7 @@ Oskari.clazz.define(
             }
             var viewBounds = this.mapModule.getCurrentExtent();
             var olExtent = [viewBounds.left, viewBounds.bottom, viewBounds.right, viewBounds.top];
-            if (geometries[0].intersectsExtent(olExtent)) {
-                return true;
-            }
-            return false;
+            return geometries[0].intersectsExtent(olExtent);
         },
 
         getTopmostLayer: function () {

--- a/bundles/mapping/layerswipe/instance.js
+++ b/bundles/mapping/layerswipe/instance.js
@@ -1,6 +1,5 @@
 import { getRenderPixel } from 'ol/render';
 import { unByKey } from 'ol/Observable';
-import VectorLayer from 'ol/layer/Vector';
 
 const SwipeAlertTypes = {
     NO_RASTER: 'noRaster',
@@ -15,8 +14,8 @@ Oskari.clazz.define(
         this.splitter = null;
         this.splitterWidth = 5;
         this.cropSize = null;
-        this.map = null;
-        this.layer = null;
+        this.mapModule = null;
+        this.layer = null; // ol layer
         this.popupService = null;
         this.loc = Oskari.getMsg.bind(null, 'LayerSwipe');
         this.eventListenerKeys = [];
@@ -37,7 +36,7 @@ Oskari.clazz.define(
         __name: 'LayerSwipe',
 
         _startImpl: function (sandbox) {
-            this.map = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule').getMap();
+            this.mapModule = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule');
             this.popupService = sandbox.getService('Oskari.userinterface.component.PopupService');
 
             const addToolButtonBuilder = Oskari.requestBuilder('Toolbar.AddToolButtonRequest');
@@ -57,6 +56,7 @@ Oskari.clazz.define(
         },
 
         setActive: function (active) {
+            const map = this.mapModule.getMap();
             if (active) {
                 this.updateSwipeLayer();
                 if (this.layer === null) {
@@ -64,7 +64,7 @@ Oskari.clazz.define(
                 }
                 this.showSplitter();
                 if (this.cropSize === null) {
-                    const mapSize = this.map.getSize();
+                    const mapSize = map.getSize();
                     this.cropSize = mapSize[0] / 2;
                 }
             } else {
@@ -72,7 +72,7 @@ Oskari.clazz.define(
                 this.hideSplitter();
             }
             this.active = active;
-            this.map.render();
+            map.render();
         },
 
         updateSwipeLayer: function () {
@@ -94,10 +94,6 @@ Oskari.clazz.define(
                 }, this.alertDebounceTime);
                 return;
             }
-
-            if (!this.layer.getVisible()) {
-                this.showAlert(SwipeAlertTypes.NOT_VISIBLE);
-            }
             this.registerEventListeners();
         },
 
@@ -114,12 +110,32 @@ Oskari.clazz.define(
             popup.show(title, message, [closeBtn]);
         },
 
+        isInGeometry: function (layer) {
+            var geometries = layer.getGeometry();
+            if (!geometries || geometries.length === 0) {
+                return true;
+            }
+            var viewBounds = this.mapModule.getCurrentExtent();
+            var olExtent = [viewBounds.left, viewBounds.bottom, viewBounds.right, viewBounds.top];
+            if (geometries[0].intersectsExtent(olExtent)) {
+                return true;
+            }
+            return false;
+        },
+
         getTopmostLayer: function () {
-            const layers = this.map
-                .getLayers()
-                .getArray()
-                .filter((layer) => !(layer instanceof VectorLayer));
-            return layers.length !== 0 ? layers[layers.length - 1] : null;
+            const layers = Oskari.getSandbox()
+                .findAllSelectedMapLayers()
+                .filter(l => l.isVisible());
+            if (!layers.length) {
+                return null;
+            }
+            const topLayer = layers[layers.length - 1];
+            if (!topLayer.isInScale(this.mapModule.getMapScale()) || !this.isInGeometry(topLayer)) {
+                this.showAlert(SwipeAlertTypes.NOT_VISIBLE);
+            }
+            const olLayers = this.mapModule.getOLMapLayers(topLayer.getId());
+            return olLayers.length !== 0 ? olLayers[0] : null;
         },
 
         registerEventListeners: function () {
@@ -133,7 +149,7 @@ Oskari.clazz.define(
                     return;
                 }
 
-                const mapSize = this.map.getSize();
+                const mapSize = this.mapModule.getMap().getSize();
                 const tl = getRenderPixel(event, [0, 0]);
                 const tr = getRenderPixel(event, [this.cropSize, 0]);
                 const bl = getRenderPixel(event, [0, mapSize[1]]);
@@ -163,6 +179,7 @@ Oskari.clazz.define(
         getSplitterElement: function () {
             if (!this.splitter) {
                 this.splitter = jQuery('<div class="layer-swipe-splitter"></div>');
+                this.splitter.css('cursor', 'grab');
                 this.splitter.draggable({
                     containment: '#mapdiv',
                     axis: 'x',
@@ -181,7 +198,7 @@ Oskari.clazz.define(
             const mapOffset = jQuery('#mapdiv').offset();
             const splitterOffset = jQuery('.layer-swipe-splitter').offset();
             this.cropSize = splitterOffset.left - mapOffset.left + this.splitterWidth / 2;
-            this.map.render();
+            this.mapModule.getMap().render();
         },
 
         showSplitter: function () {
@@ -214,8 +231,8 @@ Oskari.clazz.define(
                 }
             },
             'MapLayerVisibilityChangedEvent': function (event) {
-                if (this.active && !this.layer.getVisible()) {
-                    this.showAlert(SwipeAlertTypes.NOT_VISIBLE);
+                if (this.active) {
+                    this.updateSwipeLayer();
                 }
             }
         }

--- a/bundles/mapping/layerswipe/instance.js
+++ b/bundles/mapping/layerswipe/instance.js
@@ -113,6 +113,7 @@ Oskari.clazz.define(
         isInGeometry: function (layer) {
             var geometries = layer.getGeometry();
             if (!geometries || geometries.length === 0) {
+                // we might not have the coverage geometry so assume all is good if we don't know for sure
                 return true;
             }
             var viewBounds = this.mapModule.getCurrentExtent();

--- a/bundles/mapping/layerswipe/resources/locale/en.js
+++ b/bundles/mapping/layerswipe/resources/locale/en.js
@@ -5,10 +5,10 @@ Oskari.registerLocalization({
         toolLayerSwipe: 'Swipe: Compare the topmost map layer with other map layers',
         alert: {
             ok: 'OK',
-            swipeNoRasterTitle: 'There is no raster layer selected to use with the map swipe tool',
-            swipeNoRasterMessage: 'Set a raster map layer visible.',
-            swipeLayerNotVisibleTitle: 'Swipe feature is not working',
-            swipeLayerNotVisibleMessage: 'The topmost layer is not visible in the current view. Make it visible in Selected layers or move to a location where it can be seen.'
+            swipeNoRasterTitle: 'There is no layer selected to use with the map swipe tool',
+            swipeNoRasterMessage: 'Set a map layer visible.',
+            swipeLayerNotVisibleTitle: 'Swipe feature is not working in the current view',
+            swipeLayerNotVisibleMessage: 'The topmost layer is not visible in the current view. Move to a location where it can be seen.'
         }
     }
 });

--- a/bundles/mapping/layerswipe/resources/locale/fi.js
+++ b/bundles/mapping/layerswipe/resources/locale/fi.js
@@ -5,10 +5,10 @@ Oskari.registerLocalization({
         toolLayerSwipe: 'Vertaa ylintä karttatasoa alempiin karttatasoihin',
         alert: {
             ok: 'OK',
-            swipeNoRasterTitle: 'Yhtään rasterikarttatasoa ei ole valittuna käytettäväksi vertailutyökalun kanssa',
-            swipeNoRasterMessage: 'Aseta karttatasovalikosta rasteritaso näkyväksi',
-            swipeLayerNotVisibleTitle: 'Karttatasojen vertailu ei toimi',
-            swipeLayerNotVisibleMessage: 'Ylin karttataso ei näy tässä näkymässä. Aseta se näkyväksi kohdassa Valitut tasot tai siirry sijaintiin, jossa se näkyy.'
+            swipeNoRasterTitle: 'Yhtään karttatasoa ei ole valittuna käytettäväksi vertailutyökalun kanssa',
+            swipeNoRasterMessage: 'Aseta karttatasovalikosta taso näkyväksi',
+            swipeLayerNotVisibleTitle: 'Karttatasojen vertailu ei toimi tässä näkymässä',
+            swipeLayerNotVisibleMessage: 'Ylin karttataso ei näy tässä näkymässä. Siirry sijaintiin, jossa se näkyy.'
         }
     }
 });

--- a/bundles/mapping/layerswipe/resources/locale/sv.js
+++ b/bundles/mapping/layerswipe/resources/locale/sv.js
@@ -5,9 +5,9 @@ Oskari.registerLocalization({
         toolLayerSwipe: 'Jämför kartlagret högst uppe med nedanstående kartlager',
         alert: {
             ok: 'OK',
-            swipeNoRasterTitle: 'Inget kartlager i rasterformat har valts för jämföring',
-            swipeNoRasterMessage: 'Lägg till raster kartlager i kartvyn.',
-            swipeLayerNotVisibleTitle: 'Jämförelse av kartlager fungerar inte',
+            swipeNoRasterTitle: 'Inget kartlager har valts för jämföring',
+            swipeNoRasterMessage: 'Lägg till kartlager i kartvyn.',
+            swipeLayerNotVisibleTitle: 'Jämförelse av kartlager fungerar inte i vyn',
             swipeLayerNotVisibleMessage: 'Den kartlagret högst uppe kan inte ses i vyn.'
         }
     }


### PR DESCRIPTION
Get topmost layer from selected Oskari layers instead of ol map layers. Swipe layer is topmost visible layer (raster or vector).

Added isInGeometry (same than in LayersPlugin). I don't know if it should be in (Abstract)MapModule. First tried to handle scale and geomMatch with MapLayerVisibilityChangedEvent but it's seemed to be simpler to check them in getTopmostLayer.