### PR TITLE
Admin layereditor rasterstyle select overflow fix

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/styled.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/styled.jsx
@@ -31,4 +31,5 @@ export const DefaultStyle = styled(Checkbox)`
 
 export const StyleSelect = styled(Select)`
     flex: 1;
+    min-width: 300px;
 `;


### PR DESCRIPTION
Add min-width for styleselect. It looks like even width: 0px fixes the problem because flex grow increases width.