### PR TITLE
Add generic ErrorBoundary component

### DIFF
--- a/bundles/framework/oskariui/resources/locale/en.js
+++ b/bundles/framework/oskariui/resources/locale/en.js
@@ -2,6 +2,9 @@ Oskari.registerLocalization({
     lang: 'en',
     key: 'oskariui',
     value: {
+        error: {
+            generic: 'Something went wrong'
+        },
         table: {
             sort: {
                 desc: 'Click to sort descending',

--- a/bundles/framework/oskariui/resources/locale/fi.js
+++ b/bundles/framework/oskariui/resources/locale/fi.js
@@ -2,6 +2,9 @@ Oskari.registerLocalization({
     lang: 'fi',
     key: 'oskariui',
     value: {
+        error: {
+            generic: 'Tapahtui odottamaton virhe'
+        },
         table: {
             sort: {
                 desc: 'Lajittele laskevasti',

--- a/bundles/framework/oskariui/resources/locale/sv.js
+++ b/bundles/framework/oskariui/resources/locale/sv.js
@@ -2,6 +2,9 @@ Oskari.registerLocalization({
     lang: 'sv',
     key: 'oskariui',
     value: {
+        error: {
+            generic: 'Something went wrong'
+        },
         table: {
             sort: {
                 desc: 'Sortera i fallande ordning',

--- a/src/react/components/Table.jsx
+++ b/src/react/components/Table.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Table as AntTable } from 'antd';
 import 'antd/es/table/style/index.js';
+import { getMsg } from '../util/locale';
 
 export const getSorterFor = key => (a, b) => Oskari.util.naturalSort(a[key], b[key]);
 
@@ -12,9 +13,6 @@ export const getSorterFor = key => (a, b) => Oskari.util.naturalSort(a[key], b[k
  * - https://github.com/ant-design/ant-design/blob/master/components/locale/fi_FI.tsx
  * - https://github.com/ant-design/ant-design/pull/33372
  */
-const LOCALE_BUNDLE = 'oskariui';
-const getMsg = (key) => Oskari.getMsg(LOCALE_BUNDLE, key);
-
 export const Table = ({ ...other }) => {
     const locale = {
         triggerDesc: getMsg('table.sort.desc'), // 'Click to sort descending',

--- a/src/react/util/ErrorBoundary.jsx
+++ b/src/react/util/ErrorBoundary.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { getMsg } from './locale';
+
+const DefaultError = () => (<h1>{getMsg('error.generic')}</h1>);
+/**
+ * Usage:
+ * 1) Wrap components to "try/catch" with:
+ *
+ *     import { ErrorBoundary } from 'oskari-ui/util';
+ *     <ErrorBoundary> .. the usual JSX ... </ErrorBoundary>
+ *
+ * 2) (optional) Create custom error handler to show when error happens on wrapped components:
+ *
+ *      export const CustomError = ({info}) => {
+ *          console.log(info);
+ *          return (<b>BOOM!</b>);
+ *      };
+ *
+ * 3) (optional) Pass custom error element for customizing the error display:
+ *
+ *     import {CustomError} from './CustomError';
+ *     <ErrorBoundary errorComponent={CustomError}>
+ *
+ * 4) See more:
+ * - https://reactjs.org/docs/error-boundaries.html
+ */
+export class ErrorBoundary extends React.Component {
+    constructor(props) {
+        super(props);
+        this.errorComp = props.errorComponent;
+        this.state = { hasError: false };
+    }
+
+    componentDidCatch (error, errorInfo) {
+        this.setState({
+            hasError: true,
+            errorInfo });
+        Oskari.log('React/ErrorBoundary').error(error, errorInfo);
+    }
+
+    render () {
+        if (this.state.hasError) {
+            const ErrorComp = this.errorComp || DefaultError;
+            return (<ErrorComp info={this.state.errorInfo}/>);
+        }
+        return this.props.children;
+    }
+}
+ErrorBoundary.propTypes = {
+    children: PropTypes.node,
+    errorComponent: PropTypes.elementType
+};

--- a/src/react/util/index.js
+++ b/src/react/util/index.js
@@ -5,3 +5,4 @@
 export { StateHandler, Controller, controllerMixin } from './state';
 export { Timeout, Messaging, handleBinder } from './extras';
 export { GenericContext, withContext, LocaleProvider, LocaleConsumer } from './contexts';
+export { ErrorBoundary } from './ErrorBoundary';

--- a/src/react/util/locale.js
+++ b/src/react/util/locale.js
@@ -1,0 +1,2 @@
+const LOCALE_BUNDLE = 'oskariui';
+export const getMsg = (key) => Oskari.getMsg(LOCALE_BUNDLE, key);


### PR DESCRIPTION
Can be used to wrarp JSX and show error messages when wrapped components throw exceptions: https://reactjs.org/docs/error-boundaries.html

Usage:

1) Wrap components to "try/catch" with:
```
import { ErrorBoundary } from 'oskari-ui/util';
<ErrorBoundary> .. the usual JSX ... </ErrorBoundary>
```
2) (optional) Create custom error handler to show when error happens on wrapped components:
```
export const CustomError = ({info}) => {
    console.log(info);
    return (<b>BOOM!</b>);
};
```

3) (optional) Pass custom error element for customizing the error display:
```
import {CustomError} from './CustomError';
<ErrorBoundary errorComponent={CustomError}> .. the usual JSX ... </ErrorBoundary>
```