### PR TITLE
Fix getHoverOptions is not a function error

### DIFF
--- a/bundles/mapping/mapmodule/service/HoverHandler.js
+++ b/bundles/mapping/mapmodule/service/HoverHandler.js
@@ -142,7 +142,7 @@ export class HoverHandler {
     }
 
     setTooltipContent (layer) {
-        const options = layer.getHoverOptions();
+        const options = typeof layer.getHoverOptions === 'function' ? layer.getHoverOptions() : {};
         if (!options || !Array.isArray(options.content)) {
             return;
         }


### PR DESCRIPTION
Fix warning at getHoverOptions is not a function.
![image](https://user-images.githubusercontent.com/570159/140489907-9a79e8c6-f262-4336-8e07-35ed3f33186e.png)
