### PR TITLE
StyleEditor horizontal patterns fix

### DIFF
--- a/src/react/components/StyleEditor/AreaTab.jsx
+++ b/src/react/components/StyleEditor/AreaTab.jsx
@@ -29,14 +29,14 @@ const getFillIconSolid = (id) => {
 const getFillIconHorizontalThin = (id) => {
     const myId = 'thin_horizontal-' + id;
     return createSVG(myId, `<pattern id="${myId}" viewBox="0, 0, 12, 12" width="100%" height="100%">
-                <path d="M-1,1 l33,0, M-1,4 l33,0 M-1,7 l33,0 M-1,10 l33,0 M-1,13 l33,1" stroke="#000000" stroke-width="1"/>
+                <path d="M-1,1 l33,0 M-1,4 l33,0 M-1,7 l33,0 M-1,10 l33,0 M-1,13 l33,1" stroke="#000000" stroke-width="1"/>
             </pattern>`);
 };
 
 const getFillIconHorizontalThick = (id) => {
     const myId = 'thick_horizontal-' + id;
     return createSVG(myId, `<pattern id="${myId}" viewBox="0, 0, 12, 12" width="100%" height="100%">
-                <path d="M-1,2 l33,0, M-1,7 l33,0 M-1,12 l33,0" stroke="#000000" stroke-width="3" />
+                <path d="M-1,2 l33,0 M-1,7 l33,0 M-1,12 l33,0" stroke="#000000" stroke-width="3" />
             </pattern>`);
 };
 


### PR DESCRIPTION
Fix invalid paths. Path operations are separated with optional white space and coordinates can be separated with white space or comma.  So commas are only valid if a number is either side of them. Firefox follows the standard and draws only first line and stops because next operation was separated with illegal comma.