### PR TITLE
Improve link function

### DIFF
--- a/src/sandbox/sandbox-map-methods.js
+++ b/src/sandbox/sandbox-map-methods.js
@@ -77,6 +77,7 @@ Oskari.clazz.category('Oskari.Sandbox', 'map-methods', {
         });
 
         // Use array join to make sure the values are always separated with '&', but not the first or last
-        return bundleStates.concat(additionalParams).join('&');
+        // return null if there are no params
+        return bundleStates.concat(additionalParams).join('&') || null;
     }
 });

--- a/src/sandbox/sandbox-map-methods.js
+++ b/src/sandbox/sandbox-map-methods.js
@@ -70,13 +70,13 @@ Oskari.clazz.category('Oskari.Sandbox', 'map-methods', {
                 }
                 return bundle.getStateParameters(optimized);
             })
-            .filter(value => typeof value !== 'undefined');
+            .filter(value => typeof value !== 'undefined' && !!value);
 
         const additionalParams = Object.keys(extraParams).map(function (param) {
             return param + '=' + extraParams[param];
         });
 
         // Use array join to make sure the values are always separated with '&', but not the first or last
-        return bundleStates.concat(additionalParams).join('&') || null;
+        return bundleStates.concat(additionalParams).join('&');
     }
 });


### PR DESCRIPTION
Filter out nulls and empty strings from params when generating link. So bundles can return null or empty string when they have no params to add to link instead of returning undefined.