### PR TITLE
Move indicator selection into callback

### DIFF
--- a/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
@@ -175,11 +175,12 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
                             return;
                         }
                         me.displayInfo();
+                        me.selectSavedIndicator(indicator, data);
                     });
                 } else {
                     me.displayInfo();
+                    me.selectSavedIndicator(indicator, data);
                 }
-                me.selectSavedIndicator(indicator, data);
             });
         });
         this.setContent(this.uiElement);


### PR DESCRIPTION
Move selection into callback to ensure that indicator has been saved correctly before selection.