### PR TITLE
HoverHandler clear removed layer

### DIFF
--- a/bundles/mapping/mapmodule/service/HoverHandler.js
+++ b/bundles/mapping/mapmodule/service/HoverHandler.js
@@ -112,12 +112,19 @@ export class HoverHandler {
         this._styleCache[layer.getId()] = this._styleGenerator(layer);
     }
 
+    removeLayer (layer) {
+        const layerId = layer.getId();
+        if (this._state.layerId === layerId) {
+            this.clearHover(true);
+        }
+        delete this._styleCache[layerId];
+        delete this._vectorTileLayers[layerId];
+    }
+
     updateLayerStyle (layer) {
         const layerId = layer.getId();
         if (this._state.layerId === layerId) {
-            this.clearHover();
-            // clear layer id from state to be sure that onFeatureHover uses updated style
-            this._state.layerId = null;
+            this.clearHover(true);
         }
         this.setTooltipContent(layer);
         const vectorTileLayer = this._vectorTileLayers[layerId];
@@ -175,10 +182,10 @@ export class HoverHandler {
         };
     }
 
-    _clearState () {
+    _clearState (clearLayerId) {
         const layerId = this._state.layerId;
-        // remove others than layerId from state
-        this._state = { layerId };
+        // store layerId to avoid unnecessary style updates
+        this._state = clearLayerId ? {} : { layerId };
         if (layerId) {
             const vtLayer = this._vectorTileLayers[layerId];
             if (vtLayer) {
@@ -189,8 +196,8 @@ export class HoverHandler {
         }
     }
 
-    clearHover () {
-        this._clearState();
+    clearHover (clearLayerId) {
+        this._clearState(clearLayerId);
         this._clearTooltip();
     }
 

--- a/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
+++ b/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
@@ -40,6 +40,7 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
             this._sandbox.registerForEventByName(this, 'MapLayerVisibilityChangedEvent');
             this._sandbox.registerForEventByName(this, 'AfterChangeMapLayerOpacityEvent');
             this._sandbox.registerForEventByName(this, 'AfterChangeMapLayerStyleEvent');
+            this._sandbox.registerForEventByName(this, 'AfterMapLayerRemoveEvent');
         }
 
         /**
@@ -350,6 +351,8 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
                 this.hoverHandler.updateHoverLayer(event.getMapLayer()); break;
             case 'AfterChangeMapLayerStyleEvent':
                 this.hoverHandler.updateLayerStyle(event.getMapLayer()); break;
+            case 'AfterMapLayerRemoveEvent':
+                this.hoverHandler.removeLayer(event.getMapLayer()); break;
             }
         }
     }, {


### PR DESCRIPTION
If layer is added and then removed hoverhandler has layerId and style stored for layer. Then layer style is updated (layer isn't on map/selected). When updated layer is added and hovered layerId  doesn't change (only one vector layer selected) then hover layer's style isn't updated. Clear hover including layerId when layer is removed to be sure that style is updated.