### PR TITLE
Vectorlayer visible fix

### DIFF
--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -1040,7 +1040,11 @@ Oskari.clazz.define(
             return this._olLayers[id];
         },
         setVisibleByLayerId: function (id, visible) {
-            var layer = this.getLayerById(id);
+            const olLayer = this.getLayerById(id);
+            if (olLayer) {
+                olLayer.setVisible(visible);
+            }
+            const layer = this._oskariLayers[id];
             if (layer) {
                 layer.setVisible(visible);
             }


### PR DESCRIPTION
_getOlLayer updates visibility from oskari layer.
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js#L462
Sync oskari layer visibility for non-registered (showLayer:false) vector layers.

https://github.com/oskariorg/oskari-docs/issues/221