### PR TITLE
Stats layer empty check

### DIFF
--- a/bundles/statistics/statsgrid2016/components/IndicatorDataForm.js
+++ b/bundles/statistics/statsgrid2016/components/IndicatorDataForm.js
@@ -134,10 +134,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.IndicatorDataForm', function (l
             }
             // replace commas and cast value to number as legend expects it to be a number
             dataItem.value = dataItem.value.replace(/,/g, '.');
-            if (!isNaN(dataItem.value)) {
-                dataItem.value = Number(dataItem.value);
-                data.values.push(dataItem);
-            }
+            data.values.push(dataItem);
         });
         return data;
     },

--- a/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
@@ -163,8 +163,14 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
         saveBtn.setHandler(function () {
             const dataForm = me.indicatorForm.getValues();
             const valuesForm = me.indicatorDataForm.getValues();
+            const formValidates = me.validateFormValues(dataForm, valuesForm.values);
 
-            me.saveIndicator(dataForm, valuesForm.values, function (err, indicator) {
+            if (!formValidates) {
+                me.errorService.show(me.locale('errors.title'), me.locale('errors.indicatorSave'));
+                return;
+            }
+
+            me.saveIndicator(dataForm, function (err, indicator) {
                 if (err) {
                     me.errorService.show(me.locale('errors.title'), me.locale('errors.indicatorSave'));
                     return;
@@ -251,23 +257,30 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
             });
         });
     },
+    validateFormValues: function (data, regionValues) {
+        if (typeof (data.name) !== 'string' || data.name.length === 0) {
+            return false;
+        }
+
+        if (regionValues.length === 0) {
+            return false;
+        }
+
+        regionValues.forEach(singleRegion => {
+            console.log(singleRegion);
+            if (typeof singleRegion.value !== 'number') {
+                return false;
+            }
+        });
+
+        return true;
+    },
     /**
      * Saves the indicator name, description etc
      */
-    saveIndicator: function (data, values, callback) {
+    saveIndicator: function (data, callback) {
         var me = this;
-        // TODO: validate values
-        var isValid = function (data) {
-            if (typeof (data.name) !== 'string' || data.name.length === 0 || values.length === 0) {
-                return false;
-            }
-            return true;
-        };
 
-        if (!isValid(data)) {
-            callback('Input not valid');
-            return;
-        }
         // inject possible id for indicator
         data.id = me.indicatorId;
         me.service.saveIndicator(me.datasourceId, data, function (err, indicator) {
@@ -296,13 +309,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
                 // call self again now that we have an indicator we can attach the dataset to
                 me.saveIndicatorData(data, callback);
             });
-            return;
-        }
-
-        // TODO: validate values
-        var isValid = true;
-        if (!isValid) {
-            callback('Input not valid');
             return;
         }
 

--- a/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
@@ -163,7 +163,19 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
         saveBtn.setHandler(function () {
             const dataForm = me.indicatorForm.getValues();
             const valuesForm = me.indicatorDataForm.getValues();
-            const formValidates = me.validateFormValues(dataForm, valuesForm.values);
+
+            // Format and check that raw form data is provided as numbers
+            valuesForm.values = valuesForm.values.map((regionData) => {
+                if (!isNaN(regionData.value)) {
+                    regionData.value = Number(regionData.value);
+                    return regionData.value;
+                } else {
+                    me.errorService.show(me.locale('errors.title'), me.locale('errors.indicatorSave'));
+                    return;
+                }
+            });
+
+            const formValidates = me.validateFormValues(dataForm, valuesForm);
 
             if (!formValidates) {
                 me.errorService.show(me.locale('errors.title'), me.locale('errors.indicatorSave'));
@@ -262,15 +274,15 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
             return false;
         }
 
-        if (regionValues.length === 0) {
+        if (regionValues.values.length === 0) {
             return false;
         }
 
-        regionValues.forEach(singleRegion => {
-            if (typeof singleRegion.value !== 'number') {
+        for (const singleRegion of regionValues.values) {
+            if (typeof singleRegion === 'undefined' || !singleRegion || isNaN(singleRegion) || typeof singleRegion !== 'number') {
                 return false;
             }
-        });
+        }
 
         return true;
     },

--- a/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
@@ -267,7 +267,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
         }
 
         regionValues.forEach(singleRegion => {
-            console.log(singleRegion);
             if (typeof singleRegion.value !== 'number') {
                 return false;
             }

--- a/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
@@ -203,10 +203,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
                             Oskari.log('IndicatorFormFlyout').error(err);
                             return;
                         }
-                        onSuccess(indicator, data);
+                        onSuccess(indicator, valuesForm);
                     });
                 } else {
-                    onSuccess(indicator, data);
+                    onSuccess(indicator, valuesForm);
                 }
             });
         });

--- a/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
@@ -161,25 +161,27 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
             'clear': 'both'
         });
         saveBtn.setHandler(function () {
-            me.saveIndicator(me.indicatorForm.getValues(), function (err, indicator) {
+            const dataForm = me.indicatorForm.getValues();
+            const valuesForm = me.indicatorDataForm.getValues();
+
+            me.saveIndicator(dataForm, valuesForm.values, function (err, indicator) {
                 if (err) {
                     me.errorService.show(me.locale('errors.title'), me.locale('errors.indicatorSave'));
                     return;
                 }
-                var data = me.indicatorDataForm.getValues();
-                if (data.values.length) {
-                    me.saveIndicatorData(data, function (err, someData) {
+                if (valuesForm.values.length) {
+                    me.saveIndicatorData(valuesForm, function (err, someData) {
                         if (err) {
                             me.errorService.show(me.locale('errors.title'), me.locale('errors.indicatorSave'));
                             Oskari.log('IndicatorFormFlyout').error(err);
                             return;
                         }
                         me.displayInfo();
-                        me.selectSavedIndicator(indicator, data);
+                        me.selectSavedIndicator(indicator, valuesForm);
                     });
                 } else {
                     me.displayInfo();
-                    me.selectSavedIndicator(indicator, data);
+                    me.selectSavedIndicator(indicator, valuesForm);
                 }
             });
         });
@@ -252,11 +254,11 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
     /**
      * Saves the indicator name, description etc
      */
-    saveIndicator: function (data, callback) {
+    saveIndicator: function (data, values, callback) {
         var me = this;
         // TODO: validate values
         var isValid = function (data) {
-            if (typeof (data.name) !== 'string' || data.name.length === 0) {
+            if (typeof (data.name) !== 'string' || data.name.length === 0 || values.length === 0) {
                 return false;
             }
             return true;

--- a/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
@@ -173,14 +173,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
             const dataForm = me.indicatorForm.getValues();
             const valuesForm = me.indicatorDataForm.getValues();
 
-            // Format and check that raw form data is provided as numbers
-            valuesForm.values = valuesForm.values.map((regionData) => {
+            // Format raw form data so that it is provided as numbers
+            valuesForm.values.forEach((regionData, index) => {
                 if (!isNaN(regionData.value)) {
-                    regionData.value = Number(regionData.value);
-                    return regionData.value;
-                } else {
-                    me.errorService.show(me.locale('errors.title'), me.locale('errors.indicatorSave'));
-                    return;
+                    valuesForm.values[index].value = Number(regionData.value);
                 }
             });
 
@@ -283,12 +279,12 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
             return false;
         }
 
-        if (regionValues.values.length === 0) {
+        if (typeof regionValues.values === 'undefined' || regionValues.values.length === 0) {
             return false;
         }
 
         for (const singleRegion of regionValues.values) {
-            if (typeof singleRegion === 'undefined' || !singleRegion || isNaN(singleRegion) || typeof singleRegion !== 'number') {
+            if (typeof singleRegion.value === 'undefined' || !singleRegion.value || isNaN(singleRegion.value) || typeof singleRegion.value !== 'number') {
                 return false;
             }
         }
@@ -338,6 +334,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
         data.values.forEach(function (regionData) {
             values[regionData.id] = regionData.value;
         });
+
         me.service.saveIndicatorData(me.datasourceId, this.indicatorId, data.selectors, values, function (err, someData) {
             if (err) {
                 callback(err);


### PR DESCRIPTION
Moved _String_ to _Number_ conversion from _IndicatorDataForm.js_ to _IndicatorFlyoutForm.js_ so validation can trigger errors if form is filled incorrectly. When conversion was in its old place _String_ values didn't show up in values array but remained in visual form.