### PR TITLE
Statistics state handling fixes

### DIFF
--- a/bundles/statistics/statsgrid2016/Tile.js
+++ b/bundles/statistics/statsgrid2016/Tile.js
@@ -8,6 +8,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Tile', function (instance, serv
     this.template = null;
     this._tileExtensions = {};
     this.flyoutManager = null;
+    this._attached = false;
     this._templates = {
         extraSelection: _.template('<div class="statsgrid-functionality ${ id }" data-view="${ id }"><div class="icon"></div><div class="text">${ label }</div></div>')
     };
@@ -135,6 +136,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Tile', function (instance, serv
         Object.keys(extraOptions).forEach(function (key) {
             extraOptions[key].addClass('hidden');
         });
+        this._attached = false;
         this.flyoutManager.tileClosed();
     },
     /**
@@ -146,7 +148,11 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Tile', function (instance, serv
         Object.keys(extraOptions).forEach(function (key) {
             extraOptions[key].removeClass('hidden');
         });
+        this._attached = true;
         this.flyoutManager.tileAttached();
+    },
+    isAttached: function () {
+        return this._attached;
     },
     /**
      * [getExtensions description]

--- a/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
+++ b/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
@@ -371,7 +371,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
                 effect: 'darken'
             };
         }
-
         this.sb.postRequestByName(
             'VectorLayerRequest',
             [
@@ -460,8 +459,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
             me.render(state.getRegion());
         });
         me.service.on('StatsGrid.StateChangedEvent', function (event) {
+            me._clearRegions();
             if (event.isReset()) {
-                me._clearRegions();
                 return;
             }
             me.render(state.getRegion());

--- a/bundles/statistics/statsgrid2016/service/StateService.js
+++ b/bundles/statistics/statsgrid2016/service/StateService.js
@@ -148,7 +148,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
             // published maps or saved views may contain dublicate indicators => filter dublicates
             }).filter((ind, i, inds) => inds.findIndex(find => (find.hash === ind.hash)) === i);
 
-            let active = this.indicators.find(ind => ind.hash === activeHash);
+            const active = this.indicators.find(ind => ind.hash === activeHash);
             if (active) {
                 const { classification, series, selections } = active;
                 if (classification) {
@@ -164,15 +164,17 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
         },
         getState: function () {
             // map to keep stored states work properly
-            const indicators = this.indicators.map(ind => {
-                return {
-                    ds: ind.datasource,
-                    id: ind.indicator,
-                    selections: ind.selections,
-                    series: ind.series,
-                    classification: ind.classification || this.getClassificationOpts(ind.hash)
-                };
-            });
+            const indicators = this.indicators
+                .filter(ind => !ind.indicator.startsWith('RuntimeIndicator'))
+                .map(ind => {
+                    return {
+                        ds: ind.datasource,
+                        id: ind.indicator,
+                        selections: ind.selections,
+                        series: ind.series,
+                        classification: ind.classification || this.getClassificationOpts(ind.hash)
+                    };
+                });
             const activeInd = this.getActiveIndicator();
             return {
                 indicators,

--- a/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
@@ -160,6 +160,15 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
             'float': 'right',
             'clear': 'both'
         });
+        const onSucess = (indicator, data) => {
+            me.genericInfoPanel.close();
+            me.dataPanel.open();
+            me.indicatorParamsList.showAddDatasetForm(!me.indicatorId);
+            me.indicatorDataForm.clearUi();
+            me.updateDatasetList();
+            me.selectSavedIndicator(indicator, data);
+            me.showSuccessPopup();
+        };
         saveBtn.setHandler(function () {
             me.saveIndicator(me.indicatorForm.getValues(), function (err, indicator) {
                 if (err) {
@@ -174,12 +183,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
                             Oskari.log('IndicatorFormFlyout').error(err);
                             return;
                         }
-                        me.displayInfo();
-                        me.selectSavedIndicator(indicator, data);
+                        onSucess(indicator, data);
                     });
                 } else {
-                    me.displayInfo();
-                    me.selectSavedIndicator(indicator, data);
+                    onSucess(indicator, data);
                 }
             });
         });
@@ -196,6 +203,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
         stateService.setRegionset(selectors.regionset);
         delete selectors.regionset;
         stateService.addIndicator(ds, id, selectors);
+        const hash = stateService.getHash(ds, id, selectors);
+        stateService.setActiveIndicator(hash);
     },
     /**
      * Opens a form for user to add or edit data for indicators year/regionset
@@ -318,24 +327,13 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
             callback(null, someData);
         });
     },
-    displayInfo: function () {
-        var me = this;
+    showSuccessPopup: function () {
         var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
-        var okBtn = Oskari.clazz.create('Oskari.userinterface.component.buttons.OkButton');
-        // TODO: add a button to show the added indicator on map or just show it right away?
         // TODO: add the name of the indicator and/or year/regionset that was added/modified?
         var title = this.locale('userIndicators.dialog.successTitle');
         var content = this.locale('userIndicators.dialog.successMsg');
-        okBtn.setPrimary(true);
-        okBtn.setHandler(function () {
-            dialog.close(true);
-            me.genericInfoPanel.close();
-            me.dataPanel.open();
-            me.indicatorParamsList.showAddDatasetForm(!me.indicatorId);
-            me.indicatorDataForm.clearUi();
-            me.updateDatasetList();
-        });
-        dialog.show(title, content, [okBtn]);
+        dialog.show(title, content, [dialog.createCloseButton()]);
+        dialog.fadeout();
     }
 }, {
     extend: ['Oskari.userinterface.extension.ExtraFlyout']

--- a/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
@@ -160,7 +160,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
             'float': 'right',
             'clear': 'both'
         });
-        const onSucess = (indicator, data) => {
+        const onSuccess = (indicator, data) => {
             me.genericInfoPanel.close();
             me.dataPanel.open();
             me.indicatorParamsList.showAddDatasetForm(!me.indicatorId);
@@ -183,10 +183,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
                             Oskari.log('IndicatorFormFlyout').error(err);
                             return;
                         }
-                        onSucess(indicator, data);
+                        onSuccess(indicator, data);
                     });
                 } else {
-                    onSucess(indicator, data);
+                    onSuccess(indicator, data);
                 }
             });
         });


### PR DESCRIPTION
AfterMapLayerRemoveEvent can't use StateChangedEvent reset === true becaue it's used when state is cleared so many components assumes that there's no inicators when this event is triggered.
https://github.com/oskariorg/oskari-frontend/blob/develop/bundles/statistics/statsgrid2016/service/StateService.js#L125-L132

AfterMapLayerAddEvent changed to trigger StateChangedEvent reset === false to be sure that components make full render. Earlier state was empty when statslayer was added to map or other events were triggered.

Added add/remove maplayer to check if statsgrid is active (tile is attached) to handle only events which are triggered outside from statsgrid (e.g. layerlist, publisher). If statsgrid adds/removes layer then other events will be triggered.

Changed RegionsetViewer to clearRegions always when StateChangedEvent is triggered to be sure that regions will be added to map. Earlier removing statslayer cleared state and that cleared regions.

Gather full state only when statslayer is selected to avoid adding layer to map on refresh, publishing map, saving view.. Filter runtime indicators.

// listen for search closing to remove stats layer if no indicators was found
==> fixed to listen only search plugin hide

Own indicators: add selectSavedIndicator to set saved indicator as active to be sure that regionsetviewer renders features to map. on RegionsetChangedEvent indicator isn't added yet and IndicatorEvent isn't listened.
https://github.com/oskariorg/oskari-frontend/blob/develop/bundles/statistics/statsgrid2016/components/RegionsetViewer.js#L25

Refactor displayInfo => showSuccessPopup and move success handling out of popup's button handler.