### PR TITLE
Show only active filters on layerlist

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Filter/FilterHandler.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Filter/FilterHandler.js
@@ -18,10 +18,7 @@ class ViewHandler extends StateHandler {
             ({ properties }) => this.addFilter(properties));
 
         const throttledUpdate = Oskari.util.throttle(
-            this.refreshActiveFilters.bind(this),
-                1000,
-                { leading: false }
-         );
+            this.refreshActiveFilters.bind(this), 1000, { leading: false });
         this.eventHandlers = {
             'MapLayerEvent': event => {
                 if (['add', 'remove'].includes(event.getOperation())) {
@@ -36,7 +33,7 @@ class ViewHandler extends StateHandler {
     /**
      * "Module" name for event handling
      */
-     getName () {
+    getName () {
         return 'LayerList.FilterHandler';
     }
     /**

--- a/bundles/framework/layerlist/view/LayerViewTabs/test.util.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/test.util.js
@@ -58,7 +58,10 @@ export const addLayer = (type) => {
 export const addFilter = (id, text, tooltip) => {
     // TODO: if mapLayerService doesn't recognize the filter it returns unfiltered list.
     //  This feels like a bug but lets register the filter to both since that what the code _should_ be doing.
-    mapLayerService.registerLayerFilter(id, (layer) => !!layer);
+    if (id !== 'newest') {
+        // newest is built-in filter on maplayerservice, overriding it here creates side-effects for other tests
+        mapLayerService.registerLayerFilter(id, (layer) => !!layer);
+    }
     layerlistService.registerLayerlistFilterButton(text, tooltip, '', id);
     // TODO: unregister these on teardown()
 };

--- a/bundles/framework/layerlist/view/LayerViewTabs/test.util.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/test.util.js
@@ -3,22 +3,62 @@ import '../../../layerlist/resources/locale/en';
 import '../../../../mapping/mapmodule/service/map.state';
 import '../../service/LayerListToolingService';
 import '../../../../mapping/mapmodule/service/map.layer';
+import '../../../../mapping/mapmodule/domain/AbstractLayer';
+import '../../../../mapping/mapmodule/domain/style';
+import '../../../../mapping/mapmodule/event/map.layer';
+import '../../../../mapping/mapmodule/plugin/wmslayer/wmslayer';
+
+const sandbox = Oskari.getSandbox();
+const layerlistService = Oskari.clazz.create('Oskari.mapframework.service.LayerlistService', sandbox);
+const toolingService = Oskari.clazz.create('Oskari.mapframework.service.LayerListToolingService', sandbox);
+const mapStateService = Oskari.clazz.create('Oskari.mapframework.domain.Map', sandbox);
+const mapLayerService = Oskari.clazz.create('Oskari.mapframework.service.MapLayerService', sandbox);
+const layers = [];
 
 export const initServices = () => {
-    const sandbox = Oskari.getSandbox();
-    const layerlistService = Oskari.clazz.create('Oskari.mapframework.service.LayerlistService', sandbox);
-    const toolingService = Oskari.clazz.create('Oskari.mapframework.service.LayerListToolingService', sandbox);
-    const mapStateService = Oskari.clazz.create('Oskari.mapframework.domain.Map', sandbox);
-    const mapLayerService = Oskari.clazz.create('Oskari.mapframework.service.MapLayerService', sandbox);
     sandbox.registerService(layerlistService);
     sandbox.registerService(toolingService);
     sandbox.registerService(mapStateService);
     sandbox.registerService(mapLayerService);
 };
 
+// remove added things so we don't affect other tests
+// TODO: remove filters registered in this test
+export const teardown = () => {
+    layers.forEach(l => mapLayerService.removeLayer(l, true));
+    sandbox.unregisterService(layerlistService.getQName());
+    sandbox.unregisterService(toolingService.getQName());
+    sandbox.unregisterService(mapStateService.getQName());
+    sandbox.unregisterService(mapLayerService.getQName());
+};
+
 const bundleName = 'LayerList';
 export const getBundleInstance = () => ({
-    getSandbox: () => Oskari.getSandbox(),
+    getSandbox: () => sandbox,
     getName: () => bundleName,
     getLocalization: () => Oskari.getLocalization(bundleName)
 });
+
+const generateDummyLayer = (type) => {
+    return {
+        id: Math.round(Math.random() * 10000),
+        type: type,
+        // the "newest" filter used in test requires the "created" to be set to function
+        // without it the test will only show 2 filters
+        created: new Date()
+    };
+};
+
+export const addLayer = (type) => {
+    const newLayer = mapLayerService.createMapLayer(generateDummyLayer(type));
+    mapLayerService.addLayer(newLayer);
+    layers.push(newLayer);
+};
+
+export const addFilter = (id, text, tooltip) => {
+    // TODO: if mapLayerService doesn't recognize the filter it returns unfiltered list.
+    //  This feels like a bug but lets register the filter to both since that what the code _should_ be doing.
+    mapLayerService.registerLayerFilter(id, (layer) => !!layer);
+    layerlistService.registerLayerlistFilterButton(text, tooltip, '', id);
+    // TODO: unregister these on teardown()
+};

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -410,7 +410,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
         addLayerToGroup: function (groupId, layerId, orderNumber = 1000000, suppressEvent = false) {
             if (groupId === -1) {
                 // group of -1 is "ungrouped"
-                return
+                return;
             }
             const group = this.getAllLayerGroups(groupId);
             if (!group) {
@@ -445,7 +445,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
         removeLayerFromGroup: function (groupId, layerId, suppressEvent = false) {
             if (groupId === -1) {
                 // group of -1 is "ungrouped"
-                return
+                return;
             }
             const group = this.getAllLayerGroups(groupId);
             if (!group) {

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -1022,13 +1022,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                 Oskari.log(this.getName()).warn('[MapLayerService] not found layer filter "' + filterId + '". Returning all layers.');
                 return allLayers;
             }
-            var filteredLayers = [];
-            allLayers.forEach(function (layer) {
-                if (filterFunction(layer)) {
-                    filteredLayers.push(layer);
-                }
-            });
-            return filteredLayers;
+            return allLayers.filter(filterFunction);
         },
         /**
          * @method  @public getFilteredLayers  Get filtered layer groups

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -408,6 +408,10 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
          * @param {Boolean} suppressEvent defaults to false, true to NOT send an event (for mass updates)
          */
         addLayerToGroup: function (groupId, layerId, orderNumber = 1000000, suppressEvent = false) {
+            if (groupId === -1) {
+                // group of -1 is "ungrouped"
+                return
+            }
             const group = this.getAllLayerGroups(groupId);
             if (!group) {
                 return;
@@ -439,6 +443,10 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
          * @param {Boolean} suppressEvent defaults to false, true to NOT send an event (for mass updates)
          */
         removeLayerFromGroup: function (groupId, layerId, suppressEvent = false) {
+            if (groupId === -1) {
+                // group of -1 is "ungrouped"
+                return
+            }
             const group = this.getAllLayerGroups(groupId);
             if (!group) {
                 return;

--- a/src/sandbox/sandbox.js
+++ b/src/sandbox/sandbox.js
@@ -84,6 +84,15 @@
             registerService: function (service) {
                 services[service.getQName()] = service;
             },
+            /**
+             * @method unregisterService
+             * Removes the service from Oskari system registry
+             *
+             * @param {String} serviceQName qname of service to register (service.getQName())
+             */
+            unregisterService: function (serviceQName) {
+                delete services[serviceQName];
+            },
 
             /**
              * Method for asking a registered service


### PR DESCRIPTION
Removes layer filters from UI that are available in the Oskari instance/appsetup like 3d/timeseries but don't result in any layers to be found. 