### PR TITLE
Fix printout.PrintMapRequest

### DIFF
--- a/api/mapping/printout/request/printout.PrintMapRequest.md
+++ b/api/mapping/printout/request/printout.PrintMapRequest.md
@@ -1,3 +1,3 @@
 # printout.PrintMapRequest
 
-Prints map when requested
+Starts/opens the UI for printout functionality like user had clicked the tool icon.

--- a/bundles/framework/printout/instance.js
+++ b/bundles/framework/printout/instance.js
@@ -116,7 +116,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.printout.PrintoutBundleInstance'
             }
             // requesthandler
             this.printoutHandler = Oskari.clazz.create('Oskari.mapframework.bundle.printout.request.PrintMapRequestHandler', sandbox, function () {
-                me.instance.sandbox.postRequestByName('userinterface.UpdateExtensionRequest', [me.instance, 'attach']);
+                sandbox.postRequestByName('userinterface.UpdateExtensionRequest', [me, 'attach']);
             });
             sandbox.requestHandler('printout.PrintMapRequest', this.printoutHandler);
 


### PR DESCRIPTION
The printout request handling was probably refactored at some point with code moved to instance.js. However the code was not changed so it refers to `this.instance` but actually `this` is the instance so it resulted in a JS error. Updated the API doc to better describe what happens when `Oskari.getSandbox().postRequestByName('printout.PrintMapRequest', []);` is run.