### PR TITLE
Fix an issue with moving layers to subgroups

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -653,8 +653,9 @@ class UIHandler extends StateHandler {
                 const item = {
                     id
                 };
-                const group = this.mapLayerGroups.find(g => g.id === id);
+                const group = this.findMapLayerGroupById(id);
                 if (!group) {
+                    // this means the layer will go to "ungrouped" group
                     return item;
                 }
                 item.name = Oskari.getLocalized(group.name);
@@ -662,6 +663,24 @@ class UIHandler extends StateHandler {
             });
             this.refreshEndUserLayer(layerId, layer);
         });
+    }
+
+    /**
+     * Search through known groups for group
+     * @param {Number} groupId group to search for
+     * @param {Oskari.mapframework.bundle.layerselector2.model.LayerGroup[]} groupList optional list for recursion, default to root groups list
+     * @returns an instance of Oskari.mapframework.bundle.layerselector2.model.LayerGroup or undefined if group was not found
+     */
+    findMapLayerGroupById (groupId, groupList) {
+        const groups = groupList || this.mapLayerGroups;
+        if (!groups.length) {
+            return;
+        }
+        const result = groups.find(g => g.id === groupId);
+        if (result) {
+            return result;
+        }
+        return this.findMapLayerGroupById(groupId, groups.flatMap(g => g.getGroups()));
     }
 
     /**

--- a/bundles/mapping/mapmodule/domain/AbstractLayer.js
+++ b/bundles/mapping/mapmodule/domain/AbstractLayer.js
@@ -378,7 +378,11 @@ Oskari.clazz.define(
          * @return {String} inspire theme name under which the layer is listed in UI
          */
         getInspireName: function () {
-            return (this._groups[0]) ? this._groups[0].name : '';
+            const groups = this.getGroups();
+            if (!groups.length) {
+                return '';
+            }
+            return groups[0].name;
         },
         /**
          * @method setFeatureInfoEnabled
@@ -1286,11 +1290,18 @@ Oskari.clazz.define(
          * @method @public setGroups
          * @param {Array} groups groups array [{id:1,name:"name"}]
          */
-        setGroups: function (groups) {
-            this._groups = groups || [{ id: -1, name: '' }];
+        setGroups: function (groups = []) {
+            this._groups = groups;
+            if (!this._groups.length) {
+                // FIXME: other parts of code should handle missing groups
+                this.setGroups([{ id: -1, name: '' }]);
+            }
         },
         addGroup: function (group) {
-            this._groups.push(group);
+            // FIXME: get rid of the default group...
+            const newGroups = this.getGroups().filter(g => g.id !== -1);
+            newGroups.push(group);
+            this.setGroups(newGroups);
         },
         /**
          * @method @public getGroups get groups

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -156,6 +156,9 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                 // for each group on the layer
                 groups.forEach(function (group) {
                     // find the group details
+                    if (group.id === -1) {
+                        return;
+                    }
                     var groupConf = me.getAllLayerGroups(group.id);
                     if (!groupConf) {
                         return;


### PR DESCRIPTION
Admin functionality didn't search from subgroups so layer was listed in both "ungrouped" and the actual group.