### PR TITLE
Enable sending options for search

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -42,6 +42,9 @@ The RPC `getAllLayers()` function now includes layer `attributes` `data` block. 
 }
 ```
 
+### [mod] [rpc] SearchRequest and SearchResultEvent
+
+SearchRequest can now take an optional second parameter that is sent to the server side implementation. As the server side implementation are handled by different "channels" depending on the Oskari instance and implementation these options might or might not be handled. However the same options are returned on the SearchResultEvent enabling tracking  which event is a response to which request making the functionality more versatile whether any extra flags are supported by the server instance or not. Contact your Oskari instance administrator for options that are used by the server side on given instance.
 
 ## 2.5.0
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -44,7 +44,7 @@ The RPC `getAllLayers()` function now includes layer `attributes` `data` block. 
 
 ### [mod] [rpc] SearchRequest and SearchResultEvent
 
-SearchRequest can now take an optional second parameter that is sent to the server side implementation. As the server side implementation are handled by different "channels" depending on the Oskari instance and implementation these options might or might not be handled. However the same options are returned on the SearchResultEvent enabling tracking  which event is a response to which request making the functionality more versatile whether any extra flags are supported by the server instance or not. Contact your Oskari instance administrator for options that are used by the server side on given instance.
+SearchRequest can now take an optional second parameter that is sent to the server side implementation. As the server side implementation are handled by different "channels" depending on the Oskari instance and implementation these options might or might not be handled. However the same options are returned on the SearchResultEvent enabling tracking which event is a response to which request making the functionality more versatile whether any extra flags are supported by the server instance or not. A common handling has been implemented for the key `limit` in the options to request more or less results than the instance default. Contact your Oskari instance administrator for options that are used by the server side on given instance.
 
 ## 2.5.0
 

--- a/api/framework/search/event/SearchResultEvent.md
+++ b/api/framework/search/event/SearchResultEvent.md
@@ -1,10 +1,10 @@
 # SearchResultEvent [rpc]
 
-Notifies that search result has been got.
+Notifies that a search has been performed and the result is accessible through the event.
 
 ## Description
 
-Used to notify that the ``SearchRequest`` has received a reply from search.
+Used to notify that the ``SearchRequest`` has received a reply from server side search.
 
 ## Parameters
 
@@ -23,6 +23,9 @@ Used to notify that the ``SearchRequest`` has received a reply from search.
 <tr>
   <td> \* result</td><td> Object </td><td> search result</td><td> </td>
 </tr>
+<tr>
+  <td> options </td><td> Object </td><td> options sent in search request </td><td> </td>
+</tr>
 </table>
 
 ## Event methods
@@ -39,14 +42,18 @@ Returns search result as JSON
 ### getRequestParameters()
 Returns request parameters as JSON
 
+### getOptions()
+Returns optional flags sent in SearchRequest for this search
+
 ### getParams()
 Returns event parameters as an object:
 <pre class="event-code-block">
 <code>
 {
-    success: this._success,
-    result: this._result,
-    requestParameters: this._requestParameters
+    success: getSuccess(),
+    result: getResult(),
+    requestParameters: getRequestParameters(),
+    options: getOptions()
 };
 </code>
 </pre>
@@ -81,10 +88,10 @@ Event occurs after a search request.
         "id": 1,
         "rank": 30,
         "lon": "383183.648",
-        "village": "Hausj‰rvi",
+        "village": "Hausj√§rvi",
         "name": "Vantaa",
         "zoomScale": 11300,
-        "type": "Kyl‰, kaupunginosa tai kulmakunta",
+        "type": "Kyl√§, kaupunginosa tai kulmakunta",
         "lat": "6733424.84"
       },
       {
@@ -101,7 +108,7 @@ Event occurs after a search request.
         "id": 3,
         "rank": 50,
         "lon": "383746.169",
-        "village": "Nurmij‰rvi",
+        "village": "Nurmij√§rvi",
         "name": "Vantaa",
         "zoomScale": 2800,
         "type": "Talo",
@@ -109,7 +116,8 @@ Event occurs after a search request.
       }
     ]
   },
-  "requestParameters": "Vantaa"
+  "requestParameters": "Vantaa",
+  "options": {}
 }
 </code>
 </pre>

--- a/api/framework/search/request/SearchRequest.md
+++ b/api/framework/search/request/SearchRequest.md
@@ -26,7 +26,7 @@ Requests search results (addresses, locations) by given params. After the search
   <td> \* query</td><td> String </td><td> address or location to be searched</td><td> </td>
 </tr>
 <tr>
-  <td> options</td><td> Object </td><td> Arbitratry options to send to server side implementation. These might get handled or not depending on the backend implementation/search channel</td><td>{}</td>
+  <td> options</td><td> Object </td><td> Arbitratry options to send to server side implementation. These might get handled or not depending on the backend implementation/search channel. A common handling is for key `limit` so client can request less or more results than the instance default. However the instance admin can set a hard limit for results.</td><td>{}</td>
 </tr>
 </table>
 
@@ -35,7 +35,13 @@ Requests search results (addresses, locations) by given params. After the search
 Get search result in an RPC application:
 ```javascript
   var query = "Finland";
-  channel.postRequest('SearchRequest', [ query ],
+  channel.postRequest('SearchRequest', [ query ]);
+```
+
+Same search but limit results to 10:
+```javascript
+  var query = "Finland";
+  channel.postRequest('SearchRequest', [ query, { 'limit': 10 } ]);
 ```
 
 ## Related api

--- a/api/framework/search/request/SearchRequest.md
+++ b/api/framework/search/request/SearchRequest.md
@@ -11,7 +11,8 @@ Make a search query
 Requests search results (addresses, locations) by given params. After the search is completed a ``SearchResultEvent`` is triggered where following data is available:
 - event.getSuccess(), returns boolean. If ``true``, search is done and there is no errors
 - event.getResult(), returns search result object. Look at searchresultevent.md for more details
-- event.getRequestParameters(), returns request paremeters, which are used for search
+- event.getRequestParameters(), returns the `query` that was used for searching
+- event.getOptions(), returns options used when requesting search if any
 
 ## Parameters
 
@@ -23,6 +24,9 @@ Requests search results (addresses, locations) by given params. After the search
 </tr>
 <tr>
   <td> \* query</td><td> String </td><td> address or location to be searched</td><td> </td>
+</tr>
+<tr>
+  <td> options</td><td> Object </td><td> Arbitratry options to send to server side implementation. These might get handled or not depending on the backend implementation/search channel</td><td>{}</td>
 </tr>
 </table>
 

--- a/bundles/service/search/event/SearchResultEvent.js
+++ b/bundles/service/search/event/SearchResultEvent.js
@@ -3,77 +3,77 @@
  *
  * Response of search result
  */
-Oskari.clazz.define('Oskari.mapframework.bundle.search.event.SearchResultEvent',
-/**
- * @method create called automatically on construction
- * @static
- * @param {Boolean} success succesfully got a result or an error occured
- * @param {String} requestParameters request parameters
- * @param {Object} search result
- * @param {Object} options options that were used for searching
- */
-function (success, requestParameters, result, options = {}) {
-    this._success = !!success;
-    this._requestParameters = requestParameters;
-    this._result = result;
-    this._options = options;
-}, {
-    /** @static @property __name event name */
+Oskari.clazz.define(
+    'Oskari.mapframework.bundle.search.event.SearchResultEvent',
+    /**
+     * @method create called automatically on construction
+     * @static
+     * @param {Boolean} success succesfully got a result or an error occured
+     * @param {String} requestParameters request parameters
+     * @param {Object} search result
+     * @param {Object} options options that were used for searching
+     */
+    function (success, requestParameters, result, options = {}) {
+        this._success = !!success;
+        this._requestParameters = requestParameters;
+        this._result = result;
+        this._options = options;
+    }, {
         __name: 'SearchResultEvent',
 
-    /**
-     * @method getName
-     * Returns event name
-     * @return {String}
-     */
-    getName: function () {
-        return this.__name;
-    },
-    /**
-     * @method getSuccess
-     * Returns the successfully routing info
-     * @return {Boolean}
-     */
-    getSuccess: function () {
-        return this._success;
-    },
-    /**
-     * @method getResult
-     * Returns the search result JSON
-     * @return {Object}
-     */
-    getResult: function () {
-        return this._result;
-    },
-    /**
-     * @method getOptions
-     * Returns options that were used for searching
-     * @return {Object}
-     */
-    getOptions: function () {
-        return this._options || {};
-    },
-    /**
-     * @method getRequestParameters
-     * Returns request paremeters
-     * @return {String}
-     */
-    getRequestParameters: function () {
-        return this._requestParameters;
-    },
+        /**
+         * @method getName
+         * Returns event name
+         * @return {String}
+         */
+        getName: function () {
+            return this.__name;
+        },
+        /**
+         * @method getSuccess
+         * Returns the successfully routing info
+         * @return {Boolean}
+         */
+        getSuccess: function () {
+            return this._success;
+        },
+        /**
+         * @method getResult
+         * Returns the search result JSON
+         * @return {Object}
+         */
+        getResult: function () {
+            return this._result;
+        },
+        /**
+         * @method getOptions
+         * Returns options that were used for searching
+         * @return {Object}
+         */
+        getOptions: function () {
+            return this._options || {};
+        },
+        /**
+         * @method getRequestParameters
+         * Returns request paremeters
+         * @return {String}
+         */
+        getRequestParameters: function () {
+            return this._requestParameters;
+        },
 
-    getParams: function () {
-        return {
-            success: this.getSuccess(),
-            result: this.getResult(),
-            requestParameters: this.getRequestParameters(),
-            options: this.getOptions()
-        };
-    }
-}, {
-/**
- * @property {String[]} protocol array of superclasses as {String}
- * @static
- */
-    'protocol': ['Oskari.mapframework.event.Event']
-});
+        getParams: function () {
+            return {
+                success: this.getSuccess(),
+                result: this.getResult(),
+                requestParameters: this.getRequestParameters(),
+                options: this.getOptions()
+            };
+        }
+    }, {
+        /**
+         * @property {String[]} protocol array of superclasses as {String}
+         * @static
+         */
+        'protocol': ['Oskari.mapframework.event.Event']
+    });

--- a/bundles/service/search/event/SearchResultEvent.js
+++ b/bundles/service/search/event/SearchResultEvent.js
@@ -7,62 +7,73 @@ Oskari.clazz.define('Oskari.mapframework.bundle.search.event.SearchResultEvent',
 /**
  * @method create called automatically on construction
  * @static
- * @param {Boolean} success succesfully got route
- * @param {JSON} requestParameters request parameters
- * @param {JSON} search result
+ * @param {Boolean} success succesfully got a result or an error occured
+ * @param {String} requestParameters request parameters
+ * @param {Object} search result
+ * @param {Object} options options that were used for searching
  */
-    function (success, requestParameters, result) {
-        this._success = success;
-        this._requestParameters = requestParameters;
-        this._result = result;
-    }, {
+function (success, requestParameters, result, options = {}) {
+    this._success = !!success;
+    this._requestParameters = requestParameters;
+    this._result = result;
+    this._options = options;
+}, {
     /** @static @property __name event name */
         __name: 'SearchResultEvent',
 
-        /**
+    /**
      * @method getName
      * Returns event name
      * @return {String}
      */
-        getName: function () {
-            return this.__name;
-        },
-        /**
+    getName: function () {
+        return this.__name;
+    },
+    /**
      * @method getSuccess
      * Returns the successfully routing info
      * @return {Boolean}
      */
-        getSuccess: function () {
-            return this._success;
-        },
-        /**
+    getSuccess: function () {
+        return this._success;
+    },
+    /**
      * @method getResult
      * Returns the search result JSON
-     * @return {JSON}
+     * @return {Object}
      */
-        getResult: function () {
-            return this._result;
-        },
-        /**
+    getResult: function () {
+        return this._result;
+    },
+    /**
+     * @method getOptions
+     * Returns options that were used for searching
+     * @return {Object}
+     */
+    getOptions: function () {
+        return this._options || {};
+    },
+    /**
      * @method getRequestParameters
      * Returns request paremeters
-     * @return {JSON}
+     * @return {String}
      */
-        getRequestParameters: function () {
-            return this._requestParameters;
-        },
+    getRequestParameters: function () {
+        return this._requestParameters;
+    },
 
-        getParams: function () {
-            return {
-                success: this._success,
-                result: this._result,
-                requestParameters: this._requestParameters
-            };
-        }
-    }, {
-    /**
-     * @property {String[]} protocol array of superclasses as {String}
-     * @static
-     */
-        'protocol': ['Oskari.mapframework.event.Event']
-    });
+    getParams: function () {
+        return {
+            success: this.getSuccess(),
+            result: this.getResult(),
+            requestParameters: this.getRequestParameters(),
+            options: this.getOptions()
+        };
+    }
+}, {
+/**
+ * @property {String[]} protocol array of superclasses as {String}
+ * @static
+ */
+    'protocol': ['Oskari.mapframework.event.Event']
+});

--- a/bundles/service/search/request/SearchRequest.js
+++ b/bundles/service/search/request/SearchRequest.js
@@ -10,10 +10,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.search.request.SearchRequest',
      * @method create called automatically on construction
      * @static
      *
-     * @params {Object}
+     * @param {String} query search qyery
+     * @param {Object} options optional flags for server
      */
-    function (params) {
-        this._searchparams = params;
+    function (query, options) {
+        this._query = query;
+        this._options = options;
     }, {
         /** @static @property __name request name */
         __name: 'SearchRequest',
@@ -26,10 +28,17 @@ Oskari.clazz.define('Oskari.mapframework.bundle.search.request.SearchRequest',
         },
         /**
          * @method getSearchParams
-         * @return {Object} parameters given for search
+         * @return {String} query given for search
          */
         getSearchParams: function () {
-            return this._searchparams;
+            return this._query;
+        },
+        /**
+         * @method getSearchParams
+         * @return {Object} parameters given for search
+         */
+        getOptions: function () {
+            return this._options || {};
         }
     }, {
         /**

--- a/bundles/service/search/searchservice.js
+++ b/bundles/service/search/searchservice.js
@@ -59,12 +59,8 @@ Oskari.clazz.define('Oskari.service.search.SearchService',
          *      request to handle
          */
         handleRequest: function (core, request) {
-            var params = request.getSearchParams();
-            // backward compatibility code, can be removed in Oskari 1.36
-            if (typeof params === 'object') {
-                params = params.searchKey;
-            }
-            this.doSearch(params);
+            const params = request.getSearchParams();
+            this.doSearch(params, undefined, undefined, request.getOptions());
         },
         /**
          * @method doSearch
@@ -76,11 +72,13 @@ Oskari.clazz.define('Oskari.service.search.SearchService',
          *            onSuccess callback method for successful search
          * @param {Function}
          *            onComplete callback method for search completion
+         * @param {Object}
+         *            options optional parameters for server side implementation that may be handled by the search channels or not depending on implementation
          */
-        doSearch: function (searchString, onSuccess, onError) {
-            var lang = Oskari.getLang();
-            var sb = this.sandbox || Oskari.getSandbox();
-            var evtBuilder = Oskari.eventBuilder('SearchResultEvent');
+        doSearch: function (searchString, onSuccess, onError, options = {}) {
+            const lang = Oskari.getLang();
+            const sb = this.sandbox || Oskari.getSandbox();
+            const evtBuilder = Oskari.eventBuilder('SearchResultEvent');
             jQuery.ajax({
                 dataType: 'json',
                 type: 'POST',
@@ -89,16 +87,17 @@ Oskari.clazz.define('Oskari.service.search.SearchService',
                     'searchKey': searchString,
                     'Language': lang,
                     'epsg': sb.getMap().getSrsName(),
-                    'autocomplete': false
+                    'autocomplete': false,
+                    'options': JSON.stringify(options),
                 },
                 success: function (response) {
-                    sb.notifyAll(evtBuilder(true, searchString, response));
+                    sb.notifyAll(evtBuilder(true, searchString, response, options));
                     if (typeof onSuccess === 'function') {
                         onSuccess(response);
                     }
                 },
                 error: function (response) {
-                    sb.notifyAll(evtBuilder(false, searchString, response));
+                    sb.notifyAll(evtBuilder(false, searchString, response, options));
                     if (typeof onError === 'function') {
                         onError(response);
                     }

--- a/bundles/service/search/searchservice.js
+++ b/bundles/service/search/searchservice.js
@@ -88,7 +88,7 @@ Oskari.clazz.define('Oskari.service.search.SearchService',
                     'Language': lang,
                     'epsg': sb.getMap().getSrsName(),
                     'autocomplete': false,
-                    'options': JSON.stringify(options),
+                    'options': JSON.stringify(options)
                 },
                 success: function (response) {
                     sb.notifyAll(evtBuilder(true, searchString, response, options));


### PR DESCRIPTION
SearchRequest can now take an optional second parameter that is sent to the server side implementation. As the server side implementation are handled by different "channels" depending on the Oskari instance and implementation these options might or might not be handled. However the same options are returned on the SearchResultEvent enabling tracking which event is a response to which request making the functionality more versatile whether any extra flags are supported by the server instance or not. Contact your Oskari instance administrator for options that are used by the server side on given instance.

After oskariorg/oskari-server#765 the options are passed to search channels. There is a common handling for `limit` option for requesting more results than the instance default. Example usage:

```
Oskari.getSandbox().postRequestByName('SearchRequest', ['lake', {'limit': 1000}]);
```

Note! Oskari instance admin can have a hard limit set for results so client can't request infinity number of results.