### PR TITLE
Featuredata handle state fixes

### DIFF
--- a/bundles/framework/featuredata2/Flyout.js
+++ b/bundles/framework/featuredata2/Flyout.js
@@ -696,7 +696,8 @@ Oskari.clazz.define(
             const model = Oskari.clazz.create('Oskari.userinterface.component.GridModel');
             const selection = layer.getPropertySelection();
             if (selection.length) {
-                model.setFields([ID_FIELD, ...selection]);
+                const fields = selection.includes(ID_FIELD) ? selection : [ID_FIELD, ...selection];
+                model.setFields(fields);
             }
             model.setIdField(ID_FIELD);
             // if layer doesn't have filtered fields then fields is set from first feature

--- a/bundles/framework/featuredata2/Flyout.js
+++ b/bundles/framework/featuredata2/Flyout.js
@@ -1,4 +1,4 @@
-import { FeatureDataHandler, DEFAULT_PROPERTY_LABELS, DEFAULT_HIDDEN_FIELDS } from './view/FeatureDataHandler';
+import { FeatureDataHandler, DEFAULT_PROPERTY_LABELS, DEFAULT_HIDDEN_FIELDS, ID_FIELD } from './view/FeatureDataHandler';
 /**
  * @class Oskari.mapframework.bundle.featuredata2.Flyout
  *
@@ -694,13 +694,16 @@ Oskari.clazz.define(
          */
         createModel: function (layer, features) {
             const model = Oskari.clazz.create('Oskari.userinterface.component.GridModel');
-            model.setFields(layer.getPropertySelection());
-            model.setIdField('__fid');
+            const selection = layer.getPropertySelection();
+            if (selection.length) {
+                model.setFields([ID_FIELD, ...selection]);
+            }
+            model.setIdField(ID_FIELD);
             // if layer doesn't have filtered fields then fields is set from first feature
             features.forEach(feat => {
                 model.addData(feat);
             });
-            model.setFirstField('__fid');
+            model.setFirstField(ID_FIELD);
             return model;
         },
         _processPropertyValue: function (value) {

--- a/bundles/framework/featuredata2/view/FeatureDataHandler.js
+++ b/bundles/framework/featuredata2/view/FeatureDataHandler.js
@@ -1,5 +1,6 @@
 import { StateHandler, controllerMixin } from 'oskari-ui/util';
 
+export const ID_FIELD = '__fid';
 export const DEFAULT_HIDDEN_FIELDS = ['__fid', '__centerX', '__centerY', 'geometry'];
 export const DEFAULT_PROPERTY_LABELS = new Map([
     ['__fid', 'ID'],

--- a/bundles/framework/featuredata2/view/FeatureDataHandler.js
+++ b/bundles/framework/featuredata2/view/FeatureDataHandler.js
@@ -58,7 +58,7 @@ class ViewHandler extends StateHandler {
 
     _createEventHandlers () {
         const handlers = {
-            AfterMapMoveEvent: () => this._updateFeatureProperties(),
+            AfterMapMoveEvent: () => this._afterMapMove(),
             AfterMapLayerAddEvent: event => {
                 const layer = event.getMapLayer();
                 if (!layer.hasFeatureData()) {
@@ -96,41 +96,39 @@ class ViewHandler extends StateHandler {
         this.updateState({ selectedFeatures }, 'selectedFeatures');
     }
 
-    _updateFeatureProperties () {
+    _afterMapMove () {
         // update viewport properties only when flyout is active/open
-        const { isActive, layerId } = this.getState();
-        if (!isActive) {
+        if (!this.getState().isActive) {
             return;
         }
-        let features = [];
-        let inScale = false;
-        const layer = Oskari.getSandbox().findMapLayerFromSelectedMapLayers(layerId);
-        if (layer && layer.isInScale()) {
-            features = this._getVisibleFeatures();
-            inScale = true;
-        }
-        this.updateState({ features, inScale });
-    }
-
-    _getVisibleFeatures (layerId = this.getState().layerId) {
-        return this._getWFSPlugin().getLayerFeaturePropertiesInViewport(layerId);
+        this.updateState(this.getLayerState());
     }
 
     setActiveLayer (layerId) {
         if (layerId === this.getState().layerId) {
             return;
         }
-        const features = this._getVisibleFeatures(layerId);
         const selectedFeatures = this._getWFSService().getSelectedFeatureIds(layerId);
-        this.updateState({ layerId, features, selectedFeatures });
+        const layerState = this.getLayerState(layerId);
+        this.updateState({ layerId, selectedFeatures, ...layerState });
     }
 
     setIsActive (isActive) {
         if (isActive === this.getState().isActive) {
             return;
         }
-        const features = isActive ? this._getVisibleFeatures() : [];
-        this.updateState({ isActive, features });
+        const layerState = isActive ? this.getLayerState() : {};
+        this.updateState({ isActive, ...layerState });
+    }
+
+    getLayerState (layerId = this.getState().layerId) {
+        const layer = Oskari.getSandbox().findMapLayerFromSelectedMapLayers(layerId);
+        const features = this._getWFSPlugin().getLayerFeaturePropertiesInViewport(layerId);
+        const inScale = !!layer && layer.isInScale();
+        return {
+            inScale,
+            features
+        };
     }
 
     setHiddenProperty (property) {


### PR DESCRIPTION
Add __fid to grid model also when layer has property selection/filter defined.
Show tabs only for visible layers.
Update inScale when active layer is changed.
Set active layer when layer is added if active isn't selected.