### PR TITLE
WFSLayer wps params

### DIFF
--- a/bundles/mapping/mapwfs2/domain/WFSLayer.js
+++ b/bundles/mapping/mapwfs2/domain/WFSLayer.js
@@ -263,11 +263,23 @@ export class WFSLayer extends VectorTileLayer {
 
     /**
      * @method getWpsLayerParams
+     * @deprecated
      * @return {json} wpsLayerParams
      */
     getWpsLayerParams () {
-        const { wpsParams = {} } = this.getAttributes();
-        return wpsParams;
+        const { data = {} } = this.getAttributes();
+        const { commonId, wpsType, noDataValue } = data;
+        const wps = {};
+        if (typeof commonId !== 'undefined') {
+            wps.join_key = commonId;
+        }
+        if (typeof wpsType !== 'undefined') {
+            wps.input_type = wpsType;
+        }
+        if (typeof noDataValue !== 'undefined') {
+            wps.no_data = noDataValue;
+        }
+        return wps;
     }
 
     /**

--- a/bundles/mapping/mapwfs2/domain/WFSLayer.js
+++ b/bundles/mapping/mapwfs2/domain/WFSLayer.js
@@ -268,13 +268,13 @@ export class WFSLayer extends VectorTileLayer {
      */
     getWpsLayerParams () {
         const { data = {} } = this.getAttributes();
-        const { commonId, wpsType, noDataValue } = data;
+        const { commonId, wpsInputType, noDataValue } = data;
         const wps = {};
         if (typeof commonId !== 'undefined') {
             wps.join_key = commonId;
         }
-        if (typeof wpsType !== 'undefined') {
-            wps.input_type = wpsType;
+        if (typeof wpsInputType !== 'undefined') {
+            wps.input_type = wpsInputType;
         }
         if (typeof noDataValue !== 'undefined') {
             wps.no_data = noDataValue;


### PR DESCRIPTION
Change getWpsLayerParams() to gather values from attributes.data. Mark it as deprecated.
https://github.com/oskariorg/oskari-frontend-contrib/pull/64 changes Analysis to get values from attributes data. Maybe getWpsLayerParams() isn't needed anymore.

https://github.com/oskariorg/oskari-server/pull/710