### PR TITLE
Filter out empty groups for layerlist

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
@@ -1,5 +1,5 @@
 import { StateHandler, controllerMixin } from 'oskari-ui/util';
-import { groupLayers } from './util';
+import { groupLayers, filterOutEmptyGroups } from './util';
 import { FILTER_ALL_LAYERS } from '..';
 
 const ANIMATION_TIMEOUT = 400;
@@ -192,7 +192,8 @@ class ViewHandler extends StateHandler {
 
     updateLayerGroups () {
         const { searchText, activeId: filterId } = this.filter;
-        const layers = filterId === FILTER_ALL_LAYERS ? this.mapLayerService.getAllLayers() : this.mapLayerService.getFilteredLayers(filterId);
+        const isPresetFiltered = filterId !== FILTER_ALL_LAYERS;
+        const layers = !isPresetFiltered ? this.mapLayerService.getAllLayers() : this.mapLayerService.getFilteredLayers(filterId);
         const tools = Object.values(this.toolingService.getTools()).filter(tool => tool.getTypes().includes('layergroup'));
 
         // For admin users all groups and all data providers are provided to groupLayers function to include possible empty groups to layerlist.
@@ -206,7 +207,7 @@ class ViewHandler extends StateHandler {
             groupsToProcess = getDataProviders(this.mapLayerService.getDataProviders(), layers);
         }
 
-        const groups = groupLayers([...layers], this.groupingMethod, tools, groupsToProcess, this.loc.grouping.noGroup);
+        const groups = groupLayers([...layers], this.groupingMethod, tools, groupsToProcess, this.loc.grouping.noGroup, isPresetFiltered);
         this.updateState({ groups: filterGroups(groups, searchText) });
     }
 

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
@@ -1,5 +1,5 @@
 import { StateHandler, controllerMixin } from 'oskari-ui/util';
-import { groupLayers, filterOutEmptyGroups } from './util';
+import { groupLayers } from './util';
 import { FILTER_ALL_LAYERS } from '..';
 
 const ANIMATION_TIMEOUT = 400;

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/util.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/util.js
@@ -83,7 +83,7 @@ const createGroupModel = (group, method, allLayers, tools, admin) => {
 // This is required since previous processing only filters out groups that don't have
 //  neither layers or subgroups. Without this we might still end up with groups without
 //  layers that have with subgroups without layers
-export const filterOutEmptyGroups = (groups = []) => {
+const filterOutEmptyGroups = (groups = []) => {
     return groups.map(group => {
         group.groups = filterOutEmptyGroups(group.groups);
         if (!group.layers.length && !group.groups.length) {


### PR DESCRIPTION
Previous implementation only filtered out groups without layers when user initiated filtering wasn't on (newest or by layertype etc). Admin still sees empty groups when no filtering is done for layers by the user.