### PR TITLE
Fetch layer coverage separately

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -593,7 +593,7 @@ Oskari.clazz.define(
         /**
          * @method getProjection
          * Returns the SRS projection code for the map.
-         * Currently always 'EPSG:3067'
+         * Currently defaults to 'EPSG:3067'
          * @return {String}
          */
         getProjection: function () {

--- a/bundles/mapping/mapmodule/plugin/layers/LayersPluginClass.ol.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayersPluginClass.ol.js
@@ -89,21 +89,47 @@ export class LayersPlugin extends AbstractMapModulePlugin {
         // parse geometry if available
         const layerId = layer.getId();
         if (LAYER_WKT_STATUS[layerId] === true) {
-            // already loading or loaded
+            // already loading or loaded/handled
             return;
         }
         // set a flag to notify the layer WKT is loading/loaded/handled and we don't need to try again
         LAYER_WKT_STATUS[layerId] = true;
-        if (isNaN(layerId)) {
-            // only layers that have numeric ids can have reasonable coverage WKT
-            return;
-        }
         if (typeof layer.getGeometry !== 'function') {
             // layer type doesn't support this
             return;
         }
         if (layer.getGeometry().length > 0) {
             // already parsed, no need to parse again
+            return;
+        }
+        this.__getLayerCoverageWKT(layer, coverageWKT => {
+            if (!coverageWKT) {
+                return;
+            }
+            const geometry = WKT_READER.readGeometry(coverageWKT);
+            if (geometry) {
+                layer.setGeometryWKT(coverageWKT);
+                layer.setGeometry([geometry]);
+            }
+        });
+    }
+    /**
+     * Fetches WKT from server if required
+     * @param {AbstractLayer} layer layer to get WKT for
+     * @param {Function} callback gets the wkt as parameter or undefined if it's not available
+     * @returns callback is used for return value
+     */
+    __getLayerCoverageWKT (layer, callback) {
+        if (typeof layer.getGeometryWKT === 'function' && layer.getGeometryWKT()) {
+            // we didn't load it but the layer has WKT present -> use it.
+            // userlayers, analysis etc might do this
+            callback(layer.getGeometryWKT());
+            return;
+        }
+        const layerId = layer.getId();
+        if (isNaN(layerId)) {
+            // only layers that have numeric ids can have reasonable coverage WKT response for DescribeLayer
+            callback();
             return;
         }
         const url = Oskari.urls.getRoute('DescribeLayer', {
@@ -113,24 +139,17 @@ export class LayersPlugin extends AbstractMapModulePlugin {
         });
 
         fetch(url).then(response => {
-            if (response.ok) {
-                return response.json();
+            if (!response.ok) {
+                throw Error(response.statusText);
             }
+            return response.json();
         }).then(json => {
-            const coverageWKT = json.coverage;
-            if (!coverageWKT) {
-                // no wkt, skip
-                return;
-            }
-            const geometry = WKT_READER.readGeometry(coverageWKT);
-            if (geometry) {
-                layer.setGeometryWKT(coverageWKT);
-                layer.setGeometry([geometry]);
-            }
+            callback(json.coverage);
         }).catch(error => {
             // reset flag to try again later
             LAYER_WKT_STATUS[layerId] = false;
             Oskari.log('WKT download').warn(error);
+            callback();
         });
     }
 


### PR DESCRIPTION
So we can remove it from the layer listing response (for example in paikkatietoikkuna the coverage data is ~70% of the layer JSON size).

Server impl: https://github.com/oskariorg/oskari-server/pull/739