### PR TITLE
Handle low numbers from feature props as years

### DIFF
--- a/bundles/framework/timeseries/service/TimeseriesMetadataService.js
+++ b/bundles/framework/timeseries/service/TimeseriesMetadataService.js
@@ -85,7 +85,7 @@ export class TimeseriesMetadataService {
             const time = feature.properties[attribute];
             if (typeof time === 'number' && time < 10000) {
                 // handle as year value
-                yearSet.add(year);
+                yearSet.add(time);
             } else if (time) {
                 const year = moment(time).year();
                 yearSet.add(year);

--- a/bundles/framework/timeseries/service/TimeseriesMetadataService.js
+++ b/bundles/framework/timeseries/service/TimeseriesMetadataService.js
@@ -83,7 +83,10 @@ export class TimeseriesMetadataService {
         const yearSet = new Set();
         this.getCurrentFeatures().forEach(feature => {
             const time = feature.properties[attribute];
-            if (time) {
+            if (typeof time === 'number' && time < 10000) {
+                // handle as year value
+                yearSet.add(year);
+            } else if (time) {
                 const year = moment(time).year();
                 yearSet.add(year);
             }


### PR DESCRIPTION
Handle low numbers as is instead of parsing through moment.js. Moment.js handles number as milliseconds resulting in every year being 1970.