### PR TITLE
Sanitize layer name in admin-bundle (and most changes to remove lodash usage)

### DIFF
--- a/bundles/admin/admin/DefaultViews.js
+++ b/bundles/admin/admin/DefaultViews.js
@@ -10,10 +10,10 @@ Oskari.clazz.define('Oskari.admin.bundle.admin.DefaultViews', function (locale, 
     this.setContent(this.createUI());
 }, {
     templates: {
-        'main': _.template('<div>${ msg }<div class="grid-placeholder"></div></div>'),
-        'link': _.template('<a href="javascript:void(0);" onClick="return false;">${ msg }</a>'),
-        'errorGuest': _.template('<div>${listTitle}<ul>${list}</ul></div>'),
-        'listItem': _.template('<li>${ msg }</li>')
+        'main': ({ msg }) => `<div>${ msg }<div class="grid-placeholder"></div></div>`,
+        'link': ({ msg }) => `<a href="javascript:void(0);" onClick="return false;">${ msg }</a>`,
+        'errorGuest': ({ listTitle, list }) => `<div>${listTitle}<ul>${list}</ul></div>`,
+        'listItem': ({ msg }) => `<li>${ msg }</li>`
     },
     /**
      * Create the UI for this tab panel

--- a/bundles/admin/admin/DefaultViews.js
+++ b/bundles/admin/admin/DefaultViews.js
@@ -174,13 +174,13 @@ Oskari.clazz.define('Oskari.admin.bundle.admin.DefaultViews', function (locale, 
     __showGenericErrorSave: function (id) {
         this.instance.showMessage(
             this.locale.notifications.errorTitle,
-            _.template(this.locale.notifications.errorUpdating)({ id: id }));
+            this.locale.notifications.errorUpdating.replace('${id}', id));
     },
 
     __viewSaved: function (id, data) {
         this.instance.showMessage(
             this.locale.notifications.successTitle,
-            _.template(this.locale.notifications.viewUpdated)({ id: id }));
+            this.locale.notifications.viewUpdated.replace('${id}', id));
     },
 
     /**

--- a/bundles/admin/admin/Flyout.js
+++ b/bundles/admin/admin/Flyout.js
@@ -27,7 +27,7 @@ Oskari.clazz.define('Oskari.admin.bundle.admin.GenericAdminFlyout',
             var tabsContainer = Oskari.clazz.create('Oskari.userinterface.component.TabContainer');
             this.tabsContainer = tabsContainer;
 
-            _.each(this.tabs, function (tabDef) {
+            this.tabs.forEach((tabDef) => {
                 tabsContainer.addPanel(me.__createTab(tabDef));
             });
             tabsContainer.insertTo(this.getEl());


### PR DESCRIPTION
So we can remove Oskari.util.sanitize(); call from AbstractLayer.setName().

Also reducing lodash usage in the bundle so we can remove it at some point. 