### PR TITLE
Enable measurements for Box-type drawings

### DIFF
--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
@@ -524,6 +524,7 @@ Oskari.clazz.define(
                     me.addBufferPropertyToFeatures(features, requestedBuffer);
                 }
                 break;
+            case 'Box':
             case 'Square':
                 features.forEach(function (f) {
                     me._featuresValidity[f.getId()] = true;


### PR DESCRIPTION
Force geometry check as valid for Box-typed draw to get measurements properly in the event.