### PR TITLE
Fix an issue with indicator data with value 0 (zero)

### DIFF
--- a/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/IndicatorFormFlyout.js
@@ -284,7 +284,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.IndicatorFormFlyout', func
         }
 
         for (const singleRegion of regionValues.values) {
-            if (typeof singleRegion.value === 'undefined' || !singleRegion.value || isNaN(singleRegion.value) || typeof singleRegion.value !== 'number') {
+            if (typeof singleRegion.value === 'undefined' || isNaN(singleRegion.value) || typeof singleRegion.value !== 'number') {
                 return false;
             }
         }


### PR DESCRIPTION
When user adds "own indicator data" with some regions having a value of 0, the validator fails to validate the data correctly preventing saving the data. This fixes the issue.