### PR TITLE
Make "Add all layers in group" to map more configurable

### DIFF
--- a/bundles/framework/layerlist/Flyout.js
+++ b/bundles/framework/layerlist/Flyout.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { LocaleProvider } from 'oskari-ui/util';
 import { LayerViewTabs, LayerViewTabsHandler, TABS_ALL_LAYERS } from './view/LayerViewTabs/';
+import { LAYER_GROUP_TOGGLE_LIMIT, LAYER_GROUP_TOGGLE_DEFAULTS } from './constants';
 
 /**
  * @class Oskari.mapframework.bundle.layerlist.Flyout
@@ -18,6 +19,15 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerlist.Flyout',
      */
     function (instance) {
         this.instance = instance;
+        // show "add all layers to map" for groups that have at most 10 layers in the group
+        const defaultOpts = {
+            [LAYER_GROUP_TOGGLE_LIMIT]: LAYER_GROUP_TOGGLE_DEFAULTS.DISABLE_TOGGLE
+        };
+        const instanceConf = this.instance.conf || {};
+        this.optsForUI = {
+            ...defaultOpts,
+            ...instanceConf
+        };
         this.container = null;
         this.tabsHandler = new LayerViewTabsHandler(this.instance);
         this.tabsHandler.getLayerListHandler().loadLayers();
@@ -109,6 +119,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerlist.Flyout',
                 <LocaleProvider value={{ bundleKey: this.instance.getName() }}>
                     <LayerViewTabs
                         {...this.tabsHandler.getState()}
+                        opts={this.optsForUI}
                         controller={this.tabsHandler.getController()}/>
                 </LocaleProvider>
             );

--- a/bundles/framework/layerlist/Flyout.js
+++ b/bundles/framework/layerlist/Flyout.js
@@ -19,7 +19,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerlist.Flyout',
      */
     function (instance) {
         this.instance = instance;
-        // show "add all layers to map" for groups that have at most 10 layers in the group
+        // the show "add all layers to map" control for groups is disabled by default. Use instance conf to enable it.
         const defaultOpts = {
             [LAYER_GROUP_TOGGLE_LIMIT]: LAYER_GROUP_TOGGLE_DEFAULTS.DISABLE_TOGGLE
         };

--- a/bundles/framework/layerlist/constants.js
+++ b/bundles/framework/layerlist/constants.js
@@ -1,0 +1,8 @@
+// controls if the "add all layers in group to map" toggle is shown
+// if the group has more layers than the limit the switch is not shown to user
+export const LAYER_GROUP_TOGGLE_LIMIT = 'layerGroupToggleLimit';
+export const LAYER_GROUP_TOGGLE_DEFAULTS = {
+    UNLIMITED: -1,
+    DISABLE_TOGGLE: 0,
+    SANE_LIMIT: 10
+}

--- a/bundles/framework/layerlist/constants.js
+++ b/bundles/framework/layerlist/constants.js
@@ -2,7 +2,10 @@
 // if the group has more layers than the limit the switch is not shown to user
 export const LAYER_GROUP_TOGGLE_LIMIT = 'layerGroupToggleLimit';
 export const LAYER_GROUP_TOGGLE_DEFAULTS = {
+    // always show toggle
     UNLIMITED: -1,
+    // never show toggle
     DISABLE_TOGGLE: 0,
+    // max reasonable limit of layers to add to the map with a single click
     SANE_LIMIT: 10
-}
+};

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/AllLayersSwitch.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/AllLayersSwitch.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Confirm, Message, Switch } from 'oskari-ui';
+import { LAYER_GROUP_TOGGLE_DEFAULTS } from '../../../../constants';
 import styled from 'styled-components';
 
 const StyledSwitch = styled(Switch)`
@@ -8,7 +9,7 @@ margin-left: 5px;
 margin-right: 5px;
 `;
 
-const LIMIT_FOR_CONFIRMATION = 10;
+const LIMIT_FOR_CONFIRMATION = LAYER_GROUP_TOGGLE_DEFAULTS.SANE_LIMIT;
 
 /**
  * Component to toggle all layers on group to or from map.

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
@@ -16,7 +16,7 @@ const StyledCollapse = styled(Collapse)`
     }
 `;
 
-const LayerCollapse = ({ groups, openGroupTitles, selectedLayerIds, controller }) => {
+const LayerCollapse = ({ groups, openGroupTitles, selectedLayerIds, opts, controller }) => {
 
     if (!Array.isArray(groups) || groups.length === 0) {
         return <Alert showIcon type='info' message={<Message messageKey='errors.noResults' />} />;
@@ -33,6 +33,7 @@ const LayerCollapse = ({ groups, openGroupTitles, selectedLayerIds, controller }
                             trimmed
                             selectedLayerIds={selectedLayerIds}
                             group={group}
+                            opts={opts}
                             controller={controller}
                         />
                     );
@@ -47,6 +48,7 @@ LayerCollapse.propTypes = {
     openGroupTitles: PropTypes.array.isRequired,
     filtered: PropTypes.array,
     selectedLayerIds: PropTypes.array.isRequired,
+    opts: PropTypes.object,
     controller: PropTypes.instanceOf(Controller).isRequired
 };
 

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
@@ -23,15 +23,20 @@ const PanelToolContainer = React.memo(({group, layerCount, allLayersOnMap, contr
             controller.removeGroupLayersFromMap(group);
         }
     };
+    // the switch adds ALL the layers in the group to the map so it's misleading if we show it when some layers are not shown in the list
+    // TODO: show switch for filtered layers BUT only add the layers that match the filter when toggled
+    const filtered = typeof group.unfilteredLayerCount !== 'undefined' && layerCount !== group.unfilteredLayerCount;
+    const showAllLayersToggle = !filtered && layerCount > 0;
     return (
         <StyledCollapsePanelTools>
             <LayerCountBadge
                 layerCount={layerCount}
                 unfilteredLayerCount={group.unfilteredLayerCount} />
-            <AllLayersSwitch
+            { showAllLayersToggle && <AllLayersSwitch
                 checked={allLayersOnMap}
                 layerCount={layerCount}
                 onToggle={toggleLayersOnMap} />
+            }
             <GroupToolRow group={group} />
         </StyledCollapsePanelTools>
     );

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerList.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerList.jsx
@@ -59,7 +59,7 @@ const UpdateInProgressIndicator = ({ show, children }) => {
 };
 
 const LayerList = React.forwardRef((props, ref) => {
-    const { error, loading = false, updating = false, controller } = props;
+    const { error, loading = false, updating = false, opts, controller } = props;
     if (error) {
         return <Alert showIcon type="error" description={error}/>;
     }
@@ -69,7 +69,6 @@ const LayerList = React.forwardRef((props, ref) => {
     // Clear btn won't clear the value properly without this.
     const filterKey = `${filter.state.activeFilterId}`;
     const { searchText, filters, activeFilterId } = filter.state;
-
     return (
         <Content spacing={'15px'}>
             <Row spacing={'8px'}>
@@ -98,7 +97,7 @@ const LayerList = React.forwardRef((props, ref) => {
             { loading && <Spinner/> }
             { !loading &&
                 <UpdateInProgressIndicator show={updating}>
-                    <LayerCollapse {...collapse.state} controller={collapse.controller}/>
+                    <LayerCollapse opts={opts} {...collapse.state} controller={collapse.controller}/>
                 </UpdateInProgressIndicator>
             }
         </Content>
@@ -117,6 +116,7 @@ LayerList.propTypes = {
     filter: shapes.stateful.isRequired,
     createTools: PropTypes.array,
     grouping: PropTypes.shape(grouping).isRequired,
+    opts: PropTypes.object,
     controller: PropTypes.instanceOf(Controller).isRequired
 };
 

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerViewTabs.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerViewTabs.jsx
@@ -30,7 +30,7 @@ const focus = ref => {
     }
 };
 
-const LayerViewTabs = ({ tab, layerList, selectedLayers, autoFocusSearch, controller }) => {
+const LayerViewTabs = ({ tab, layerList, selectedLayers, autoFocusSearch, opts, controller }) => {
     // NOT sure why search would not focus when rendered and the ref/focus code could be inside LayerList-component?
     // The effect should be that when that tab is shown we focus on the search
     const searchTermInputRef = useRef(null);
@@ -53,7 +53,7 @@ const LayerViewTabs = ({ tab, layerList, selectedLayers, autoFocusSearch, contro
                 key={TABS_ALL_LAYERS}
                 tab={<Message messageKey='tabs.layerList' />}
             >
-                <LayerList ref={searchTermInputRef} {...layerList.state} controller={layerList.controller} />
+                <LayerList ref={searchTermInputRef} opts={opts} {...layerList.state} controller={layerList.controller} />
             </TabPane>
             <TabPane
                 key={TABS_SELECTED_LAYERS}
@@ -75,6 +75,7 @@ LayerViewTabs.propTypes = {
     layerList: shapes.stateful.isRequired,
     selectedLayers: shapes.stateful.isRequired,
     tab: PropTypes.string,
+    opts: PropTypes.object,
     autoFocusSearch: PropTypes.bool,
     controller: PropTypes.instanceOf(Controller).isRequired
 };


### PR DESCRIPTION
Add a config for the bundle: `layerGroupToggleLimit` that can be used to configure if the switch should be shown in the layer listing. The default value is 0 which meand the toggle is never shown. A negative value means that the toggle is always shown. A positive value can be used to limit groups that will have the toggle where `5` means that groups with 5 layers or less show the toggle.