### PR TITLE
Suppress app.start event when using Oskari.app.playBundle()

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -97,14 +97,16 @@
             /** 
              * @param  {Function} done callback
              */
-            processSequence: function (done) {
+            processSequence: function (done, suppressStartEvent = false) {
                 var me = this;
                 if (sequence.length === 0) {
                     // everything has been loaded
                     if (typeof done === 'function') {
                         done(result);
                     }
-                    o.trigger('app.start', result);
+                    if (!suppressStartEvent) {
+                        o.trigger('app.start', result);
+                    }
                     return;
                 }
                 var seqToLoad = sequence.shift();

--- a/src/oskari.app.js
+++ b/src/oskari.app.js
@@ -89,7 +89,8 @@ jQuery.ajaxSetup({ cache: false });
                 config = this.appConfig;
             }
             var loader = Oskari.loader([recData], config);
-            loader.processSequence(callback);
+            // send suppress event flag as ture since this is used to trigger single bundle starts for testing mostly (via dev-console etc)
+            loader.processSequence(callback, true);
         },
         /**
          * Convenience function to load appsetup from url with given params and startup the Oskari app.

--- a/src/oskari.app.js
+++ b/src/oskari.app.js
@@ -89,7 +89,7 @@ jQuery.ajaxSetup({ cache: false });
                 config = this.appConfig;
             }
             var loader = Oskari.loader([recData], config);
-            // send suppress event flag as ture since this is used to trigger single bundle starts for testing mostly (via dev-console etc)
+            // send suppress event flag as true since this is used to trigger single bundle starts for testing mostly (via dev-console etc)
             loader.processSequence(callback, true);
         },
         /**


### PR DESCRIPTION
Oskari.app.playBundle() is mostly used for testing via browser dev-console for triggering start for bundles that are not part of the "appsetup" according to the database/server config. Currently it triggers the `app.start` event that some bundles listen to detect when the app is fully started. The problem is that using playBundle() the event is triggered twice so bundles listening to the event might behave in unexpected ways.

This PR makes playBundle() do things "silently" and not trigger the app.start again as it never was intentional to do so more than once.