### PR TITLE
Refactored featuredata feature queries

### DIFF
--- a/bundles/framework/featuredata2/FilterSelector.js
+++ b/bundles/framework/featuredata2/FilterSelector.js
@@ -1,4 +1,3 @@
-
 import { WFS_ID_KEY, WFS_FTR_ID_KEY } from '../../mapping/mapmodule/domain/constants';
 import { getFilterAlternativesAsArray, filterFeaturesByAttribute } from '../../mapping/mapmodule/util/vectorfeatures/filter';
 

--- a/bundles/framework/featuredata2/FilterSelector.js
+++ b/bundles/framework/featuredata2/FilterSelector.js
@@ -8,7 +8,7 @@ const getFeatureId = (feature) => feature.id || feature.properties[WFS_ID_KEY] |
  * properties (by filters from Oskari.userinterface.component.FilterDialog)
  */
 export class FilterSelector {
-    constructor(featureQueryFn, selectionService) {
+    constructor (featureQueryFn, selectionService) {
         this.featureQueryFn = featureQueryFn;
         this.selectionService = selectionService;
     }
@@ -51,13 +51,12 @@ export class FilterSelector {
                 .forEach(id => filteredIds.add(id));
         });
         this.selectionService.setSelectedFeatureIds(layerId, [...filteredIds]);
-
     }
+
     /**
      * Selects features intersecting the geometry from the requested layers.
      * @param {Object} filterFeature GeoJSONLike object with geometry key to query features for selection
      * @param {String[]|Number[]} layers layers to query from
-     * @returns 
      */
     selectWithGeometry (filterFeature = {}, layers = []) {
         if (!this.selectionService) {
@@ -77,13 +76,14 @@ export class FilterSelector {
             this.selectionService.setSelectedFeatureIds(layerId, selectedFeatureIds);
         });
     }
+
     /**
      * Returns a layer ids to query from by filtering out non-vector layers
      * @param {Oskari.mapframework.domain.AbstractLayer[]} selectedLayers selection of layers for filtering
      * @param {Boolean} fromAllLayers true to return all queryable layers or false for the top most layer
      * @returns {String[]|Number[]} layer ids for querying
      */
-    getLayersToQuery(selectedLayers = [], fromAllLayers = false) {
+    getLayersToQuery (selectedLayers = [], fromAllLayers = false) {
         const selectedVectorLayers = selectedLayers
             .filter(l => l.hasFeatureData() && l.isVisible())
             .map(l => l.getId());

--- a/bundles/framework/featuredata2/FilterSelector.js
+++ b/bundles/framework/featuredata2/FilterSelector.js
@@ -1,0 +1,82 @@
+
+import { WFS_ID_KEY, WFS_FTR_ID_KEY } from '../../mapping/mapmodule/domain/constants';
+import { getFilterAlternativesAsArray, filterFeaturesByAttribute } from '../../mapping/mapmodule/util/vectorfeatures/filter';
+
+const getFeatureId = (feature) => feature.id || feature.properties[WFS_ID_KEY] || feature.properties[WFS_FTR_ID_KEY];
+
+export class FilterSelector {
+    constructor(featureQueryFn, selectionService) {
+        this.featureQueryFn = featureQueryFn;
+        this.selectionService = selectionService;
+    }
+    selectWithProperties (filters = [], layerId) {
+        if (!this.selectionService) {
+            Oskari.log('FeatureData').error('VectorFeatureSelectionService is not available in appsetup');
+            return;
+        }
+        if (!filters || !filters.length === 0 || !layerId) {
+            Oskari.log('FeatureData').info('Requested filtering without filters or layer id');
+            return;
+        }
+        const result = this.featureQueryFn(null, { layers: [layerId] });
+        const { error, ...layerData } = result;
+        if (error) {
+            Oskari.log('FeatureData').warn('Error querying features:', error);
+            return;
+        }
+
+        const records = layerData[layerId].features || [];
+        if (!records.length) {
+            Oskari.log('FeatureData').debug('No features on layer:', layerId);
+            return;
+        }
+        const filteredIds = new Set();
+        const alternatives = getFilterAlternativesAsArray(filters);
+        alternatives.forEach(attributeFilters => {
+            let filteredList = records;
+            attributeFilters.forEach(filter => {
+                filteredList = filterFeaturesByAttribute(filteredList, filter);
+            });
+            filteredList
+                .map(getFeatureId)
+                .filter(id => !!id)
+                .forEach(id => filteredIds.add(id));
+        });
+        this.selectionService.setSelectedFeatureIds(layerId, [...filteredIds]);
+
+    }
+
+    selectWithGeometry (filterFeature = {}, layers = []) {
+        if (!this.selectionService) {
+            Oskari.log('FeatureData').error('VectorFeatureSelectionService is not available in appsetup');
+            return;
+        }
+        const result = this.featureQueryFn({ geometry: filterFeature.geometry }, { layers });
+        const { error, ...layerData } = result;
+        if (error) {
+            Oskari.log('FeatureData').warn('Error querying features:', error);
+            return;
+        }
+
+        Object.keys(layerData).forEach(layerId => {
+            const layerFeatures = layerData[layerId].features || [];
+            const selectedFeatureIds = layerFeatures.map(getFeatureId);
+            this.selectionService.setSelectedFeatureIds(layerId, selectedFeatureIds);
+        });
+    }
+
+    getLayersToQuery(selectedLayers = [], fromAllLayers = false) {
+        const selectedVectorLayers = selectedLayers
+            .filter(l => l.hasFeatureData())
+            .map(l => l.getId());
+        if (!selectedVectorLayers.length) {
+            Oskari.log('FeatureData').debug('No vector layers to select from');
+            return;
+        }
+
+        if (fromAllLayers) {
+            return selectedVectorLayers;
+        }
+        return [selectedVectorLayers[0]];
+    }
+};

--- a/bundles/framework/featuredata2/FilterSelector.js
+++ b/bundles/framework/featuredata2/FilterSelector.js
@@ -96,6 +96,6 @@ export class FilterSelector {
         if (fromAllLayers) {
             return selectedVectorLayers;
         }
-        return [selectedVectorLayers[0]];
+        return [selectedVectorLayers[selectedVectorLayers.length - 1]];
     }
 };

--- a/bundles/framework/featuredata2/FilterSelector.js
+++ b/bundles/framework/featuredata2/FilterSelector.js
@@ -4,11 +4,20 @@ import { getFilterAlternativesAsArray, filterFeaturesByAttribute } from '../../m
 
 const getFeatureId = (feature) => feature.id || feature.properties[WFS_ID_KEY] || feature.properties[WFS_FTR_ID_KEY];
 
+/**
+ * Helper for selecting features based on geometry or
+ * properties (by filters from Oskari.userinterface.component.FilterDialog)
+ */
 export class FilterSelector {
     constructor(featureQueryFn, selectionService) {
         this.featureQueryFn = featureQueryFn;
         this.selectionService = selectionService;
     }
+    /**
+     * Selects features matching the properties filters from the requested layer.
+     * @param {Object[]} filters array from Oskari.userinterface.component.FilterDialog
+     * @param {String|Number} layerId layer to make selection from
+     */
     selectWithProperties (filters = [], layerId) {
         if (!this.selectionService) {
             Oskari.log('FeatureData').error('VectorFeatureSelectionService is not available in appsetup');
@@ -45,7 +54,12 @@ export class FilterSelector {
         this.selectionService.setSelectedFeatureIds(layerId, [...filteredIds]);
 
     }
-
+    /**
+     * Selects features intersecting the geometry from the requested layers.
+     * @param {Object} filterFeature GeoJSONLike object with geometry key to query features for selection
+     * @param {String[]|Number[]} layers layers to query from
+     * @returns 
+     */
     selectWithGeometry (filterFeature = {}, layers = []) {
         if (!this.selectionService) {
             Oskari.log('FeatureData').error('VectorFeatureSelectionService is not available in appsetup');
@@ -64,10 +78,15 @@ export class FilterSelector {
             this.selectionService.setSelectedFeatureIds(layerId, selectedFeatureIds);
         });
     }
-
+    /**
+     * Returns a layer ids to query from by filtering out non-vector layers
+     * @param {Oskari.mapframework.domain.AbstractLayer[]} selectedLayers selection of layers for filtering
+     * @param {Boolean} fromAllLayers true to return all queryable layers or false for the top most layer
+     * @returns {String[]|Number[]} layer ids for querying
+     */
     getLayersToQuery(selectedLayers = [], fromAllLayers = false) {
         const selectedVectorLayers = selectedLayers
-            .filter(l => l.hasFeatureData())
+            .filter(l => l.hasFeatureData() && l.isVisible())
             .map(l => l.getId());
         if (!selectedVectorLayers.length) {
             Oskari.log('FeatureData').debug('No vector layers to select from');

--- a/bundles/framework/featuredata2/Flyout.js
+++ b/bundles/framework/featuredata2/Flyout.js
@@ -256,9 +256,7 @@ Oskari.clazz.define(
             );
 
             me.filterDialog.setUpdateButtonHandler(function (filters) {
-                // throw event to new wfs
-                var event = Oskari.eventBuilder('WFSSetPropertyFilter')(filters, layer.getId());
-                me.instance.sandbox.notifyAll(event);
+                me.instance.getFilterSelector().selectWithProperties(filters, layer.getId());
             });
 
             if (me.service) {

--- a/bundles/framework/featuredata2/Flyout.js
+++ b/bundles/framework/featuredata2/Flyout.js
@@ -243,7 +243,7 @@ Oskari.clazz.define(
 
             // this is needed to add the functionality to filter with aggregate analyse values
             // if value is true, the link to filter with aggregate analyse values is added to dialog
-            var isAggregateValueAvailable = me.checkIfAggregateValuesAreAvailable();
+            var isAggregateValueAvailable = false; // me.checkIfAggregateValuesAreAvailable();
 
             var fixedOptions = {
                 bboxSelection: true,
@@ -255,11 +255,10 @@ Oskari.clazz.define(
                 fixedOptions
             );
 
-            me.filterDialog.setUpdateButtonHandler(function (filters) {
-                me.instance.getFilterSelector().selectWithProperties(filters, layer.getId());
+            me.filterDialog.setUpdateButtonHandler(function (values = {}) {
+                me.instance.getFilterSelector().selectWithProperties(values.filters, layer.getId());
             });
-
-            if (me.service) {
+            if (isAggregateValueAvailable) {
                 me.aggregateAnalyseFilter = Oskari.clazz.create(
                     'Oskari.analysis.bundle.analyse.aggregateAnalyseFilter',
                     me.instance,
@@ -277,6 +276,11 @@ Oskari.clazz.define(
 
         // function gives value to addLinkToAggregateValues (true/false)
         checkIfAggregateValuesAreAvailable: function () {
+            // Force false since 99,999% of users don't have aggregate analysis saved and this only adds confusion to most people.
+            // We could enable it if we detect that user actually have these OR add error handling that tells the user the
+            //  links is not functioning before there are aggregate analysis available for the user
+            return false;
+            /*
             this.service = this.instance.sandbox.getService(
                 'Oskari.analysis.bundle.analyse.service.AnalyseService'
             );
@@ -284,6 +288,7 @@ Oskari.clazz.define(
                 return false;
             }
             return true;
+            */
         },
 
         /**

--- a/bundles/framework/featuredata2/PopupHandler.js
+++ b/bundles/framework/featuredata2/PopupHandler.js
@@ -32,7 +32,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.PopupHandler',
             mapModule.startPlugin(me.selectionPlugin);
         }
 
-        this.WFSLayerService = Oskari.getSandbox().getService('Oskari.mapframework.bundle.mapwfs2.service.WFSLayerService');
         this.buttons = {
             point: {
                 iconCls: 'selection-point',

--- a/bundles/framework/featuredata2/event/WFSSetFilter.js
+++ b/bundles/framework/featuredata2/event/WFSSetFilter.js
@@ -1,7 +1,7 @@
 /**
  * @class Oskari.mapframework.bundle.featuredata2.event.WFSSetFilter
  *
- * <GIEV MIEH! COMMENTS>
+ * @deprecated - use mapmodule.getVectorFeatures() and VectorFeatureSelectionService instead
  */
 Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.event.WFSSetFilter',
     /**

--- a/bundles/framework/featuredata2/event/WFSSetPropertyFilter.js
+++ b/bundles/framework/featuredata2/event/WFSSetPropertyFilter.js
@@ -1,7 +1,7 @@
 /**
  * @class Oskari.mapframework.bundle.featuredata2.event.WFSSetPropertyFilter
  *
- * <GIEV MIEH! COMMENTS>
+ * @deprecated - use mapmodule.getVectorFeatures() and VectorFeatureSelectionService instead
  */
 Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.event.WFSSetPropertyFilter',
     /**

--- a/bundles/framework/featuredata2/instance.js
+++ b/bundles/framework/featuredata2/instance.js
@@ -338,19 +338,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
                     return;
                 }
                 var geojson = evt.getGeoJson();
-                var pixelTolerance = 15;
-                if (geojson.features.length > 0) {
-                    geojson.features[0].properties.buffer_radius = this.selectionPlugin.getMapModule().getResolution() * pixelTolerance;
-                } else {
-                    // no features
+                if (!geojson.features.length) {
+                    // no features drawn
                     return;
                 }
-                const allLayers = this.selectionPlugin.isSelectFromAllLayers();
-                this.selectionPlugin.setFeatures(geojson.features);
+                // const filterFeature = geojson.features[0];
+                this._selectFeaturesWithGeometry(geojson, this.selectionPlugin.isSelectFromAllLayers());
                 this.selectionPlugin.stopDrawing();
-                const event = Oskari.eventBuilder('WFSSetFilter')(geojson, null, allLayers);
-                this.sandbox.notifyAll(event);
-
                 this.popupHandler.removeButtonSelection();
             },
             'AfterMapMoveEvent': function () {
@@ -381,6 +375,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
 
             this.sandbox.unregister(this);
             this.started = false;
+        },
+        _selectFeaturesWithGeometry: function (geojson, fromAllLayers) {
+            const event = Oskari.eventBuilder('WFSSetFilter')(geojson, null, fromAllLayers);
+            this.sandbox.notifyAll(event);
         },
 
         /**

--- a/bundles/framework/featuredata2/plugin/MapSelectionPlugin.js
+++ b/bundles/framework/featuredata2/plugin/MapSelectionPlugin.js
@@ -19,8 +19,6 @@ Oskari.clazz.define(
         me.currentDrawMode = null;
         me.prefix = 'Default.';
         me.sandbox = sandbox;
-        me._features = null;
-        me._drawing = null;
         me.selectFromAllLayers = false;
 
         if (me._config && me._config.id) {
@@ -131,34 +129,6 @@ Oskari.clazz.define(
                     ]);
                 }
             };
-        },
-        /**
-         * @Return the drawn geometry from the draw layer from drawing event
-         * @method setDrawing
-         */
-        setDrawing: function (drawing) {
-            this._drawing = drawing;
-        },
-        /**
-         * @Return the drawn geometry from the draw layer
-         * @method getDrawing
-         */
-        getDrawing: function () {
-            return this._drawing;
-        },
-        /**
-         * @method setFeatures
-         * @param features Features from the drawing event when drawing is finished
-         */
-        setFeatures: function (features) {
-            this._features = features;
-        },
-        /**
-         * @Return {String} the drawn geometry from the draw layer
-         * @method getFeatures
-         */
-        getFeatures: function () {
-            return this._features;
         }
     }, {
         'extend': ['Oskari.mapping.mapmodule.plugin.AbstractMapModulePlugin'],

--- a/bundles/mapping/mapmodule/util/vectorfeatures/filter.js
+++ b/bundles/mapping/mapmodule/util/vectorfeatures/filter.js
@@ -1,4 +1,3 @@
-
 import GeoJSONReader from 'jsts/org/locationtech/jts/io/GeoJSONReader';
 import RelateOp from 'jsts/org/locationtech/jts/operation/relate/RelateOp';
 import Envelope from 'jsts/org/locationtech/jts/geom/Envelope';

--- a/bundles/mapping/mapmodule/util/vectorfeatures/filter.js
+++ b/bundles/mapping/mapmodule/util/vectorfeatures/filter.js
@@ -61,14 +61,10 @@ export const filterFeaturesByExtent = (features, extent) => {
 
 /**
  * @method getFilterAlternativesAsArray Arranges attribute filters based on AND & OR statements.
- * @param {WFSSetPropertyFilter} event event containing the filters
+ * @param {WFSSetPropertyFilter} filters array from WFSSetPropertyFilter
  * @return {Array} An array of arrays containing attribute filters for each OR statement.
  */
-export const getFilterAlternativesAsArray = event => {
-    if (!event || !event.getFilters()) {
-        return;
-    }
-    const { filters } = event.getFilters();
+export const getFilterAlternativesAsArray = filters => {
     if (!filters || filters.length === 0) {
         return;
     }

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/ReqEventHandler.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/ReqEventHandler.js
@@ -63,7 +63,6 @@ export class ReqEventHandler {
                 const keepPrevious = Oskari.ctrlKeyDown();
                 const featureCollection = event.getGeoJson();
                 const filterFeature = featureCollection.features[0];
-                // TODO: move to validate getVectorFeatures() call
                 if (['Polygon', 'MultiPolygon'].indexOf(filterFeature.geometry.type) >= 0 && typeof filterFeature.properties.area !== 'number') {
                     return;
                 }

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/ReqEventHandler.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/ReqEventHandler.js
@@ -108,7 +108,9 @@ export class ReqEventHandler {
                     return;
                 }
                 const filteredIds = new Set();
-                const alternatives = getFilterAlternativesAsArray(event.getFilters());
+                // filters is an object with key "filters" that we actually want to process...
+                const { filters = [] } = event.getFilters();
+                const alternatives = getFilterAlternativesAsArray(filters);
                 alternatives.forEach(attributeFilters => {
                     let filteredList = records;
                     attributeFilters.forEach(filter => {

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/ReqEventHandler.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/ReqEventHandler.js
@@ -63,6 +63,7 @@ export class ReqEventHandler {
                 const keepPrevious = Oskari.ctrlKeyDown();
                 const featureCollection = event.getGeoJson();
                 const filterFeature = featureCollection.features[0];
+                // TODO: move to validate getVectorFeatures() call
                 if (['Polygon', 'MultiPolygon'].indexOf(filterFeature.geometry.type) >= 0 && typeof filterFeature.properties.area !== 'number') {
                     return;
                 }
@@ -108,7 +109,7 @@ export class ReqEventHandler {
                     return;
                 }
                 const filteredIds = new Set();
-                const alternatives = getFilterAlternativesAsArray(event);
+                const alternatives = getFilterAlternativesAsArray(event.getFilters());
                 alternatives.forEach(attributeFilters => {
                     let filteredList = records;
                     attributeFilters.forEach(filter => {


### PR DESCRIPTION
Changes featuredata bundle to query features for display and selection using the `mapmodule.getVectorFeatures()` function and `Oskari.mapframework.service.VectorFeatureSelectionService`. Previously used `WFSSetFilter` and `WFSSetPropertyFilter` that had a couple of problems:
- the events were used like requests
- the events were defined in `featuredata` bundle but the actual handling is done in `mapwfs` bundle

The events were only deprecated in this PR since there might be other functionalities that use them.