### PR TITLE
HoverHandler id property fix

### DIFF
--- a/bundles/mapping/mapmodule/service/HoverHandler.js
+++ b/bundles/mapping/mapmodule/service/HoverHandler.js
@@ -1,4 +1,4 @@
-import { LAYER_TYPE, LAYER_HOVER, WFS_ID_KEY, FTR_PROPERTY_ID, LAYER_ID, WFS_TYPE, VECTOR_TYPE } from '../domain/constants';
+import { LAYER_TYPE, LAYER_HOVER, WFS_ID_KEY, FTR_PROPERTY_ID, LAYER_ID, VECTOR_TILE_TYPE, VECTOR_TYPE } from '../domain/constants';
 import { getStyleForGeometry } from '../oskariStyle/generator.ol';
 import olOverlay from 'ol/Overlay';
 import olLayerVector from 'ol/layer/Vector';
@@ -52,19 +52,19 @@ export class HoverHandler {
         const layerId = olLayer.get(LAYER_ID);
         this.updateTooltipContent(layerId, feature);
 
-        // Vectorhandler updates vector layers' feature styles but tooltip is handled by hoverhandler
-        if (layerType === VECTOR_TYPE) {
-            return;
-        }
         const layerChanged = this._state.layerId !== layerId;
         this._state = {
             feature,
             layerId
         };
+        // Vectorhandler updates vector layers' feature styles but tooltip is handled by hoverhandler
+        if (layerType === VECTOR_TYPE) {
+            return;
+        }
         // Try first if layer has stored vectorlayer
         const vtLayer = this._vectorTileLayers[layerId];
         if (vtLayer) {
-            const idProp = WFS_TYPE === layerType ? WFS_ID_KEY : FTR_PROPERTY_ID;
+            const idProp = this._getIdProperty(layerType);
             this._state.renderFeatureId = feature.get(idProp);
             vtLayer.changed();
             return;
@@ -211,7 +211,9 @@ export class HoverHandler {
     }
 
     _getIdProperty (layerType) {
-        return WFS_TYPE === layerType ? WFS_ID_KEY : FTR_PROPERTY_ID;
+        // WFS layer plugin handles additional layer types which uses '_oid' key but layer type isn't wfs
+        // It's clearer to check layers which uses 'id' key
+        return layerType === VECTOR_TILE_TYPE || layerType === VECTOR_TYPE ? FTR_PROPERTY_ID : WFS_ID_KEY;
     }
 
     /**


### PR DESCRIPTION
Userlayer, myplaces, analysis is handled by wfs plugin which sets _oid property for features.
https://github.com/oskariorg/oskari-frontend/blob/develop/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js#L208
Using '_oid' for wfs layer type wasn't enough to handle id properly.

MVT layers (RenderFeatures) doesn't have feature ids (feature.getId()) so have to get id from properties. Also VectorTile layer seems to use 'id'. MVT rendered WFS layers have '_oid' which is added in oskari backend.

Vector layer:
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js#L760

feature.getId() and feature.getProperties() for:

WFS geojson:
<img width="170" alt="wfs_gj" src="https://user-images.githubusercontent.com/22147092/143201701-6b64fdc6-64df-447b-9fe0-ff9422f4888a.PNG">

WFS mvt:
<img width="242" alt="wfs_mvt" src="https://user-images.githubusercontent.com/22147092/143201750-ddba1796-41f2-4786-84c5-93f37321e35a.PNG">

MVT/VectorTile:
<img width="125" alt="mvt" src="https://user-images.githubusercontent.com/22147092/143201630-9ca0325f-38a1-4ae7-9a01-53a769079b53.PNG">

Vector:
<img width="125" alt="vector" src="https://user-images.githubusercontent.com/22147092/143201787-ce8dedfd-ced4-433f-89a9-3757d9f76a2d.PNG">


