### PR TITLE
Style generator label fix

### DIFF
--- a/bundles/mapping/mapmodule/oskariStyle/generator.ol.js
+++ b/bundles/mapping/mapmodule/oskariStyle/generator.ol.js
@@ -227,8 +227,8 @@ const _setFeatureLabel = (feature, textStyle, label = {}) => {
     } else {
         value = feature.get(property);
     }
-    if (!value) {
-        return;
+    if (typeof value === 'undefined') {
+        value = '';
     }
     const featureLabel = text ? text + ': ' + value : value;
     textStyle.setText(featureLabel);


### PR DESCRIPTION
If labelProperty is used value has to be set to every feature. This fixes issue where label leaked from previous feature if feature property didn't have value. Also convert undefined to '' to avoid 'label: undefined' if both labelProperty and labelText is used but feature doesn't have such property (misconfigured or geojson may drop properties without values).