### PR TITLE
Add identifiers for automated tests

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/Layer/Layer.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/Layer/Layer.jsx
@@ -54,7 +54,7 @@ const LayerName = ({ layer }) => {
 
 const Layer = ({ model, selected, controller }) => {
     return (
-        <LayerDiv className="layer">
+        <LayerDiv className="t_layer" data-id={model.getId()}>
             <CustomTools className="custom-tools">
                 {
                     model.getTools()

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
@@ -153,7 +153,11 @@ const LayerCollapsePanel = (props) => {
     //   between render as whole vs render when the panel is opened.
     const isPanelOpen = propsNeededForPanel.isActive;
     return (
-        <StyledCollapsePanel {...propsNeededForPanel} 
+        <StyledCollapsePanel {...propsNeededForPanel}
+            // TODO: remove gid_[id] once data-attributes work for AntD Collapse.Panels
+            className={`t_group gid_${group.getId()}`}
+            // data-attr doesn't seem to work for the panel in AntD-version 4.8.5
+            data-gid={group.getId()}
             header={group.getTitle()}
             extra={
                 <PanelToolContainer


### PR DESCRIPTION
So we can find the elements in DOM more easily.