### PR TITLE
Handle groups created at runtime

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
@@ -11,7 +11,7 @@ const getLayerGroups = (groups = []) => {
         return {
             id: group.id,
             name: Oskari.getLocalized(group.name),
-            layers: group.getLayers() || [],
+            layers: group.getChildren().filter(c => c.type === 'layer') || [],
             groups: getLayerGroups(group.getGroups())
         };
     });

--- a/bundles/mapping/mapmodule/domain/MaplayerGroup.js
+++ b/bundles/mapping/mapmodule/domain/MaplayerGroup.js
@@ -9,7 +9,7 @@ Oskari.clazz.define('Oskari.mapframework.domain.MaplayerGroup',
 
         me.id = json.id;
         me.layersModels = [];
-        me.layers = json.layers ? json.layers : null;
+        me.layers = json.layers || [];
         me.name = json.name;
         me.orderNumber = (typeof json.orderNumber !== 'undefined') ? json.orderNumber : 1000000;
         me.parentId = (typeof json.parentId !== 'undefined') ? json.parentId : -1;
@@ -32,7 +32,7 @@ Oskari.clazz.define('Oskari.mapframework.domain.MaplayerGroup',
         },
         addChildren: function (children) {
             this.children.push(children);
-            this.sort();
+            //this.sort();
         },
         setChildren: function (json) {
             var me = this;
@@ -103,6 +103,10 @@ Oskari.clazz.define('Oskari.mapframework.domain.MaplayerGroup',
         setName: function (name) {
             this.name = name;
         },
+        /**
+         * You probably shouldn't be using this but getChildren().filter(c => c.type === 'layer')
+         * @returns probably not the thing you were looking for...
+         */
         getLayers: function () {
             return this.layers;
         },

--- a/bundles/mapping/mapmodule/domain/MaplayerGroup.js
+++ b/bundles/mapping/mapmodule/domain/MaplayerGroup.js
@@ -32,7 +32,6 @@ Oskari.clazz.define('Oskari.mapframework.domain.MaplayerGroup',
         },
         addChildren: function (children) {
             this.children.push(children);
-            //this.sort();
         },
         setChildren: function (json) {
             var me = this;

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -566,6 +566,19 @@ Oskari.clazz.define(
             if (options.showLayer) {
                 // Show layer in layer selector
                 if (!mapLayerService.findMapLayer(layer.getId())) {
+                    // check if we have a group for this layer in maplayer service
+                    const groupForLayer = layer.getGroups()[0];
+                    const mapLayerGroup = mapLayerService.getAllLayerGroups(groupForLayer.id);
+                    if (!mapLayerGroup) {
+                        const group = {
+                            id: groupForLayer.id,
+                            name: {
+                                [Oskari.getLang()]: groupForLayer.name
+                            }
+                        };
+                        mapLayerService.addLayerGroup(Oskari.clazz.create('Oskari.mapframework.domain.MaplayerGroup', group));
+                    }
+
                     mapLayerService.addLayer(layer);
                 }
                 if (options.showLayer !== 'registerOnly' && !this._sandbox.findMapLayerFromSelectedMapLayers(layer.getId())) {

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -775,9 +775,8 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
          */
         _loadAllLayerGroupsAjaxCallBack: function (pResp, callbackSuccess) {
             var me = this;
-
-            me._layerGroups = [];
-
+            // we don't want to reset "this._layerGroups" at the beginning since there groups
+            //  created at runtime like one for statistical regionsets and we don't want to remove those.
             pResp.groups.forEach(function (group) {
                 var groupDom = Oskari.clazz.create('Oskari.mapframework.domain.MaplayerGroup', group);
                 me._layerGroups.push(groupDom);


### PR DESCRIPTION
- Don't overwrite groups that we have when the layerlisting XHR completes (removing runtime generated groups like one for statistical data)
- Ensure that we have a group for the layer referenced in VectorLayerRequests on maplayer service 
- Use group.getChildren() to get layers that are on the group since group.getLayers() doesn't have the layers in the group at least for runtime layers.