### PR TITLE
Fix dropdowns in statistical maps

### DIFF
--- a/bundles/statistics/statsgrid2016/components/classification/editclassification/colorselect.scss
+++ b/bundles/statistics/statsgrid2016/components/classification/editclassification/colorselect.scss
@@ -9,6 +9,11 @@ $colorHeight: 16px;
 .oskari-color-selection-main {
     position: relative;
 
+    div {
+        /* AntD global reset changes default sizing to border-box which breaks SumoSelect */
+        box-sizing: content-box;
+    }
+
     &.disabled {
         .oskari-selected-color {
             border: 1px solid $disabledBorderColor;

--- a/bundles/statistics/statsgrid2016/resources/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/resources/scss/style.scss
@@ -7,6 +7,12 @@ $inputWidth: 94%;
 $buttonWidth: 86%;
 
 $flyoutPadding: 16px;
+.SumoSelect {
+    .select-all {
+        /* AntD global reset changes default sizing to border-box which breaks SumoSelect */
+        box-sizing: content-box !important;
+    }
+}
 
 /* ********************************************
  * These are for common code in statsgrid


### PR DESCRIPTION
Broken by recent AntD upgrade and addition in global reset CSS because of that.