### PR TITLE
Refactor "All layers" switch to it's own component

### DIFF
--- a/bundles/framework/layerlist/Flyout.js
+++ b/bundles/framework/layerlist/Flyout.js
@@ -45,6 +45,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerlist.Flyout',
          */
         setEl: function (el, flyout, width, height) {
             this.container = el[0];
+            if (!jQuery(this.container).hasClass('layerlist')) {
+                jQuery(this.container).addClass('layerlist');
+            }
+            if (!flyout.hasClass('layerlist')) {
+                flyout.addClass('layerlist');
+            }
         },
 
         /**

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/AllLayersSwitch.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/AllLayersSwitch.jsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Confirm, Message, Switch } from 'oskari-ui';
+import styled from 'styled-components';
+
+const StyledSwitch = styled(Switch)`
+margin-left: 5px;
+margin-right: 5px;
+`;
+
+
+
+const selectGroup = (event, setVisible, checked, group, controller) => {
+    setVisible(false);
+    // if switch is checked, we add the groups layers to selected layers, if not, we remove all the layers from checked layers
+    !checked ? controller.addGroupLayersToMap(group) : controller.removeGroupLayersFromMap(group); 
+    event.stopPropagation();
+}
+
+const onGroupSelect = (event, setVisible, checked, group, controller) => { 
+    // check if we need to show warning (over 10 layers inside the group)
+    if(checked && group.layers.length > 10) {
+        setVisible(true);
+    } else {
+        selectGroup(event, setVisible, !checked, group, controller);
+    }
+    event.stopPropagation();
+};
+
+
+const onCancel = (event, setVisible) => {
+    setVisible(false);
+    event.stopPropagation();
+};
+
+const LayerToggle = ({ onToggle, checked = false }) => {
+    return (<StyledSwitch size="small" checked={checked}
+        onChange={(checked, event) => {
+            onToggle(checked);
+            event.stopPropagation();
+        }} />);
+}
+
+/*
+<AllLayersSwitch checked={active} onToggle={(checked) => !checked ? controller.addGroupLayersToMap(group) : controller.removeGroupLayersFromMap(group); }
+*/
+export const AllLayersSwitch = ({ checked, onToggle, layerCount = 0 }) => {
+    //const [visible, setVisible] = useState(false);
+    const ToggleComp = (<LayerToggle checked={checked} onToggle={onToggle} />);
+    return ToggleComp;
+    /*
+    if (layerCount < 10) {
+        return ToggleComp;
+    }
+    return (<Confirm
+        title={<Message messageKey='grouping.manyLayersWarn'/>}
+        visible={visible}
+        onConfirm={(event) => {
+            setVisible(false);
+            onToggle(active);
+            event.stopPropagation();
+        }}
+        onCancel={(event) => onCancel(event, setVisible)}
+        okText={<Message messageKey='yes'/>}
+        cancelText={<Message messageKey='cancel'/>}
+        placement='top'
+        popupStyle={{zIndex: '999999'}}
+    >
+        {ToggleComp}
+    </Confirm>);
+    */
+};
+
+AllLayersSwitch.propTypes = {
+    checked: PropTypes.bool,
+    layerCount: PropTypes.number,
+    onToggle: PropTypes.func.isRequired
+};
+
+                        

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/AllLayersSwitch.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/AllLayersSwitch.jsx
@@ -8,67 +8,50 @@ margin-left: 5px;
 margin-right: 5px;
 `;
 
+const LIMIT_FOR_CONFIRMATION = 10;
 
-
-const selectGroup = (event, setVisible, checked, group, controller) => {
-    setVisible(false);
-    // if switch is checked, we add the groups layers to selected layers, if not, we remove all the layers from checked layers
-    !checked ? controller.addGroupLayersToMap(group) : controller.removeGroupLayersFromMap(group); 
-    event.stopPropagation();
-}
-
-const onGroupSelect = (event, setVisible, checked, group, controller) => { 
-    // check if we need to show warning (over 10 layers inside the group)
-    if(checked && group.layers.length > 10) {
-        setVisible(true);
-    } else {
-        selectGroup(event, setVisible, !checked, group, controller);
-    }
-    event.stopPropagation();
-};
-
-
-const onCancel = (event, setVisible) => {
-    setVisible(false);
-    event.stopPropagation();
-};
-
-const LayerToggle = ({ onToggle, checked = false }) => {
-    return (<StyledSwitch size="small" checked={checked}
-        onChange={(checked, event) => {
-            onToggle(checked);
-            event.stopPropagation();
-        }} />);
-}
-
-/*
-<AllLayersSwitch checked={active} onToggle={(checked) => !checked ? controller.addGroupLayersToMap(group) : controller.removeGroupLayersFromMap(group); }
-*/
+/**
+ * Component to toggle all layers on group to or from map.
+ * Shows a warning if more than 10 layers would be added.
+ */
 export const AllLayersSwitch = ({ checked, onToggle, layerCount = 0 }) => {
-    //const [visible, setVisible] = useState(false);
-    const ToggleComp = (<LayerToggle checked={checked} onToggle={onToggle} />);
-    return ToggleComp;
-    /*
-    if (layerCount < 10) {
-        return ToggleComp;
+    const [confirmOnScreen, showConfirm] = useState(false);
+    if (checked || layerCount < LIMIT_FOR_CONFIRMATION) {
+        return (<StyledSwitch size="small" checked={checked}
+            onChange={(checked) => {
+                onToggle(checked);
+        }} />);
     }
-    return (<Confirm
-        title={<Message messageKey='grouping.manyLayersWarn'/>}
-        visible={visible}
-        onConfirm={(event) => {
-            setVisible(false);
-            onToggle(active);
-            event.stopPropagation();
-        }}
-        onCancel={(event) => onCancel(event, setVisible)}
-        okText={<Message messageKey='yes'/>}
-        cancelText={<Message messageKey='cancel'/>}
-        placement='top'
-        popupStyle={{zIndex: '999999'}}
-    >
-        {ToggleComp}
-    </Confirm>);
-    */
+    return (
+        <Confirm
+            title={<Message messageKey='grouping.manyLayersWarn'/>}
+            visible={confirmOnScreen}
+            onConfirm={(event) => {
+                showConfirm(false);
+                onToggle(true);
+                event.stopPropagation();
+            }}
+            onCancel={(event) => {
+                showConfirm(false);
+                event.stopPropagation();
+            }}
+            okText={<Message messageKey='yes'/>}
+            // TODO: try to link tooltip to the flyout so it's removed if the flyout is closed.
+            // These didn't solve the problem but might be helpful
+            // div.oskari-flyout.layerlist
+            //getPopupContainer={(triggerNode) => document.querySelector('div.oskari-flyout.layerlist')}
+            //destroyTooltipOnHide={true}
+            cancelText={<Message messageKey='cancel'/>}
+            placement='top'
+            popupStyle={{zIndex: '999999'}}
+        >
+            <StyledSwitch
+                size="small"
+                checked={checked} onClickCapture={(event) => {
+                    event.stopPropagation();
+                    showConfirm(true);
+                }} />
+        </Confirm>);
 };
 
 AllLayersSwitch.propTypes = {

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
@@ -1,10 +1,11 @@
 
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Collapse, Confirm, CollapsePanel, List, ListItem, Message, Tooltip, Switch } from 'oskari-ui';
+import { Collapse, CollapsePanel, List, ListItem, Message, Tooltip } from 'oskari-ui';
 import { Controller } from 'oskari-ui/util';
 import { Layer } from './Layer/';
 import { LayerCountBadge } from './LayerCountBadge';
+import { AllLayersSwitch } from './AllLayersSwitch';
 import styled from 'styled-components';
 
 const StyledSubCollapse = styled(Collapse)`
@@ -34,10 +35,6 @@ const StyledEditGroup = styled.span`
     padding-right: 5px;
 `;
 
-const StyledSwitch = styled(Switch)`
-    margin-left: 5px;
-    margin-right: 5px;
-`;
 
 
 const renderLayer = ({ model, even, selected, controller }) => {
@@ -69,28 +66,6 @@ const onToolClick = (event, tool, group) => {
     event.stopPropagation();
 };
 
-const selectGroup = (event, setVisible, checked, group, controller) => {
-    setVisible(false);
-    // if switch is checked, we add the groups layers to selected layers, if not, we remove all the layers from checked layers
-    !checked ? controller.addGroupLayersToMap(group) : controller.removeGroupLayersFromMap(group); 
-    event.stopPropagation();
-}
-
-const onGroupSelect = (event, setVisible, checked, group, controller) => { 
-    // check if we need to show warning (over 10 layers inside the group)
-    if(checked && group.layers.length > 10) {
-        setVisible(true);
-    } else {
-        selectGroup(event, setVisible, !checked, group, controller);
-    }
-    event.stopPropagation();
-};
-
-const onCancel = (event, setVisible) => {
-    setVisible(false);
-    event.stopPropagation();
-}
-
 
 const getLayerRowModels = (layers = [], selectedLayerIds = [], controller) => {
     return layers.map((oskariLayer, index) => {
@@ -105,7 +80,6 @@ const getLayerRowModels = (layers = [], selectedLayerIds = [], controller) => {
 };
 const SubCollapsePanel = ({ active, group, selectedLayerIds, controller, propsNeededForPanel }) => {
 
-    const [visible, setVisible] = useState(false);
     const layerRows = getLayerRowModels(group.getLayers(), selectedLayerIds, controller);
 
     return (
@@ -117,19 +91,14 @@ const SubCollapsePanel = ({ active, group, selectedLayerIds, controller, propsNe
                         <LayerCountBadge
                             layerCount={layerRows.length}
                             unfilteredLayerCount={group.unfilteredLayerCount} />
-                            <Confirm
-                                title={<Message messageKey='grouping.manyLayersWarn'/>}
-                                visible={visible}
-                                onConfirm={(event) => selectGroup(event, setVisible, active, group, controller)}
-                                onCancel={(event) => onCancel(event, setVisible)}
-                                okText={<Message messageKey='yes'/>}
-                                cancelText={<Message messageKey='cancel'/>}
-                                placement='top'
-                                popupStyle={{zIndex: '999999'}}
-                            >
-                                <StyledSwitch size="small" checked={active}
-                                    onChange={(checked, event) => onGroupSelect(event, setVisible, checked, group, controller)} />
-                            </Confirm>
+                        <AllLayersSwitch checked={active}
+                            onToggle={(checked) => {
+                                if (checked) {
+                                    controller.addGroupLayersToMap(group);
+                                } else {
+                                    controller.removeGroupLayersFromMap(group);
+                                }
+                            }} />
                         {
                             group.isEditable() && group.getTools().filter(t => t.getTypes().includes(group.groupMethod)).map((tool, i) =>
                                 <Tooltip title={tool.getTooltip()} key={`${tool.getName()}_${i}`}>
@@ -184,22 +153,14 @@ const LayerCollapsePanel = (props) => {
                     <LayerCountBadge
                         layerCount={layerRows.length}
                         unfilteredLayerCount={group.unfilteredLayerCount} />
-                    <Confirm
-                        title={<Message messageKey='grouping.manyLayersWarn'/>}
-                        visible={visible}
-                        onConfirm={(event) => selectGroup(event, setVisible, active, group, controller)}
-                        onCancel={(event) => onCancel(event, setVisible)}
-                        okText={<Message messageKey='yes'/>}
-                        cancelText={<Message messageKey='cancel'/>}
-                        placement='top'
-                        popupStyle={{zIndex: '999999'}}
-                    >
-                        <StyledSwitch
-                            size="small"
-                            checked={active}
-                            onChange={(checked, event) => onGroupSelect(event, setVisible, checked, group, controller)}
-                        />
-                    </Confirm>
+                    <AllLayersSwitch checked={active}
+                        onToggle={(checked) => {
+                            if (checked) {
+                                controller.addGroupLayersToMap(group);
+                            } else {
+                                controller.removeGroupLayersFromMap(group);
+                            }
+                        }} />
                     {
                         group.isEditable() && group.getTools().filter(t => t.getTypes().includes(group.groupMethod)).map((tool, i) =>
                             <Tooltip title={tool.getTooltip()} key={`${tool.getName()}_${i}`}>

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
@@ -1,7 +1,7 @@
 
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { Collapse, CollapsePanel, List, ListItem, Message, Tooltip } from 'oskari-ui';
+import { Collapse, CollapsePanel, List, ListItem, Tooltip } from 'oskari-ui';
 import { Controller } from 'oskari-ui/util';
 import { Layer } from './Layer/';
 import { LayerCountBadge } from './LayerCountBadge';
@@ -78,9 +78,17 @@ const getLayerRowModels = (layers = [], selectedLayerIds = [], controller) => {
         };
     });
 };
+
 const SubCollapsePanel = ({ active, group, selectedLayerIds, controller, propsNeededForPanel }) => {
 
     const layerRows = getLayerRowModels(group.getLayers(), selectedLayerIds, controller);
+    const toggleLayersOnMap = (addLayers) => {
+        if (addLayers) {
+            controller.addGroupLayersToMap(group);
+        } else {
+            controller.removeGroupLayersFromMap(group);
+        }
+    };
 
     return (
         <StyledSubCollapse>
@@ -91,14 +99,10 @@ const SubCollapsePanel = ({ active, group, selectedLayerIds, controller, propsNe
                         <LayerCountBadge
                             layerCount={layerRows.length}
                             unfilteredLayerCount={group.unfilteredLayerCount} />
-                        <AllLayersSwitch checked={active}
-                            onToggle={(checked) => {
-                                if (checked) {
-                                    controller.addGroupLayersToMap(group);
-                                } else {
-                                    controller.removeGroupLayersFromMap(group);
-                                }
-                            }} />
+                        <AllLayersSwitch
+                            checked={active}
+                            layerCount={layerRows.length}
+                            onToggle={toggleLayersOnMap} />
                         {
                             group.isEditable() && group.getTools().filter(t => t.getTypes().includes(group.groupMethod)).map((tool, i) =>
                                 <Tooltip title={tool.getTooltip()} key={`${tool.getName()}_${i}`}>
@@ -141,10 +145,14 @@ const SubCollapsePanel = ({ active, group, selectedLayerIds, controller, propsNe
 
 const LayerCollapsePanel = (props) => {
     const { active, group, selectedLayerIds, controller, ...propsNeededForPanel } = props;
-    const [visible, setVisible] = useState(false);
-
     const layerRows = getLayerRowModels(group.getLayers(), selectedLayerIds, controller);
-
+    const toggleLayersOnMap = (addLayers) => {
+        if (addLayers) {
+            controller.addGroupLayersToMap(group);
+        } else {
+            controller.removeGroupLayersFromMap(group);
+        }
+    };
     return (
         <StyledCollapsePanel {...propsNeededForPanel} 
             header={group.getTitle()}
@@ -153,14 +161,10 @@ const LayerCollapsePanel = (props) => {
                     <LayerCountBadge
                         layerCount={layerRows.length}
                         unfilteredLayerCount={group.unfilteredLayerCount} />
-                    <AllLayersSwitch checked={active}
-                        onToggle={(checked) => {
-                            if (checked) {
-                                controller.addGroupLayersToMap(group);
-                            } else {
-                                controller.removeGroupLayersFromMap(group);
-                            }
-                        }} />
+                    <AllLayersSwitch
+                        checked={active}
+                        layerCount={layerRows.length}
+                        onToggle={toggleLayersOnMap} />
                     {
                         group.isEditable() && group.getTools().filter(t => t.getTypes().includes(group.groupMethod)).map((tool, i) =>
                             <Tooltip title={tool.getTooltip()} key={`${tool.getName()}_${i}`}>


### PR DESCRIPTION
Previously part of `LayerCollapse` component. This improves readability and hides the hack for popping up a confirm. Also makes it easier to remove by config since we'll want to enable that kind of config.