### PR TITLE
Admin layereditor service legend fix

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/RasterStyle.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/RasterStyle.jsx
@@ -25,7 +25,8 @@ const additionalLegendsToStyles = (styles, legends, globalTitle) => {
 const RasterStyle = ({ layer, controller, getMessage }) => {
     const { options = {}, capabilities = {}, style: defaultName } = layer;
     const { styles = [] } = capabilities;
-    const { legends = {} } = options;
+    const { legends = {} } = options; // overriding legend urls
+
     // Used to generate style-objects for styles that have been removed from the service
     // so we can show the override legends urls that we have saved for the layer
     // and notify admin that such styles don't exist any more on the service
@@ -34,11 +35,10 @@ const RasterStyle = ({ layer, controller, getMessage }) => {
     const firstOption = styleOptions.length > 0 ? styleOptions[0].name : '';
     const [selected, setSelected] = useState(defaultName || firstOption);
 
-    const style = styleOptions.find(s => s.name === selected);
-    const name = style ? style.name : GLOBAL_LEGEND;
-    const styleLegend = style ? style.legend : '';
     // user/layer gets legend in following order: named override, global override, defined in service/capabilities/style
-    const legendUrl = legends[name] || legends[GLOBAL_LEGEND] || '';
+    const { name: nameForLegendUrl = GLOBAL_LEGEND } = styleOptions.find(s => s.name === selected) || {};
+    const { legend: serviceLegendUrl = '' } = styles.find(s => s.name === selected) || {};
+    const legendUrl = legends[nameForLegendUrl] || '';
 
     return (
         <Fragment>
@@ -54,7 +54,7 @@ const RasterStyle = ({ layer, controller, getMessage }) => {
                         controller = {controller}>
                     </RasterStyleSelect>
                     <StyledFormField>
-                        <ServiceLegend url = {styleLegend} />
+                        <ServiceLegend url = {serviceLegendUrl} />
                     </StyledFormField>
                     <StyledFormField>
                         <Fragment>
@@ -67,7 +67,7 @@ const RasterStyle = ({ layer, controller, getMessage }) => {
                             }
                             <TextInput
                                 value = {legendUrl}
-                                onChange={evt => controller.setLegendUrl(name, evt.target.value)}
+                                onChange={evt => controller.setLegendUrl(nameForLegendUrl, evt.target.value)}
                                 allowClear = {true}
                             />
                         </Fragment>


### PR DESCRIPTION
styleOptions contains also additional legends. So:
`
const style = styleOptions.find(s => s.name === selected);
const styleLegend = style ? style.legend : '';
`
Showed additional legend without style also as service legend.
