### PR TITLE
Fetch localization instead of showing the key to user

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -1008,7 +1008,7 @@ class UIHandler extends StateHandler {
                 Object.keys(__VALIDATOR_CACHE).forEach(key => delete __VALIDATOR_CACHE[key]);
             }).catch(error => {
                 this.log.error(error);
-                Messaging.error('messages.errorFetchUserRolesAndPermissionTypes');
+                Messaging.error(getMessage('messages.errorFetchUserRolesAndPermissionTypes'));
             });
     }
 


### PR DESCRIPTION
in admin-layereditor error message.