### PR TITLE
Make MapLayerUpdateRequest reload WFS features

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -15,6 +15,11 @@ Some extra tags:
 
 Added initial bundle documentation. Userstyle functionality has been moved from wfsvector to own bundle.
 
+### [mod] MapModulePlugin.MapLayerUpdateRequest
+
+Added documentation for the request. The request itself has been available from 1.x already but the it wasn't documented. 
+Since 2.5 it can also be used to force reload of features from a service on a vector/WFS-layer.
+
 ## 2.4.0
 
 ### [rem] Removed unmaintained bundles

--- a/api/mapping/mapmodule/request/MapModulePlugin.MapLayerUpdateRequest.md
+++ b/api/mapping/mapmodule/request/MapModulePlugin.MapLayerUpdateRequest.md
@@ -1,0 +1,31 @@
+# MapModulePlugin.MapLayerUpdateRequest
+
+Update the map layer data on map.
+
+## Use cases
+
+- Update WMS-layer with additional parameters on GetMap calls
+- Refetches features from vector source from the server
+
+## Description
+
+Can be used to refresh a WMS-layer by adding parameters to the GetMap requests like SLD on compatible services or after updating contents of a WFS-service refetch the updated features.
+
+## Parameters
+
+(* means the parameter is required)
+
+<table class="table">
+<tr>
+  <th> Name</th><th> Type</th><th> Description</th><th> Default value</th>
+</tr>
+<tr>
+  <td> \* MapLayerId </td><td> String </td><td> id of map/vector layer used in Oskari.mapframework.service.MapLayerService </td><td> </td>
+</tr>
+<tr>
+  <td> forced </td><td> Boolean </td><td> Forces the update (attaches a timestamp variable for WMS etc). Some parameters might not trigger the update automatically so this tries to make sure the content is refetched from the service. </td><td> </td>
+</tr>
+<tr>
+  <td> params </td><td> Object </td><td> For adding parameters to the request you can attach an object where keys are the params with values being the param value. Does not affect WFS layers currently. </td><td> </td>
+</tr>
+</table>

--- a/api/mapping/mapmodule/request/MapModulePlugin.MapLayerUpdateRequest.md
+++ b/api/mapping/mapmodule/request/MapModulePlugin.MapLayerUpdateRequest.md
@@ -5,7 +5,7 @@ Update the map layer data on map.
 ## Use cases
 
 - Update WMS-layer with additional parameters on GetMap calls
-- Refetches features from vector source from the server
+- Refetches features of a vector source from the server/service
 
 ## Description
 
@@ -23,9 +23,9 @@ Can be used to refresh a WMS-layer by adding parameters to the GetMap requests l
   <td> \* MapLayerId </td><td> String </td><td> id of map/vector layer used in Oskari.mapframework.service.MapLayerService </td><td> </td>
 </tr>
 <tr>
-  <td> forced </td><td> Boolean </td><td> Forces the update (attaches a timestamp variable for WMS etc). Some parameters might not trigger the update automatically so this tries to make sure the content is refetched from the service. </td><td> </td>
+  <td> forced </td><td> Boolean </td><td> Forces the update (attaches a timestamp variable for WMS etc). Some parameters might not trigger the update automatically so this tries to make sure the content is refetched from the service. </td><td> false </td>
 </tr>
 <tr>
-  <td> params </td><td> Object </td><td> For adding parameters to the request you can attach an object where keys are the params with values being the param value. Does not affect WFS layers currently. </td><td> </td>
+  <td> params </td><td> Object </td><td> For adding parameters to the request you can attach an object where keys are the params with values being the param value. Does not affect WFS layers currently. </td><td> {} </td>
 </tr>
 </table>

--- a/bundles/mapping/mapmodule/AbstractMapLayerPlugin.js
+++ b/bundles/mapping/mapmodule/AbstractMapLayerPlugin.js
@@ -315,21 +315,22 @@ Oskari.clazz.define(
          * A generic implementation of forcing a redraw on a layer. Override in layer plugins where necessary.
          */
         updateLayerParams: function (layer, forced, params) {
-            var olLayerList = this.getMapModule().getOLMapLayers(layer.getId());
-            if (olLayerList) {
-                for (var i = 0; i < olLayerList.length; ++i) {
-                    if (olLayerList[i].redraw && typeof (olLayerList[i].redraw) === 'function') {
-                        olLayerList[i].redraw(forced);
-                    } else if (typeof (olLayerList[i].getSource) === 'function' && typeof (olLayerList[i].getSource().updateParams) === 'function') {
-                        var updatedParams = jQuery.extend(true, {}, olLayerList[i].getSource().getParams(), params);
-                        // add timestamp to make sure that params are changed and layer is forced to redraw
-                        if (forced === true) {
-                            updatedParams._ts = Date.now();
-                        }
-                        olLayerList[i].getSource().updateParams(updatedParams);
-                    }
-                }
+            const olLayerList = this.getMapModule().getOLMapLayers(layer.getId());
+            if (!olLayerList) {
+                return;
             }
+            olLayerList.forEach(olLayer => {
+                if (typeof (olLayer.getSource) !== 'function' || typeof (olLayer.getSource().updateParams) !== 'function') {
+                    this._log.warn(`Tried updating layer (${ layer.getId() }), but plugin (${ this.getName() }) doesn't support update operation`);
+                    return;
+                }
+                const updatedParams = jQuery.extend(true, {}, olLayer.getSource().getParams(), params);
+                // add timestamp to make sure that params are changed and layer is forced to redraw
+                if (forced === true) {
+                    updatedParams._ts = Date.now();
+                }
+                olLayer.getSource().updateParams(updatedParams);
+            });
         }
     }, {
         extend: ['Oskari.mapping.mapmodule.plugin.AbstractMapModulePlugin'],

--- a/bundles/mapping/mapmodule/AbstractMapLayerPlugin.js
+++ b/bundles/mapping/mapmodule/AbstractMapLayerPlugin.js
@@ -321,7 +321,7 @@ Oskari.clazz.define(
             }
             olLayerList.forEach(olLayer => {
                 if (typeof (olLayer.getSource) !== 'function' || typeof (olLayer.getSource().updateParams) !== 'function') {
-                    this._log.warn(`Tried updating layer (${ layer.getId() }), but plugin (${ this.getName() }) doesn't support update operation`);
+                    this._log.warn(`Tried updating layer (${layer.getId()}), but plugin (${this.getName()}) doesn't support update operation`);
                     return;
                 }
                 const updatedParams = jQuery.extend(true, {}, olLayer.getSource().getParams(), params);

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -2468,17 +2468,15 @@ Oskari.clazz.define(
          * @param {Object} params
          */
         handleMapLayerUpdateRequest: function (layerId, forced, params) {
-            var me = this;
-            var sandbox = me.getSandbox();
-            var layerPlugins = me.getLayerPlugins();
-            var layer = sandbox.findMapLayerFromSelectedMapLayers(layerId);
+            const layer = this.getSandbox().findMapLayerFromSelectedMapLayers(layerId);
             if (!layer) {
                 // couldn't find layer to update
                 return;
             }
+            const layerPlugins = this.getLayerPlugins();
             Object.values(layerPlugins).forEach((plugin) => {
                 // true if either plugin doesn't have the function or says the layer is supported.
-                var isSupported = typeof plugin.isLayerSupported === 'function' && plugin.isLayerSupported(layer);
+                const isSupported = typeof plugin.isLayerSupported === 'function' && plugin.isLayerSupported(layer);
                 if (isSupported && typeof plugin.updateLayerParams === 'function') {
                     plugin.updateLayerParams(layer, forced, params);
                 }

--- a/bundles/mapping/mapmyplaces/plugin/MyPlacesLayerPlugin.ol.js
+++ b/bundles/mapping/mapmyplaces/plugin/MyPlacesLayerPlugin.ol.js
@@ -36,13 +36,7 @@ Oskari.clazz.define(
             const wfsPlugin = this.getMapModule().getLayerPlugins('wfs');
             if (typeof wfsPlugin.registerLayerType === 'function') {
                 // Let wfs plugin handle this layertype
-                const me = this;
-                const eventHandlers = {
-                    'MyPlaces.MyPlacesChangedEvent': event => {
-                        wfsPlugin.refreshLayersOfType(me.layertype);
-                    }
-                };
-                wfsPlugin.registerLayerType(this.layertype, layerClass, layerModelBuilder, eventHandlers);
+                wfsPlugin.registerLayerType(this.layertype, layerClass, layerModelBuilder);
                 this.unregister();
                 return;
             }

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
@@ -151,6 +151,16 @@ export class WfsVectorLayerPlugin extends AbstractMapLayerPlugin {
     }
 
     /**
+     * @method updateLayerParams
+     * Force updating features on layer
+     */
+    updateLayerParams (layer, forced, params) {
+        const handler = this._getLayerHandler(layer);
+        if (handler) {
+            handler.refreshLayer(layer);
+        }
+    }
+    /**
      * @method getPropertiesForIntersectingGeom
      * To get feature properties as a list. Returns features that intersect with given geometry.
      *

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/MvtLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/MvtLayerHandler.ol.js
@@ -98,6 +98,7 @@ export class MvtLayerHandler extends AbstractLayerHandler {
         source.tileCache.clear();
         source.clear();
         source.refresh();
+        this._log.warn('Server caches MVT-rendered tiles, use GeoJSON for layers that need to be updated at runtime or add a way to update cache on server.');
     }
 
     _setupTileGrid (config) {


### PR DESCRIPTION
If rendermode is set to MVT, prints out a warning to developer console about server side caching.