### PR TITLE
Layerservice update

### DIFF
--- a/bundles/framework/myplaces3/CategoryHandler.js
+++ b/bundles/framework/myplaces3/CategoryHandler.js
@@ -149,24 +149,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.CategoryHandler',
             }
             return layer;
         },
-        updateLayer: function (layerJson) {
-            const { id, name, options } = layerJson;
-            const layer = this.mapLayerService.findMapLayer(id);
-            if (!layer) {
-                this.log.warn('tried to update layer which does not exist, id: ' + id);
-                return;
-            }
-            layer.setName(name);
-            layer.setOptions(options);
-            const evt = Oskari.eventBuilder('MapLayerEvent')(id, 'update');
-            this.sandbox.notifyAll(evt);
-            if (this.sandbox.isLayerAlreadySelected(id)) {
-                // update layer on map
-                this.sandbox.postRequestByName('MapModulePlugin.MapLayerUpdateRequest', [id, true]);
-                this.sandbox.postRequestByName('ChangeMapLayerStyleRequest', [id]);
-            }
-            this._notifyUpdate();
-        },
         refreshLayerIfSelected: function (categoryId) {
             const id = this.getMapLayerId(categoryId);
             if (this.sandbox.isLayerAlreadySelected(id)) {
@@ -239,7 +221,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.CategoryHandler',
                     if (isNew) {
                         this.addLayerToService(layerJson);
                     } else {
-                        this.updateLayer(layerJson);
+                        this.mapLayerService.refreshLayerOnMap(layerJson);
+                        this._notifyUpdate();
                     }
                     if (callback) {
                         callback(this.parseCategoryId(layerJson.id));

--- a/bundles/framework/myplacesimport/UserLayersTab.js
+++ b/bundles/framework/myplacesimport/UserLayersTab.js
@@ -282,7 +282,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.UserLayersTab',
                         if (typeof response === 'object') {
                             msg = me.loc('tab.notification.editedMsg');
                             title = me.loc('tab.title');
-                            me.instance.getService().updateLayer(data.id, response);
+                            me.instance.getService().updateLayer(response);
                             me.refresh();
                             fadeout = true;
                         } else {

--- a/bundles/framework/myplacesimport/service/MyPlacesImportService.js
+++ b/bundles/framework/myplacesimport/service/MyPlacesImportService.js
@@ -87,20 +87,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
      * @param {String} id
      * @param {Object} updatedLayer
      */
-    updateLayer: function (id, updatedLayer) {
-        const layer = this.instance.getMapLayerService().findMapLayer(id);
-        layer.setName(updatedLayer.name);
-        layer.setSource(updatedLayer.source);
-        layer.setDescription(updatedLayer.description);
-        layer.setOptions(updatedLayer.options);
-
-        var evt = Oskari.eventBuilder('MapLayerEvent')(id, 'update');
-        this.sandbox.notifyAll(evt);
-        if (this.sandbox.isLayerAlreadySelected(id)) {
-            // update layer on map
-            this.instance.sandbox.postRequestByName('MapModulePlugin.MapLayerUpdateRequest', [id, true]);
-            this.instance.sandbox.postRequestByName('ChangeMapLayerStyleRequest', [layer.getId()]);
-        }
+    updateLayer: function (layerJson) {
+        this.instance.getMapLayerService().refreshLayerOnMap(layerJson, this.addInfoToMaplayer.bind(this));
     },
     /**
      * Adds the layers to the map layer service.
@@ -149,6 +137,17 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
         const mapLayerService = this.instance.getMapLayerService();
         // Create the layer model
         const mapLayer = mapLayerService.createMapLayer(layerJson);
+        this.addInfoToMaplayer(mapLayer);
+        // Add the layer to the map layer service
+        mapLayerService.addLayer(mapLayer, skipEvent);
+        if (typeof cb === 'function') {
+            cb(mapLayer);
+        }
+        return mapLayer;
+    },
+
+    // adding or updating layer
+    addInfoToMaplayer: function (mapLayer) {
         // mark that this has been added by this bundle.
         // There might be other userlayer typed layers in maplayerservice from link parameters that might NOT be this users layers.
         // This is used to filter out other users shared layers when listing layers on the My Data functionality.
@@ -160,13 +159,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
             id: this.groupId,
             name: loclayer.inspire
         }]);
-        // Add the layer to the map layer service
-        mapLayerService.addLayer(mapLayer, skipEvent);
-        if (typeof cb === 'function') {
-            cb(mapLayer);
-        }
-        return mapLayer;
     }
+
 }, {
     protocol: ['Oskari.mapframework.service.Service']
 });


### PR DESCRIPTION
Move refreshLayerOnMap from admin layereditor to layer service. Use it for myplaces and userlayer update. Userlayer bundle adds organization and group to layer. Normally layer plugin's model builder does that. Also bundle mark that layer has been added by userlayer bundle (users own layer). These had to be added before layer is added (or send another events). So decided to add modifier to refreshLayerOnMap.

This is alternative solution to get VectorStyles updated on userlayer and myplaces update:
https://github.com/oskariorg/oskari-frontend/pull/1650

