### PR TITLE
MyPlaces blank style fix

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/styled.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/styled.jsx
@@ -3,4 +3,5 @@ import styled from 'styled-components';
 
 export const MetadataButton = styled(SelectOutlined)`
     margin-left: 10px;
+    color: #0091ff;
 `;

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.jsx
@@ -5,7 +5,7 @@ import { Numeric } from '../Numeric';
 import { LocaleConsumer, Controller } from 'oskari-ui/util';
 import styled from 'styled-components';
 import { getZoomLevelHelper } from '../../../../../mapping/mapmodule/util/scale';
-import { PlusCircleOutlined, MinusCircleOutlined } from '@ant-design/icons';
+import { PlusCircleOutlined, MinusCircleOutlined, WarningOutlined } from '@ant-design/icons';
 
 const VerticalComponent = styled('div')`
     display: flex;
@@ -16,6 +16,11 @@ const VerticalComponent = styled('div')`
 
 const FieldLabel = styled('div')`
     padding-bottom: 5px;
+`;
+
+const WarningIcon = styled(WarningOutlined)`
+    color: #da5151;
+    padding-left: 10px;
 `;
 
 const SliderContainer = styled('div')`
@@ -57,6 +62,8 @@ const Scale = ({ layer, scales = [], controller, getMessage }) => {
         // if max zoom is undefined the slider needs to be at the max value
         layerMaxZoom = maxZoomUnrestrictedValue;
     }
+    // if min scale is defined and it's under map scales or invalid order, layer isInScale is always false
+    const invalidScale = minscale > 0 && (minscale < mapScales[mapScales.length - 1] || minscale < maxscale);
     const onValueChange = ([min, max]) => {
         if (min < 0) {
             min = -1;
@@ -72,7 +79,9 @@ const Scale = ({ layer, scales = [], controller, getMessage }) => {
     };
     return (
         <VerticalComponent>
-            <Message messageKey='fields.scale' LabelComponent={FieldLabel} />
+            <Message messageKey='fields.scale' LabelComponent={FieldLabel}>
+                { invalidScale && <WarningIcon /> }
+            </Message>
             <ScaleInput
                 prefix="1:"
                 placeholder={locNoLimit}

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VectorStyle.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VectorStyle.jsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import { VectorStyleSelect } from './VectorStyle/VectorStyleSelect';
 import { VectorNameInput } from './VectorStyle/VectorNameInput';
 import { LocaleConsumer, Controller } from 'oskari-ui/util';
-import { Button, Message, Modal, Space, StyleEditor } from 'oskari-ui';
+import { Button, Message, Modal, Space } from 'oskari-ui';
+import { StyleEditor } from 'oskari-ui/components/StyleEditor';
 import { PlusOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
 

--- a/bundles/framework/myplaces3/MyPlacesLayerForm.jsx
+++ b/bundles/framework/myplaces3/MyPlacesLayerForm.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Message, TextInput, Divider, Modal, StyleEditor } from 'oskari-ui';
+import { Message, TextInput, Divider, Modal } from 'oskari-ui';
+import { StyleEditor } from 'oskari-ui/components/StyleEditor';
 import { OSKARI_BLANK_STYLE } from 'oskari-ui/components/StyleEditor/index';
 
 export const MyPlacesLayerForm = ({ name, style, onSave, onCancel }) => {

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -34,4 +34,3 @@ export { GenericForm } from './components/GenericForm';
 export { DateRange } from './components/DateRange';
 export { ColorPicker } from './components/ColorPicker';
 export { Modal } from './components/Modal';
-export { StyleEditor } from './components/StyleEditor';


### PR DESCRIPTION
New layers are made with null style and MyPlacesLayerForm stores editorState. If user doesn't make any changes then editorState doesn't have style definitions. Initialize editorState with StyleEditor's blank style so user gets style definitions which are shown in StyleEditor UI.

WFS plugin handles myplaces layers but it didn't register default feature style for it. So without style definitions myplaces layer had ol style function which didn't render visible features.