### PR TITLE
Fix an issue where group for user generated content (my places/userlayer) is not always shown on layerlisting

### DIFF
--- a/bundles/admin/admin-layereditor/instance.js
+++ b/bundles/admin/admin-layereditor/instance.js
@@ -351,7 +351,7 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
                 });
             };
             const popupTitle = id ? this.loc('editTheme') : this.loc('addTheme');
-            const hasSubgroups = id ? this._getLayerService().getAllLayerGroups(id).hasSubgroups() : false;
+            const hasSubgroups = id ? this._getLayerService().findLayerGroupById(id).hasSubgroups() : false;
             this.themeFlyout = new LocalizingFlyout(this, popupTitle, {
                 headerMessageKey: 'themeName',
                 id,

--- a/bundles/framework/myplacesimport/service/MyPlacesImportService.js
+++ b/bundles/framework/myplacesimport/service/MyPlacesImportService.js
@@ -11,7 +11,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
     this.urls.get = Oskari.urls.getRoute('GetUserLayers', { srs: srsName });
     this.urls.edit = Oskari.urls.getRoute('EditUserLayer');
     // negative value for group id means that admin isn't presented with tools for it
-    this.groupId = -1 * Oskari.seq.nextVal('usergeneratedGroup');
+    this.groupId = -10 * Oskari.seq.nextVal('usergeneratedGroup');
 }, {
     __name: 'MyPlacesImport.MyPlacesImportService',
     __qname: 'Oskari.mapframework.bundle.myplacesimport.MyPlacesImportService',

--- a/bundles/framework/myplacesimport/service/MyPlacesImportService.js
+++ b/bundles/framework/myplacesimport/service/MyPlacesImportService.js
@@ -11,7 +11,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
     this.urls.get = Oskari.urls.getRoute('GetUserLayers', { srs: srsName });
     this.urls.edit = Oskari.urls.getRoute('EditUserLayer');
     // negative value for group id means that admin isn't presented with tools for it
-    this.groupId = -10 * Oskari.seq.nextVal('usergeneratedGroup');
+    this.groupId = -1 * Oskari.getSeq('usergeneratedGroup').nextVal();
 }, {
     __name: 'MyPlacesImport.MyPlacesImportService',
     __qname: 'Oskari.mapframework.bundle.myplacesimport.MyPlacesImportService',

--- a/bundles/framework/myplacesimport/service/MyPlacesImportService.js
+++ b/bundles/framework/myplacesimport/service/MyPlacesImportService.js
@@ -112,7 +112,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
     _addLayersToService: function (layers = [], cb) {
         // initialize the group these layers will be in:
         const mapLayerService = this.instance.getMapLayerService();
-        const mapLayerGroup = mapLayerService.getAllLayerGroups(this.groupId);
+        const mapLayerGroup = mapLayerService.findLayerGroupById(this.groupId);
         if (!mapLayerGroup) {
             const loclayer = this.instance.getLocalization().layer;
             const group = {

--- a/bundles/mapping/mapmodule/domain/MaplayerGroup.js
+++ b/bundles/mapping/mapmodule/domain/MaplayerGroup.js
@@ -19,7 +19,7 @@ Oskari.clazz.define('Oskari.mapframework.domain.MaplayerGroup',
         me.setChildren(json);
     }, {
         getGroups: function () {
-            return this.groups;
+            return this.groups || [];
         },
         setGroups: function (groups) {
             this.groups = groups;

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -814,7 +814,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
          */
         findLayerGroupById: function (id, groupsToSearchFrom) {
             if (!groupsToSearchFrom) {
-                return findLayerGroupById(id, this._layerGroups);
+                return this.findLayerGroupById(id, this.getAllLayerGroups());
             }
             let requestedGroup = null;
             groupsToSearchFrom.forEach(group => {

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -159,7 +159,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                     if (group.id === -1) {
                         return;
                     }
-                    var groupConf = me.getAllLayerGroups(group.id);
+                    var groupConf = me.findLayerGroupById(group.id);
                     if (!groupConf) {
                         return;
                     }
@@ -408,7 +408,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                 // group of -1 is "ungrouped"
                 return;
             }
-            const group = this.getAllLayerGroups(groupId);
+            const group = this.findLayerGroupById(groupId);
             if (!group) {
                 return;
             }
@@ -443,7 +443,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                 // group of -1 is "ungrouped"
                 return;
             }
-            const group = this.getAllLayerGroups(groupId);
+            const group = this.findLayerGroupById(groupId);
             if (!group) {
                 return;
             }
@@ -468,86 +468,28 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
          * @param {Boolean}          deleteLayers deleteLayers
          */
         deleteLayerGroup: function (id, parentId, deleteLayers) {
-            var me = this;
-            var editable = me.getAllLayerGroups(parentId);
-
-            var getGroupIndexInArray = function (arr) {
-                var founded = -1;
-                for (var i = 0; i < arr.length; i++) {
-                    var group = arr[i];
-                    if (group.id === id) {
-                        founded = i;
-                        break;
-                    }
+            let groupsList = this.getAllLayerGroups();
+            if (parentId) {
+                const parentGroup = this.findLayerGroupById(parentId);
+                if (parentGroup) {
+                    groupsList = parentGroup.getGroups();
                 }
-                return founded;
-            };
-
-            var groupIndex = getGroupIndexInArray(editable.groups || editable);
-            if (groupIndex >= 0 && editable.groups) {
-                editable.groups.splice(groupIndex, 1);
-            } else {
-                editable.splice(groupIndex, 1);
             }
+            const allLayers = this.getAllLayers();
+            const isLayerInGroup = (layer) => layer.getGroups().filter(g => g.getId() === id).length > 0;
+            const layersInDeletedGroup = allLayers.filter(isLayerInGroup).map(l => l.getId());
+
             if (deleteLayers) {
-                // Remove layers
-                const deletedLayerIds = this._loadedLayersList.filter(l => l._groups.filter(g => g.id === id).length > 0).map(l => l.getId());
-                this._loadedLayersList = this._loadedLayersList.filter(l => !deletedLayerIds.includes(l._id));
-            } else if (typeof deleteLayers !== 'undefined' && !deleteLayers) {
-                // Clear group from needed layers.
-                this.getAllLayers().filter(l => l._groups.filter(g => g.id === id).length > 0).map(l => {
-                    const groups = [...l._groups];
-                    const index = groups.findIndex(g => g.id === id);
-                    if (index !== -1) {
-                        groups.splice(index, 1);
-                        l._groups = groups;
-                    }
-                });
+                layersInDeletedGroup.forEach(layerId => this.removeLayer(layerId));
+            } else {
+                layersInDeletedGroup.forEach(layerId => this.removeLayerFromGroup(id, layerId, true));
+            }
+
+            const groupIndex = groupsList.findIndex(group => group.id === id);
+            if (groupIndex >= 0) {
+                groupsList.splice(groupIndex, 1);
             }
             this.trigger('theme.update');
-        },
-        /**
-         * Updata layer groups
-         * @method updateLayerGroups
-         * @param  {Object}          data data
-         */
-        updateLayerGroups: function (data) {
-            var me = this;
-            var editable = me.getAllLayerGroups(data.id);
-            // if found then update only
-            if (editable && editable.name) {
-                editable.name = data.name;
-                editable.parentId = data.parentId;
-                editable.selectable = data.selectable;
-            } else if (data.parentId === -1) {
-                me.getAllLayerGroups().push(
-                    Oskari.clazz.create('Oskari.mapframework.domain.MaplayerGroup', {
-                        groups: [],
-                        id: data.id,
-                        name: data.name,
-                        layers: [],
-                        parentId: data.parentId,
-                        selectable: data.selectable
-                    })
-                );
-            } else {
-                me.getAllLayerGroups(data.parentId).groups.push(
-                    Oskari.clazz.create('Oskari.mapframework.domain.MaplayerGroup', {
-                        groups: [],
-                        id: data.id,
-                        name: data.name,
-                        layers: [],
-                        parentId: data.parentId,
-                        selectable: data.selectable
-                    })
-                );
-
-                me.getAllLayerGroups(data.parentId).children.push({
-                    type: 'group',
-                    id: data.id,
-                    order: 100000000
-                });
-            }
         },
 
         /**
@@ -852,44 +794,41 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
         },
 
         /**
-         * @method getLayerGroup
-         * Returns a group that matches given id
-         * @param {String|Integer} id if defined and not equal -1 return only wanted group
-         * @param {String|Integer} id if defined and not equal -1 return only wanted group
-         * @return {Oskari.clazz.define.getGroups}
-         */
-        getLayerGroup: function (group, id) {
-            if (group.id + '' === id + '') {
-                return group;
-            }
-            if (group.groups) {
-                for (let g of group.groups) {
-                    let foundGroup = this.getLayerGroup(g, id);
-                    if (foundGroup) {
-                        return foundGroup;
-                    }
-                }
-            }
-            return null;
-        },
-
-        /**
          * @method getAllLayerGroups
          * Returns an array of layer groups added to the service
-         * @param {String|Integer} id if defined and not equal -1 return only wanted group
+         * @param {String|Integer} id if defined return only requested group (deprecated - use findLayerGroupById() instead)
          * @return {Oskari.clazz.define.getGroups[]}
          */
         getAllLayerGroups: function (id) {
-            var layerGroups = null;
-            if (id && id !== -1) {
-                for (let group of this._layerGroups) {
-                    layerGroups = this.getLayerGroup(group, id);
-                    if (layerGroups) {
-                        break;
-                    }
-                }
+            if (typeof id !== 'undefined' && id !== null) {
+                return this.findLayerGroupById(id);
             }
-            return (id && id !== -1) ? layerGroups : this._layerGroups;
+            return this._layerGroups;
+        },
+        /**
+         * @method findLayerGroupById
+         * Returns the requested group matching the id or null if not found.
+         * @param {String|Integer} id id for requested group
+         * @param {Oskari.mapframework.domain.MaplayerGroup[]} array of groups to search from (optional, defaults to all groups). Recurses to subgroups
+         * @return {Oskari.clazz.define.getGroups[]}
+         */
+        findLayerGroupById: function (id, groupsToSearchFrom) {
+            if (!groupsToSearchFrom) {
+                return findLayerGroupById(id, this._layerGroups);
+            }
+            let requestedGroup = null;
+            groupsToSearchFrom.forEach(group => {
+                if (group.getId() + '' === id + '') {
+                    requestedGroup = group;
+                }
+                if (requestedGroup) {
+                    // already found it
+                    return;
+                }
+                // keep searching - result may be null so we might need to dig deeper still
+                requestedGroup = this.findLayerGroupById(id, group.getGroups());
+            });
+            return requestedGroup;
         },
 
         /**

--- a/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
+++ b/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
@@ -27,7 +27,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmyplaces.domain.MyPlacesLayer
             }
             if (!this.groupId) {
                 // negative value for group id means that admin isn't presented with tools for it
-                this.groupId = -1 * Oskari.seq.nextVal('usergeneratedGroup');
+                this.groupId = -10 * Oskari.seq.nextVal('usergeneratedGroup');
                 const mapLayerGroup = maplayerService.getAllLayerGroups(this.groupId);
                 if (!mapLayerGroup) {
                     const group = {

--- a/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
+++ b/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
@@ -27,7 +27,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmyplaces.domain.MyPlacesLayer
             }
             if (!this.groupId) {
                 // negative value for group id means that admin isn't presented with tools for it
-                this.groupId = -10 * Oskari.seq.nextVal('usergeneratedGroup');
+                this.groupId = -1 * Oskari.getSeq('usergeneratedGroup').nextVal();
                 const mapLayerGroup = maplayerService.findLayerGroupById(this.groupId);
                 if (!mapLayerGroup) {
                     const group = {

--- a/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
+++ b/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
@@ -28,7 +28,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmyplaces.domain.MyPlacesLayer
             if (!this.groupId) {
                 // negative value for group id means that admin isn't presented with tools for it
                 this.groupId = -10 * Oskari.seq.nextVal('usergeneratedGroup');
-                const mapLayerGroup = maplayerService.getAllLayerGroups(this.groupId);
+                const mapLayerGroup = maplayerService.findLayerGroupById(this.groupId);
                 if (!mapLayerGroup) {
                     const group = {
                         id: this.groupId,


### PR DESCRIPTION
For some reason MapLayerService.getAllLayerGroups(-1) returns the whole list instead of group with id -1 as there's a special handling for -1. For this reason the layer group for my places (or userlayer or analysis) might not be added to the service and as a result is not listed on layerlisting. 

Refactored layer group handling in MapLayerService:
- removed getLayerGroup() as it was only used internally by MapLayerService
- removed updateLayerGroups() as it was not used at all
- added findLayerGroupById(id) as drop-in replacement for getAllLayerGroups(id)
- removed special handling for getAllLayerGroups(-1). Previously returned full list of root groups with -1 used as id. See https://github.com/oskariorg/oskari-frontend/blob/2.5.1/bundles/mapping/mapmodule/service/map.layer.js#L882-L893
- refactored deleteLayerGroup() to use existing functions to manipulate layer and group lists

Also fixed the sequence counter reference to actually use named sequence with:
`Oskari.seq.nextVal('name')` -> `Oskari.getSeq('name').nextVal()`

