### PR TITLE
Refactor StyleEditor Preview

### DIFF
--- a/src/react/components/StyleEditor/Preview.jsx
+++ b/src/react/components/StyleEditor/Preview.jsx
@@ -1,17 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { OSKARI_BLANK_STYLE } from './OskariDefaultStyle';
+import { StyleMapper } from './Preview/StyleMapper';
+import { SVGWrapper } from './Preview/SVGWrapper';
+import { getPointSVG } from './Preview/point';
+import { getLineSVG } from './Preview/line';
+import { getAreaSVG } from './Preview/area';
+
 
 // Size for preview svg
 const previewSize = '80px';
-
-// Viewbox settings for preview svg
-const previewViewbox = {
-    minX: 0,
-    minY: 0,
-    width: 60,
-    height: 60
-};
 
 // Style settings for wrapping preview rectangle
 const previewWrapperStyle = {
@@ -20,219 +17,17 @@ const previewWrapperStyle = {
     width: previewSize
 };
 
-const linePreviewSVG = '<svg viewBox="0 0 80 80" width="80" height="80" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke="#000000" d="M10,15L20,35L40,25" stroke-width="3" stroke-linejoin="miter" stroke-linecap="butt" strokeDasharray="0"></path></svg>';
-const areaPreviewSVG = '<svg viewBox="0 0 80 80" width="80" height="80" xmlns="http://www.w3.org/2000/svg"><defs><pattern id="checker" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse"><rect fill="#eee" x="0" width="10" height="10" y="0"><rect fill="#eee" x="10" width="10" height="10" y="10"></rect></rect></pattern></defs><rect x="0" y="0" width="80" height="80" fill="url(#checker)"></rect><path d="M10,17L40,12L29,40Z" stroke-linejoin="miter" stroke-linecap="butt" stroke-dasharray="0"></path></svg>';
-const defaultPatternId = 'patternPreview'; // Static pattern id filled into svg - with this we identify pattern made solely for preview from other dom-elements
-
-let previewAttributes = {
-    strokeColor: OSKARI_BLANK_STYLE.stroke.color,
-    strokeWidth: OSKARI_BLANK_STYLE.stroke.width,
-    strokeLineCap: OSKARI_BLANK_STYLE.stroke.lineCap,
-    fill: OSKARI_BLANK_STYLE.defaultFill, // empty string here?
-    fillColor: OSKARI_BLANK_STYLE.fill.color,
-    pattern: '' //OSKARI_BLANK_STYLE.fill.area.pattern <- this will be part of an SVG IF we are doing an area style with fill pattern
-};
-
-let size = 3; // Size of the preview depending on the format - default 3 is for area
-
-/**
- * @method _getPreviewLineDash
- * @param {String} format - format of the current preview
- * @param {Object} oskariStyle - current Oskari style
- * @description Parses current Oskari style on outputs correct linedash value for preview
- * @returns {String} value of the preview linedash or empty string for point tab
- */
-const _getPreviewLineDash = (format, oskariStyle) => {
-    if ((format === 'line' && oskariStyle.stroke.lineDash === 'dash') ||
-        (format === 'area' && oskariStyle.stroke.area.lineDash === 'dash')) {
-        return '4, 4';
+const getSVGContent = (format, propsForSVG, markers, areaFills) => {
+    if (format === 'point') {
+        return getPointSVG(propsForSVG, markers);
+    } else if (format === 'line') {
+        return getLineSVG(propsForSVG);
+    } else if (format === 'area') {
+        return getAreaSVG(propsForSVG, areaFills);
     }
     return '';
-}
+};
 
-/**
- * @method _parsePath
- * @param {String} format - format of the current icon as string (point | line | area)
- * @description Parses correct svg based on provided format
- *
- * @returns rawHtmlPath - DOM object of parsed SVG
- */
-const _parsePath = (baseSvg) => {
-    const domParser = new DOMParser();
-    const parsed = domParser.parseFromString(baseSvg, 'image/svg+xml');
-    const rawHtmlPath = parsed.getElementsByTagName('path')[0];
-
-    return rawHtmlPath;
-}
-
-/**
- * @method _parsePattern
- * @param {String} pattern - current pattern to be parsed as DOM SVG element
- * @description Parses provided pattern and fills it with correct attributes
- *
- * @returns rawHtmlPath - DOM object of current SVG
- */
-const _parsePattern = (pattern) => {
-    const domParser = new DOMParser();
-    const parsed = domParser.parseFromString(pattern.data, 'image/svg+xml');
-    const rawHtmlPath = parsed.getElementsByTagName('path')[0];
-    rawHtmlPath.setAttribute('stroke', previewAttributes.fillColor);
-
-    return rawHtmlPath;
-}
-
-/**
- * @method _composeSvgPattern
- * @param {HTMLElement} patternPath pattern as DOM node element
- * @description Combine provided plain pattern path with definitive svg base
- * @returns {String} full pattern as string
- */
-const _composeSvgPattern = (patternPath, patternId) => {
-    return '<defs><pattern id="' + patternId +'" viewBox="0, 0, 12, 12" width="100%" height="100%">' + patternPath.outerHTML + '</pattern></defs>';
-}
-
-const _composePreviewViewbox = () => {
-    let viewboxString = ''
-    const widthV = previewViewbox.width - (5 * size); // multiply by negative to shrink viewbox
-    const heightV = previewViewbox.height - (5 * size); // multiply by negative to shrink viewbox
-    viewboxString = previewViewbox.minX + ' ' + previewViewbox.minY + ' ' +  widthV + ' ' + heightV;
-    return viewboxString;
-}
-
-/**
- * @method _composePointPath
- * @description Composes point svg path
- * @returns {String} point svg path
- */
-const _composePointPath = (oskariStyle, markers) => {
-    const path = _parsePath(markers[oskariStyle.image.shape].data);
-
-    previewAttributes.strokeColor = '#000000';
-    previewAttributes.fillColor = oskariStyle.fill.color;
-    previewAttributes.fill = oskariStyle.image.fill.color;
-    previewAttributes.strokeWidth = OSKARI_BLANK_STYLE.defaultStrokeWidth;
-    previewAttributes.strokeLineCap = OSKARI_BLANK_STYLE.stroke.lineCap;
-    previewAttributes.strokeDashArray = '';
-    previewAttributes.strokeLineJoin = OSKARI_BLANK_STYLE.stroke.area.lineJoin;
-
-    path.setAttribute('stroke', previewAttributes.strokeColor);
-    path.setAttribute('stroke-width', previewAttributes.strokeWidth);
-    path.setAttribute('stroke-linecap', previewAttributes.strokeLineCap);
-    path.setAttribute('stroke-dasharray', previewAttributes.strokeDashArray);
-    path.setAttribute('stroke-linejoin', previewAttributes.strokeLineJoin);
-    path.setAttribute('fill', previewAttributes.fill);
-    
-    size = oskariStyle.image.size;
-
-    return path.outerHTML;
-}
-
-/**
- * @method _composeLinePath
- * @description Composes line svg path
- * @returns {String} line svg path
- */
-const _composeLinePath = (oskariStyle) => {
-    const path = _parsePath(linePreviewSVG);        
-
-    previewAttributes.strokeColor = oskariStyle.stroke.color;
-    previewAttributes.fillColor = oskariStyle.fill.color;
-    previewAttributes.fill = OSKARI_BLANK_STYLE.fill.color;
-
-    previewAttributes.strokeWidth = oskariStyle.stroke.width;
-    previewAttributes.strokeLineCap = oskariStyle.stroke.lineCap;
-    previewAttributes.strokeDashArray = _getPreviewLineDash('line', oskariStyle);
-    previewAttributes.strokeLineJoin = oskariStyle.stroke.area.lineJoin;
-
-    path.setAttribute('stroke', previewAttributes.strokeColor);
-    path.setAttribute('stroke-width', previewAttributes.strokeWidth);
-    path.setAttribute('stroke-linecap', previewAttributes.strokeLineCap);
-    path.setAttribute('stroke-dasharray', previewAttributes.strokeDashArray);
-    path.setAttribute('stroke-linejoin', previewAttributes.strokeLineJoin);
-
-    size = OSKARI_BLANK_STYLE.image.size;
-
-    return path.outerHTML;
-}
-
-/**
- * @method _composeAreaPath
- * @description Composes area svg path
- * @returns {String} area svg path
- */
-let patternIdCounter = 0;
-const _composeAreaPath = (oskariStyle, areaFills) => {
-    const path = _parsePath(areaPreviewSVG);
-    const patternId = defaultPatternId + patternIdCounter++;
-
-    previewAttributes.strokeColor = oskariStyle.stroke.area.color;
-    previewAttributes.fillColor = oskariStyle.fill.color;
-    previewAttributes.fill = 'url(#' + patternId + ')';
-
-    let patternName = 'SOLID';
-    if (oskariStyle.fill.area.pattern === 0) {
-        patternName = 'DIAGONAL_THIN';
-    } else if (oskariStyle.fill.area.pattern === 1) {
-        patternName = 'DIAGONAL_THICK';
-    } else if (oskariStyle.fill.area.pattern === 2) {
-        patternName = 'HORIZONTAL_THIN';
-    } else if (oskariStyle.fill.area.pattern === 3) {
-        patternName = 'HORIZONTAL_THICK';
-    } else if (oskariStyle.fill.area.pattern === 4) {
-        patternName = 'TRANSPARENT';
-    } else if (oskariStyle.fill.area.pattern === 5) {
-        patternName = 'SOLID';
-    }
-
-    const patternPath = _parsePattern(areaFills.find(pattern => pattern.name === patternName));
-    previewAttributes.pattern = _composeSvgPattern(patternPath, patternId); // this has to be set after fillColor
-
-    previewAttributes.strokeWidth = oskariStyle.stroke.area.width;
-    previewAttributes.strokeLineCap = OSKARI_BLANK_STYLE.stroke.lineCap;
-    previewAttributes.strokeDashArray = _getPreviewLineDash('area', oskariStyle);
-    previewAttributes.strokeLineJoin = OSKARI_BLANK_STYLE.stroke.area.lineJoin;
-
-    path.setAttribute('stroke', previewAttributes.strokeColor);
-    path.setAttribute('stroke-width', previewAttributes.strokeWidth);
-    path.setAttribute('stroke-linecap', previewAttributes.strokeLineCap);
-    path.setAttribute('stroke-dasharray', previewAttributes.strokeDashArray);
-    path.setAttribute('stroke-linejoin', previewAttributes.strokeLineJoin);
-    path.setAttribute('fill', previewAttributes.fill);
-
-    size = OSKARI_BLANK_STYLE.image.size;
-
-    return path.outerHTML;
-}
-
-const getTestParamsObject = (format, style) => {
-
-    const additionalAttrs = {
-        format,
-        size
-    };
-    if (format === 'point') {
-        additionalAttrs.size = style.image.size;
-        additionalAttrs.color = style.image.fill.color;
-        additionalAttrs.shape = style.image.shape;
-    } else if (format === 'line') {
-        additionalAttrs.color = style.stroke.color;
-        additionalAttrs.size = style.stroke.width;
-        additionalAttrs.linecap = style.stroke.lineCap;
-        additionalAttrs.linedash = style.stroke.lineDash;
-        additionalAttrs.linejoin = style.stroke.area.lineJoin;
-    } else if (format === 'area') {
-        additionalAttrs.color = style.fill.color;
-        additionalAttrs.strokecolor = style.stroke.area.color;
-        additionalAttrs.size = style.stroke.area.width;
-        additionalAttrs.strokestyle = style.stroke.area.lineDash;
-        additionalAttrs.pattern = style.fill.area.pattern;
-    }
-    const testAttrs = {};
-    Object.keys(additionalAttrs).forEach(key => {
-        testAttrs['data-' + key] = additionalAttrs[key];
-    });
-    return testAttrs;
-}
 /**
  * @class Preview
  * @calssdesc <Preview>
@@ -244,24 +39,17 @@ const getTestParamsObject = (format, style) => {
  * @example <caption>Basic usage</caption>
  * <Preview }/>
  */
-
 export const Preview = ({markers, areaFills, format, oskariStyle}) => {
-    const svgIcon =
-        format === 'area' ? _composeAreaPath(oskariStyle, areaFills) :
-        format === 'line' ? _composeLinePath(oskariStyle) :
-        format === 'point' ? _composePointPath(oskariStyle, markers) :
-        false;
-    const combinedSvg = previewAttributes.pattern + svgIcon; // Add pattern to svg icon
+    const propsForSVG = StyleMapper.getPropsForFormat(format, oskariStyle);
+    const flagsForSelenium = StyleMapper.getAsDataAttributes(format, propsForSVG);
+    const svgIcon = getSVGContent(format, propsForSVG, markers, areaFills);
     return (
-        <div style={ previewWrapperStyle } className="t_preview" { ...getTestParamsObject(format, oskariStyle) } >
-            <svg
-                viewBox={ _composePreviewViewbox() }
+        <div style={ previewWrapperStyle } className="t_preview" { ...flagsForSelenium } >
+            <SVGWrapper
                 width={ previewSize }
                 height={ previewSize }
-                xmlns="http://www.w3.org/2000/svg"
-                dangerouslySetInnerHTML={ {__html: combinedSvg } }
-            >
-            </svg>
+                content={ svgIcon }
+                iconSize={ format === 'point' ? propsForSVG.size : null} />
         </div>
     );
 };

--- a/src/react/components/StyleEditor/Preview.jsx
+++ b/src/react/components/StyleEditor/Preview.jsx
@@ -43,13 +43,14 @@ export const Preview = ({markers, areaFills, format, oskariStyle}) => {
     const propsForSVG = StyleMapper.getPropsForFormat(format, oskariStyle);
     const flagsForSelenium = StyleMapper.getAsDataAttributes(format, propsForSVG);
     const svgIcon = getSVGContent(format, propsForSVG, markers, areaFills);
+    const size = format === 'point' ? propsForSVG.size : undefined;
     return (
         <div style={ previewWrapperStyle } className="t_preview" { ...flagsForSelenium } >
             <SVGWrapper
                 width={ previewSize }
                 height={ previewSize }
                 content={ svgIcon }
-                iconSize={ format === 'point' ? propsForSVG.size : null} />
+                iconSize={ size } />
         </div>
     );
 };

--- a/src/react/components/StyleEditor/Preview/SVGHelper.js
+++ b/src/react/components/StyleEditor/Preview/SVGHelper.js
@@ -1,0 +1,14 @@
+
+const PARSER = new DOMParser();
+
+/**
+ * @method parsePath
+ * @param {String} baseSvg - svg as string
+ * @description Parses correct svg based on provided format
+ *
+ * @returns DOM Element - First path element in the base svg
+ */
+export const parsePathFromSVG = (baseSvg) => {
+    const parsed = PARSER.parseFromString(baseSvg, 'image/svg+xml');
+    return parsed.getElementsByTagName('path')[0];
+};

--- a/src/react/components/StyleEditor/Preview/SVGWrapper.jsx
+++ b/src/react/components/StyleEditor/Preview/SVGWrapper.jsx
@@ -15,6 +15,11 @@ const maxSize = 5;
 const multiplier = 2.5;
 
 const _composePreviewViewbox = (size) => {
+    if (typeof size === 'undefined') {
+        // for area and line so they are centered
+        return '2.5 2.5 45 45';
+    }
+    // calculate viewbox for centering point symbols
     const minX = previewViewbox.minX - (multiplier * (maxSize-size));
     const minY = previewViewbox.minY - (multiplier * (maxSize-size));
     const widthV = previewViewbox.width - (2 * multiplier * size) - multiplier; // multiply by negative to shrink viewbox
@@ -22,7 +27,7 @@ const _composePreviewViewbox = (size) => {
     return minX + ' ' + minY + ' ' +  widthV + ' ' + heightV;
 };
 
-export const SVGWrapper = ({ width = defaultPreviewSize, height = defaultPreviewSize, iconSize = 3, content = '' }) => {
+export const SVGWrapper = ({ width = defaultPreviewSize, height = defaultPreviewSize, iconSize, content = '' }) => {
     return (<svg
         viewBox={ _composePreviewViewbox(iconSize) }
         width={ width }

--- a/src/react/components/StyleEditor/Preview/SVGWrapper.jsx
+++ b/src/react/components/StyleEditor/Preview/SVGWrapper.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Viewbox settings for preview svg
+const previewViewbox = {
+    minX: 0,
+    minY: 0,
+    width: 60,
+    height: 60
+};
+
+// Size for preview svg
+const defaultPreviewSize = '80px';
+
+const _composePreviewViewbox = (size) => {
+    let viewboxString = ''
+    const widthV = previewViewbox.width - (5 * size); // multiply by negative to shrink viewbox
+    const heightV = previewViewbox.height - (5 * size); // multiply by negative to shrink viewbox
+    viewboxString = previewViewbox.minX + ' ' + previewViewbox.minY + ' ' +  widthV + ' ' + heightV;
+    return viewboxString;
+};
+
+export const SVGWrapper = ({ width = defaultPreviewSize, height = defaultPreviewSize, iconSize = 3, content = '' }) => {
+    return (<svg
+        viewBox={ _composePreviewViewbox(iconSize) }
+        width={ width }
+        height={ height }
+        xmlns="http://www.w3.org/2000/svg"
+        dangerouslySetInnerHTML={ { __html: content } }
+    >
+    </svg>);
+};
+
+SVGWrapper.propTypes = {
+    content: PropTypes.string.isRequired,
+    width: PropTypes.string,
+    height: PropTypes.string,
+    iconSize: PropTypes.number
+};

--- a/src/react/components/StyleEditor/Preview/SVGWrapper.jsx
+++ b/src/react/components/StyleEditor/Preview/SVGWrapper.jsx
@@ -11,13 +11,15 @@ const previewViewbox = {
 
 // Size for preview svg
 const defaultPreviewSize = '80px';
+const maxSize = 5;
+const multiplier = 2.5;
 
 const _composePreviewViewbox = (size) => {
-    let viewboxString = ''
-    const widthV = previewViewbox.width - (5 * size); // multiply by negative to shrink viewbox
-    const heightV = previewViewbox.height - (5 * size); // multiply by negative to shrink viewbox
-    viewboxString = previewViewbox.minX + ' ' + previewViewbox.minY + ' ' +  widthV + ' ' + heightV;
-    return viewboxString;
+    const minX = previewViewbox.minX - (multiplier * (maxSize-size));
+    const minY = previewViewbox.minY - (multiplier * (maxSize-size));
+    const widthV = previewViewbox.width - (2 * multiplier * size) - multiplier; // multiply by negative to shrink viewbox
+    const heightV = previewViewbox.height - (2 * multiplier * size) - multiplier; // multiply by negative to shrink viewbox
+    return minX + ' ' + minY + ' ' +  widthV + ' ' + heightV;
 };
 
 export const SVGWrapper = ({ width = defaultPreviewSize, height = defaultPreviewSize, iconSize = 3, content = '' }) => {

--- a/src/react/components/StyleEditor/Preview/StyleMapper.js
+++ b/src/react/components/StyleEditor/Preview/StyleMapper.js
@@ -1,0 +1,54 @@
+
+export const getAsDataAttributes = (format, props) => {
+    const testAttrs = {
+        'data-format': format
+    };
+    Object.keys(props).forEach(key => {
+        testAttrs['data-' + key] = props[key];
+    });
+};
+
+export const getPropsForFormat = (format, style) => {
+    if (format === 'point') {
+        return getPointPropsFromStyle(style);
+    } else if (format === 'line') {
+        return getLinePropsFromStyle(style);
+    } else if (format === 'area') {
+        return getAreaPropsFromStyle(style);
+    }
+    throw new Error("Unrecognized format");
+}
+
+
+export const getAreaPropsFromStyle = (style) => {
+    return {
+        color: style.fill.color,
+        strokecolor: style.stroke.area.color,
+        size: style.stroke.area.width,
+        strokestyle: style.stroke.area.lineDash,
+        pattern: style.fill.area.pattern
+    };
+};
+
+export const getLinePropsFromStyle = (style) => {
+    return {
+        color: style.stroke.color,
+        size: style.stroke.width,
+        linecap: style.stroke.lineCap,
+        linedash: style.stroke.lineDash,
+        linejoin: style.stroke.area.lineJoin
+    };
+};
+
+export const getPointPropsFromStyle = (style) => {
+    return {
+        color: style.image.fill.color,
+        size: style.image.size,
+        shape: style.image.shape
+    };
+};
+
+export const StyleMapper = {
+    getPropsForFormat,
+    getAsDataAttributes
+};

--- a/src/react/components/StyleEditor/Preview/StyleMapper.js
+++ b/src/react/components/StyleEditor/Preview/StyleMapper.js
@@ -1,14 +1,25 @@
-
-export const getAsDataAttributes = (format, props) => {
+/**
+ * Prefix object keys with "data-" so we can safely pass them to DOM element
+ * @param {String} format point, line or area
+ * @param {Object} props flags for style selection based on format
+ */
+const getAsDataAttributes = (format, props) => {
     const testAttrs = {
         'data-format': format
     };
     Object.keys(props).forEach(key => {
         testAttrs['data-' + key] = props[key];
     });
+    return testAttrs;
 };
 
-export const getPropsForFormat = (format, style) => {
+/**
+ * Returns a simplified object based on format for generating preview SVG
+ * @param {String} format geometry type: point, line or area
+ * @param {Object} style Oskari style object
+ * @returns simplified style object for SVG generator
+ */
+const getPropsForFormat = (format, style) => {
     if (format === 'point') {
         return getPointPropsFromStyle(style);
     } else if (format === 'line') {
@@ -19,8 +30,7 @@ export const getPropsForFormat = (format, style) => {
     throw new Error("Unrecognized format");
 }
 
-
-export const getAreaPropsFromStyle = (style) => {
+const getAreaPropsFromStyle = (style) => {
     return {
         color: style.fill.color,
         strokecolor: style.stroke.area.color,
@@ -30,7 +40,7 @@ export const getAreaPropsFromStyle = (style) => {
     };
 };
 
-export const getLinePropsFromStyle = (style) => {
+const getLinePropsFromStyle = (style) => {
     return {
         color: style.stroke.color,
         size: style.stroke.width,
@@ -40,7 +50,7 @@ export const getLinePropsFromStyle = (style) => {
     };
 };
 
-export const getPointPropsFromStyle = (style) => {
+const getPointPropsFromStyle = (style) => {
     return {
         color: style.image.fill.color,
         size: style.image.size,

--- a/src/react/components/StyleEditor/Preview/area.js
+++ b/src/react/components/StyleEditor/Preview/area.js
@@ -1,0 +1,71 @@
+import { parsePathFromSVG } from './SVGHelper';
+import { OSKARI_BLANK_STYLE } from '../OskariDefaultStyle';
+
+const areaPreviewSVG = `<svg viewBox="0 0 80 80" width="80" height="80" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <pattern id="checker" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+            <rect fill="#eee" x="0" width="10" height="10" y="0">
+                <rect fill="#eee" x="10" width="10" height="10" y="10"></rect>
+            </rect>
+        </pattern>
+    </defs>
+    <rect x="0" y="0" width="80" height="80" fill="url(#checker)"></rect>
+    <path d="M10,17L40,12L29,40Z" stroke-linejoin="miter" stroke-linecap="butt" stroke-dasharray="0"></path>
+</svg>`;
+
+/**
+ * @method _composeSvgPattern
+ * @param {HTMLElement} patternPath pattern as DOM node element
+ * @description Combine provided plain pattern path with definitive svg base
+ * @returns {String} full pattern as string
+ */
+ const _composeSvgPattern = (patternPath, patternId) => {
+    return '<defs><pattern id="' + patternId +'" viewBox="0, 0, 12, 12" width="100%" height="100%">' + patternPath.outerHTML + '</pattern></defs>';
+}
+
+const getPatternName = (patternId) => {
+    switch (patternId) {
+        case 0:
+            return 'DIAGONAL_THIN';
+        case 1:
+            return 'DIAGONAL_THICK';
+        case 2:
+            return 'HORIZONTAL_THIN';
+        case 3:
+            return 'HORIZONTAL_THICK';
+        case 4:
+            return 'TRANSPARENT';
+        default:
+            return 'SOLID';
+    };
+}
+
+const getPatternSVG = (areaFills, patternId) => {
+    const name = getPatternName(patternId);
+    const patternSVG = areaFills.find(pattern => pattern.name === name);
+    return parsePathFromSVG(patternSVG.data);
+}
+
+/**
+* @method getAreaSVG
+* @description Composes area svg path
+* @returns {String} area svg path
+*/
+let patternIdCounter = 0;
+export const getAreaSVG = (areaParams, areaFills) => {
+   const { color, strokecolor, size, strokestyle, pattern } = areaParams;
+   const path = parsePathFromSVG(areaPreviewSVG);
+
+   path.setAttribute('stroke', strokecolor);
+   path.setAttribute('stroke-width', size);
+   path.setAttribute('stroke-linecap', OSKARI_BLANK_STYLE.stroke.lineCap);
+   path.setAttribute('stroke-dasharray', strokestyle === 'dash' ? '4, 4': '');
+   path.setAttribute('stroke-linejoin', OSKARI_BLANK_STYLE.stroke.area.lineJoin);
+
+   const patternId = 'patternPreview' + patternIdCounter++;
+   const fillPatternSVG = getPatternSVG(areaFills, pattern);
+   fillPatternSVG.setAttribute('stroke', color);
+   path.setAttribute('fill', 'url(#' + patternId + ')');
+
+   return _composeSvgPattern(fillPatternSVG, patternId) + path.outerHTML;
+};

--- a/src/react/components/StyleEditor/Preview/line.js
+++ b/src/react/components/StyleEditor/Preview/line.js
@@ -1,0 +1,29 @@
+import { parsePathFromSVG } from './SVGHelper';
+
+const linePreviewSVG = `<svg viewBox="0 0 80 80" width="80" height="80" xmlns="http://www.w3.org/2000/svg">
+    <path d="M10,15L20,35L40,25"
+        stroke-width="3"
+        stroke-linejoin="miter"
+        stroke-linecap="butt"
+        strokeDasharray="0"
+        fill="none"
+        stroke="#000000"></path>
+</svg>`;
+
+/**
+ * @method _composeLinePath
+ * @description Composes line svg path
+ * @returns {String} line svg path
+ */
+export const getLineSVG = (lineParams) => {
+    const { color, size, linecap, linedash, linejoin } = lineParams;
+    const path = parsePathFromSVG(linePreviewSVG);
+
+    path.setAttribute('stroke', color);
+    path.setAttribute('stroke-width', size);
+    path.setAttribute('stroke-linecap', linecap);
+    path.setAttribute('stroke-dasharray', linedash === 'dash' ? '4, 4': '');
+    path.setAttribute('stroke-linejoin', linejoin);
+
+    return path.outerHTML;
+};

--- a/src/react/components/StyleEditor/Preview/point.js
+++ b/src/react/components/StyleEditor/Preview/point.js
@@ -1,0 +1,16 @@
+import { parsePathFromSVG } from './SVGHelper';
+import { OSKARI_BLANK_STYLE } from '../OskariDefaultStyle';
+
+export const getPointSVG = (pointParams, markers) => {
+    const { color, shape } = pointParams;
+    const path = parsePathFromSVG(markers[shape].data);
+
+    path.setAttribute('stroke', '#000000');
+    path.setAttribute('stroke-width', OSKARI_BLANK_STYLE.defaultStrokeWidth);
+    path.setAttribute('stroke-linecap', OSKARI_BLANK_STYLE.stroke.lineCap);
+    path.setAttribute('stroke-dasharray', '');
+    path.setAttribute('stroke-linejoin', OSKARI_BLANK_STYLE.stroke.area.lineJoin);
+    path.setAttribute('fill', color);
+
+    return path.outerHTML;
+};


### PR DESCRIPTION
- Make functions pure instead of them sharing "global' ish" variables.
- Make Point symbol preview stay at the center of the preview box.
- This could further be simplied to NOT parse string -> xml -> [modify] -> string but rather have a string template to handle the modify but there's enough changes to make it a bigger change than is easy to track.