### PR TITLE
Admin-layereditor interval timeseries fix

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/SelectedTime.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/SelectedTime.jsx
@@ -7,7 +7,7 @@ import { StyledFormField } from '../styled';
 export const SelectedTime = ({ layer, controller }) => {
     const value = layer.params ? layer.params.selectedTime : '';
     const { capabilities } = layer;
-    if (!capabilities.times) {
+    if (!Array.isArray(capabilities.times)) {
         return null;
     }
     return (


### PR DESCRIPTION
Don't render select if times isn't array. At least for FMI timeseries layers it doesn't make sense to populate time options to choose default time because time range isn't fixed  (last 7 days) and there is more than 2K time options. Also start, end and interval values are shown in capabilities text box.

![image](https://user-images.githubusercontent.com/22147092/137889119-632cc9b4-3a3a-4a6a-8dcc-2b2379d04ea6.png)
