### PR TITLE
Handle unsupported layertypes in admin-layereditor

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -144,6 +144,7 @@ Oskari.registerLocalization(
                 }
             },
             "layerStatus": {
+                "unsupportedType": "Admin functionality doesn't support the layer type",
                 "existing": "The map layer is already registered to this service. By selecting this you will be adding a duplicate layer.",
                 "problematic": "There were some issues parsing the capabilities for this layer. This layer might not work properly if added.",
                 "unsupported": "According to capabilities this layer doesn't support projections used on this service. This layer might not work properly if added."

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -145,6 +145,7 @@ Oskari.registerLocalization(
                 }
             },
             "layerStatus": {
+                "unsupportedType": "Ylläpitotoiminnallisuus ei tue tasotyyppiä",
                 "existing": "Taso on jo rekisteröity palveluun. Valitsemalla tämän tulet lisäämään saman tason useampaan kertaan.",
                 "problematic": "Tason capabilities parsinnassa ongelmia. Taso ei välttämättä toimi oikein.",
                 "unsupported": "Taso ei capabilitiesin mukaan tue käytössä olevia projektioita. Taso ei välttämättä toimi oikein."

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -87,8 +87,8 @@ Oskari.registerLocalization(
             "themeName": "Teman namn",
             "addTheme": "Lägg till tema",
             "editTheme": "Redigera tema",
-            "addSubtheme": "Lägg subtema", // FIX!? Is this correct translation?
-            "editSubtheme": "Redigera subtema",  // FIX!? Is this correct translation?
+            "addSubtheme": "Lägg undertema",
+            "editSubtheme": "Redigera undertema",
             "selectMapLayerGroupsButton": "Välj grupp",
             "cancel": "Tillbaka",
             "close": "Stäng",
@@ -143,6 +143,7 @@ Oskari.registerLocalization(
                 }
             },
             "layerStatus": {
+                "unsupportedType": "Admin-funktionalitet stöder inte lagertypen",
                 "existing": "Lagret är redan registrerat i tjänsten. Genom att välja det lägger du till samma lager flera gånger.",
                 "problematic": "Det förekom problem vid tolkningen av lagrets capabilities dokument. Lagret fungerar kanske inte normalt.",
                 "unsupported": "Lagret stöder inte de projektioner, som tjänsten använder. Lagret fungerar kanske inte normalt."

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerForm.jsx
@@ -56,6 +56,7 @@ const AdminLayerForm = ({
     validationErrors = [],
     scales
 }) => {
+    const isLayerTypeSupported = propertyFields.length > 0;
     // For returning to add multiple layers from service endpoint
     const hasCapabilitiesSupport = propertyFields.includes(LayerComposingModel.CAPABILITIES);
     let validPermissions = true;
@@ -95,7 +96,7 @@ const AdminLayerForm = ({
                     controller={controller}/>
             </TabPane>
         </Tabs>
-        <MemoedSaveButton isNew={!!layer.isNew} onSave={onSave} validationErrors={validationErrors} />
+        { isLayerTypeSupported && <MemoedSaveButton isNew={!!layer.isNew} onSave={onSave} validationErrors={validationErrors} /> }
         { !layer.isNew &&
             <React.Fragment>
                 <Confirm

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/GeneralTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/GeneralTabPane.jsx
@@ -10,6 +10,7 @@ import { Groups } from './Groups';
 import { TileGrid } from './TileGrid';
 import { Version } from './Version';
 import { Mandatory } from '../Mandatory';
+import { LayerTypeNotSupported } from '../LayerTypeNotSupported';
 
 const {
     API_KEY,
@@ -24,18 +25,24 @@ const {
     VERSION
 } = Oskari.clazz.get('Oskari.mapframework.domain.LayerComposingModel');
 
-const GeneralTabPane = ({ validators, mapLayerGroups, dataProviders, versions, layer, propertyFields, controller }) => (
-    <Fragment>
-        { wrapMandatory(validators, layer, 'url', getEndpointField(layer, propertyFields, controller)) }
-        { wrapMandatory(validators, layer, 'version', getVersionField(layer, propertyFields, controller, versions)) }
-        { wrapMandatory(validators, layer, 'srs', getSRSField(layer, propertyFields, controller)) }
-        { wrapMandatory(validators, layer, 'options.tileGrid', getTileGridField(layer, propertyFields, controller)) }
-        { wrapMandatory(validators, layer, 'name', getNameField(layer, propertyFields, controller)) }
-        { wrapMandatory(validators, layer, `locale.${Oskari.getSupportedLanguages()[0]}.name`, getLocaleField(layer, propertyFields, controller)) }
-        { wrapMandatory(validators, layer, 'dataProviderId', getDataproviderField(layer, propertyFields, controller, dataProviders)) }
-        { wrapMandatory(validators, layer, 'groups', getGroupsField(layer, propertyFields, controller, mapLayerGroups)) }
-    </Fragment>
-);
+const GeneralTabPane = ({ validators, mapLayerGroups, dataProviders, versions, layer, propertyFields, controller }) => {
+    const isLayerTypeSupported = propertyFields.length > 0;
+    if (!isLayerTypeSupported) {
+        return (<LayerTypeNotSupported type={layer.type} />);
+    }
+    return (
+        <Fragment>
+            { wrapMandatory(validators, layer, 'url', getEndpointField(layer, propertyFields, controller)) }
+            { wrapMandatory(validators, layer, 'version', getVersionField(layer, propertyFields, controller, versions)) }
+            { wrapMandatory(validators, layer, 'srs', getSRSField(layer, propertyFields, controller)) }
+            { wrapMandatory(validators, layer, 'options.tileGrid', getTileGridField(layer, propertyFields, controller)) }
+            { wrapMandatory(validators, layer, 'name', getNameField(layer, propertyFields, controller)) }
+            { wrapMandatory(validators, layer, `locale.${Oskari.getSupportedLanguages()[0]}.name`, getLocaleField(layer, propertyFields, controller)) }
+            { wrapMandatory(validators, layer, 'dataProviderId', getDataproviderField(layer, propertyFields, controller, dataProviders)) }
+            { wrapMandatory(validators, layer, 'groups', getGroupsField(layer, propertyFields, controller, mapLayerGroups)) }
+        </Fragment>
+    );
+};
 
 // TODO: this isn't as elegant as it could. Maybe refactor so we can loop the field names and get Fields and
 // validators/Mandatory based on that

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/LayerTypeNotSupported.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/LayerTypeNotSupported.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Message } from 'oskari-ui';
+import { Empty } from 'antd';
+
+const StyledDiv = styled('div')`
+    margin: 25px;
+`;
+
+const LayerTypeNotSupported = ({ type }) => (
+    <StyledDiv>
+        <Empty description={
+            <span><Message messageKey='layerStatus.unsupportedType' />: <b>{type}</b></span>
+        }/>
+    </StyledDiv>
+);
+
+LayerTypeNotSupported.propTypes = {
+    type: PropTypes.string.isRequired
+};
+
+export { LayerTypeNotSupported };

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VisualizationTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VisualizationTabPane.jsx
@@ -14,6 +14,7 @@ import { StyledColumn } from './styled';
 import { RasterStyle } from './RasterStyle';
 import { TimeSeries } from './TimeSeries';
 import { VectorStyle } from './VectorStyle';
+import { LayerTypeNotSupported } from '../LayerTypeNotSupported';
 
 const {
     OPACITY,
@@ -29,8 +30,12 @@ const {
     CESIUM_ION
 } = Oskari.clazz.get('Oskari.mapframework.domain.LayerComposingModel');
 
-export const VisualizationTabPane = ({ layer, scales, propertyFields, controller }) => (
-    <Fragment>
+export const VisualizationTabPane = ({ layer, scales, propertyFields, controller }) => {
+    const isLayerTypeSupported = propertyFields.length > 0;
+    if (!isLayerTypeSupported) {
+        return (<LayerTypeNotSupported type={layer.type} />);
+    }
+    return (<Fragment>
         <StyledColumn.Left>
             { propertyFields.includes(OPACITY) &&
                 <Opacity layer={layer} controller={controller} />
@@ -71,8 +76,8 @@ export const VisualizationTabPane = ({ layer, scales, propertyFields, controller
                 <Scale layer={layer} scales={scales} controller={controller} />
             }
         </StyledColumn.Right>
-    </Fragment>
-);
+    </Fragment>);
+};
 
 VisualizationTabPane.propTypes = {
     layer: PropTypes.object.isRequired,


### PR DESCRIPTION
- Show a message about layer type instead of empty UI when layer type is not supported
- Hide save for admin when editing unsupported layer type since things clicking save might remove the name and other details for the layer