### PR TITLE
Visual fixes for infobox content

### DIFF
--- a/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
+++ b/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
@@ -284,7 +284,22 @@ Oskari.clazz.define(
                 type: popupType
             };
 
+            if (me.adaptable && !isInMobileMode) {
+                if (positioning && positioning !== 'no-position-info') {
+                    me._adaptPopupSizeWithPositioning(id, refresh);
+                    // if refresh, we need to reset the positioning
+                    if (refresh) {
+                        popup.setPositioning(null);
+                    }
+                    // update the correct positioning (width + height now known so the position in pixels gets calculated correctly by ol)
+                    popup.setPositioning(positioning);
+                } else {
+                    me._adaptPopupSize(id, refresh);
+                }
+            }
+
             // Fix popup header height to match title content height if using desktop popup
+            // we need to do this AFTER _adaptPopupSize() since it might make the popup smaller -> making the title add more height
             if (title && !isInMobileMode) {
                 var popupEl = jQuery(popup.getElement());
                 var popupHeaderEl = popupEl.find('.popupHeader');
@@ -312,19 +327,6 @@ Oskari.clazz.define(
                 popupHeaderEl.height(fixedHeight);
             }
 
-            if (me.adaptable && !isInMobileMode) {
-                if (positioning && positioning !== 'no-position-info') {
-                    me._adaptPopupSizeWithPositioning(id, refresh);
-                    // if refresh, we need to reset the positioning
-                    if (refresh) {
-                        popup.setPositioning(null);
-                    }
-                    // update the correct positioning (width + height now known so the position in pixels gets calculated correctly by ol)
-                    popup.setPositioning(positioning);
-                } else {
-                    me._adaptPopupSize(id, refresh);
-                }
-            }
             if (popupType === 'desktop') {
                 setTimeout(me._panMapToShowPopup.bind(me, lonlatArray, positioning), 0);
             }

--- a/bundles/mapping/mapmodule/resources/scss/getinfo.scss
+++ b/bundles/mapping/mapmodule/resources/scss/getinfo.scss
@@ -25,7 +25,7 @@
 	background-color: #424343;
 	margin-top: 14px;
 	margin-bottom: 10px;
-	height: 15px;
+	height: 17px;
 	
 	.icon-bubble-left {
 		height: 15px;


### PR DESCRIPTION
Reserve space for title AFTER the popup size has been determined. Previously the popup might be wider when space for title was calculated, adaptSize() changed the popup size changed making a long title wrap to more lines than was used for calculating height.

Also fixes another small issue caused by AntD global reset for box-sizing affecting layer name boxes on GFI responses.