### PR TITLE
Capabilities "update now" parsing for admin

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -986,9 +986,7 @@ class UIHandler extends StateHandler {
         }).then(data => {
             const { success, error, layerUpdate = {} } = data;
             if (success.includes(`${layer.id}`)) {
-                const { admin = {} } = layerUpdate;
-                const { capabilities } = admin;
-                layer.capabilities = capabilities;
+                layer.capabilities = layerUpdate;
                 this.updateState({
                     layer
                 });

--- a/src/react/components/Message.jsx
+++ b/src/react/components/Message.jsx
@@ -65,7 +65,7 @@ Message.propTypes = {
     bundleKey: PropTypes.string.isRequired,
     messageKey: PropTypes.string,
     defaultMsg: PropTypes.string,
-    messageArgs: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+    messageArgs: PropTypes.object,
     getMessage: PropTypes.func,
     children: PropTypes.node,
     LabelComponent: PropTypes.elementType,


### PR DESCRIPTION
A change was made how the capabilities are written to response in: https://github.com/oskariorg/oskari-server/pull/737. Changing frontend parsing to match.

Also a small fix for Message tag proptypes for `messageArgs`. This is the only instance using them in oskari-frontend and the typing was off. The prop is not an array but an object.