### PR TITLE
Restore margin for selected layers badge

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/SelectedTab.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/SelectedTab.jsx
@@ -25,7 +25,7 @@ const StyledBadge = styled.div`
     font-size: 12px;
     display: inline;
     line-height: 20px;
-    margin-right: 10px;
+    margin-left: 8px;
     font-weight: 700;
     ${props => props.blink && css`
         animation: ${animation} ${BLINK_DURATION_IN_SECONDS}s;


### PR DESCRIPTION
Mistakenly changed to margin-right in #1413(?)
![badge_before](https://user-images.githubusercontent.com/2210335/115419743-3e5fcf00-a203-11eb-8c74-8e7d3b3eaed3.png)
![badge_after](https://user-images.githubusercontent.com/2210335/115419764-428bec80-a203-11eb-9a9b-67499138bfc5.png)

