### PR TITLE
Generate runtime groups for myplaces and userlayer layers

### DIFF
--- a/bundles/framework/myplacesimport/service/MyPlacesImportService.js
+++ b/bundles/framework/myplacesimport/service/MyPlacesImportService.js
@@ -10,6 +10,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
     this.urls.create = Oskari.urls.getRoute('CreateUserLayer', { srs: srsName });
     this.urls.get = Oskari.urls.getRoute('GetUserLayers', { srs: srsName });
     this.urls.edit = Oskari.urls.getRoute('EditUserLayer');
+    // negative value for group id means that admin isn't presented with tools for it
+    this.groupId = -1 * Oskari.seq.nextVal('usergeneratedGroup');
 }, {
     __name: 'MyPlacesImport.MyPlacesImportService',
     __qname: 'Oskari.mapframework.bundle.myplacesimport.MyPlacesImportService',
@@ -109,6 +111,20 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
      * @param {Function} cb
      */
     _addLayersToService: function (layers = [], cb) {
+        // initialize the group these layers will be in:
+        const mapLayerService = this.instance.getMapLayerService();
+        const mapLayerGroup = mapLayerService.getAllLayerGroups(this.groupId);
+        if (!mapLayerGroup) {
+            const loclayer = this.instance.getLocalization().layer;
+            const group = {
+                id: this.groupId,
+                name: {
+                    [Oskari.getLang()]: loclayer.inspire
+                }
+            };
+            mapLayerService.addLayerGroup(Oskari.clazz.create('Oskari.mapframework.domain.MaplayerGroup', group));
+        }
+
         layers.forEach((layerJson) => {
             this.addLayerToService(layerJson, true);
         });
@@ -141,7 +157,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
         var loclayer = this.instance.getLocalization().layer;
         mapLayer.setOrganizationName(loclayer.organization);
         mapLayer.setGroups([{
-            id: 'USERLAYER',
+            id: this.groupId,
             name: loclayer.inspire
         }]);
         // Add the layer to the map layer service

--- a/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
+++ b/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
@@ -7,6 +7,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmyplaces.domain.MyPlacesLayer
         this.localization = Oskari.getLocalization('MapMyPlaces');
         this.sandbox = sandbox;
         this.wfsBuilder = Oskari.clazz.create('Oskari.mapframework.bundle.mapwfs2.domain.WfsLayerModelBuilder', sandbox);
+        // created in parseLayer so it can be used to detect if we have already done it
+        this.groupId = null;
     }, {
         /**
          * parses any additional fields to model
@@ -23,9 +25,23 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmyplaces.domain.MyPlacesLayer
             if (loclayer.organization) {
                 layer.setOrganizationName(loclayer.organization);
             }
+            if (!this.groupId) {
+                // negative value for group id means that admin isn't presented with tools for it
+                this.groupId = -1 * Oskari.seq.nextVal('usergeneratedGroup');
+                const mapLayerGroup = maplayerService.getAllLayerGroups(this.groupId);
+                if (!mapLayerGroup) {
+                    const group = {
+                        id: this.groupId,
+                        name: {
+                            [Oskari.getLang()]: loclayer.inspire
+                        }
+                    };
+                    maplayerService.addLayerGroup(Oskari.clazz.create('Oskari.mapframework.domain.MaplayerGroup', group));
+                }
+            }
             if (loclayer.inspire) {
                 layer.setGroups([{
-                    id: layer.getId(),
+                    id: this.groupId,
                     name: loclayer.inspire
                 }]);
             }


### PR DESCRIPTION
With hierarchy layerlist the groups need to be initialized so they are listed on the layerlist UI. Just having references to groups that are _not_ "registered" in maplayerservice does nothing for the layerlisting. So we need to initialize the groups manually for any layers that are generated at runtime (== not part of the "normal" layer listing from server).