### PR TITLE
Vectortilelayer set style fix

### DIFF
--- a/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
@@ -219,8 +219,8 @@ class VectorTileLayerPlugin extends AbstractMapLayerPlugin {
             olLayer.set(LAYER_TYPE, layer.getLayerType(), silent);
             this.mapModule.addLayer(olLayer, !keepLayerOnTop);
         });
-        vectorTileLayer.setStyle(this._getLayerCurrentStyleFunction(layer));
         this.setOLMapLayers(layer.getId(), olLayers);
+        vectorTileLayer.setStyle(this._getLayerCurrentStyleFunction(layer));
     }
 
     createSource (layer, options) {


### PR DESCRIPTION
Set style after setOLMapLayers because mapboxStyleFunction needs ol layer to set style. Fixes issue where external style didn't work when vectortilelayer/mvt was added to map (layer was rendered with default ol style). 