### PR TITLE
Add classes to allow easier CSS-selectors for testing

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Filter/Filter.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Filter/Filter.jsx
@@ -10,6 +10,7 @@ const Filter = ({ filters, activeFilterId, controller }) => {
             <Select
                 onChange={controller.setActiveFilterId}
                 value={activeFilterId}
+                className="t_filter"
             >
                 {
                     filters.map(({ id, text, tooltip }) => (

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Grouping.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Grouping.jsx
@@ -7,7 +7,7 @@ import { Controller } from 'oskari-ui/util';
 
 const Grouping = ({ selected, options, controller }) =>
     <Labelled label={'grouping.title'}>
-        <Select value={selected} onChange={controller.setGrouping}>
+        <Select value={selected} onChange={controller.setGrouping} className="t_grouping">
             {
                 options.map(cur =>
                     <Option key={cur.getKey()} value={cur.getKey()}>


### PR DESCRIPTION
Layerlist select item elements:
- layer grouping can now be found by: `document.querySelector('div.layerlist .t_grouping .ant-select-selection-item')`
- filter can now be found by: `document.querySelector('div.layerlist .t_filter .ant-select-selection-item');`
