### PR TITLE
Fix an issue where opacity as string causes js error on OL

### DIFF
--- a/bundles/mapping/mapmodule/request/map.layer.handler.js
+++ b/bundles/mapping/mapmodule/request/map.layer.handler.js
@@ -44,10 +44,11 @@ Oskari.clazz.define('map.layer.handler',
                 this.mapState.moveLayer(request.getMapLayerId(), request.getToPosition(), request._creator);
             } else if (request.getName() === 'ChangeMapLayerOpacityRequest') {
                 layer = this.mapState.getSelectedLayer(request.getMapLayerId());
-                if (!layer) {
+                const opacity = request.getOpacity();
+                if (!layer || isNaN(opacity)) {
                     return;
                 }
-                layer.setOpacity(request.getOpacity());
+                layer.setOpacity(Number(opacity));
 
                 evt = Oskari.eventBuilder('AfterChangeMapLayerOpacityEvent')(layer);
                 evt._creator = request._creator;


### PR DESCRIPTION
Happens on map links as opacity is parsed as string for mapfull.state -> ChangeMapLayerOpacityRequest is sent with the string value and OpenLayers validation causes an error when layer.setOpacity("100") is called.