### PR TITLE
Featuredata refactor propeties handling

### DIFF
--- a/bundles/framework/featuredata2/Flyout.js
+++ b/bundles/framework/featuredata2/Flyout.js
@@ -776,7 +776,7 @@ Oskari.clazz.define(
             this.handler.setIsActive(!!isEnabled);
             // feature info activation disabled if object data grid flyout active and vice versa
             var gfiReqBuilder = Oskari.requestBuilder(
-                'MapModulePlugin.GetFeatureInfoActivationRequest' // TODO: fix
+                'MapModulePlugin.GetFeatureInfoActivationRequest'
             );
             const name = this.instance.getName();
             if (gfiReqBuilder) {

--- a/bundles/framework/featuredata2/Flyout.js
+++ b/bundles/framework/featuredata2/Flyout.js
@@ -204,6 +204,9 @@ Oskari.clazz.define(
             if (this.resizable) {
                 this._enableResize();
             }
+            // update panels to add layers that are added before handler and panel container is initialized
+            // handler setState doesn't trigger _updatePanels, only add/remove layer updates panels
+            this._updatePanels(this.handler.getState().layerIds);
         },
         update: function (state, updated) {
             // some optimization for jQuery rendering
@@ -214,14 +217,17 @@ Oskari.clazz.define(
             }
             if (updated === 'layerIds') {
                 const { layerIds } = state;
-                layerIds.filter(id => !this.hasPanel(id)).forEach(id => this.createPanel(id));
-                const stringIds = layerIds.map(id => '' + id);
-                Object.keys(this.panels).filter(id => !stringIds.includes(id)).forEach(id => this.removePanel(id));
+                this._updatePanels(layerIds);
                 return;
             }
             if (state.isActive) {
                 this._renderFeatureData(state);
             }
+        },
+        _updatePanels: function (layerIds) {
+            layerIds.filter(id => !this.hasPanel(id)).forEach(id => this.createPanel(id));
+            const stringIds = layerIds.map(id => '' + id);
+            Object.keys(this.panels).filter(id => !stringIds.includes(id)).forEach(id => this.removePanel(id));
         },
         turnOnClickOff: function () {
             var me = this;

--- a/bundles/framework/featuredata2/Flyout.js
+++ b/bundles/framework/featuredata2/Flyout.js
@@ -1,4 +1,4 @@
-
+import { FeatureDataHandler, PROPERTY_NAMES, DEFAULT_HIDDEN_FIELDS } from './view/FeatureDataHandler';
 /**
  * @class Oskari.mapframework.bundle.featuredata2.Flyout
  *
@@ -20,12 +20,10 @@ Oskari.clazz.define(
         this.container = null;
         this.flyout = null;
         this.state = null;
-        this.layers = {};
+        this.panels = {};
         this._fixedDecimalCount = 2;
 
         this.tabsContainer = null;
-        this.selectedTab = null;
-        this.active = false;
         this.templateLink = jQuery('<a href="JavaScript:void(0);"></a>');
 
         this.templateLocateOnMap = jQuery('<div class="featuredata-go-to-location"></div>');
@@ -52,14 +50,15 @@ Oskari.clazz.define(
                 this.template[p] = jQuery(this.__templates[p]);
             }
         }
-
         for (var t in this.eventHandlers) {
             if (this.eventHandlers.hasOwnProperty(t)) {
                 this.sandbox.registerForEventByName(this, t);
             }
         }
-
-        this.wfsLayerService = null;
+        this.WFSLayerService = null;
+        this.handler = new FeatureDataHandler(this.instance);
+        this.handler.addStateListener(state => this._renderFeatureData(state));
+        this.handler.addCustomStateListener(({ selectedFeatures }) => this._renderFeatureData(selectedFeatures));
     }, {
         __templates: {
             wrapper: '<div class="gridMessageContainer" style="margin-top:30px; margin-left: 10px;"></div>'
@@ -99,7 +98,7 @@ Oskari.clazz.define(
         startPlugin: function () {
             this.tabsContainer = Oskari.clazz.create(
                 'Oskari.userinterface.component.TabContainer',
-                this.instance.getLocalization('nodata')
+                this.instance.loc('nodata')
             );
         },
 
@@ -117,7 +116,7 @@ Oskari.clazz.define(
          * @return {String} localized text for the title of the flyout
          */
         getTitle: function () {
-            return this.instance.getLocalization('title');
+            return this.instance.loc('title');
         },
 
         /**
@@ -126,7 +125,7 @@ Oskari.clazz.define(
          * flyout
          */
         getDescription: function () {
-            return this.instance.getLocalization('desc');
+            return this.instance.loc('desc');
         },
 
         /**
@@ -138,7 +137,10 @@ Oskari.clazz.define(
         },
 
         isActive: function () {
-            return !!this.active;
+            if (!this.handler) {
+                return false;
+            }
+            return this.handler.getState().isActive;
         },
 
         /**
@@ -160,48 +162,48 @@ Oskari.clazz.define(
         setResizable: function (resizable) {
             this.resizable = resizable;
         },
-
+        setPanel (layerId, panel) {
+            this.panels[layerId] = panel;
+        },
+        getPanel (layerId) {
+            return this.panels[layerId];
+        },
+        getPanelIds () {
+            return Object.keys(this.panels);
+        },
+        removePanel (layerId) {
+            delete this.panels[layerId];
+        },
         /**
          * @method createUi
          * Creates the UI for a fresh start
          */
         createUi: function () {
-            const me = this;
-            const flyout = jQuery(me.container);
-            const sandbox = me.instance.sandbox;
-            const reqBuilder = Oskari.requestBuilder('activate.map.layer');
-            flyout.empty();
-            me.WFSLayerService = sandbox.getService('Oskari.mapframework.bundle.mapwfs2.service.WFSLayerService');
-
+            const container = jQuery(this.container);
+            container.empty();
             // if previous panel is undefined -> just added first tab
             // if selectedPanel is undefined -> just removed last tab
-            me.tabsContainer.addTabChangeListener(
-                function (previousPanel, selectedPanel) {
-                    var request;
+            this.tabsContainer.addTabChangeListener(
+                (previousPanel, selectedPanel) => {
                     // sendout dim request for unselected tab
                     if (previousPanel) {
-                        request = reqBuilder(previousPanel.layer.getId(), false);
-                        sandbox.request(me.instance.getName(), request);
                         previousPanel.getContainer().hide();
                     }
-                    me.selectedTab = selectedPanel;
                     if (selectedPanel) {
                         if (selectedPanel.getContainer().css('display') === 'none') {
                             selectedPanel.getContainer().show();
                         }
-                        // sendout activation request for selected tab
-                        if (me.active) {
-                            request = reqBuilder(selectedPanel.layer.getId(), true);
-                            sandbox.request(me.instance.getName(), request);
-                        }
-                        me.updateData(selectedPanel.layer);
+                    }
+                    const { layer } = selectedPanel;
+                    if (layer) {
+                        this.handler.setActiveLayer(layer.getId());
                     }
                 }
             );
-            me.tabsContainer.insertTo(flyout);
+            this.tabsContainer.insertTo(container);
 
             // Check if  tabcontainer is rendered flyout, fix then flyout overflow
-            var containerEl = me.tabsContainer.getElement();
+            var containerEl = this.tabsContainer.getElement();
             containerEl.parents('.oskari-flyoutcontentcontainer').css('overflow', 'hidden');
         },
         turnOnClickOff: function () {
@@ -210,7 +212,7 @@ Oskari.clazz.define(
         },
 
         addFilterFunctionality: function (event, layer) {
-            if (layer.isLayerOfType('userlayer')) { // Filter functionality is not implemented for userlayers
+            if (!layer.isFilterSupported()) {
                 return;
             }
 
@@ -263,6 +265,7 @@ Oskari.clazz.define(
             }
             return true;
         },
+
         /**
          * @method layerAdded
          * @param {Oskari.mapframework.domain.WfsLayer} layer
@@ -270,29 +273,26 @@ Oskari.clazz.define(
          * Adds a tab for the layer
          */
         layerAdded: function (layer) {
-            var me = this,
-                panel = Oskari.clazz.create(
-                    'Oskari.userinterface.component.TabPanel'
-                );
+            const panel = Oskari.clazz.create('Oskari.userinterface.component.TabPanel');
             panel.getContainer().append(
-                this.instance.getLocalization('loading')
+                this.instance.loc('loading')
             );
             const name = layer.getName();
             panel.setTitle(name);
             panel.setTooltip(name);
             panel.layer = layer;
-            this.layers['' + layer.getId()] = panel;
+            this.setPanel(layer.getId(), panel);
             this.tabsContainer.addPanel(panel);
-            if (!layer.isLayerOfType('userlayer')) { // Filter functionality is not implemented for userlayers
-                panel.setTitleIcon('icon-funnel', function (event) {
-                    me.addFilterFunctionality(event, layer);
+            if (layer.isFilterSupported()) {
+                panel.setTitleIcon('icon-funnel', event => {
+                    this.addFilterFunctionality(event, layer);
                 });
-                panel.getHeader().find('.icon-funnel').prop('title', this.instance.getLocalization('filterDialogTooltip'));
+                panel.getHeader().find('.icon-funnel').prop('title', this.instance.loc('filterDialogTooltip'));
             }
             this.updatePanelTitles();
         },
         updatePanelTitles: function () {
-            const panels = this.layers;
+            const panels = this.panels;
             const ids = Object.keys(panels);
             if (!this.flyout || !ids.length) return;
             const spaceForLabel = (this.flyout.width() - 45) / ids.length;
@@ -315,114 +315,34 @@ Oskari.clazz.define(
          * Removes the tab for the layer
          */
         layerRemoved: function (layer) {
-            var layerId = '' + layer.getId(),
-                panel = this.layers[layerId];
-            this.tabsContainer.removePanel(panel);
-            // clean up
+            const layerId = layer.getId();
+            const panel = this.getPanel(layerId);
             if (panel) {
-                panel.grid = null;
-                delete panel.grid;
-                panel.layer = null;
-                delete panel.layer;
-                this.layers[layerId] = null;
-                delete this.layers[layerId];
                 panel.getContainer().remove();
+                this.tabsContainer.removePanel(panel);
+                this.removePanel(layerId);
             }
             this.updatePanelTitles(true);
         },
-        /**
-         * @method  @public selectGridValues select grid values
-         * @param  {Array} selected     selected values
-         * @param  {Oskari.mapframework.domain.WfsLayer} layer     WFS layer that was select features
-         */
-        selectGridValues: function (selected, layer) {
-            if (!selected) {
-                return;
-            }
-            var me = this;
-            var panel = me.layers['' + layer.getId()];
+
+        selectGridValues: function () {
+            const { selectedFeatures, layerId } = this.handler.getState();
+            const panel = this.getPanel(layerId);
             if (!panel || !panel.grid) {
                 return;
             }
-            panel.grid.select(selected, false);
+            panel.grid.select(selectedFeatures, false);
         },
 
-        /**
-         * @method updateData
-         * @param {Oskari.mapframework.domain.WfsLayer} layer
-         *           WFS layer that was added
-         * Updates data for layer
-         */
-        updateData: function (layer) {
-            var panel = this.layers['' + layer.getId()];
-            var isOk = this.tabsContainer.isSelected(panel);
-            if (!layer || !isOk) {
+        moveSelectedRowsTop: function (layerId) {
+            const panel = this.getPanel(layerId);
+            if (!panel || !panel.grid) {
                 return;
             }
-
-            var map = this.instance.sandbox.getMap(),
-                container = panel.getContainer();
-
-            container.empty();
-            if (!layer.isInScale(map.getScale())) {
-                container.append(this.instance.getLocalization('errorscale'));
-                return;
-            }
-            if (layer.getFields().length === 0) {
-                container.append(this.instance.getLocalization('errorNoFields'));
-                return;
-            }
-            if (layer.getActiveFeatures().length === 0) {
-                container.parent().children('.tab-tools').remove();
-                container.removeAttr('style');
-                container.append(this.instance.getLocalization('layer')['out-of-content-area']);
-
-                if (!panel.grid) {
-                    container.parent().find('.grid-tools').remove();
-                }
-
-                return;
-            }
-            container.append(this.instance.getLocalization('loading'));
-
-            if (this.instance.__loadingStatus[layer.getId()] === 'error') {
-                return;
-            }
-
-            // in scale, proceed
-            this._prepareData(layer);
-
-            // Grid opacity
-            this.setGridOpacity(layer, 1.0);
-        },
-
-        moveSelectedRowsTop: function (layer) {
-            var me = this;
-            if (me.getSelectedFeatureIds() && me.layers[layer.getId()] && me.layers[layer.getId()].showSelectedRowsFirst) {
-                me.layers[layer.getId()].grid.moveSelectedRowsTop(true);
+            if (panel.showSelectedRowsFirst) {
+                panel.grid.moveSelectedRowsTop(true);
             }
         },
-
-        getSelectedFeatureIds: function (layer) {
-            var me = this;
-            if (!me.wfsLayerService) {
-                me.wfsLayerService = me.instance.sandbox.getService('Oskari.mapframework.bundle.mapwfs2.service.WFSLayerService');
-            }
-            return me.wfsLayerService.getSelectedFeatureIds(layer.getId());
-        },
-
-        /**
-         * @method updateGrid
-         * @param {Object} user's selection on map
-         * Updates grid for drawn places
-         */
-        updateGrid: function () {
-            if (!this.selectedTab) {
-                return;
-            }
-            this.updateData(this.selectedTab.layer);
-        },
-
         /**
          * @method _enableResize
          * Enables the flyout resizing
@@ -516,319 +436,235 @@ Oskari.clazz.define(
                 flyout.append(resizer);
             }
         },
+        calculateSize: function () {
+            const flyoutEl = this.flyout;
+            const flyoutContent = jQuery(this.container);
+            // Define default size for the object data list
+            var tabContent = flyoutEl.find('div.tab-content');
+            var flyoutContainer = flyoutEl.find('.oskari-flyoutcontentcontainer');
 
-        // helper for removing item (indexOf is not in IE8)
-        remove_item: function (a, val) {
-            var key;
-            for (key in a) {
-                if (a[key] === val) {
-                    a.splice(key, 1);
-                    break;
-                }
+            // FIXME Need calculate different way or only use styles
+            var paddings = flyoutContent.find('.grid-tools').height() +
+                flyoutContent.find('.tabsHeader').height() +
+                parseInt(tabContent.css('padding-top') || 0) +
+                parseInt(tabContent.css('padding-bottom') || 0) +
+                (flyoutContent.find('.exporter').height() || 0) + 10;
+
+            if (parent.height() === null) {
+                tabContent.css('max-height', '100%');
+            } else {
+                tabContent.css('height', (parent.height() - paddings) + 'px');
             }
-            return a;
+            const mapdiv = this.instance.sandbox.findRegisteredModuleInstance('MainMapModule').getMapEl();
+            flyoutContainer.css('max-width', mapdiv.width().toString() + 'px');
         },
-
-        /**
-         * Get visible fields
-         * @method @public getVisibleFields
-         * @param  {Object} layer
-         * @return {Array}  visible fields
-         */
-        getVisibleFields: function (layer) {
-            var fields = layer.getFields();
-            var hiddenFields = [];
-            var visibleFields = [];
-            hiddenFields.push('__fid');
-            hiddenFields.push('__centerX');
-            hiddenFields.push('__centerY');
-            hiddenFields.push('geometry');
-            // helper function for visibleFields
-            var contains = function (a, obj) {
-                for (var i = 0; i < a.length; i += 1) {
-                    if (a[i] === obj) {
-                        return true;
-                    }
-                }
-                return false;
-            };
-            // filter out certain fields
-            for (var i = 0; i < fields.length; i += 1) {
-                if (!contains(hiddenFields, fields[i])) {
-                    visibleFields.push(fields[i]);
-                }
-            }
-            return visibleFields;
-        },
-
-        /**
-         * @private @method _prepareData
-         * Updates data for layer
-         *
-         * @param {Oskari.mapframework.domain.WfsLayer} layer
-         * WFS layer that was added
-         * @param {Object} data
-         * WFS data JSON
-         *
-         */
-        _prepareData: function (layer) {
-            var me = this,
-                panel = this.layers['' + layer.getId()],
-                isOk = this.tabsContainer.isSelected(panel),
-                conf = me.instance.conf,
-                isManualRefresh = layer.isManualRefresh(),
-                allowLocateOnMap = isManualRefresh && this.instance && this.instance.conf && this.instance.conf.allowLocateOnMap;
-
-            if (isOk) {
-                panel.getContainer().parent().find('.featuredata2-show-selected-first').remove();
-                panel.getContainer().empty();
-                panel.getContainer().parent().find('.grid-tools').remove();
-
-                // create model
-                var model = Oskari.clazz.create(
-                    'Oskari.userinterface.component.GridModel'
-                );
-                model.setIdField('__fid');
-
-                // hidden fields (hide all - remove if not empty)
-                var hiddenFields = layer.getFields().slice(0);
-
-                // get data
-                var fields = layer.getFields().slice(0),
-                    locales = layer.getLocales().slice(0),
-                    features = layer.getActiveFeatures().slice(0),
-                    selectedFeatures = layer.getSelectedFeatures().slice(0); // filter
-
-                me._addFeatureValues(model, fields, hiddenFields, features, selectedFeatures);
-                me._addFeatureValues(model, fields, hiddenFields, selectedFeatures, null);
-
-                fields = model.getFields();
-
-                // ONLY AVAILABLE FOR WFS LAYERS WITH MANUAL REFRESH!
-                if (allowLocateOnMap) {
-                    fields.unshift('locate_on_map');
-                }
-
-                // check if properties (fields or locales) have changed
-                if (!panel.fields || !panel.locales || !me._isArrayEqual(fields, panel.fields) || !me._isArrayEqual(locales, panel.locales)) {
-                    panel.fields = fields;
-                    panel.locales = locales;
-                    panel.propertiesChanged = true;
-                }
-
-                var visibleFields = [];
-                var panelParent = panel.getContainer().parent();
-                var gridEl = jQuery('<div class="featuredata2-grid"></div>');
-
-                if (!panel.grid) {
-                    panel.grid = Oskari.clazz.create(
-                        'Oskari.userinterface.component.Grid',
-                        me.instance.getLocalization('columnSelectorTooltip')
-                    );
-
-                    // set selection handler
-                    panel.grid.addSelectionListener(function (pGrid, dataId, isCtrlKey) {
-                        me._handleGridSelect(layer, dataId, isCtrlKey);
-                    });
-
-                    // set popup handler for inner data
-                    var showMore = me.instance.getLocalization('showmore');
-                    panel.grid.setAdditionalDataHandler(showMore,
-                        function (link, content) {
-                            var dialog = Oskari.clazz.create(
-                                'Oskari.userinterface.component.Popup'
-                            );
-                            dialog.show(showMore, content);
-                            dialog.moveTo(link, 'bottom');
-                            if (me.dialog) {
-                                me.dialog.close(true);
-                            }
-                            me.dialog = dialog;
-                        });
-
-                    panel.grid.setColumnSelector(true);
-                    panel.grid.setResizableColumns(true);
-                    if (conf && !conf.disableExport) {
-                        panel.grid.setExcelExporter(
-                            layer.getPermission('download') === 'download_permission_ok'
-                        );
-                    }
-                }
-
-                if (panel.propertiesChanged) {
-                    panel.propertiesChanged = false;
-                    var k;
-
-                    // Data source & metadata link
-                    panel.grid.setDataSource(
-                        layer.getSource && layer.getSource() ? layer.getSource() : layer.getOrganizationName()
-                    );
-                    panel.grid.setMetadataLink(layer.getMetadataIdentifier());
-
-                    // localizations
-                    if (locales && locales.length > 0) {
-                        for (k = 0; k < locales.length; k += 1) {
-                            panel.grid.setColumnUIName(fields[k], locales[k]);
-                        }
-                    } else {
-                        panel.grid.setColumnUIName('__fid', 'ID');
-                        panel.grid.setColumnUIName('__centerX', 'X');
-                        panel.grid.setColumnUIName('__centerY', 'Y');
-                    }
-                    visibleFields = me.getVisibleFields(layer);
-
-                    panel.grid.setVisibleFields(visibleFields);
-                }
-                panel.grid.setDataModel(model);
-                _.forEach(visibleFields, function (field) {
-                    panel.grid.setNumericField(field, me._fixedDecimalCount);
-                });
-
-                // custom renderer for locating feature on map
-                if (allowLocateOnMap) {
-                    panel.grid.setColumnUIName('locate_on_map', ' ');
-                    panel.grid.setColumnValueRenderer('locate_on_map', function (name, data) {
-                        var div = me.templateLocateOnMap.clone();
-                        var fid = data.__fid;
-                        div.attr('data-fid', fid);
-
-                        var markers = Oskari.getMarkers();
-                        var normalIcon = markers[me.locateOnMapIcon];
-                        var normalIconObj = jQuery(normalIcon.data);
-                        normalIconObj.find('path').attr({
-                            fill: me.colors.locateOnMap.normal,
-                            stroke: '#000000'
-                        });
-                        normalIconObj.attr({
-                            x: 0,
-                            y: 0
-                        });
-                        var activeIcon = markers[me.locateOnMapIcon];
-                        var activeIconObj = jQuery(activeIcon.data);
-                        activeIconObj.find('path').attr({
-                            fill: me.colors.locateOnMap.active,
-                            stroke: '#000000'
-                        });
-                        activeIconObj.attr({
-                            x: 0,
-                            y: 0
-                        });
-
-                        div.html(normalIconObj.outerHTML());
-
-                        if (me.locateOnMapFID !== null && me.locateOnMapFID !== undefined && fid === me.locateOnMapFID) {
-                            div.html(activeIconObj.outerHTML());
-                        }
-
-                        div.on('click', function (event) {
-                            // Save clicked feature fid to check centered status
-                            me.locateOnMapFID = fid;
-                            jQuery('.featuredata-go-to-location').html(normalIconObj.outerHTML());
-                            jQuery(this).html(activeIconObj.outerHTML());
-
-                            // create the eventhandler for this particular fid
-                            me.instance.eventHandlers.WFSFeatureGeometriesEvent = function (event) {
-                                var wkts = event.getGeometries(),
-                                    wkt;
-                                for (var i = 0; i < wkts.length; i++) {
-                                    if (wkts[i][0] === fid) {
-                                        wkt = wkts[i][1];
-                                        break;
-                                    }
-                                }
-                                var viewportInfo = me.instance.mapModule.getViewPortForGeometry(wkt);
-                                if (viewportInfo) {
-                                    // feature didn't fit -> zoom to bounds
-                                    if (viewportInfo.bounds) {
-                                        setTimeout(function () {
-                                            me.instance.sandbox.postRequestByName('MapMoveRequest', [viewportInfo.x, viewportInfo.y, viewportInfo.bounds]);
-                                        }, 1000);
-                                    } else {
-                                        // else just set center.
-                                        setTimeout(function () {
-                                            me.instance.sandbox.postRequestByName('MapMoveRequest', [viewportInfo.x, viewportInfo.y]);
-                                        }, 1000);
-                                    }
-                                }
-                                me.instance.sandbox.unregisterFromEventByName(me.instance, 'WFSFeatureGeometriesEvent');
-                                me.instance.eventHandlers.WFSFeatureGeometriesEvent = null;
-                            };
-                            me.instance.sandbox.registerForEventByName(me.instance, 'WFSFeatureGeometriesEvent');
-                        });
-                        return div;
-                    });
-                }
-
-                panel.getContainer().append(gridEl);
-                panel.grid.renderTo(gridEl, null, panelParent);
-
-                // define flyout size to adjust correctly to arbitrary tables
-                var mapdiv = this.instance.sandbox.findRegisteredModuleInstance('MainMapModule').getMapEl(),
-                    content = jQuery('div.oskari-flyoutcontent.featuredata'),
-                    flyout = content.parent().parent();
-
-                if (!me.resized) {
-                    // Define default size for the object data list
-                    var tabContent = flyout.find('div.tab-content');
-                    var parent = tabContent.parent('.oskari-flyoutcontentcontainer');
-
-                    // FIXME Need calculate different way or only use styles
-                    var paddings = flyout.find('.grid-tools').height() +
-                        flyout.find('.tabsHeader').height() +
-                        parseInt(tabContent.css('padding-top') || 0) +
-                        parseInt(tabContent.css('padding-bottom') || 0) +
-                        (flyout.find('.exporter').height() || 0) + 10;
-
-                    if (parent.height() === null) {
-                        tabContent.css('max-height', '100%');
-                    } else {
-                        tabContent.css('height', (parent.height() - paddings) + 'px');
-                    }
-                    flyout.css('max-width', mapdiv.width().toString() + 'px');
-                }
-                if (me.resizable) {
-                    this._enableResize();
-                }
-
-                // Extra header message on top of grid
-                this._appendHeaderMessage(panel, locales, layer);
-
-                if (!panel.selectedFirstCheckbox) {
-                    panel.selectedFirstCheckbox = Oskari.clazz.create('Oskari.userinterface.component.CheckboxInput');
-                    var locale = me.instance.getLocalization();
-                    panel.selectedFirstCheckbox.setTitle(locale.showSelectedFirst);
-                    panel.selectedFirstCheckbox.setChecked(false);
-                    panel.selectedFirstCheckbox.setHandler(function () {
-                        panel.grid.moveSelectedRowsTop(panel.selectedFirstCheckbox.isChecked());
-                    });
-                }
-
-                panel.selectedFirstCheckbox.setChecked(panel.selectedFirstCheckbox.isChecked() === true);
-
-                // Checkbox
-                var checkboxEl = jQuery(panel.selectedFirstCheckbox.getElement());
-                checkboxEl.addClass('featuredata2-show-selected-first');
-                var gridToolsEl = panelParent.find('.grid-tools:visible');
-                gridToolsEl.find('.featuredata2-show-selected-first').remove();
-                if (conf && !conf.disableExport && layer.getPermission('download') === 'download_permission_ok') {
-                    checkboxEl.insertAfter(gridToolsEl);
-                    jQuery('<div class="featuredata2-show-selected-first" style="clear:both;"></div>').insertAfter(gridToolsEl);
-                } else {
-                    checkboxEl.css('margin-top', '7px');
-                    gridToolsEl.append(checkboxEl);
-                }
-
-                var selected = me.getSelectedFeatureIds(layer);
-                if (selected && selected.length > 0) {
-                    me.selectGridValues(selected, layer);
-                }
-            }
-        },
-        setGridOpacity: function (layer, opacity) {
-            if (!this.active || !layer || isNaN(opacity)) {
+        _renderFeatureData: function ({ layerId, inScale, features, hiddenProperties }) {
+            var panel = this.getPanel(layerId);
+            if (!this.tabsContainer.isSelected(panel)) {
                 return;
             }
-            var panel = this.layers['' + layer.getId()],
+            const { layer } = panel;
+            if (!layer) {
+                return;
+            }
+            const flyoutContent = jQuery(this.container);
+            const panelContent = panel.getContainer();
+            panelContent.empty();
+            if (!inScale) {
+                panelContent.append(this.instance.loc('errorscale'));
+                return;
+            }
+            if (features.length === 0) {
+                flyoutContent.find('.tab-tools').remove();
+                panelContent.removeAttr('style');
+                panelContent.append(this.instance.loc('layer.out-of-content-area'));
+
+                if (!panel.grid) {
+                    flyoutContent.find('.grid-tools').remove();
+                }
+                return;
+            }
+            panelContent.append(this.instance.loc('loading'));
+
+            if (this.instance.__loadingStatus[layer.getId()] === 'error') { // TODO this.instance.setLoadingStatus(id, status);
+                return;
+            }
+
+            // TODO cleanup only when needed
+            flyoutContent.find('.featuredata2-show-selected-first').remove();
+            flyoutContent.find('.grid-tools').remove();
+            panelContent.empty();
+
+            const grid = this.createGrid(layer);
+            const model = this.createModel(layer, features, hiddenProperties);
+            this.updateGridProperties(layer, grid, model);
+            const gridEl = jQuery('<div class="featuredata2-grid"></div>');
+            panelContent.append(gridEl);
+            grid.renderTo(gridEl, null, panel.getContainer().parent());
+            panel.grid = grid;
+
+            // Grid opacity
+            this.setGridOpacity(layer, 1.0);
+
+            this.selectGridValues();
+
+            // TODO: is resized really needed??
+            if (!this.resized) {
+                this.calculateSize();
+            }
+
+            // TODO: move to correct place
+            if (this.resizable) {
+                this._enableResize();
+            }
+
+            // Extra header message on top of grid
+            // TODO: add header for analysis
+            // this._appendHeaderMessage(panel, locales, layer);
+            if (!panel.selectedFirstCheckbox) {
+                panel.selectedFirstCheckbox = this.createShowSelectedFirst(grid);
+            }
+            const gridToolsEl = flyoutContent.find('.grid-tools:visible');
+            gridToolsEl.find('.featuredata2-show-selected-first').remove();
+            const checkboxEl = jQuery(panel.selectedFirstCheckbox.getElement());
+            const { disableExport } = this.instance.getConfiguration();
+            if (!disableExport && layer.getPermission('download') === 'download_permission_ok') {
+                checkboxEl.insertAfter(gridToolsEl);
+                jQuery('<div class="featuredata2-show-selected-first" style="clear:both;"></div>').insertAfter(gridToolsEl);
+            } else {
+                checkboxEl.css('margin-top', '7px');
+                gridToolsEl.append(checkboxEl);
+            }
+        },
+        createGrid: function (layer) {
+            const grid = Oskari.clazz.create(
+                'Oskari.userinterface.component.Grid',
+                this.instance.loc('columnSelectorTooltip')
+            );
+
+            // set selection handler
+            grid.addSelectionListener((pGrid, dataId, isCtrlKey) => {
+                this._handleGridSelect(layer, dataId, !isCtrlKey);
+            });
+
+            // set popup handler for inner data
+            const showMore = this.instance.loc('showmore');
+            grid.setAdditionalDataHandler(showMore, (link, content) => {
+                const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+                dialog.show(showMore, content);
+                dialog.moveTo(link, 'bottom');
+                if (this.dialog) {
+                    this.dialog.close(true);
+                }
+                this.dialog = dialog;
+            });
+
+            grid.setColumnSelector(true);
+            grid.setResizableColumns(true);
+            const { disableExport } = this.instance.getConfiguration();
+            if (!disableExport) {
+                grid.setExcelExporter(
+                    layer.getPermission('download') === 'download_permission_ok'
+                );
+            }
+            return grid;
+        },
+        updateGridProperties: function (layer, grid, model) {
+            // Data source & metadata link
+            const dataSource = typeof layer.getSource === 'function' && layer.getSource() ? layer.getSource() : layer.getOrganizationName();
+            grid.setDataSource(dataSource);
+            grid.setMetadataLink(layer.getMetadataIdentifier());
+            // localizations
+            PROPERTY_NAMES.forEach((key, value) => grid.setColumnUIName(key, value));
+            Object.entries(layer.getPropertyNames()).forEach(([key, value]) => grid.setColumnUIName(key, value));
+            // TODO fix hidden fields handling. In createGrid or getState
+            // const hidden = this.handler.getState().hiddenProperties[layer.getId()];
+            const visibleFields = model.getFields().filter(field => !DEFAULT_HIDDEN_FIELDS.includes(field));
+            visibleFields.forEach(field => grid.setNumericField(field, this._fixedDecimalCount));
+            grid.setVisibleFields(visibleFields);
+            grid.setDataModel(model);
+        },
+        createLocateMapColumn: function (grid) {
+            // custom renderer for locating feature on map
+            grid.setColumnUIName('locate_on_map', ' ');
+            grid.setColumnValueRenderer('locate_on_map', (name, data) => {
+                const div = this.templateLocateOnMap.clone();
+                const { __fid } = data;
+                div.attr('data-fid', __fid);
+
+                const iconData = Oskari.getMarkers()[this.locateOnMapIcon].data;
+                const icon = jQuery(iconData);
+                const fillColor = __fid === this.locateOnMapFID ? this.colors.locateOnMap.active : this.colors.locateOnMap.normal;
+                icon.find('path').attr('fill', fillColor);
+                icon.attr({
+                    x: 0,
+                    y: 0
+                });
+                /*
+                const activeIcon = jQuery(iconData);
+                activeIcon.find('path').attr('fill', this.colors.locateOnMap.active);
+                activeIcon.attr({
+                    x: 0,
+                    y: 0
+                });
+                */
+                div.html(icon.outerHTML());
+
+                div.on('click', event => {
+                    // Save clicked feature fid to check centered status
+                    this.locateOnMapFID = __fid;
+                    // TODO: reset old
+                    // jQuery('.featuredata-go-to-location').html(normalIconObj.outerHTML());
+                    // jQuery(this).html(activeIconObj.outerHTML());
+                    icon.find('path').attr('fill', this.colors.locateOnMap.active);
+
+                    // create the eventhandler for this particular fid
+                    this.instance.eventHandlers.WFSFeatureGeometriesEvent = event => {
+                        const wkts = event.getGeometries();
+                        let wkt;
+                        for (var i = 0; i < wkts.length; i++) {
+                            if (wkts[i][0] === __fid) {
+                                wkt = wkts[i][1];
+                                break;
+                            }
+                        }
+                        var viewportInfo = this.instance.mapModule.getViewPortForGeometry(wkt);
+                        if (viewportInfo) {
+                            // feature didn't fit -> zoom to bounds
+                            if (viewportInfo.bounds) {
+                                setTimeout(() => {
+                                    this.instance.sandbox.postRequestByName('MapMoveRequest', [viewportInfo.x, viewportInfo.y, viewportInfo.bounds]);
+                                }, 1000);
+                            } else {
+                                // else just set center.
+                                setTimeout(() => {
+                                    this.instance.sandbox.postRequestByName('MapMoveRequest', [viewportInfo.x, viewportInfo.y]);
+                                }, 1000);
+                            }
+                        }
+                        this.instance.sandbox.unregisterFromEventByName(this.instance, 'WFSFeatureGeometriesEvent');
+                        this.instance.eventHandlers.WFSFeatureGeometriesEvent = null;
+                    };
+                    this.instance.sandbox.registerForEventByName(this.instance, 'WFSFeatureGeometriesEvent');
+                });
+                return div;
+            });
+        },
+        createShowSelectedFirst: function (grid) {
+            const checkbox = Oskari.clazz.create('Oskari.userinterface.component.CheckboxInput');
+            checkbox.setTitle(this.instance.loc('showSelectedFirst'));
+            checkbox.addClass('featuredata2-show-selected-first');
+            checkbox.setHandler(() => {
+                grid.moveSelectedRowsTop(checkbox.isChecked());
+            });
+            return checkbox;
+        },
+
+        setGridOpacity: function (layer, opacity) {
+            if (!this.isActive() || !layer || isNaN(opacity)) {
+                return;
+            }
+            var panel = this.panels['' + layer.getId()],
                 tabContent = jQuery('div.oskari-flyoutcontent.featuredata').find('div.tab-content'),
                 isOk = this.tabsContainer.isSelected(panel);
 
@@ -836,7 +672,12 @@ Oskari.clazz.define(
                 tabContent.css({ 'opacity': opacity });
             }
         },
-
+        getWFSLayerService: function () {
+            if (!this.WFSLayerService) {
+                this.WFSLayerService = Oskari.getSandbox().getService('Oskari.mapframework.bundle.mapwfs2.service.WFSLayerService');
+            }
+            return this.WFSLayerService;
+        },
         /**
          * @method _addFeatureValues
          * @private
@@ -845,56 +686,33 @@ Oskari.clazz.define(
          *
          * Adds features to the model data
          */
-        _addFeatureValues: function (model, fields, hiddenFields, features, selectedFeatures) {
-            var i,
-                j,
-                k,
-                featureData,
-                urlLink,
-                values;
-            eachFeature:
-            for (i = 0; i < features.length; i += 1) {
-                featureData = {};
-                values = features[i];
-
-                // remove from selected if in feature list
-                if (selectedFeatures !== null && selectedFeatures !== undefined && selectedFeatures.length > 0) {
-                    for (k = 0; k < selectedFeatures.length; k += 1) {
-                        if (values[0] === selectedFeatures[k][0]) { // fid match
-                            selectedFeatures.splice(k, 1);
-                        }
-                    }
-                }
-
-                for (j = 0; j < fields.length; j += 1) {
-                    if (!values || values[j] === null || values[j] === undefined || values[j] === '') {
-                        featureData[fields[j]] = '';
-                    } else {
-                        // Generate and url links
-                        if (this._isUrlValid(values[j])) {
-                            if (values[j].substring(0, 4) === 'http') {
-                                urlLink = values[j];
-                            } else {
-                                urlLink = 'http://' + values[j];
-                            }
-                            featureData[fields[j]] = '<a href="' + urlLink + '" target="_blank">' + values[j] + '</a>';
-                        } else {
-                            featureData[fields[j]] = values[j];
-                        }
-                        // remove from empty fields
-                        this.remove_item(hiddenFields, fields[j]);
-                    }
-                }
-
-                // Remove this when better solution to handle duplicates is implemented
-                var tableData = model.getData();
-                for (j = 0; j < tableData.length; j += 1) {
-                    if (tableData[j].__fid === featureData.__fid) {
-                        continue eachFeature;
-                    }
-                }
-                model.addData(featureData);
+        createModel: function (layer, features) {
+            // ONLY AVAILABLE FOR WFS LAYERS WITH MANUAL REFRESH!
+            const conf = this.instance.getConfiguration();
+            const isManualRefresh = layer.isManualRefresh();
+            const allowLocateOnMap = isManualRefresh && conf.allowLocateOnMap;
+            if (allowLocateOnMap) {
+                this.createLocateMapColumn(); //TODO: grid? or move 
             }
+            const model = Oskari.clazz.create('Oskari.userinterface.component.GridModel');
+            model.setFields(layer.getPropertySelection());
+            model.setIdField('__fid');
+            // if layer doesn't have filtered fields then fields is set from first feature
+            features.forEach(feat => {
+                model.addData(feat);
+            });
+            model.setFirstField('__fid');
+            return model;
+        },
+        _processPropertyValue: function (value) {
+            if (value === null || value === undefined) {
+                return '';
+            }
+            if (this._isUrlValid(value)) {
+                const url = value.startsWith('http') ? value : 'http://' + value;
+                return '<a href="' + url + '" target="_blank">' + value + '</a>';
+            }
+            return value;
         },
 
         /**
@@ -914,82 +732,30 @@ Oskari.clazz.define(
         },
 
         /**
-         * @method _isArrayEqual
-         * @private
-         * @param {String[]} current
-         * @param {String[]} old
-         *
-         * Checks if the arrays are equal
-         */
-        _isArrayEqual: function (current, old) {
-            var i;
-
-            if (old.length !== current.length) {
-                // arrays have different lengths, no way are they equal
-                return false;
-            }
-
-            for (i = 0; i < current.length; i += 1) {
-                if (current[i] !== old[i]) {
-                    return false;
-                }
-            }
-
-            return true;
-        },
-
-        /**
          * @method _handleGridSelect
          * @private
          * @param {Oskari.mapframework.domain.WfsLayer} layer
          *           WFS layer that was added
-         * @param {String} dataId
-         *           id for the data that was selected
-         * @param {Boolean} keepCollection
+         * @param {String} featureId
+         *           id for the feature that was selected
+         * @param {Boolean} makeNewSelection
          *           true to keep previous selection, false to clear before selecting
          * Notifies components that a selection was made
          */
-        _handleGridSelect: function (layer, dataId, keepCollection) {
-            var sandbox = this.instance.sandbox,
-                featureIds = [dataId],
-                builder = Oskari.eventBuilder('WFSFeaturesSelectedEvent'),
-                panel = this.layers['' + layer.getId()],
-                isOk = this.tabsContainer.isSelected(panel);
-
-            if (!isOk) {
+        // TODO: why WFSLayerService doesn't send selected events??
+        _handleGridSelect: function (layer, featureId, makeNewSelection) {
+            const layerId = layer.getId();
+            const panel = this.getPanel(layerId);
+            if (!this.tabsContainer.isSelected(panel)) {
                 return;
             }
-            if (!keepCollection) {
-                this.WFSLayerService.emptyWFSFeatureSelections(layer);
-            }
-            this.WFSLayerService.setWFSFeaturesSelections(layer._id, featureIds);
-            var event = builder(this.WFSLayerService.getSelectedFeatureIds(layer._id), layer, true);
-            sandbox.notifyAll(event);
+            const service = this.getWFSLayerService();
+            const builder = Oskari.eventBuilder('WFSFeaturesSelectedEvent');
+            service.setWFSFeaturesSelections(layerId, [featureId], makeNewSelection);
+            var event = builder(service.getSelectedFeatureIds(layerId), layer, true);
+            this.instance.sandbox.notifyAll(event);
         },
 
-        /**
-         * @method featureSelected
-         *
-         * @param {Oskari.mapframework.bundle.mapwfs.event.WFSFeaturesSelectedEvent} event
-         * Handles changes on the UI when a feature has been selected (highlights grid row)
-         *
-         */
-        featureSelected: function (layer) {
-            var me = this,
-                panel = this.layers['' + layer.getId()],
-                isOk = !!panel,
-                selected = me.getSelectedFeatureIds(layer);
-
-            if (!isOk) {
-                return;
-            }
-
-            if (selected && selected.length > 0) {
-                this.selectGridValues(selected, layer);
-            } else if (panel && panel.grid && isOk) {
-                panel.grid.removeSelections();
-            }
-        },
 
         /**
          * @method setEnabled
@@ -999,49 +765,25 @@ Oskari.clazz.define(
          * @param {Boolean} isEnabled
          *
          */
-        setEnabled: function (isEnabled, clearContent) {
-            if (this.active === isEnabled) {
-                return;
-            }
-
-            this.active = !!isEnabled;
-            var sandbox = this.instance.sandbox,
-                request;
-
+        setEnabled: function (isEnabled) {
+            this.handler.setIsActive(!!isEnabled);
             // feature info activation disabled if object data grid flyout active and vice versa
             var gfiReqBuilder = Oskari.requestBuilder(
                 'MapModulePlugin.GetFeatureInfoActivationRequest'
             );
             if (gfiReqBuilder) {
-                sandbox.request(
+                this.instance.sandbox.request(
                     this.instance.getName(),
-                    gfiReqBuilder(!this.active)
+                    gfiReqBuilder(!isEnabled)
                 );
             }
-            var activateReqBuilder = Oskari.requestBuilder('activate.map.layer');
-
-            // disabled
-            if (!this.active && this.selectedTab) {
-                // dim possible highlighted layer
-                request = activateReqBuilder(this.selectedTab.layer.getId(), false);
-                sandbox.request(this.instance.getName(), request);
+            if (!isEnabled) {
+                return;
             }
-            // enabled
-            else if (this.selectedTab) {
-                // highlight layer if any
-                request = activateReqBuilder(this.selectedTab.layer.getId(), true);
-                sandbox.request(this.instance.getName(), request);
-
-                if (clearContent) {
-                    // clear panels
-                    for (var panel in this.layers) {
-                        if (panel.getContainer) {
-                            panel.getContainer().empty();
-                        }
-                    }
-
-                    // update data
-                    this.updateGrid();
+            // clear panels
+            for (var panel in this.panels) {
+                if (panel.getContainer) {
+                    panel.getContainer().empty();
                 }
             }
         },
@@ -1052,7 +794,7 @@ Oskari.clazz.define(
          */
         showLoadingIndicator: function (layerId, blnLoading) {
             this.__addOrRemoveClassFromHeader(
-                this.layers[layerId], blnLoading, 'loading');
+                this.panels[layerId], blnLoading, 'loading');
         },
         /**
          * Shows/removes an error indicator for the layer
@@ -1061,7 +803,7 @@ Oskari.clazz.define(
          */
         showErrorIndicator: function (layerId, blnError) {
             this.__addOrRemoveClassFromHeader(
-                this.layers[layerId], blnError, 'error');
+                this.panels[layerId], blnError, 'error');
         },
         /**
          * Actual implementation to show/remove indicator. Just
@@ -1099,7 +841,7 @@ Oskari.clazz.define(
             var sandbox = this.instance.getSandbox();
             var inputid;
             var inputlayer;
-            var loc = this.instance.getLocalization('gridFooter');
+            const loc = this.instance.getLocalization();
             var message;
             // clean up the old headermessage in case there was one
             jQuery(panel.html).parent().find('div.gridMessageContainer').remove();
@@ -1112,7 +854,7 @@ Oskari.clazz.define(
             if (inputlayer && inputlayer.getLayerType().toUpperCase() === 'WFS') {
                 if (inputlayer.getWpsLayerParams()) {
                     if (inputlayer.getWpsLayerParams().no_data) {
-                        message = loc.noDataCommonMessage + ' (' + inputlayer.getWpsLayerParams().no_data + ').';
+                        message = loc('gridFooter.noDataCommonMessage') + ' (' + inputlayer.getWpsLayerParams().no_data + ').';
                         if (locales) {
                             // TODO: better management for recognasing private data messages
                             _.forEach(locales, function (field) {

--- a/bundles/framework/featuredata2/Flyout.js
+++ b/bundles/framework/featuredata2/Flyout.js
@@ -780,10 +780,11 @@ Oskari.clazz.define(
             var gfiReqBuilder = Oskari.requestBuilder(
                 'MapModulePlugin.GetFeatureInfoActivationRequest' // TODO: fix
             );
+            const name = this.instance.getName();
             if (gfiReqBuilder) {
                 this.instance.sandbox.request(
-                    this.instance.getName(),
-                    gfiReqBuilder(!isEnabled)
+                    name,
+                    gfiReqBuilder(!isEnabled, name)
                 );
             }
             if (!isEnabled) {

--- a/bundles/framework/featuredata2/Flyout.js
+++ b/bundles/framework/featuredata2/Flyout.js
@@ -184,14 +184,15 @@ Oskari.clazz.define(
                     if (previousPanel) {
                         previousPanel.getContainer().hide();
                     }
-                    if (selectedPanel) {
-                        if (selectedPanel.getContainer().css('display') === 'none') {
-                            selectedPanel.getContainer().show();
-                        }
+                    if (!selectedPanel) {
+                        return;
                     }
                     const { layer } = selectedPanel;
                     if (layer) {
                         this.handler.setActiveLayer(layer.getId());
+                    }
+                    if (selectedPanel.getContainer().css('display') === 'none') {
+                        selectedPanel.getContainer().show();
                     }
                 }
             );

--- a/bundles/framework/featuredata2/Flyout.js
+++ b/bundles/framework/featuredata2/Flyout.js
@@ -617,14 +617,6 @@ Oskari.clazz.define(
                     x: 0,
                     y: 0
                 });
-                /*
-                const activeIcon = jQuery(iconData);
-                activeIcon.find('path').attr('fill', this.colors.locateOnMap.active);
-                activeIcon.attr({
-                    x: 0,
-                    y: 0
-                });
-                */
                 div.html(icon.outerHTML());
 
                 div.on('click', event => {
@@ -762,7 +754,6 @@ Oskari.clazz.define(
             var event = builder(service.getSelectedFeatureIds(layerId), layer, true);
             this.instance.sandbox.notifyAll(event);
         },
-
 
         /**
          * @method setEnabled

--- a/bundles/framework/featuredata2/PopupHandler.js
+++ b/bundles/framework/featuredata2/PopupHandler.js
@@ -33,78 +33,36 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.PopupHandler',
         }
 
         this.WFSLayerService = this.instance.sandbox.getService('Oskari.mapframework.bundle.mapwfs2.service.WFSLayerService');
-        this.localization = Oskari.getLocalization('FeatureData2');
-        this.loc = this.localization.selectionTools;
         this.buttons = {
-            'point': {
+            point: {
                 iconCls: 'selection-point',
-                tooltip: me.loc.tools.point.tooltip,
+                tooltip: this.instance.loc('selectionTools.tools.point.tooltip'),
                 sticky: false,
-                callback: function (startDrawing) {
-                    if (startDrawing) {
-                        me.selectionPlugin.startDrawing({
-                            drawMode: 'point'
-                        });
-                    } else {
-                        me.selectionPlugin.stopDrawing();
-                    }
-                }
+                callback: start => this.selectToolHandler('point', start)
             },
-            'line': {
+            line: {
                 iconCls: 'selection-line',
-                tooltip: me.loc.tools.line.tooltip,
+                tooltip: this.instance.loc('selectionTools.tools.line.tooltip'),
                 sticky: false,
-                callback: function (startDrawing) {
-                    if (startDrawing) {
-                        me.selectionPlugin.startDrawing({
-                            drawMode: 'line'
-                        });
-                    } else {
-                        me.selectionPlugin.stopDrawing();
-                    }
-                }
+                callback: start => this.selectToolHandler('line', start)
             },
-            'polygon': {
+            polygon: {
                 iconCls: 'selection-area',
-                tooltip: me.loc.tools.polygon.tooltip,
+                tooltip: this.instance.loc('selectionTools.tools.polygon.tooltip'),
                 sticky: false,
-                callback: function (startDrawing) {
-                    if (startDrawing) {
-                        me.selectionPlugin.startDrawing({
-                            drawMode: 'polygon'
-                        });
-                    } else {
-                        me.selectionPlugin.stopDrawing();
-                    }
-                }
+                callback: start => this.selectToolHandler('polygon', start)
             },
-            'square': {
+            square: {
                 iconCls: 'selection-square',
-                tooltip: me.loc.tools.square.tooltip,
+                tooltip: this.instance.loc('selectionTools.tools.square.tooltip'),
                 sticky: false,
-                callback: function (startDrawing) {
-                    if (startDrawing) {
-                        me.selectionPlugin.startDrawing({
-                            drawMode: 'square'
-                        });
-                    } else {
-                        me.selectionPlugin.stopDrawing();
-                    }
-                }
+                callback: start => this.selectToolHandler('square', start)
             },
-            'circle': {
+            circle: {
                 iconCls: 'selection-circle',
-                tooltip: me.loc.tools.circle.tooltip,
+                tooltip: this.instance.loc('selectionTools.tools.circle.tooltip'),
                 sticky: false,
-                callback: function (startDrawing) {
-                    if (startDrawing) {
-                        me.selectionPlugin.startDrawing({
-                            drawMode: 'circle'
-                        });
-                    } else {
-                        me.selectionPlugin.stopDrawing();
-                    }
-                }
+                callback: start => this.selectToolHandler('circle', start)
             }
         };
 
@@ -118,10 +76,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.PopupHandler',
     }, {
 
         __templates: {
-            'wrapper': '<div class="FeatureDataPopupWrapper"></div>',
-            'toolsButton': '<div style= "display: inline-block;"></div>',
-            'instructions': '<div class="instructions" style="padding: 20px 0px 0px 0px;"></div>',
-            'selectOptions': '<div>' +
+            wrapper: '<div class="FeatureDataPopupWrapper"></div>',
+            toolsButton: '<div style= "display: inline-block;"></div>',
+            instructions: '<div class="instructions" style="padding: 20px 0px 0px 0px;"></div>',
+            selectOptions: '<div>' +
                 '  <label id="select-from-top-layer" class="selectFeaturesOptions">' +
                 '    <input type="radio" name="selectOption" />' +
                 '    <span></span>' +
@@ -131,89 +89,74 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.PopupHandler',
                 '    <span></span>' +
                 '  </label>' +
                 '</div>',
-            'link': '<div class="link"><a href="javascript:void(0);"></a></div></div>'
+            link: '<div class="link"><a href="javascript:void(0);"></a></div></div>'
+        },
+        selectToolHandler: function (drawMode, startDrawing) {
+            if (startDrawing) {
+                this.selectionPlugin.startDrawing({ drawMode });
+            } else {
+                this.selectionPlugin.stopDrawing();
+            }
         },
         /**
          * @method showSelectionTools
          * Handles tool button click -> opens selection tool dialog
          */
-        'showSelectionTools': function () {
-            var me = this,
-                dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup'),
-                popupLoc = this.loc.title,
-                content = me.template.wrapper.clone();
+        showSelectionTools: function () {
+            const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+            const content = this.template.wrapper.clone();
 
+            // TODO this.popup
             // Safety check at not show more than one popup
             if (jQuery('.tools_selection').is(':visible')) {
                 return;
             }
 
             // renders selections tools to the content
-            me.renderSelectionToolButtons(content);
-
-            var instructions = me.template.instructions.clone();
-            instructions.append(this.loc.instructions);
+            this.renderSelectionToolButtons(content);
+            const instructions = this.template.instructions.clone();
+            instructions.append(this.instance.loc('selectionTools.instructions'));
             content.append(instructions);
 
-            const selectOptions = me.template.selectOptions.clone();
+            const selectOptions = this.template.selectOptions.clone();
             const selectFromTop = selectOptions.find('#select-from-top-layer');
             const selectFromAll = selectOptions.find('#select-from-all-layers');
 
-            selectFromTop.find('span').html(this.loc.selectFromTop);
-            selectFromAll.find('span').html(this.loc.selectAll);
+            selectFromTop.find('span').html(this.instance.loc('selectionTools.selectFromTop'));
+            selectFromAll.find('span').html(this.instance.loc('selectionTools.selectAll'));
             if (this.WFSLayerService.isSelectFromAllLayers()) {
                 selectFromAll.find('input').prop('checked', true);
             } else {
                 selectFromTop.find('input').prop('checked', true);
             }
-            selectFromTop.on('click', function () {
-                me.WFSLayerService.setSelectFromAllLayers(false);
-            });
-            selectFromAll.on('click', function () {
-                me.WFSLayerService.setSelectFromAllLayers(true);
-            });
+            selectFromTop.on('click', () => this.WFSLayerService.setSelectFromAllLayers(false));
+            selectFromAll.on('click', () => this.WFSLayerService.setSelectFromAllLayers(true));
             content.append(selectOptions);
 
-            var controlButtons = [];
-            var emptyBtn = Oskari.clazz.create('Oskari.userinterface.component.Button');
-            emptyBtn.setTitle(this.loc.button.empty);
-            emptyBtn.setHandler(function () {
+            const controlButtons = [];
+            const emptyBtn = Oskari.clazz.create('Oskari.userinterface.component.Button');
+            emptyBtn.setTitle(this.instance.loc('selectionTools.button.empty'));
+            emptyBtn.setHandler(() => {
                 // Remove selections
-                var sandbox = me.instance.getSandbox();
-                var layers = sandbox.findAllSelectedMapLayers();
-                for (var i = 0; i < layers.length; ++i) {
-                    if (layers[i].hasFeatureData()) {
-                        me.WFSLayerService.emptyWFSFeatureSelections(layers[i]);
-                    }
-                }
-                this.blur();
+                const layers = this.instance.getSandbox().findAllSelectedMapLayers().filter(l => l.hasFeatureData());
+                layers.forEach(l => this.WFSLayerService.emptyWFSFeatureSelections(l));
             });
-            emptyBtn.blur();
             controlButtons.push(emptyBtn);
-            var cancelBtn = Oskari.clazz.create('Oskari.userinterface.component.Button');
-            cancelBtn.setTitle(this.loc.button.cancel);
-            cancelBtn.setHandler(function () {
-                me.close(true);
-            });
-            cancelBtn.addClass('primary');
-            cancelBtn.blur();
-            controlButtons.push(cancelBtn);
+            controlButtons.push(dialog.createCloseButton());
 
             dialog.addClass('tools_selection');
-            dialog.show(popupLoc, content, controlButtons);
+            dialog.show(this.instance.loc('selectionTools.title'), content, controlButtons);
             dialog.moveTo('#toolbar div.toolrow[tbgroup=default-selectiontools]', 'top');
             this.dialog = dialog;
-            this.isOpen = true;
         },
 
-        close: function (selectDefault) {
-            if (!this.isOpen) {
+        close: function (selectDefault) { // TODO
+            if (!this.dialog) {
                 return;
             }
             // destroy the active sketch, disable the selected control
             this.selectionPlugin.stopDrawing();
             this.dialog.close(true);
-            this.isOpen = false;
 
             if (!selectDefault) {
                 return;
@@ -232,24 +175,25 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.PopupHandler',
          * @param {html element} content
          */
         renderSelectionToolButtons: function (content) {
-            var me = this,
-                activeTool = null,
-                startDrawing;
+            let activeTool = null;
+            let startDrawing;
 
             content.addClass('selectionToolsDiv');
 
-            _.forEach(me.buttons, function (button) {
-                var btnContainer = me.template.toolsButton.clone();
+            Object.keys(this.buttons).forEach(key => {
+                const button = this.buttons[key];
+                var btnContainer = this.template.toolsButton.clone();
 
                 btnContainer.attr('title', button.tooltip);
                 btnContainer.addClass(button.iconCls);
                 btnContainer.addClass('tool');
-                btnContainer.on('click', function (evt, deselect) {
-                    me.removeButtonSelection(content);
+                // TODO cb select/deselect
+                btnContainer.on('click', (evt, deselect) => {
+                    this.removeButtonSelection(content);
                     if (deselect) {
                         activeTool = null;
                         startDrawing = false;
-                        me.selectionPlugin.clearDrawing();
+                        this.selectionPlugin.clearDrawing();
                         return;
                     }
                     if (button === activeTool) {
@@ -263,7 +207,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.PopupHandler',
                         button.callback(startDrawing);
                     }
                 });
-                me.btnContainer = btnContainer;
+                this.btnContainer = btnContainer;
                 content.append(btnContainer);
             });
         },

--- a/bundles/framework/featuredata2/instance.js
+++ b/bundles/framework/featuredata2/instance.js
@@ -106,9 +106,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
 
             // check if preselected layers included wfs layers -> act if they are added now
             const selectedLayers = this.sandbox.findAllSelectedMapLayers().filter(l => l.hasFeatureData());
-            selectedLayers.forEach(l => this.plugins['Oskari.userinterface.Flyout'].layerAdded(l));
             if (selectedLayers.length) {
-                this.plugin.refresh(); // TODO is this needed here??
+                this.plugin.refresh();
             }
 
             this.sandbox.requestHandler('ShowFeatureDataRequest', this.requestHandlers.showFeatureHandler);
@@ -193,7 +192,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
             var event = Oskari.eventBuilder('MapLayerEvent')(null, 'tool');
             this.sandbox.notifyAll(event);
         },
-
+        getLayerLoadingStatus: function (layerId) {
+            return this.__loadingStatus[layerId];
+        },
         __refreshLoadingStatus: function () {
             const status = {
                 loading: [],
@@ -235,9 +236,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
 
                     if (layer && layer.isManualRefresh()) {
                         if (event.getNop()) {
-                            this.plugins['Oskari.userinterface.Flyout'].setGridOpacity(layer, 0.5);
-                        } else if (event.getRequestType() === event.type.image && layer._activeFeatures.length === 0) {
-                            this.plugins['Oskari.userinterface.Flyout'].setGridOpacity(layer, 0.5);
+                            this.plugins['Oskari.userinterface.Flyout'].setGridOpacity(layer.getId(), 0.5);
                         }
                     }
                 }
@@ -273,7 +272,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
             'AfterMapLayerRemoveEvent': function (event) {
                 if (event.getMapLayer().hasFeatureData()) {
                     this.plugin.refresh();
-                    this.plugins['Oskari.userinterface.Flyout'].layerRemoved(event.getMapLayer());
                     delete this.__loadingStatus['' + event.getMapLayer().getId()];
                     this.__refreshLoadingStatus();
                 }
@@ -288,7 +286,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
             'AfterMapLayerAddEvent': function (event) {
                 if (event.getMapLayer().hasFeatureData()) {
                     this.plugin.refresh();
-                    this.plugins['Oskari.userinterface.Flyout'].layerAdded(event.getMapLayer());
                 }
             },
 
@@ -354,7 +351,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
             },
             'AfterMapMoveEvent': function () {
                 this.plugin.mapStatusChanged();
-                this.plugins['Oskari.userinterface.Flyout'].locateOnMapFID = null; // TODO
             },
             'Toolbar.ToolSelectedEvent': function (event) {
                 if (event.getGroupId() === 'selectiontools' || event.getToolId() === 'dialog') {

--- a/bundles/framework/featuredata2/instance.js
+++ b/bundles/framework/featuredata2/instance.js
@@ -14,9 +14,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
      */
     function () {
         this.sandbox = null;
+        this.mapModule = null;
         this.started = false;
         this.plugins = {};
         this.localization = null;
+        this.loc = Oskari.getMsg.bind(null, this.getName());
         this.popupHandler = null;
         this.selectionPlugin = null;
         this.conf = {};
@@ -32,7 +34,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
          * @method getName
          * @return {String} the name for the component
          */
-        'getName': function () {
+        getName: function () {
             return this.__name;
         },
 
@@ -53,85 +55,48 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
             return this.sandbox;
         },
         /**
-         * @method getLocalization
-         * Returns JSON presentation of bundles localization data for current language.
-         * If key-parameter is not given, returns the whole localization data.
-         *
-         * @param {String} key (optional) if given, returns the value for key
-         * @return {String/Object} returns single localization string or
-         *      JSON object for complete data depending on localization
-         *      structure and if parameter key is given
-         */
-        getLocalization: function (key) {
-            if (!this._localization) {
-                this._localization = Oskari.getLocalization(this.getName());
-            }
-            if (key) {
-                return this._localization[key];
-            }
-            return this._localization;
-        },
-
-        /**
          * @method start
          * implements BundleInstance protocol start methdod
          */
-        'start': function () {
+        start: function () {
             if (this.started) {
                 return;
             }
+            this.started = true;
 
-            var me = this,
-                sandboxName = (this.conf ? this.conf.sandbox : null) || 'sandbox',
-                sandbox = Oskari.getSandbox(sandboxName),
-                p,
-                localization,
-                layers = sandbox.findAllSelectedMapLayers(),
-                i;
-
-            me.started = true;
-            me.sandbox = sandbox;
-
-            this.localization = Oskari.getLocalization(this.getName());
-            sandbox.register(me);
-
-            for (p in me.eventHandlers) {
-                if (me.eventHandlers.hasOwnProperty(p)) {
-                    sandbox.registerForEventByName(me, p);
-                }
-            }
+            const sandboxName = (this.conf ? this.conf.sandbox : null) || 'sandbox';
+            this.sandbox = Oskari.getSandbox(sandboxName);
+            this.sandbox.register(this);
+            this.mapModule = this.sandbox.findRegisteredModuleInstance('MainMapModule');
+            Object.getOwnPropertyNames(this.eventHandlers).forEach(p => this.sandbox.registerForEventByName(this, p));
 
             // Let's extend UI
             var requestBuilder = Oskari.requestBuilder('userinterface.AddExtensionRequest');
             if (requestBuilder) {
                 var request = requestBuilder(this);
-                sandbox.request(this, request);
+                this.sandbox.request(this, request);
             }
 
             // draw ui
-            me.createUi();
-
-            localization = this.getLocalization('selectionTools');
+            this.createUi();
 
             // sends request via config to add tool selection button
             if (this.conf && this.conf.selectionTools === true) {
                 this.popupHandler = Oskari.clazz.create('Oskari.mapframework.bundle.featuredata2.PopupHandler', this);
-                var addBtnRequestBuilder = Oskari.requestBuilder('Toolbar.AddToolButtonRequest'),
-                    btn = {
-                        iconCls: 'tool-feature-selection',
-                        tooltip: localization.tools.select.tooltip,
-                        sticky: true,
-                        callback: function () {
-                            me.popupHandler.showSelectionTools();
-                        }
-                    };
-                sandbox.request(this, addBtnRequestBuilder('dialog', 'selectiontools', btn));
+                const addBtnRequestBuilder = Oskari.requestBuilder('Toolbar.AddToolButtonRequest');
+                const btn = {
+                    iconCls: 'tool-feature-selection',
+                    tooltip: this.loc('selectionTools.tools.select.tooltip'),
+                    sticky: true,
+                    callback: () => this.popupHandler.showSelectionTools()
+                };
+                this.sandbox.request(this, addBtnRequestBuilder('dialog', 'selectiontools', btn));
 
                 this.selectionPlugin = this.sandbox.findRegisteredModuleInstance('MainMapModuleMapSelectionPlugin');
 
                 if (!this.selectionPlugin) {
                     var config = {
-                        id: 'FeatureData'
+                        id: this.getName()
                     };
                     this.selectionPlugin = Oskari.clazz.create('Oskari.mapframework.bundle.featuredata2.plugin.MapSelectionPlugin', config, this.sandbox);
                     this.mapModule.registerPlugin(this.selectionPlugin);
@@ -140,14 +105,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
             }
 
             // check if preselected layers included wfs layers -> act if they are added now
-            for (i = 0; i < layers.length; ++i) {
-                if (layers[i].hasFeatureData()) {
-                    this.plugin.refresh();
-                    this.plugins['Oskari.userinterface.Flyout'].layerAdded(layers[i]);
-                }
+            const selectedLayers = this.sandbox.findAllSelectedMapLayers().filter(l => l.hasFeatureData());
+            selectedLayers.forEach(l => this.plugins['Oskari.userinterface.Flyout'].layerAdded(l));
+            if (selectedLayers.length) {
+                this.plugin.refresh(); // TODO is this needed here??
             }
 
-            sandbox.requestHandler('ShowFeatureDataRequest', this.requestHandlers.showFeatureHandler);
+            this.sandbox.requestHandler('ShowFeatureDataRequest', this.requestHandlers.showFeatureHandler);
             this.__setupLayerTools();
         },
 
@@ -155,10 +119,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
          * @method init
          * implements Module protocol init method - does nothing atm
          */
-        'init': function () {
-            var me = this;
+        init: function () {
             this.requestHandlers = {
-                showFeatureHandler: Oskari.clazz.create('Oskari.mapframework.bundle.featuredata2.request.ShowFeatureDataRequestHandler', me)
+                showFeatureHandler: Oskari.clazz.create('Oskari.mapframework.bundle.featuredata2.request.ShowFeatureDataRequestHandler', this)
             };
             return null;
         },
@@ -175,7 +138,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
          * @method update
          * implements BundleInstance protocol update method - does nothing atm
          */
-        'update': function () {
+        update: function () {
 
         },
 
@@ -202,48 +165,33 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
 
         /**
          * Adds the Feature data tool for layer
-         * @param  {String| Number} layerId layer to process
+         * @param  {Object} layer layer to process
          * @param  {Boolean} suppressEvent true to not send event about updated layer (optional)
          */
-        __addTool: function (layerModel, suppressEvent) {
-            var me = this;
-            var service = this.getLayerService();
-            if (typeof layerModel !== 'object') {
-                // detect layerId and replace with the corresponding layerModel
-                layerModel = service.findMapLayer(layerModel);
-            }
-            if (!layerModel || !layerModel.hasFeatureData()) {
+        __addTool: function (layer, suppressEvent) {
+            if (!layer || !layer.hasFeatureData()) {
                 return;
             }
-
             // add feature data tool for layer
-            var layerLoc = this.getLocalization('layer') || {},
-                label = layerLoc['object-data'] || 'Feature data',
-                tool = Oskari.clazz.create('Oskari.mapframework.domain.Tool');
+            const tool = Oskari.clazz.create('Oskari.mapframework.domain.Tool');
+            const label = this.loc('layer.object-data');
             tool.setName('objectData');
             tool.setIconCls('show-featuredata-tool');
             tool.setTitle(label);
             tool.setTooltip(label);
-            tool.setCallback(function () {
-                me.sandbox.postRequestByName('ShowFeatureDataRequest', [layerModel.getId()]);
-            });
+            tool.setCallback(() => this.sandbox.postRequestByName('ShowFeatureDataRequest', [layer.getId()]));
 
-            service.addToolForLayer(layerModel, tool, suppressEvent);
+            this.getLayerService().addToolForLayer(layer, tool, suppressEvent);
         },
         /**
          * Adds tools for all layers
          */
         __setupLayerTools: function () {
-            var me = this;
             // add tools for feature data layers
-            var service = this.getLayerService();
-            var layers = service.getAllLayers();
-            _.each(layers, function (layer) {
-                me.__addTool(layer, true);
-            });
+            this.getLayerService().getAllLayers().forEach(layer => this.__addTool(layer, true));
             // update all layers at once since we suppressed individual events
             var event = Oskari.eventBuilder('MapLayerEvent')(null, 'tool');
-            me.sandbox.notifyAll(event);
+            this.sandbox.notifyAll(event);
         },
 
         __refreshLoadingStatus: function () {
@@ -307,9 +255,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
                     // only handle add layer
                     return;
                 }
-
-                if (event.getLayerId()) {
-                    this.__addTool(event.getLayerId());
+                const id = event.getLayerId();
+                if (id) {
+                    const layer = this.getLayerService.findMapLayer(id);
+                    this.__addTool(layer);
                 } else {
                     // ajax call for all layers
                     this.__setupLayerTools();
@@ -344,56 +293,23 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
             },
 
             /**
-             * @method WFSPropertiesEvent
-             * Update grid headers
-             */
-            'WFSPropertiesEvent': function (event) {
-                // update grid information [don't update the grid if not active]
-                const flyout = this.plugins['Oskari.userinterface.Flyout'];
-                if (flyout.isActive()) {
-                    flyout.updateData(event.getLayer());
-                }
-            },
-
-            /**
-             * @method WFSFeatureEvent
-             * Update grid data
-             */
-            'WFSFeatureEvent': function (event) {
-                // update grid information [don't update the grid if not active]
-                const flyout = this.plugins['Oskari.userinterface.Flyout'];
-                if (flyout.isActive()) {
-                    flyout.updateData(event.getLayer());
-                }
-            },
-
-            /**
-             * @method WFSFeaturesSelectedEvent
-             * Highlight the feature on flyout
-             */
-            'WFSFeaturesSelectedEvent': function (event) {
-                var layer = event.getMapLayer();
-                this.plugins['Oskari.userinterface.Flyout'].featureSelected(layer);
-            },
-
-            /**
              * @method userinterface.ExtensionUpdatedEvent
              * Disable grid updates on close, otherwise enable updates
              */
             'userinterface.ExtensionUpdatedEvent': function (event) {
-                var plugin = this.plugins['Oskari.userinterface.Flyout'];
-
                 // ExtensionUpdateEvents are fired a lot, only let featuredata2 extension event to be handled when enabled
                 if (event.getExtension().getName() !== this.getName()) {
-                    // wasn't me or disabled -> do nothing
-
-                } else if (event.getViewState() === 'close') {
-                    plugin.setEnabled(false);
+                    // wasn't me -> do nothing
+                    return;
+                }
+                const flyout = this.plugins['Oskari.userinterface.Flyout'];
+                if (event.getViewState() === 'close') {
+                    flyout.setEnabled(false);
                     if (this.plugin) {
                         this.plugin.handleCloseFlyout();
                     }
                 } else {
-                    plugin.setEnabled(true, true);
+                    flyout.setEnabled(true);
                 }
             },
 
@@ -401,55 +317,44 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
              * @method FeatureData.FinishedDrawingEvent
              */
             'FeatureData.FinishedDrawingEvent': function () {
-                var me = this;
-
-                if (!me.selectionPlugin) {
-                    me.selectionPlugin = me.sandbox.findRegisteredModuleInstance('MainMapModuleMapSelectionPlugin');
+                if (!this.selectionPlugin) {
+                    return;
                 }
+                const features = this.selectionPlugin.getFeaturesAsGeoJSON();
+                this.selectionPlugin.clearDrawing();
 
-                var features = me.selectionPlugin.getFeaturesAsGeoJSON();
-
-                me.selectionPlugin.clearDrawing();
-
-                var evt = Oskari.eventBuilder('WFSSetFilter')(features);
-                me.sandbox.notifyAll(evt);
+                const evt = Oskari.eventBuilder('WFSSetFilter')(features);
+                this.sandbox.notifyAll(evt);
             },
             'DrawingEvent': function (evt) {
-                var me = this;
-                if (!evt.getIsFinished()) {
+                if (!evt.getIsFinished() || !this.selectionPlugin) {
                     // only interested in finished drawings
                     return;
                 }
-
-                if (!me.selectionPlugin) {
-                    me.selectionPlugin = me.sandbox.findRegisteredModuleInstance('MainMapModuleMapSelectionPlugin');
-                }
-                // published maps won't have selection plugin always
-                if (!me.selectionPlugin || me.selectionPlugin.DRAW_REQUEST_ID !== evt.getId()) {
+                if (this.selectionPlugin.DRAW_REQUEST_ID !== evt.getId()) {
                     // event is from some other functionality
                     return;
                 }
                 var geojson = evt.getGeoJson();
                 var pixelTolerance = 15;
                 if (geojson.features.length > 0) {
-                    geojson.features[0].properties.buffer_radius = me.selectionPlugin.getMapModule().getResolution() * pixelTolerance;
+                    geojson.features[0].properties.buffer_radius = this.selectionPlugin.getMapModule().getResolution() * pixelTolerance;
                 } else {
                     // no features
                     return;
                 }
 
-                me.selectionPlugin.setFeatures(geojson.features);
-                me.selectionPlugin.stopDrawing();
+                this.selectionPlugin.setFeatures(geojson.features);
+                this.selectionPlugin.stopDrawing();
 
-                var event = Oskari.eventBuilder('WFSSetFilter')(geojson);
-                me.sandbox.notifyAll(event);
+                const event = Oskari.eventBuilder('WFSSetFilter')(geojson);
+                this.sandbox.notifyAll(event);
 
-                me.popupHandler.removeButtonSelection();
+                this.popupHandler.removeButtonSelection();
             },
             'AfterMapMoveEvent': function () {
-                var me = this;
-                me.plugin.mapStatusChanged();
-                this.plugins['Oskari.userinterface.Flyout'].locateOnMapFID = null;
+                this.plugin.mapStatusChanged();
+                this.plugins['Oskari.userinterface.Flyout'].locateOnMapFID = null; // TODO
             },
             'Toolbar.ToolSelectedEvent': function (event) {
                 if (event.getGroupId() === 'selectiontools' || event.getToolId() === 'dialog') {
@@ -461,27 +366,18 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
                 if (this.popupHandler) {
                     this.popupHandler.close();
                 }
-            },
-
-            WFSFeatureGeometriesEvent: null
+            }
         },
 
         /**
          * @method stop
          * implements BundleInstance protocol stop method
          */
-        'stop': function () {
-            var sandbox = this.sandbox(),
-                p;
-            for (p in this.eventHandlers) {
-                if (this.eventHandlers.hasOwnProperty(p)) {
-                    sandbox.unregisterFromEventByName(this, p);
-                }
-            }
+        stop: function () {
+            Object.getOwnPropertyNames(this.eventHandlers).forEach(p => this.sandbox.unregisterFromEventByName(this, p));
 
-            var request = Oskari.requestBuilder('userinterface.RemoveExtensionRequest')(this);
-
-            sandbox.request(this, request);
+            const request = Oskari.requestBuilder('userinterface.RemoveExtensionRequest')(this);
+            this.sandbox.request(this, request);
 
             this.sandbox.unregister(this);
             this.started = false;
@@ -521,7 +417,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
          * @return {String} localized text for the title of the component
          */
         getTitle: function () {
-            return this.getLocalization('title');
+            return this.loc('title');
         },
 
         /**
@@ -529,34 +425,32 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
          * @return {String} localized text for the description of the component
          */
         getDescription: function () {
-            return this.getLocalization('desc');
+            return this.loc('desc');
         },
-
+        getConfiguration: function () {
+            return this.conf || {};
+        },
         /**
          * @method createUi
          * (re)creates the UI for "selected layers" functionality
          */
         createUi: function () {
             this.plugins['Oskari.userinterface.Flyout'].createUi();
-            var mapModule = this.sandbox.findRegisteredModuleInstance('MainMapModule'),
-                plugin = Oskari.clazz.create('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataPlugin', {
-                    instance: this
-                });
-            mapModule.registerPlugin(plugin);
-            mapModule.startPlugin(plugin);
-            this.plugin = plugin;
+            this.plugin = Oskari.clazz.create('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataPlugin', {
+                instance: this
+            });
+            this.mapModule.registerPlugin(this.plugin);
+            this.mapModule.startPlugin(this.plugin);
 
             // get the plugin order straight in mobile toolbar even for the tools coming in late
             if (Oskari.util.isMobile()) {
-                mapModule.redrawPluginUIs(true);
+                this.mapModule.redrawPluginUIs(true);
             }
-
-            this.mapModule = mapModule;
         }
     }, {
         /**
          * @property {String[]} protocol
          * @static
          */
-        'protocol': ['Oskari.bundle.BundleInstance', 'Oskari.mapframework.module.Module', 'Oskari.userinterface.Extension']
+        protocol: ['Oskari.bundle.BundleInstance', 'Oskari.mapframework.module.Module', 'Oskari.userinterface.Extension']
     });

--- a/bundles/framework/featuredata2/instance.js
+++ b/bundles/framework/featuredata2/instance.js
@@ -256,7 +256,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
                 }
                 const id = event.getLayerId();
                 if (id) {
-                    const layer = this.getLayerService.findMapLayer(id);
+                    const layer = this.getLayerService().findMapLayer(id);
                     this.__addTool(layer);
                 } else {
                     // ajax call for all layers

--- a/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
+++ b/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
@@ -130,15 +130,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
          * @method  @public mapStatusChanged map status changed
          * @param  {Boolean} changed is map status changed
          */
-        mapStatusChanged: function (changed) {
-            var me = this,
-                statusChanged = changed;
-            me._mapStatusChanged = statusChanged;
+        mapStatusChanged: function (changed = true) {
+            this._mapStatusChanged = changed;
         },
 
         getMapStatusChanged: function () {
-            var me = this;
-            return me._mapStatusChanged;
+            return this._mapStatusChanged;
         },
 
         _bindLinkClick: function (link) {
@@ -258,7 +255,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
                  * @method AfterMapMoveEvent
                  * Shows map center coordinates after map move
                  */
-                'AfterMapMoveEvent': function (event) {
+                AfterMapMoveEvent: function (event) {
                     this.refresh();
                 }
             };

--- a/bundles/framework/featuredata2/view/FeatureDataHandler.js
+++ b/bundles/framework/featuredata2/view/FeatureDataHandler.js
@@ -1,0 +1,151 @@
+import { StateHandler, controllerMixin } from 'oskari-ui/util';
+
+export const DEFAULT_HIDDEN_FIELDS = ['__fid', '__centerX', '__centerY', 'geometry'];
+export const PROPERTY_NAMES = new Map([
+    ['__fid', 'ID'],
+    ['__centerX', 'X'],
+    ['__centerY', 'Y']
+]);
+
+class ViewHandler extends StateHandler {
+    constructor (instance) {
+        super();
+        this.instance = instance;
+        this.sandbox = instance.getSandbox();
+        this.wfsPlugin = null;
+        this.wfsLayerService = null;
+        this.state = {
+            isActive: false,
+            layerId: null,
+            features: [],
+            selectedFeatures: {},
+            hiddenProperties: {},
+            inScale: true
+        };
+        this.eventHandlers = this._createEventHandlers();
+        this.customStateListeners = []; // for jQuery optimization
+    }
+
+    getName () {
+        return 'FeatureDataHandler';
+    }
+
+    addCustomStateListener (consumer) {
+        this.customStateListeners.push(consumer);
+    }
+
+    // update state without notify() to optimize jQuery rendering
+    updateStateSilently (props) {
+        this.state = {
+            ...this.state,
+            ...props
+        };
+        const updated = Object.keys(props);
+        // notify custom state listeners that state has changed but no need to render all components
+        this.customStateListeners.forEach(consumer => consumer(this.getState(), updated));
+    }
+
+    onEvent (event) {
+        const handler = this.eventHandlers[event.getName()];
+        if (!handler) {
+            return;
+        }
+        return handler.apply(this, [event]);
+    }
+
+    _createEventHandlers () {
+        const handlers = {
+            AfterMapMoveEvent: event => this._updateFeatureProperties(event),
+            AfterMapLayerAddEvent: event => {}, // TODO init hidden fields??, store layerIds??
+            WFSSetFilter: event => {
+
+            },
+            WFSFeaturesSelectedEvent: event => {
+                if (!this.state.isActive) {
+                    return;
+                }
+                const layerId = event.getMapLayer().getId();
+                if (layerId === this.state.layerId) {
+                    this._updateSelectedFeatureIds();
+                }
+            },
+            WFSPropertiesEvent: event => {},
+            WFSFeatureEvent: event => {
+
+            }
+        };
+        Object.getOwnPropertyNames(handlers).forEach(p => this.sandbox.registerForEventByName(this, p));
+        return handlers;
+    }
+
+    _updateSelectedFeatureIds () {
+        const { layerId } = this.state;
+        const selectedFeatures = this._getWFSService().getSelectedFeatureIds(layerId);
+        this.updateStateSilently({ selectedFeatures });
+    }
+
+    _updateFeatureProperties (event) {
+        // update viewport properties only when flyout is active/open
+        if (!this.state.isActive) {
+            return;
+        }
+        let features = [];
+        let inScale = false;
+        const layer = Oskari.getSandbox().findMapLayerFromSelectedMapLayers(this.state.layerId);
+        if (layer && layer.isInScale(event.getScale())) {
+            features = this._getVisibleFeatures();
+            inScale = true;
+        }
+        this.updateState({ features, inScale });
+    }
+
+    _getVisibleFeatures () {
+        return this._getWFSPlugin().getLayerFeaturePropertiesInViewport(this.state.layerId);
+    }
+
+    setActiveLayer (layerId) {
+        if (layerId === this.state.layerId) {
+            return;
+        }
+        const features = this._getVisibleFeatures();
+        this.updateState({ layerId, features });
+    }
+
+    setIsActive (isActive) {
+        if (isActive === this.state.isActive) {
+            return;
+        }
+        const features = isActive ? this._getVisibleFeatures() : [];
+        this.updateState({ isActive, features });
+    }
+
+    setHiddenProperty (property) {
+        let hiddenProperties = [...this.state.hiddenProperties];
+        if (hiddenProperties.contains(property)) {
+            hiddenProperties = hiddenProperties.filter(p => p !== property);
+        } else {
+            hiddenProperties.push(property);
+        }
+        this.updateState({ hiddenProperties }); //
+    }
+
+    _getWFSPlugin () {
+        if (!this.wfsPlugin) {
+            this.wfsPlugin = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule').getLayerPlugins('wfs');
+        }
+        return this.wfsPlugin;
+    }
+
+    _getWFSService () {
+        if (!this.wfsLayerService) {
+            this.wfsLayerService = Oskari.getSandbox().getService('Oskari.mapframework.bundle.mapwfs2.service.WFSLayerService');
+        }
+        return this.wfsLayerService;
+    }
+}
+
+export const FeatureDataHandler = controllerMixin(ViewHandler, [
+    'setIsActive',
+    'setActiveLayer',
+    'setHiddenProperty'
+]);

--- a/bundles/framework/featuredata2/view/FeatureDataHandler.js
+++ b/bundles/framework/featuredata2/view/FeatureDataHandler.js
@@ -1,7 +1,7 @@
 import { StateHandler, controllerMixin } from 'oskari-ui/util';
 
 export const DEFAULT_HIDDEN_FIELDS = ['__fid', '__centerX', '__centerY', 'geometry'];
-export const PROPERTY_NAMES = new Map([
+export const DEFAULT_PROPERTY_LABELS = new Map([
     ['__fid', 'ID'],
     ['__centerX', 'X'],
     ['__centerY', 'Y']

--- a/bundles/framework/featuredata2/view/FeatureDataHandler.js
+++ b/bundles/framework/featuredata2/view/FeatureDataHandler.js
@@ -18,7 +18,7 @@ class ViewHandler extends StateHandler {
             features: [],
             inScale: true,
             layerIds: this._getSelectedLayerIds(),
-            selectedFeatures: {},
+            selectedFeatures: [],
             hiddenProperties: {}
         });
         this.eventHandlers = this._createEventHandlers();
@@ -81,9 +81,6 @@ class ViewHandler extends StateHandler {
 
             },
             WFSFeaturesSelectedEvent: event => {
-                if (!this.state.isActive) {
-                    return;
-                }
                 const layerId = event.getMapLayer().getId();
                 if (layerId === this.getState().layerId) {
                     this._updateSelectedFeatureIds();
@@ -121,15 +118,15 @@ class ViewHandler extends StateHandler {
         this.updateState({ features, inScale });
     }
 
-    _getVisibleFeatures () {
-        return this._getWFSPlugin().getLayerFeaturePropertiesInViewport(this.getState().layerId);
+    _getVisibleFeatures (layerId = this.getState().layerId) {
+        return this._getWFSPlugin().getLayerFeaturePropertiesInViewport(layerId);
     }
 
     setActiveLayer (layerId) {
         if (layerId === this.getState().layerId) {
             return;
         }
-        const features = this._getVisibleFeatures();
+        const features = this._getVisibleFeatures(layerId);
         this.updateState({ layerId, features });
     }
 

--- a/bundles/framework/featuredata2/view/FeatureDataHandler.js
+++ b/bundles/framework/featuredata2/view/FeatureDataHandler.js
@@ -57,7 +57,7 @@ class ViewHandler extends StateHandler {
 
     _createEventHandlers () {
         const handlers = {
-            AfterMapMoveEvent: event => this._updateFeatureProperties(event),
+            AfterMapMoveEvent: () => this._updateFeatureProperties(),
             AfterMapLayerAddEvent: event => {
                 const layer = event.getMapLayer();
                 if (!layer.hasFeatureData()) {
@@ -77,18 +77,11 @@ class ViewHandler extends StateHandler {
                     layerId: layerId === removedId ? this._getFirstLayerId() : layerId
                 }, 'layerIds'); // jQuery optimization
             },
-            WFSSetFilter: event => {
-
-            },
             WFSFeaturesSelectedEvent: event => {
                 const layerId = event.getMapLayer().getId();
                 if (layerId === this.getState().layerId) {
                     this._updateSelectedFeatureIds();
                 }
-            },
-            WFSPropertiesEvent: event => {},
-            WFSFeatureEvent: event => {
-
             }
         };
         const sb = Oskari.getSandbox();
@@ -102,7 +95,7 @@ class ViewHandler extends StateHandler {
         this.updateState({ selectedFeatures }, 'selectedFeatures');
     }
 
-    _updateFeatureProperties (event) {
+    _updateFeatureProperties () {
         // update viewport properties only when flyout is active/open
         const { isActive, layerId } = this.getState();
         if (!isActive) {
@@ -111,7 +104,7 @@ class ViewHandler extends StateHandler {
         let features = [];
         let inScale = false;
         const layer = Oskari.getSandbox().findMapLayerFromSelectedMapLayers(layerId);
-        if (layer && layer.isInScale(event.getScale())) {
+        if (layer && layer.isInScale()) {
             features = this._getVisibleFeatures();
             inScale = true;
         }
@@ -127,7 +120,8 @@ class ViewHandler extends StateHandler {
             return;
         }
         const features = this._getVisibleFeatures(layerId);
-        this.updateState({ layerId, features });
+        const selectedFeatures = this._getWFSService().getSelectedFeatureIds(layerId);
+        this.updateState({ layerId, features, selectedFeatures });
     }
 
     setIsActive (isActive) {

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/MvtLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/MvtLayerHandler.ol.js
@@ -112,6 +112,7 @@ export class MvtLayerHandler extends AbstractLayerHandler {
             tileSize: [tileSize, tileSize]
         };
     }
+
     /**
      * @method _createDebugLayer Helper for debugging purposes.
      * Use from console. Set breakpoint when new FeatureExposingMVTSource() is called

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/MvtLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/MvtLayerHandler.ol.js
@@ -112,10 +112,10 @@ export class MvtLayerHandler extends AbstractLayerHandler {
             tileSize: [tileSize, tileSize]
         };
     }
-
     /**
      * @method _createDebugLayer Helper for debugging purposes.
-     * Use from console. Set breakpoint to _createLayerSource and add desired layer to map.
+     * Use from console. Set breakpoint when new FeatureExposingMVTSource() is called
+     *  and add desired layer to map.
      *
      * Like so:
      * Set breakpoint on "const source = new FeatureExposingMVTSource(options);"


### PR DESCRIPTION
Refactor featuredata to handle feature properties after: https://github.com/oskariorg/oskari-frontend/pull/1469

Added statehandler to trigger rendering. Flyout content and Grid uses jQuery so had to make some ugly jQuery optimization (some state changes doesn't trigger full render).

Splitted _prepareData to smaller functions.

Force GFI to be disabled until Flyout is closed e.g. reset state doesn't enable GFI if Flyout is attached.

Note! locateOnMap doesn't add icons to grid but it did't work properly before these changes. If manualRefresh layers aren't used then locateOnMap could be removed from Featuredata.