### PR TITLE
Fix overflow issue in Firefox with layerselector

### DIFF
--- a/bundles/framework/divmanazer/resources/scss/divman.scss
+++ b/bundles/framework/divmanazer/resources/scss/divman.scss
@@ -317,6 +317,7 @@ body {
         border: 0;
         overflow: auto;
         max-height: 500px;
+        min-width: 580px;
     }
 }
 

--- a/bundles/framework/divmanazer/resources/scss/divman.scss
+++ b/bundles/framework/divmanazer/resources/scss/divman.scss
@@ -317,7 +317,6 @@ body {
         border: 0;
         overflow: auto;
         max-height: 500px;
-        min-width: 580px;
     }
 }
 

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerViewTabs.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerViewTabs.jsx
@@ -12,6 +12,7 @@ const TAB_CHANGE_UI_UPDATE_MS = 200;
 
 const StyledTabs = styled(Tabs)`
     max-width: 600px;
+    width: -moz-fit-content; // without this vendor prefix layerlist scrollbar doesn't have enough space and cuts content
 `;
 
 const ControlledTabs = ({ tab, ...rest }) => {


### PR DESCRIPTION
This should fix issue where content in layerselector goes under scroll bar. Other content should stay unaffected as every flyout is rather large in size.