### PR TITLE
Vectorlayer registerOnly fix

### DIFF
--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -584,6 +584,10 @@ Oskari.clazz.define(
                 if (options.showLayer !== 'registerOnly' && !this._sandbox.findMapLayerFromSelectedMapLayers(layer.getId())) {
                     var request = Oskari.requestBuilder('AddMapLayerRequest')(layer.getId());
                     this._sandbox.request(this, request);
+                } else if (options.showLayer === 'registerOnly') {
+                    // remove maplayer from map because _getOlLayer adds it to map and this is only for registering layer
+                    // FIXME: refactor _getOlLayer -> handle get, update and add separately
+                    this.removeMapLayerFromMap(layer);
                 }
             }
 

--- a/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
+++ b/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
@@ -459,11 +459,14 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
             me.render(state.getRegion());
         });
         me.service.on('StatsGrid.StateChangedEvent', function (event) {
-            me._clearRegions();
             if (event.isReset()) {
                 return;
             }
+            me._clearRegions();
             me.render(state.getRegion());
+        });
+        me.service.on('AfterMapLayerRemoveEvent', function () {
+            me._clearRegions();
         });
 
         me.service.on('FeatureEvent', function (event) {

--- a/bundles/statistics/statsgrid2016/instance.js
+++ b/bundles/statistics/statsgrid2016/instance.js
@@ -329,13 +329,17 @@ Oskari.clazz.define(
                 }
             },
             'AfterMapLayerRemoveEvent': function (event) {
-                // listen event only when statsgrid isn't active
-                if (event.getMapLayer().getId() === this._layerId || this.getTile().isAttached()) {
+                if (event.getMapLayer().getId() !== this._layerId) {
+                    return;
+                }
+                if (!this.getTile().isAttached()) {
+                    // clear ui if statsgrid isn't active
                     this.clearDataProviderInfo();
                     this._setClassificationViewVisible(false);
                     this._setSeriesControlVisible(false);
                     this.flyoutManager.hideFlyouts();
                 }
+                this.statsService.notifyOskariEvent(event);
             },
             /**
              * @method MapLayerEvent


### PR DESCRIPTION
Remove maplayer from map because _getOlLayer adds it to map and this is only for registering layer. If layer is added to map too early it may be added with wrong index.

Statsgrid: clear regions when statslayer is removed.