### PR TITLE
Support 3d-tiles style with and without featureStyle object

### DIFF
--- a/bundles/mapping/mapmodule/mapmodule.olcs.js
+++ b/bundles/mapping/mapmodule/mapmodule.olcs.js
@@ -968,7 +968,17 @@ class MapModuleOlCesium extends MapModuleOl {
         const oskariStyle = {};
         const extStyle = {};
         if (styleDefs) {
-            jQuery.extend(true, oskariStyle, styleDefs.oskari);
+            let oskariStyleFromLayer = styleDefs.oskari;
+            // WFS-layers have "featureStyle" object for the actual style
+            // 3D-layers have not required it since there hasn't been hover styles implemented yet
+            // for consistency, dig the style from under the "featureStyle" so we can have both:
+            //  - backwards compatibility == featureStyle is NOT REQUIRED as part of the style
+            //  - consistency == featureStyle IS RECOGNIZED so we can use the visual style editor for WFS and 3D
+            if (oskariStyleFromLayer && oskariStyleFromLayer.featureStyle) {
+                oskariStyleFromLayer = oskariStyleFromLayer.featureStyle;
+            }
+
+            jQuery.extend(true, oskariStyle, oskariStyleFromLayer);
             jQuery.extend(true, extStyle, styleDefs.external);
         }
 


### PR DESCRIPTION
For consistency (`featureStyle` object is used for styles on WFS-layers and other vector feature sources) so the visual style editor works better with 3D-layers (mostly area fill color but better than before) and maintaining backwards compatibility == `featureStyle` object for style is not required (like before with 3D).