### PR TITLE
Fix an issue with Cesium asset paths on build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,8 +14,8 @@ const proxyPort = 8081;
 const isDirectory = source => lstatSync(source).isDirectory();
 const getDirectories = source => readdirSync(source).map(name => path.join(source, name)).filter(isDirectory);
 
-// The path to the CesiumJS source code
-const cesiumSource = 'node_modules/cesium/Source';
+// The path to the CesiumJS source code (normal and dev mode)
+const cesiumSourceOptions = ['../cesium/Source', 'node_modules/cesium/Source'];
 const cesiumTarget = 'cesium';
 
 module.exports = (env, argv) => {
@@ -36,13 +36,15 @@ module.exports = (env, argv) => {
     plugins.push(new NormalModuleReplacementPlugin(/..\/..\/style\/index\.less/, replacement));
 
     // Copy Cesium Assets, Widgets, and Workers to a static directory
-    plugins.push(new CopywebpackPlugin([
-        { from: path.join(__dirname, cesiumSource, '../Build/Cesium/Workers'), to: cesiumTarget + '/Workers' },
-        { from: path.join(__dirname, cesiumSource, 'Assets'), to: cesiumTarget + '/Assets' },
-        { from: path.join(__dirname, cesiumSource, 'Widgets'), to: cesiumTarget + '/Widgets' },
-        // copy Cesium's minified third-party scripts
-        { from: path.join(__dirname, cesiumSource, '../Build/Cesium/ThirdParty'), to: cesiumTarget + '/ThirdParty' }
-    ]));
+    cesiumSourceOptions.forEach(possibleSrcPath => {
+        plugins.push(new CopywebpackPlugin([
+            { from: path.join(__dirname, possibleSrcPath, '../Build/Cesium/Workers'), to: cesiumTarget + '/Workers' },
+            { from: path.join(__dirname, possibleSrcPath, 'Assets'), to: cesiumTarget + '/Assets' },
+            { from: path.join(__dirname, possibleSrcPath, 'Widgets'), to: cesiumTarget + '/Widgets' },
+            // copy Cesium's minified third-party scripts
+            { from: path.join(__dirname, possibleSrcPath, '../Build/Cesium/ThirdParty'), to: cesiumTarget + '/ThirdParty' }
+        ]));
+    });
 
     // Define relative base path in Cesium for loading assets
     plugins.push(new DefinePlugin({


### PR DESCRIPTION
The previous version assumed `cesium` is found under `oskari-frontend/node_modules/cesium` which is true when running the build on "dev-mode", but a more common use case is that the build is run with `oskari-frontend` as usual dependency and in that case `cesium` is found _next to_ `oskari-frontend` with the relative path `../cesium` and not _under_ its `node_modules`. This fixes the issue by copying the files from which ever they are found from.