### PR TITLE
Remove raster style name requirement from admin-component

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/RasterStyle/RasterStyleSelect.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/RasterStyle/RasterStyleSelect.jsx
@@ -58,7 +58,7 @@ const RasterStyleSelect = ({ selected, styles, defaultName, setSelected, control
 RasterStyleSelect.propTypes = {
     selected: PropTypes.string.isRequired,
     styles: PropTypes.array.isRequired,
-    defaultName: PropTypes.string.isRequired,
+    defaultName: PropTypes.string,
     setSelected: PropTypes.func.isRequired,
     controller: PropTypes.instanceOf(Controller).isRequired,
     getMessage: PropTypes.func.isRequired


### PR DESCRIPTION
Not all layers have declared style, removing requirement to prevent error being logged on such case.