### PR TITLE
Divmanazer close popup fix

### DIFF
--- a/bundles/framework/divmanazer/component/Popup.js
+++ b/bundles/framework/divmanazer/component/Popup.js
@@ -19,6 +19,8 @@ Oskari.clazz.define('Oskari.userinterface.component.Popup',
         this._isVisible = false;
         // for preventing things going infinity with onClose() handlers. show() and close() use this.
         this._closingInProgress = false;
+        this._fadeoutTime = 3000;
+        this._fadeoutTimer = null;
     }, {
         /**
          * @method show
@@ -32,34 +34,30 @@ Oskari.clazz.define('Oskari.userinterface.component.Popup',
             var me = this;
             var contentDiv = this.dialog.find('div.content');
             var actionDiv = this.dialog.find('div.actions');
-            var i;
-            var focusedButton = -1;
             var screenWidth = window.innerWidth;
             var screenHeight = window.innerHeight;
-
             this.setTitle(title);
             this.setContent(message);
+            buttons = Array.isArray(buttons) ? buttons : [];
 
             // Remove previous buttons
             actionDiv.empty();
-            if (buttons && buttons.length > 0) {
-                for (i = 0; i < buttons.length; i += 1) {
-                    buttons[i].insertTo(actionDiv);
-                    if (buttons[i].isFocus()) {
-                        focusedButton = i;
-                    }
-                }
-            } else if (!this.dialog.find('.close-icon')) {
+            if (buttons.length) {
+                buttons.forEach(btn => btn.insertTo(actionDiv));
+            } else if (!this.dialog.find('.close-icon').length) {
                 // if no actions, the user can click on popup to close it
                 this.dialog.on('click', function () {
                     me.close(true);
                 });
+                this.fadeout(5000);
             } else {
                 actionDiv.remove();
+                this.fadeout();
             }
             jQuery('body').append(this.dialog);
-            if (focusedButton >= 0) {
-                buttons[focusedButton].focus();
+            const focusedIndex = buttons.lastIndexOf(btn => btn.isFocused());
+            if (focusedIndex > 0) {
+                buttons[focusedIndex].focus();
             }
 
             this._setReasonableHeight();
@@ -157,15 +155,11 @@ Oskari.clazz.define('Oskari.userinterface.component.Popup',
          * Removes the popup after given time has passed
          * @param {Number} timeout milliseconds
          */
-        fadeout: function (timeout) {
-            var me = this,
-                timer = 3000;
-            if (timeout) {
-                timer = timeout;
-            }
-            setTimeout(function () {
-                me.close();
-            }, timer);
+        fadeout: function (timeout = this._fadeoutTime) {
+            clearTimeout(this._fadeoutTimer);
+            this._fadeoutTimer = setTimeout(() => {
+                this.close();
+            }, timeout);
         },
         /**
          * @method addClass


### PR DESCRIPTION
!this.dialog.find('.close-icon') is always false. Changed to check length to fix issue where user doesn't have any way to close popup if there's no actions (buttons or close-icon). Also added fadeout() because it's not clear that clicking popup will close it without actions.
