### PR TITLE
Sanitize layer names

### DIFF
--- a/bundles/catalogue/metadataflyout/view/MetadataPanel.js
+++ b/bundles/catalogue/metadataflyout/view/MetadataPanel.js
@@ -541,7 +541,7 @@ Oskari.clazz.define('Oskari.catalogue.bundle.metadataflyout.view.MetadataPanel',
             ),
             'layerItem': _.template(
                 '<li>' +
-                '   <%=layer.getName()%>&nbsp;&nbsp;' +
+                '   <%=Oskari.util.sanitize(layer.getName())%>&nbsp;&nbsp;' +
                 '   <a href="JavaScript:void(0);" class="layerLink">' +
                 '       <%=hidden ? locale.layerList.show : locale.layerList.hide%>' +
                 '   </a>' +

--- a/bundles/framework/divmanazer/component/FilterDialog.js
+++ b/bundles/framework/divmanazer/component/FilterDialog.js
@@ -115,7 +115,7 @@ Oskari.clazz.define('Oskari.userinterface.component.FilterDialog',
                 return;
             }
             popupContent = this.getFilterDialogContent(me._layer, clickedFeatures, selectedTemporaryFeatures);
-            popupTitle = this.loc.description + ' ' + me._layer.getName();
+            popupTitle = this.loc.description + ' ' + Oskari.util.sanitize(me._layer.getName());
 
             // Create the actual popup dialog
             me.popup = Oskari.clazz.create('Oskari.userinterface.component.Popup');

--- a/bundles/framework/divmanazer/component/TabPanel.js
+++ b/bundles/framework/divmanazer/component/TabPanel.js
@@ -79,12 +79,12 @@ Oskari.clazz.define('Oskari.userinterface.component.TabPanel',
                 header.attr('id', headerElementId);
             }
             link = header.find('a');
-            link.html(this.getTitle());
+            link.text(this.getTitle());
         },
         updateTitle: function (title) {
             if (!this.header) return;
             this.title = title;
-            this.header.find('a').html(title);
+            this.header.find('a').text(title);
         },
         /**
          * @method setTitleIcon
@@ -100,7 +100,7 @@ Oskari.clazz.define('Oskari.userinterface.component.TabPanel',
             var iconDiv = this.templateIconTemplate.clone();
             iconDiv.addClass(iconClass);
             this.header.find('a').after(iconDiv);
-            if (_.isFunction(clickHandler)) {
+            if (typeof clickHandler === 'function') {
                 iconDiv.on('click', clickHandler);
             }
         },

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/Layer/Layer.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/Layer/Layer.jsx
@@ -45,13 +45,6 @@ const onToolClick = tool => {
     }
 };
 
-// The layer model has entity-references for < > etc (&gt; &lt;)
-// FIXME: after 2.4.0 when we remove the older layerlisting bundles we can
-//  have the name in the model without encoding and NOT use dangerouslySetInnerHTML
-const LayerName = ({ layer }) => {
-    return (<div dangerouslySetInnerHTML={{__html: layer.getName()}} />);
-};
-
 const Layer = ({ model, selected, controller }) => {
     return (
         <LayerDiv className="t_layer" data-id={model.getId()}>
@@ -73,7 +66,7 @@ const Layer = ({ model, selected, controller }) => {
                     <Switch size="small" checked={selected}
                         onChange={checked => onSelect(checked, model.getId(), controller)}
                         disabled={model.isSticky()} />
-                    <LayerName layer={ model } />
+                    <div>{model.getName()}</div>
                 </Label>
             </Body>
             <LayerTools model={model} controller={controller}/>

--- a/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/LayerBox.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/LayerBox.jsx
@@ -43,10 +43,7 @@ const LayerBox = ({ layer, index, visibilityInfo, controller }) => {
         controller.removeLayer(layer);
     };
     const getName = () => {
-        // The layer model has entity-references for < > etc (&gt; &lt;)
-        // FIXME: after 2.4.0 when we remove the older layerlisting bundles we can
-        //  have the name in the model without encoding and NOT use dangerouslySetInnerHTML
-        const field = <b dangerouslySetInnerHTML={{__html: layer.getName()}} />;
+        const field = <b>{layer.getName()}</b>;
         const description = layer.getDescription();
         if (!description) {
             return field;

--- a/bundles/framework/maplegend/Flyout.js
+++ b/bundles/framework/maplegend/Flyout.js
@@ -127,7 +127,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.Flyout',
                 layer = layers[n];
                 layerContainer = this._createLayerContainer(layer);
 
-                const layerTitle = jQuery('<div class="maplegend-layer-title">' + layer.getName() + '</div>');
+                const layerTitle = jQuery('<div class="maplegend-layer-title">' + Oskari.util.sanitize(layer.getName()) + '</div>');
                 const uuid = layer.getMetadataIdentifier();
                 if (uuid) {
                     layerTitle.append(me.templateTools.clone());

--- a/bundles/framework/maplegend/plugin/MapLegendPlugin.js
+++ b/bundles/framework/maplegend/plugin/MapLegendPlugin.js
@@ -335,7 +335,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
                 }
                 var layerObject = {
                     id: layer.getId(),
-                    title: layer.getName()
+                    title: Oskari.util.sanitize(layer.getName())
                 };
                 legendLayers.push(layerObject);
             });

--- a/bundles/framework/maplegend/publisher/MapLegend.js
+++ b/bundles/framework/maplegend/publisher/MapLegend.js
@@ -52,7 +52,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.MapLegend',
 
                 var layerObject = {
                     id: layer.getId(),
-                    title: layer.getName()
+                    title: Oskari.util.sanitize(layer.getName())
                 };
 
                 legendLayers.push(layerObject);

--- a/bundles/framework/myplaces3/CategoryHandler.js
+++ b/bundles/framework/myplaces3/CategoryHandler.js
@@ -92,6 +92,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.CategoryHandler',
             return {
                 categoryId: this.parseCategoryId(layerId),
                 layerId,
+                // TODO: check if we need to sanitize name here or somewhere down the line
                 name: layer.getName(),
                 isDefault: !!layer.getOptions().isDefault,
                 style: featureStyle || {}
@@ -403,7 +404,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.CategoryHandler',
                 dialog.close();
             });
             buttons.push(operationalBtn);
-            var locParams = [mapLayer.getName()];
+            var locParams = [Oskari.util.sanitize(mapLayer.getName())];
 
             if (makePublic) {
                 operationalBtn.setTitle(this.loc('buttons.changeToPublic'));

--- a/bundles/framework/printout/view/BasicPrintout.js
+++ b/bundles/framework/printout/view/BasicPrintout.js
@@ -310,7 +310,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.view.BasicPrintout',
             const checkUnsupportedLayers = () => {
                 const layerNames = this.instance.sandbox.findAllSelectedMapLayers()
                     .filter(l => l.getLayerType() === 'wmts')
-                    .map(l => l.getName());
+                    .map(l => Oskari.util.sanitize(l.getName()));
                 if (layerNames.length === 0) return;
                 const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
                 const message = '<div>' + me.loc.scale.unsupportedLayersMessage + ':</div><ul><li>' + layerNames.join('</li><li>') + '</li></ul>';

--- a/bundles/framework/publisher2/tools/LayerSelectionTool.js
+++ b/bundles/framework/publisher2/tools/LayerSelectionTool.js
@@ -211,7 +211,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.LayerSelectionTool',
                 return;
             }
 
-            layerDiv.find('label').append(layer.getName());
+            layerDiv.find('label').append(Oskari.util.sanitize(layer.getName()));
             layerDiv.attr('data-id', layer.getId());
             var input = layerDiv.find('input');
             input.attr('id', 'checkbox' + layer.getId());

--- a/bundles/framework/publisher2/tools/ToolbarTool.js
+++ b/bundles/framework/publisher2/tools/ToolbarTool.js
@@ -488,7 +488,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ToolbarTool',
 
             for (i = 0; i < myplaces.length; i++) {
                 layerSelectOption = jQuery(me.templates.layerSelectOption).clone();
-                layerSelectOption.attr('value', myplaces[i].getId()).append(myplaces[i].getName());
+                layerSelectOption.attr('value', myplaces[i].getId()).text(myplaces[i].getName());
                 // select correct layer
                 if (me.publishedmyplaces2Config.layer !== null && me.publishedmyplaces2Config.layer !== undefined &&
                     myplaces[i].getId() === me.publishedmyplaces2Config.layer) {

--- a/bundles/framework/publisher2/view/FlyoutStartView.js
+++ b/bundles/framework/publisher2/view/FlyoutStartView.js
@@ -198,7 +198,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.FlyoutStartView'
                 if (reasons.length) {
                     txt += ' (' + reasons.join(', ') + ')';
                 }
-                item.append(txt);
+                item.text(txt);
                 listElement.append(item);
             });
             return layerList;

--- a/bundles/framework/publisher2/view/PanelMapLayers.js
+++ b/bundles/framework/publisher2/view/PanelMapLayers.js
@@ -284,7 +284,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapLayers',
                 layerContainer.attr('data-id', layer.getId());
 
                 // setup id
-                layerContainer.find('div.layer-title h4').append(layer.getName());
+                layerContainer.find('div.layer-title h4').append(Oskari.util.sanitize(layer.getName()));
                 layerContainer.find('div.layer-title').append(layer.getDescription());
 
                 // remove layer from selected tool
@@ -391,12 +391,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapLayers',
                     contentPanel.append(promotion.text);
                     for (j = 0; j < promoLayerList.length; j += 1) {
                         layer = promoLayerList[j];
+                        // FIXME: there isn't any templateTool available. This code should be removed
                         layerContainer = this.templateTool.clone();
                         layerContainer.attr('data-id', layer.getId());
                         layerContainer.find('label').attr(
                             'for',
                             'checkbox' + layer.getId()
-                        ).append(layer.getName());
+                        ).append(Oskari.util.sanitize(layer.getName()));
                         input = layerContainer.find('input');
                         input.attr('id', 'checkbox' + layer.getId());
                         input.on('change', closureMagic(layer));

--- a/bundles/mapping/mapmodule/domain/AbstractLayer.js
+++ b/bundles/mapping/mapmodule/domain/AbstractLayer.js
@@ -186,11 +186,11 @@ Oskari.clazz.define(
             if (name && typeof name === 'object') {
                 var values = {};
                 Object.keys(name).forEach(function (key) {
-                    values[key] = Oskari.util.sanitize(name[key]);
+                    values[key] = name[key];
                 });
                 this._name = values;
             } else {
-                this._name = Oskari.util.sanitize(name);
+                this._name = name;
             }
         },
         /**

--- a/bundles/mapping/mapmodule/plugin/datasource/DataSourcePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/datasource/DataSourcePlugin.js
@@ -298,7 +298,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.DataSourcePlugi
                 infoIcon = this.templateinfoIcon.clone(),
                 layerName = layer.getName();
             if (layerName) {
-                var layerItem = jQuery('<li>' + layerName + '</li>');
+                var layerItem = jQuery('<li></li>');
+                layerItem.text(layerName);
                 // metadata link
                 var uuid = layer.getMetadataIdentifier();
                 if (uuid) {

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.js
@@ -112,7 +112,7 @@ Oskari.clazz.category('Oskari.mapframework.mapmodule.GetInfoPlugin', 'formatter'
                 var headerWrapper = me.template.header.clone();
                 var titleWrapper = me.template.headerTitle.clone();
 
-                titleWrapper.append(fragmentTitle);
+                titleWrapper.text(fragmentTitle);
                 titleWrapper.attr('title', fragmentTitle);
                 headerWrapper.append(titleWrapper);
                 contentWrapper.append(headerWrapper);

--- a/bundles/mapping/mapmodule/plugin/layers/BackgroundLayerSelectionPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/layers/BackgroundLayerSelectionPlugin.js
@@ -357,7 +357,7 @@ Oskari.clazz.define(
                     ).attr(
                         'title',
                         layer.getName()
-                    ).html(
+                    ).text(
                         layer.getName()
                     );
                     list.append(listItem);

--- a/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPlugin.js
@@ -273,7 +273,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionP
                 div = this.templates.layer.clone(),
                 input = this.templates.checkbox.clone();
 
-            div.find('span').append(layer.getName());
+            div.find('span').text(layer.getName());
 
             input.attr('value', layer.getId());
 

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -279,10 +279,10 @@ Oskari.clazz.define(
             groups.forEach(function (group) {
                 var tpl = me.templates.dataSourceGroup.clone();
                 tpl.addClass(group.id);
-                tpl.find('h4').html(group.name);
+                tpl.find('h4').text(group.name);
                 group.items.forEach(function (item) {
                     var itemTpl = jQuery('<div></div>');
-                    itemTpl.append(item.name);
+                    itemTpl.text(item.name);
                     itemTpl.append(me.__formatItemSources(item.source));
                     tpl.append(itemTpl);
                 });
@@ -309,7 +309,7 @@ Oskari.clazz.define(
                 }
                 var link = jQuery('<a target="_blank"></a>');
                 link.attr('href', item.url);
-                link.append(item.name);
+                link.text(item.name);
                 return link;
             };
             var tpl = jQuery('<span></span>');


### PR DESCRIPTION
Removing Oskari.util.sanitize() from AbstractLayer.setName() and revert #1512. All components displaying layer names should now sanitize when showing the name. This helps with future development for migrating to React-based components.