### PR TITLE
Handle WMTS source opt 'wrapX'

### DIFF
--- a/bundles/mapping/mapwmts/service/WmtsLayerService.ol.js
+++ b/bundles/mapping/mapwmts/service/WmtsLayerService.ol.js
@@ -129,6 +129,8 @@ Oskari.clazz.define('Oskari.mapframework.wmts.service.WMTSLayerService', functio
             // override capabilities url with the configured one
             options.urls = [config.url];
         }
+        // allows layer.options.wrapX to be passed to source. For some reason optionsFromCapabilities() overrides it.
+        options.wrapX = !!config.wrapX;
         var wmtsLayer = new olLayerTile({
             source: new olSourceWMTS(options),
             opacity: layer.getOpacity() / 100.0,


### PR DESCRIPTION
Make sure we pass wrapX from layer options to WMTSSource. For some reason the OL function merging the config with WMTS-capabilities loses this flag. It's required for example in Arctic-SDI geoportal for showing WMTS with EPSG:4326 matrix on the polar projections/looking at north pole (EPSG:3575 etc).