### PR TITLE
Rewrite grouping logic

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/util.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/util.js
@@ -1,84 +1,78 @@
-/**
- * If both layers have same group, they are ordered by layer.getName()
- * @param {Oskari.mapframework.domain.WmsLayer/Oskari.mapframework.domain.WfsLayer/Oskari.mapframework.domain.VectorLayer/Object} a comparable layer 1
- * @param {Oskari.mapframework.domain.WmsLayer/Oskari.mapframework.domain.WfsLayer/Oskari.mapframework.domain.VectorLayer/Object} b comparable layer 2
- * @param {String} method layer method name to sort by
- */
-const comparator = (a, b, method) => {
-    var nameA = a[method]().toLowerCase();
-    var nameB = b[method]().toLowerCase();
-    if (nameA === nameB && (a.getName() && b.getName())) {
-        nameA = a.getName().toLowerCase();
-        nameB = b.getName().toLowerCase();
-    }
-    return Oskari.util.naturalSort(nameA, nameB);
-};
 
 const sortGroupsAlphabetically = (groups = []) => {
     if (!Array.isArray(groups)) {
         return null;
     }
-    const sorted = [...groups].sort((a, b) => Oskari.util.naturalSort(a.name, b.name));
+    const sorted = [...groups].sort((a, b) => {
+        // ensure that empty groups are at the top
+        // not sure if this is requested functionality or not
+        const layerCountA = a.layers.length;
+        const layerCountB = b.layers.length;
+        if (layerCountA === 0 && layerCountB !== 0) {
+            return -1;
+        }
+        if (layerCountA !== 0 && layerCountB === 0) {
+            return 1;
+        }
+        // sort by name (for most cases use this)
+        return Oskari.util.naturalSort(a.getTitle(), b.getTitle());
+    });
     sorted.forEach(group => {
         group.setGroups(sortGroupsAlphabetically(group.getGroups()));
     });
     return sorted;
 };
 
-const createGroupModel = (group, method, layers, tools, admin) => {
+/*
+const group = {
+    id: -1,
+    name: '',
+    layers: [{id}],
+    groups: []
+};
+createGroupModel(group, ...)
+*/
+const createGroupModel = (group, method, allLayers, tools, admin) => {
     const groupLayers = group.layers || [];
+    // TODO: check if subgroups have layers?
     if (groupLayers.length === 0 && !admin) {
         // non-admin users get only groups with layers
         return;
     }
     // check that group has layers
-    const lang = Oskari.getLang();
-    const name = group.getName();
+    const name = group.name;
+    // const name = group.getName();
     const newGroup = Oskari.clazz.create(
         'Oskari.mapframework.bundle.layerselector2.model.LayerGroup',
-        group.id, method, name[lang]
+        group.id, method, name
     );
     newGroup.setTools(tools);
     // attach layers to group
     const groupLayerIds = groupLayers.map(l => l.id);
-    newGroup.setLayers(layers.filter(layer => {
+    const layerModels = allLayers.filter(layer => {
         if (typeof layer.getId !== 'function') {
             return false;
         }
         return groupLayerIds.includes(layer.getId());
-    }));
+    });
+    layerModels.sort((a, b) => Oskari.util.naturalSort(a.getName(), b.getName()));
+    newGroup.setLayers(layerModels);
     // TODO: should we check if we got the referenced layers?
     //  or if the group doesn't have layers at this point?
     //  or sort them based on or groupLayers.orderNumber/alphabetically?
 
     // group has subgroups
-    if (!group.hasSubgroups()) {
+    if (!group.groups.length) {
         return newGroup;
     }
-    const mappedSubgroups = group.getGroups()
+    const mappedSubgroups = group.groups
         // recursion for subgroups
-        .map(subgroup => createGroupModel(subgroup, method, layers, tools, admin))
+        .map(subgroup => createGroupModel(subgroup, method, allLayers, tools, admin))
         // remove any subgroups that mapped to null:
         //  (groups without layers for non-admins etc)
         .filter(g => typeof g !== 'undefined');
     newGroup.setGroups(mappedSubgroups);
     return newGroup;
-};
-
-const determineGroupId = (method, layerGroups = [], layerAdmin) => {
-    let groupId;
-    if (method === 'getInspireName') {
-        if (layerGroups.length) {
-            groupId = layerGroups[0] ? layerGroups[0].id : undefined;
-        } else {
-            groupId = -1;
-        }
-    } else {
-        groupId = layerAdmin ? layerAdmin.organizationId : undefined;
-    }
-    // My map layers, my places, own analysis and 'orphan' groups don't have id so use negated random number
-    // as unique Id (with positive id group is interpret as editable and group tools are shown in layer list).
-    return typeof groupId === 'number' ? groupId : -Math.random();
 };
 
 /**
@@ -88,46 +82,43 @@ const determineGroupId = (method, layerGroups = [], layerAdmin) => {
  * @param {Oskari.mapframework.domain.AbstractLayer[]} layers layers to group
  * @param {String} method layer method name to sort by
  * @param {Oskari.mapframework.domain.Tool[]} tools tools to group
- * @param {Oskari.mapframework.domain.MaplayerGroup[]} allGroups all user groups available in Oskari
- * @param {Object[]} allDataProviders all dataproviders available in Oskari
+ * @param {Object[]} allGroups all layer groups or all dataproviders available in Oskari
  */
-export const groupLayers = (layers, method, tools, allGroups = [], allDataProviders = [], noGroupTitle) => {
+export const groupLayers = (layers, method, tools, allGroups = [], noGroupTitle) => {
     let groupForOrphans = null;
     const isUserAdmin = tools.length > 0;
-
-    // sort layers by grouping & name
-    layers.sort((a, b) => comparator(a, b, method))
+    // generate a group for layers without "natural" grouping if needed
+    layers
         .filter(layer => !layer.getMetaType || layer.getMetaType() !== 'published')
+        // if method call returns a value we can map it to a group, filter ones we can't
+        .filter(layer => !layer[method]())
         .forEach(layer => {
-            let groupAttr = layer[method]();
-            let groupId = determineGroupId(method, layer.getGroups(), layer.getAdmin());
-            // Create group for orphan layers if not already created and add layer to it
-            if (!groupAttr) {
-                if (!groupForOrphans) {
-                    groupForOrphans = Oskari.clazz.create(
-                        'Oskari.mapframework.bundle.layerselector2.model.LayerGroup',
-                        groupId, method, '(' + noGroupTitle + ')'
-                    );
-                }
+            if (groupForOrphans) {
+                // add layer to runtime generated orphan group
                 groupForOrphans.addLayer(layer);
+                return;
             }
+            // Create group for orphan layers if not already created
+            const newGroup = {
+                // My map layers, my places, own analysis and 'orphan' groups don't have id so use negated random number
+                // as unique Id (with positive id group is interpret as editable and group tools are shown in layer list).
+                id: -Math.random(),
+                name: '(' + noGroupTitle + ')',
+                layers: [{ id: layer.getId() }],
+                groups: []
+            };
+            groupForOrphans = createGroupModel(newGroup, method, layers, tools, isUserAdmin);
         });
     // recursively map groups and layers together
     const groupList = allGroups
-        .map(parentGroup => createGroupModel(parentGroup, method, layers, tools, isUserAdmin))
+        .map(rootGroup => createGroupModel(rootGroup, method, layers, tools, isUserAdmin))
         .filter(group => typeof group !== 'undefined');
     const sortedGroups = sortGroupsAlphabetically(groupList);
 
-    let groupsWithoutLayers = [];
-    if (method !== 'getInspireName') {
-        groupsWithoutLayers = allDataProviders
-            .filter(t => sortedGroups.filter(g => g.id === t.id).length === 0)
-            .map(d => {
-                const group = Oskari.clazz.create('Oskari.mapframework.bundle.layerselector2.model.LayerGroup', d.id, method, d.name);
-                group.setTools(tools);
-                return group;
-            });
-        groupsWithoutLayers = sortGroupsAlphabetically(groupsWithoutLayers);
+    const result = [...sortedGroups];
+    if (groupForOrphans) {
+        // if there's an orphan group, make it the first one
+        result.unshift(groupForOrphans);
     }
-    return groupForOrphans ? [groupForOrphans, ...groupsWithoutLayers, ...sortedGroups] : [...groupsWithoutLayers, ...sortedGroups];
+    return result;
 };


### PR DESCRIPTION
Create a normalized input for both groups and dataproviders for util.js `groupLayers()` instead of trying to figure out where to get the data on the function that prepares the final data model.