### PR TITLE
Fix "did you mean React.forwardRef()" errors

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
@@ -106,7 +106,7 @@ const AdminLayerForm = ({
                     cancelText={getMessage('cancel')}
                     placement='bottomLeft'
                 >
-                    <StyledButton>
+                    <StyledButton danger>
                         <Message messageKey='delete'/>
                     </StyledButton>
                 </Confirm>

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
@@ -106,11 +106,9 @@ const AdminLayerForm = ({
                     cancelText={getMessage('cancel')}
                     placement='bottomLeft'
                 >
-                    <span>
-                        <StyledButton>
-                            <Message messageKey='delete'/>
-                        </StyledButton>
-                    </span>
+                    <StyledButton>
+                        <Message messageKey='delete'/>
+                    </StyledButton>
                 </Confirm>
                 { hasCapabilitiesSupport &&
                     <StyledButton onClick={() => controller.addNewFromSameService() }>

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
@@ -105,9 +105,11 @@ const AdminLayerForm = ({
                     cancelText={getMessage('cancel')}
                     placement='bottomLeft'
                 >
-                    <StyledButton>
-                        <Message messageKey='delete'/>
-                    </StyledButton>
+                    <span>
+                        <StyledButton>
+                            <Message messageKey='delete'/>
+                        </StyledButton>
+                    </span>
                 </Confirm>
                 { hasCapabilitiesSupport &&
                     <StyledButton onClick={() => controller.addNewFromSameService() }>

--- a/bundles/admin/admin-layereditor/view/LayerWizard/LayerCapabilitiesListing.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard/LayerCapabilitiesListing.jsx
@@ -115,11 +115,9 @@ const getItem = (onSelect, item, getMessage) => {
             okText={getMessage('ok')}
             cancelText={getMessage('cancel')}
         >
-            <span>
-                <StyledListItem item={item}>
-                    {item.layer.name} / {item.title} {getIcon(item)}
-                </StyledListItem>
-            </span>
+            <StyledListItem item={item}>
+                {item.layer.name} / {item.title} {getIcon(item)}
+            </StyledListItem>
         </Confirm>);
     }
     return (

--- a/bundles/admin/admin-layereditor/view/LayerWizard/LayerCapabilitiesListing.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard/LayerCapabilitiesListing.jsx
@@ -115,9 +115,11 @@ const getItem = (onSelect, item, getMessage) => {
             okText={getMessage('ok')}
             cancelText={getMessage('cancel')}
         >
-            <StyledListItem item={item}>
-                {item.layer.name} / {item.title} {getIcon(item)}
-            </StyledListItem>
+            <span>
+                <StyledListItem item={item}>
+                    {item.layer.name} / {item.title} {getIcon(item)}
+                </StyledListItem>
+            </span>
         </Confirm>);
     }
     return (

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/AllLayersSwitch.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/AllLayersSwitch.jsx
@@ -55,14 +55,12 @@ export const AllLayersSwitch = ({ checked, onToggle, layerCount = 0 }) => {
             placement='top'
             popupStyle={{zIndex: '999999'}}
         >
-            <span>
-                <StyledSwitch
-                    size="small"
-                    checked={checked} onClickCapture={(event) => {
-                        event.stopPropagation();
-                        showConfirm(true);
-                    }} />
-            </span>
+            <StyledSwitch
+                size="small"
+                checked={checked} onClickCapture={(event) => {
+                    event.stopPropagation();
+                    showConfirm(true);
+                }} />
         </Confirm>);
 };
 

--- a/src/react/components/Confirm.jsx
+++ b/src/react/components/Confirm.jsx
@@ -6,8 +6,31 @@ import 'antd/es/popconfirm/style/index.js';
 // NOTE! z-index is overridden in resources/css/portal.css
 // Without the override the confirm is shown behind flyouts (for example in admin)
 
+/*
+Note! The same span-wrapper is done in Tooltip.jsx and it has the same issue.
+AntD confirm extends AntD tooltip but since we have wrappers for both we need to do the extra span in both.
+Children that are NOT created with styled-components wrapper don't need the span but we add it always for now
+so the developer doesn't need to care or know that an extra prop should be used to include the wrapper-span.
+It shouldn't hurt even if it's not always needed:
+https://github.com/oskariorg/oskari-frontend/pull/1550
+
+The children of Tooltip are wrapped in a `span` to prevent JS-errors like this:
+
+Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?
+
+Check the render method of `styled__IconButton`.
+    in Button (created by styled__IconButton)
+    in styled__IconButton (created by Trigger)
+    in Trigger (created by ForwardRef(Tooltip))
+    in ForwardRef(Tooltip) (created by Tooltip)
+    in Tooltip (created by Tooltip)
+```
+
+There seems to be a problem with tooltips with styled-components as direct children:
+https://stackoverflow.com/questions/61450739/understanding-warning-function-components-cannot-be-given-refs
+*/
 export const Confirm = ({ children, ...other }) => (
-    <Popconfirm {...other}>{children}</Popconfirm>
+    <Popconfirm {...other}><span>{children}</span></Popconfirm>
 );
 
 Confirm.propTypes = {

--- a/src/react/components/Tooltip.jsx
+++ b/src/react/components/Tooltip.jsx
@@ -3,6 +3,13 @@ import { Tooltip as AntTooltip } from 'antd';
 import 'antd/es/tooltip/style/index.js';
 
 /*
+Note! The same span-wrapper is done in Confirm.jsx and it has the same issue.
+AntD confirm extends AntD tooltip but since we have wrappers for both we need to do the extra span in both.
+Children that are NOT created with styled-components wrapper don't need the span but we add it always for now
+so the developer doesn't need to care or know that an extra prop should be used to include the wrapper-span.
+It shouldn't hurt even if it's not always needed:
+https://github.com/oskariorg/oskari-frontend/pull/1550
+
 The children of Tooltip are wrapped in a `span` to prevent JS-errors like this:
 
 Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?


### PR DESCRIPTION
AntD confirm that has a direct child of a styled-component 'tag' gives this error. It works but the dev-console shows an error. Wrapping the `<StyledX` to an empty span is not clean or elegant but it removes the error from being generated. Maybe we should create a wrapper component just for this purpose instead?


```
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

Check the render method of `styled__StyledButton`.
    in Button (created by styled__StyledButton)
    in styled__StyledButton (created by Trigger)
    in Trigger (created by ForwardRef(Tooltip))
    in ForwardRef(Tooltip) (created by Tooltip)
    in Tooltip (created by ForwardRef)
    in ForwardRef (created by Confirm)
    in Confirm (created by AdminLayerForm)
    in div (created by styled__StyledRoot)