### PR TITLE
Admin layereditor additional legend selection fix

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/RasterStyle.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/RasterStyle.jsx
@@ -31,11 +31,10 @@ const RasterStyle = ({ layer, controller, getMessage }) => {
     // and notify admin that such styles don't exist any more on the service
     const additionalLegends = additionalLegendsToStyles(styles, legends, getMessage('styles.raster.legendImage'));
     const styleOptions = [...styles, ...additionalLegends];
-
     const firstOption = styleOptions.length > 0 ? styleOptions[0].name : '';
     const [selected, setSelected] = useState(defaultName || firstOption);
 
-    const style = styles.find(s => s.name === selected);
+    const style = styleOptions.find(s => s.name === selected);
     const name = style ? style.name : GLOBAL_LEGEND;
     const styleLegend = style ? style.legend : '';
     // user/layer gets legend in following order: named override, global override, defined in service/capabilities/style


### PR DESCRIPTION
setLegendUrl uses name (not selected) because if layer doesn't have style select isn't rendered and admin can add global legend (not style related). Fix to find style/name from styleOptions which contains also additional legends.