### PR TITLE
Fix an issue with proj select after lodash removal

### DIFF
--- a/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
+++ b/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
@@ -187,16 +187,16 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
          * @method @private _showPopup
          */
         _showPopup: function () {
-            var me = this,
-                loc = me._locale,
-                popupTitle = loc('display.popup.title'),
-                popupContent = me._templates.popupContent.clone(),
-                crs = me.getMapModule().getProjection(),
-                popupName = 'xytoolpopup',
-                popupLocation,
-                isMobile = Oskari.util.isMobile(),
-                mapmodule = me.getMapModule(),
-                popupService = me.getSandbox().getService('Oskari.userinterface.component.PopupService');
+            const me = this;
+            const loc = me._locale;
+            const popupTitle = loc('display.popup.title');
+            const popupContent = me._templates.popupContent.clone();
+            const crs = me.getMapModule().getProjection();
+            const popupName = 'xytoolpopup';
+            const isMobile = Oskari.util.isMobile();
+            const mapmodule = me.getMapModule();
+            const popupService = me.getSandbox().getService('Oskari.userinterface.component.PopupService');
+            let popupLocation;
 
             const crsText = loc('display.crs')[crs] || loc('display.crs.default', { crs: crs });
             me._popup = popupService.createPopup();
@@ -226,7 +226,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
             popupContent.find('.coordinatetool__popup__content').html(loc('display.popup.info'));
             popupContent.find('.mousecoordinates-label').html(loc('display.popup.showMouseCoordinates'));
 
-            var centerToCoordsBtn = Oskari.clazz.create('Oskari.userinterface.component.Button');
+            const centerToCoordsBtn = Oskari.clazz.create('Oskari.userinterface.component.Button');
             centerToCoordsBtn.setTitle(loc('display.popup.searchButton'));
             centerToCoordsBtn.setHandler(function () {
                 // Check valid
@@ -245,7 +245,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
                     me._showCoordinatesNotValidMessage();
                 }
             });
-            var buttons = [centerToCoordsBtn];
+            const buttons = [centerToCoordsBtn];
             me._centerToCoordsBtn = centerToCoordsBtn;
             if (me._markersSupported()) {
                 var addMarkerBtn = Oskari.clazz.create('Oskari.userinterface.component.Button');

--- a/bundles/framework/coordinatetool/plugin/CoordinateTransformationExtension.js
+++ b/bundles/framework/coordinatetool/plugin/CoordinateTransformationExtension.js
@@ -40,10 +40,19 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
         initCoordinatesTransformChange: function (popupContent) {
             const me = this;
             const config = this._config || {};
-            const hasMoreProjConfigs = config.supportedProjections && Object.keys(config.supportedProjections) > 1;
+            const supportedProjs = config.supportedProjections || [];
+            let amountOfProjections = 0;
+            if (Array.isArray(supportedProjs)) {
+                amountOfProjections = supportedProjs.length;
+            } else if (typeof supportedProjs === 'object') {
+                // Note! Supported projs seems to be an array always when present. However old code used _.keys() to calculate length which
+                // suggests that this might be an object at some point. Probably can be removed if refactored to React.js
+                amountOfProjections = Object.keys(supportedProjs).length;
+            }
+
             me._popupContent = popupContent;
 
-            if (hasMoreProjConfigs) {
+            if (amountOfProjections > 1) {
                 me._popupContent.find('.srs').append(me._templates.projectionTransformSelect.clone());
 
                 me._popupContent.find('.coordinatetool-projection-change-header').html(me._locale('display.coordinatesTransform.header'));
@@ -82,8 +91,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
          */
         _populateCoordinatesTransformSelect: function (select) {
             var me = this;
-            var projections = me._config.supportedProjections || [];
-            projections.forEach(function (key) {
+            const config = this._config || {};
+            const supportedProjs = config.supportedProjections || [];
+            supportedProjs.forEach(function (key) {
                 var option = me._templates.projectionSelectOption.clone();
                 option.val(key);
                 if (me._locale('display.coordinatesTransform.projections.' + key)) {


### PR DESCRIPTION
Fixes an issue caused by #1706 on coordinatetool that removed projection select from the UI and as a result caused hover events to trigger errors for mouse hover coordinates displaying.