### PR TITLE
Fix XSLT formatted GFI responses

### DIFF
--- a/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.js
@@ -32,11 +32,18 @@ Oskari.clazz.category('Oskari.mapframework.mapmodule.GetInfoPlugin', 'formatter'
          * @param {pValue} datum response data to format
          * @return {jQuery} formatted HMTL
          */
-        json: function (pValue) {
+        json: function (pValue, pluginLocale) {
             if (!pValue) {
                 return;
             }
             var value = jQuery('<span></span>');
+            let myLoc = pluginLocale;
+            if (!myLoc) {
+                // Get localized name for attribute
+                // TODO this should only apply to omat tasot?
+                const pluginLoc = this.getMapModule().getLocalization('plugin', true) || {};
+                myLoc = pluginLoc[this._name] || {};
+            }
             // if value is an array -> format it first
             // TODO: maybe some nicer formatting?
             if (Array.isArray(pValue)) {
@@ -44,20 +51,14 @@ Oskari.clazz.category('Oskari.mapframework.mapmodule.GetInfoPlugin', 'formatter'
                     obj,
                     objAttr,
                     innerValue,
-                    pluginLoc,
-                    myLoc,
                     localizedAttr;
 
                 for (i = 0; i < pValue.length; i += 1) {
                     obj = pValue[i];
                     for (objAttr in obj) {
                         if (obj.hasOwnProperty(objAttr)) {
-                            innerValue = this.formatters.json(obj[objAttr]);
+                            innerValue = this.formatters.json(obj[objAttr], myLoc);
                             if (innerValue) {
-                                // Get localized attribute name
-                                // TODO this should only apply to omat tasot?
-                                pluginLoc = this.getMapModule().getLocalization('plugin', true);
-                                myLoc = pluginLoc[this._name];
                                 localizedAttr = myLoc[objAttr];
                                 value.append(localizedAttr || objAttr);
                                 value.append(': ');
@@ -200,14 +201,21 @@ Oskari.clazz.category('Oskari.mapframework.mapmodule.GetInfoPlugin', 'formatter'
      * @param {Object} datum response data to format
      * @return {jQuery} formatted HMTL
      */
-    _formatGfiDatum: function (datum) {
+    _formatGfiDatum: function (datum, pluginLocale) {
         // FIXME this function is too complicated, chop it to pieces
         if (!datum.presentationType) {
             return null;
         }
 
-        var me = this,
-            response = me.template.wrapper.clone();
+        const me = this;
+        let response = me.template.wrapper.clone();
+        let myLoc = pluginLocale;
+        if (!myLoc) {
+            // Get localized name for attribute
+            // TODO this should only apply to omat tasot?
+            const pluginLoc = this.getMapModule().getLocalization('plugin', true) || {};
+            myLoc = pluginLoc[this._name] || {};
+        }
 
         if (datum.presentationType === 'JSON' || (datum.content && datum.content.parsed)) {
             var even = false,
@@ -220,8 +228,6 @@ Oskari.clazz.category('Oskari.mapframework.mapmodule.GetInfoPlugin', 'formatter'
                 value,
                 row,
                 labelCell,
-                pluginLoc,
-                myLoc,
                 localizedAttr,
                 valueCell;
 
@@ -238,7 +244,7 @@ Oskari.clazz.category('Oskari.mapframework.mapmodule.GetInfoPlugin', 'formatter'
                     if (!jsonData.hasOwnProperty(attr)) {
                         continue;
                     }
-                    value = me.formatters.json(jsonData[attr]);
+                    value = me.formatters.json(jsonData[attr], myLoc);
                     if (!value) {
                         continue;
                     }
@@ -251,9 +257,6 @@ Oskari.clazz.category('Oskari.mapframework.mapmodule.GetInfoPlugin', 'formatter'
 
                     labelCell = me.template.tableCell.clone();
                     // Get localized name for attribute
-                    // TODO this should only apply to omat tasot?
-                    pluginLoc = this.getMapModule().getLocalization('plugin', true);
-                    myLoc = pluginLoc[this._name];
                     localizedAttr = myLoc[attr];
                     labelCell.append(localizedAttr || attr);
                     row.append(labelCell);

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.js
@@ -62,7 +62,7 @@ Oskari.clazz.category('Oskari.mapframework.mapmodule.GetInfoPlugin', 'formatter'
                                 localizedAttr = myLoc[objAttr];
                                 value.append(localizedAttr || objAttr);
                                 value.append(': ');
-                                value.append(innerValue);
+                                value.append(Oskari.util.sanitize(innerValue));
                                 value.append('<br class="innerValueBr" />');
                             }
                         }
@@ -71,10 +71,10 @@ Oskari.clazz.category('Oskari.mapframework.mapmodule.GetInfoPlugin', 'formatter'
             } else if (pValue.indexOf && pValue.indexOf('://') > 0 && pValue.indexOf('://') < 7) {
                 var link = jQuery('<a target="_blank" rel="noopener"></a>');
                 link.attr('href', pValue);
-                link.append(pValue);
+                link.text(pValue);
                 value.append(link);
             } else {
-                value.append(pValue);
+                value.text(pValue);
             }
             return value;
         },
@@ -261,7 +261,7 @@ Oskari.clazz.category('Oskari.mapframework.mapmodule.GetInfoPlugin', 'formatter'
                     labelCell.append(localizedAttr || attr);
                     row.append(labelCell);
                     valueCell = me.template.tableCell.clone();
-                    valueCell.append(Oskari.util.sanitize(value));
+                    valueCell.append(value);
                     row.append(valueCell);
                     table.append(row);
                 }

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.js
@@ -1,7 +1,7 @@
 import { getFormatter } from './ValueFormatters';
 const ID_SKIP_LABEL = '$SKIP$__';
 
-const jsonFormatter =  (pValue, pluginLocale = {}) => {
+const jsonFormatter = (pValue, pluginLocale = {}) => {
     if (!pValue) {
         return;
     }
@@ -32,7 +32,7 @@ const jsonFormatter =  (pValue, pluginLocale = {}) => {
         value.text(pValue);
     }
     return value;
-}
+};
 
 Oskari.clazz.category('Oskari.mapframework.mapmodule.GetInfoPlugin', 'formatter', {
     __templates: {

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.js
@@ -19,7 +19,7 @@ const jsonFormatter =  (pValue, pluginLocale = {}) => {
             const innerValue = jsonFormatter(pValue[subAttrName], pluginLocale);
             if (innerValue) {
                 value.append(pluginLocale[subAttrName] || subAttrName + ': ');
-                value.append(Oskari.util.sanitize(innerValue));
+                value.append(innerValue);
                 value.append('<br class="innerValueBr" />');
             }
         });

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.test.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.test.js
@@ -118,6 +118,38 @@ describe('GetInfoPlugin', () => {
                 expect(scriptTags.length).toEqual(0);
             });
         });
+        describe('json', () => {
+            const dummyLocale = {};
+            test('is function', () => {
+                expect(typeof plugin.formatters.json).toEqual('function');
+            });
+            test('returns jQuery object', () => {
+                const result = plugin.formatters.json(235, dummyLocale);
+                expect(result instanceof jQuery).toEqual(true);
+            });
+            test('wraps content to additional div', () => {
+                const result = plugin.formatters.json(`My data`, dummyLocale);
+                expect(result.outerHTML()).toEqual('<span>My data</span>');
+
+                const result2 = plugin.formatters.json(`<div></div>`, dummyLocale);
+                expect(removeWhitespace(result2.outerHTML())).toEqual('<span><div></div></span>');
+            });
+            /*
+            test('removes script tags', () => {
+                const result = plugin.formatters.json(`
+                    <div>
+                        <script>alert('Bazinga!')</script>
+                    </div>
+                `, dummyLocale);
+                const scriptTags = result.find('script');
+                expect(scriptTags.length).toEqual(0);
+            });
+            test('renders arrays', () => {
+                const result = plugin.formatters.json(['testing', 1, 2, 'data'], dummyLocale);
+                expect(result.outerHTML()).toEqual('<span>tadaa</span>');
+            });
+            */
+        });
     });
     describe('_formatWFSFeaturesForInfoBox', () => {
         test('is function', () => {
@@ -183,6 +215,38 @@ describe('GetInfoPlugin', () => {
             const html = result[0].markup.outerHTML();
             // should skip "Image" label" and write colspan=2. Should have <img></img> but outerHTML() probably messes it up
             expect(html).toEqual(`<table class="getinforesult_table"><tr class="odd"><td>Label for test</td><td>TESTING</td></tr><tr><td colspan="2"><img class="oskari_gfi_img" src="http://test.domain/test.png"></td></tr></table>`);
+        });
+    });
+
+    describe('_formatGfiDatum', () => {
+        const dummyLocale = {};
+        test('is function', () => {
+            expect(typeof plugin._formatGfiDatum).toEqual('function');
+        });
+        test('reproduce erronous html escaping', () => {
+            const content = {
+                "layerId": 1888,
+                "type": "arcgis93layer",
+                "presentationType": "JSON",
+                "content": {
+                    "parsed": [{
+                        "Vaesto15Lkm": 1230293,
+                        "VesiPAla_km2": 21.4067,
+                        "TaajNimi": "Helsingin kt.",
+                        "Vaesto00Lkm": 1048039,
+                        "TKTaajTunnus": "0001"
+                    }]
+                }
+            };
+            const result = plugin._formatGfiDatum(content, dummyLocale);
+            expect(removeWhitespace(result.outerHTML())).toEqual(removeWhitespace(`<div>
+                <table class="getinforesult_table">
+                    <tr class="odd"><td>Vaesto15Lkm</td><td>[object Object]</td></tr>
+                    <tr><td>VesiPAla_km2</td><td>[object Object]</td></tr>
+                    <tr class="odd"><td>TaajNimi</td><td>[object Object]</td></tr>
+                    <tr><td>Vaesto00Lkm</td><td>[object Object]</td></tr>
+                    <tr class="odd"><td>TKTaajTunnus</td><td>[object Object]</td></tr>
+                </table></div>`));
         });
     });
 });

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.test.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.test.js
@@ -154,6 +154,21 @@ describe('GetInfoPlugin', () => {
                     <span>data</span><br class="innerValueBr">
                 </span>`));
             });
+            test('renders object arrays', () => {
+                const result = plugin.formatters.json([{
+                    test: 'testing',
+                    one: 1,
+                    two: 2,
+                    data: 'data'}], dummyLocale);
+                expect(removeWhitespace(result.outerHTML())).toEqual(removeWhitespace(`<span>
+                    <span>
+                        test:<span>testing</span><brclass="innerValueBr">
+                        one:<span>1</span><brclass="innerValueBr">
+                        two:<span>2</span><brclass="innerValueBr">
+                        data:<span>data</span><brclass="innerValueBr">
+                    </span><brclass="innerValueBr">
+                </span>`));
+            });
             
         });
     });

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.test.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.test.js
@@ -144,12 +144,17 @@ describe('GetInfoPlugin', () => {
                 const scriptTags = result.find('script');
                 expect(scriptTags.length).toEqual(0);
             });
-            /*
-            test('renders arrays', () => {
+            
+            test('renders value arrays', () => {
                 const result = plugin.formatters.json(['testing', 1, 2, 'data'], dummyLocale);
-                expect(result.outerHTML()).toEqual('<span>tadaa</span>');
+                expect(removeWhitespace(result.outerHTML())).toEqual(removeWhitespace(`<span>
+                    <span>testing</span><br class="innerValueBr">
+                    <span>1</span><br class="innerValueBr">
+                    <span>2</span><br class="innerValueBr">
+                    <span>data</span><br class="innerValueBr">
+                </span>`));
             });
-            */
+            
         });
     });
     describe('_formatWFSFeaturesForInfoBox', () => {

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.test.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.test.js
@@ -144,7 +144,6 @@ describe('GetInfoPlugin', () => {
                 const scriptTags = result.find('script');
                 expect(scriptTags.length).toEqual(0);
             });
-            
             test('renders value arrays', () => {
                 const result = plugin.formatters.json(['testing', 1, 2, 'data'], dummyLocale);
                 expect(removeWhitespace(result.outerHTML())).toEqual(removeWhitespace(`<span>
@@ -155,11 +154,13 @@ describe('GetInfoPlugin', () => {
                 </span>`));
             });
             test('renders object arrays', () => {
-                const result = plugin.formatters.json([{
-                    test: 'testing',
-                    one: 1,
-                    two: 2,
-                    data: 'data'}], dummyLocale);
+                const result = plugin.formatters.json([
+                    {
+                        test: 'testing',
+                        one: 1,
+                        two: 2,
+                        data: 'data'
+                    }], dummyLocale);
                 expect(removeWhitespace(result.outerHTML())).toEqual(removeWhitespace(`<span>
                     <span>
                         test:<span>testing</span><brclass="innerValueBr">
@@ -169,7 +170,6 @@ describe('GetInfoPlugin', () => {
                     </span><brclass="innerValueBr">
                 </span>`));
             });
-            
         });
     });
     describe('_formatWFSFeaturesForInfoBox', () => {
@@ -246,16 +246,16 @@ describe('GetInfoPlugin', () => {
         });
         test('test formatting for JSON response', () => {
             const content = {
-                "layerId": 1888,
-                "type": "arcgis93layer",
-                "presentationType": "JSON",
-                "content": {
-                    "parsed": [{
-                        "Vaesto15Lkm": 1230293,
-                        "VesiPAla_km2": 21.4067,
-                        "TaajNimi": "Helsingin kt.",
-                        "Vaesto00Lkm": 1048039,
-                        "TKTaajTunnus": "0001"
+                layerId: 1888,
+                type: 'arcgis93layer',
+                presentationType: 'JSON',
+                content: {
+                    parsed: [{
+                        Vaesto15Lkm: 1230293,
+                        VesiPAla_km2: 21.4067,
+                        TaajNimi: 'Helsingin kt.',
+                        Vaesto00Lkm: 1048039,
+                        TKTaajTunnus: '0001'
                     }]
                 }
             };

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.test.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.test.js
@@ -127,14 +127,14 @@ describe('GetInfoPlugin', () => {
                 const result = plugin.formatters.json(235, dummyLocale);
                 expect(result instanceof jQuery).toEqual(true);
             });
-            test('wraps content to additional div', () => {
+            test('wraps content to additional span', () => {
                 const result = plugin.formatters.json(`My data`, dummyLocale);
                 expect(result.outerHTML()).toEqual('<span>My data</span>');
-
-                const result2 = plugin.formatters.json(`<div></div>`, dummyLocale);
-                expect(removeWhitespace(result2.outerHTML())).toEqual('<span><div></div></span>');
             });
-            /*
+            test('does links', () => {
+                const result = plugin.formatters.json(`https://my.domain`, dummyLocale);
+                expect(result.outerHTML()).toEqual('<span><a target="_blank" rel="noopener" href="https://my.domain">https://my.domain</a></span>');
+            });
             test('removes script tags', () => {
                 const result = plugin.formatters.json(`
                     <div>
@@ -144,6 +144,7 @@ describe('GetInfoPlugin', () => {
                 const scriptTags = result.find('script');
                 expect(scriptTags.length).toEqual(0);
             });
+            /*
             test('renders arrays', () => {
                 const result = plugin.formatters.json(['testing', 1, 2, 'data'], dummyLocale);
                 expect(result.outerHTML()).toEqual('<span>tadaa</span>');
@@ -223,7 +224,7 @@ describe('GetInfoPlugin', () => {
         test('is function', () => {
             expect(typeof plugin._formatGfiDatum).toEqual('function');
         });
-        test('reproduce erronous html escaping', () => {
+        test('test formatting for JSON response', () => {
             const content = {
                 "layerId": 1888,
                 "type": "arcgis93layer",
@@ -241,11 +242,11 @@ describe('GetInfoPlugin', () => {
             const result = plugin._formatGfiDatum(content, dummyLocale);
             expect(removeWhitespace(result.outerHTML())).toEqual(removeWhitespace(`<div>
                 <table class="getinforesult_table">
-                    <tr class="odd"><td>Vaesto15Lkm</td><td>[object Object]</td></tr>
-                    <tr><td>VesiPAla_km2</td><td>[object Object]</td></tr>
-                    <tr class="odd"><td>TaajNimi</td><td>[object Object]</td></tr>
-                    <tr><td>Vaesto00Lkm</td><td>[object Object]</td></tr>
-                    <tr class="odd"><td>TKTaajTunnus</td><td>[object Object]</td></tr>
+                    <tr class="odd"><td>Vaesto15Lkm</td><td><span>1230293</span></td></tr>
+                    <tr><td>VesiPAla_km2</td><td><span>21.4067</span></td></tr>
+                    <tr class="odd"><td>TaajNimi</td><td><span>Helsingin kt.</span></td></tr>
+                    <tr><td>Vaesto00Lkm</td><td><span>1048039</span></td></tr>
+                    <tr class="odd"><td>TKTaajTunnus</td><td><span>0001</span></td></tr>
                 </table></div>`));
         });
     });


### PR DESCRIPTION
Fixes an issue causing GFI responses formatted with XSLT to show [object Object] instead of attribute value:
![gfi-formatting-json](https://user-images.githubusercontent.com/2210335/128866666-b72f5839-5886-4453-bc65-2989ce38fff9.png)
