### PR TITLE
Popup show fadeout fix

### DIFF
--- a/bundles/admin/admin/instance.js
+++ b/bundles/admin/admin/instance.js
@@ -26,6 +26,9 @@ Oskari.clazz.define('Oskari.admin.bundle.admin.GenericAdminBundleInstance',
             if (location) {
                 this._dialog.moveTo(location.target, location.align);
             }
+            if (!buttons || !buttons.length) {
+                this._dialog.fadeout();
+            }
         },
         afterStart: function () {
             // register request handler

--- a/bundles/framework/divmanazer/component/Popup.js
+++ b/bundles/framework/divmanazer/component/Popup.js
@@ -44,15 +44,8 @@ Oskari.clazz.define('Oskari.userinterface.component.Popup',
             actionDiv.empty();
             if (buttons.length) {
                 buttons.forEach(btn => btn.insertTo(actionDiv));
-            } else if (!this.dialog.find('.close-icon').length) {
-                // if no actions, the user can click on popup to close it
-                this.dialog.on('click', function () {
-                    me.close(true);
-                });
-                this.fadeout(5000);
             } else {
                 actionDiv.remove();
-                this.fadeout();
             }
             jQuery('body').append(this.dialog);
             const focusedIndex = buttons.lastIndexOf(btn => btn.isFocused());


### PR DESCRIPTION
Revert fadeout on popup.show() and remove click-close without actions  because there could be other close handlers and fadeout and click-close caused unwanted behavior.

Add fadeout to admin showMessage.