### PR TITLE
Handle coordinate with value 0

### DIFF
--- a/bundles/framework/mapfull/instance.js
+++ b/bundles/framework/mapfull/instance.js
@@ -386,7 +386,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
          */
         __setStateImplLocation: function (state = {}) {
             const sandbox = this.getSandbox();
-            if (state.east) {
+            if (typeof state.east !== 'undefined') {
                 sandbox.getMap().moveTo(
                     state.east,
                     state.north,


### PR DESCRIPTION
Fix for changes in #1525 where east coordinate with value 0 didn't set the location and zoom from map state.