### PR TITLE
Wfs single hover layer

### DIFF
--- a/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
@@ -209,7 +209,7 @@ class VectorTileLayerPlugin extends AbstractMapLayerPlugin {
         zoomLevelHelper.setOLZoomLimits(vectorTileLayer, layer.getMinScale(), layer.getMaxScale());
 
         const vectorFeatureService = this.getSandbox().getService('Oskari.mapframework.service.VectorFeatureService');
-        const hoverLayer = vectorFeatureService.createHoverLayer(layer, vectorTileLayer.getSource());
+        const hoverLayer = vectorFeatureService.registerHoverLayer(layer, vectorTileLayer.getSource());
         const olLayers = [vectorTileLayer, hoverLayer];
         olLayers.forEach(olLayer => {
             // Properties id and type are being used in VectorFeatureService.

--- a/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
+++ b/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
@@ -38,6 +38,8 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
         _registerEventHandlers () {
             this._sandbox.registerForEventByName(this, 'MouseHoverEvent');
             this._sandbox.registerForEventByName(this, 'MapClickedEvent');
+            this._sandbox.registerForEventByName(this, 'MapLayerVisibilityChangedEvent');
+            this._sandbox.registerForEventByName(this, 'AfterChangeMapLayerOpacityEvent');
         }
 
         /**
@@ -242,8 +244,20 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
             this.hoverHandler.onFeatureHover(event, feature, layer);
         }
 
-        createHoverLayer (layer, source) {
-            return this.hoverHandler.createHoverLayer(layer, source);
+        /**
+         * @method registerHoverLayer
+         * Register layer and hover style for ol/layer/Vector
+         * Create and return hover layer for ol/source/VectorTile
+         *
+         * @param {OskariLayer} layer
+         * @param {ol/source/VectorTile} source for VectorTile layers
+         * @return ol/source/VectorTile for VectorTile layers
+         */
+        registerHoverLayer (layer, source) {
+            if (source) {
+                return this.hoverHandler.createVectorTileLayer(layer, source);
+            }
+            this.hoverHandler.registerLayer(layer);
         }
 
         setVectorLayerHoverTooltip (layer) {
@@ -314,6 +328,7 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
                 me.getSandbox().notifyAll(clickEvent);
             }
         }
+
         /**
          * @public @method onEvent
          * Event is handled forwarded to correct #eventHandlers if found or
@@ -327,6 +342,13 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
                 this._onMapHover(event); break;
             case 'MapClickedEvent':
                 this._onMapClicked(event); break;
+            case 'MapLayerVisibilityChangedEvent':
+                this.hoverHandler.updateHoverLayer(
+                    event.getMapLayer(),
+                    (!event.isInScale() || !event.isGeometryMatch()));
+                break;
+            case 'AfterChangeMapLayerOpacityEvent':
+                this.hoverHandler.updateHoverLayer(event.getMapLayer()); break;
             }
         }
     }

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
@@ -196,14 +196,17 @@ export class WfsVectorLayerPlugin extends AbstractMapLayerPlugin {
         const added = handler.addMapLayerToMap(layer, keepLayerOnTop, isBaseMap);
         // Set oskari properties for vector feature service functionalities.
         added.forEach(lyr => {
+            handler.applyZoomBounds(layer, lyr);
             const silent = true;
             lyr.set(LAYER_ID, layer.getId(), silent);
             lyr.set(LAYER_TYPE, layer.getLayerType(), silent);
+            // don't add style for hover layer
             if (layer.isVisible() && !lyr.get(LAYER_HOVER)) {
                 // Only set style if visible as it's an expensive operation
                 // assumes style will be set on MapLayerVisibilityChangedEvent when layer is made visible
                 lyr.setStyle(this.getCurrentStyleFunction(layer, handler));
             }
+            this.getMapModule().addLayer(lyr, !keepLayerOnTop);
         });
     }
 
@@ -313,6 +316,10 @@ export class WfsVectorLayerPlugin extends AbstractMapLayerPlugin {
         }
         const style = this.getCurrentStyleFunction(layer);
         olLayers.forEach(lyr => {
+            if (lyr.get(LAYER_HOVER)) {
+                // don't add style for hover layer
+                return;
+            }
             lyr.setStyle(style);
             if (this.renderMode === RENDER_MODE_VECTOR && this.getMapModule().getSupports3D()) {
                 // Trigger features changed to synchronize 3D view

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/MvtLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/MvtLayerHandler.ol.js
@@ -65,13 +65,13 @@ export class MvtLayerHandler extends AbstractLayerHandler {
             renderMode: 'hybrid',
             source
         });
-        this.applyZoomBounds(layer, vectorTileLayer);
-        this.plugin.getMapModule().addLayer(vectorTileLayer, !keepLayerOnTop);
-        this.plugin.setOLMapLayers(layer.getId(), vectorTileLayer);
 
         this._registerLayerEvents(layer.getId(), source);
-
-        return vectorTileLayer;
+        const hoverLayer = this.plugin.vectorFeatureService.registerHoverLayer(layer, source);
+        const olLayers = [vectorTileLayer, hoverLayer];
+        this.plugin.setOLMapLayers(layer.getId(), olLayers);
+        return olLayers;
+        // TODO: fix layer opacity
     }
 
     _getMinZoom (config) {

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/MvtLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/MvtLayerHandler.ol.js
@@ -71,7 +71,6 @@ export class MvtLayerHandler extends AbstractLayerHandler {
         const olLayers = [vectorTileLayer, hoverLayer];
         this.plugin.setOLMapLayers(layer.getId(), olLayers);
         return olLayers;
-        // TODO: fix layer opacity
     }
 
     _getMinZoom (config) {

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
@@ -142,15 +142,7 @@ export class VectorLayerHandler extends AbstractLayerHandler {
             clusterLayer.set(LAYER_CLUSTER, true, silent);
             olLayers.push(clusterLayer);
         }
-
-        const hoverLayer = this.plugin.vectorFeatureService.createHoverLayer(layer);
-        olLayers.push(hoverLayer);
-
-        olLayers.forEach(olLayer => {
-            this.applyZoomBounds(layer, olLayer);
-            this.plugin.getMapModule().addLayer(olLayer, !keepLayerOnTop);
-        });
-
+        this.plugin.vectorFeatureService.registerHoverLayer(layer);
         this.plugin.setOLMapLayers(layer.getId(), olLayers);
         if (this.plugin.getMapModule().getSupports3D()) {
             this._loadFeaturesForLayer(layer);


### PR DESCRIPTION
Add only one common hover layer for WFS layers. WFS layers registers hover style to hover service. If hovered WFS layer is changed then style and opacity is updated for common hover layer.

Also fixed hover for mvt rendered wfs layer. Had to make same solution than pure mvt layers have (copy of layer with same source + hover style and style function that renders RenderFeature only if hovered id property matches).