### PR TITLE
StyleEditor disable ColorPicker with transparent pattern

### DIFF
--- a/bundles/framework/oskariui/resources/locale/en.js
+++ b/bundles/framework/oskariui/resources/locale/en.js
@@ -25,6 +25,9 @@ Oskari.registerLocalization({
                 lineTab: 'Line',
                 areaTab: 'Area'
             },
+            tooltips: {
+                noFillColor: 'Please select a different fill pattern first'
+            },
             fill: {
                 color: 'Fill colour',
                 area: {

--- a/bundles/framework/oskariui/resources/locale/fi.js
+++ b/bundles/framework/oskariui/resources/locale/fi.js
@@ -26,6 +26,9 @@ Oskari.registerLocalization({
                 lineTab: 'Viiva',
                 areaTab: 'Alue'
             },
+            tooltips: {
+                noFillColor: 'Valitse ensin joku muu täyttökuvio'
+            },
             fill: {
                 color: 'Täyttöväri',
                 area: {

--- a/bundles/framework/oskariui/resources/locale/sv.js
+++ b/bundles/framework/oskariui/resources/locale/sv.js
@@ -25,6 +25,9 @@ Oskari.registerLocalization({
                 lineTab: 'Linje',
                 areaTab: 'Området'
             },
+            tooltips: {
+                noFillColor: 'Vänligen välj först ett annat mönster'
+            },
             fill: {
                 color: 'Ifyllnadsfärg för område',
                 area: {

--- a/src/react/components/ColorPicker.jsx
+++ b/src/react/components/ColorPicker.jsx
@@ -58,20 +58,15 @@ const getContent = (props) => {
         </StyledColorPicker>
     );
 };
-const getIcon = value => {
-    const style = {
-        fontSize: '20px',
-        color: Oskari.util.isDarkColor(value) ? '#FFFFFF' :'#000000'
-    };
-    return (
-        <BgColorsOutlined style = {style}/>
-    );
-};
-
 
 export const ColorPicker = (props) => {
-    const { value = '#000000' } = props;
+    const { value = '#000000', disabled = false } = props;
     const [visible, setVisible] = useState(false);
+    const chooseIconStyle = {
+        fontSize: '20px',
+        color: disabled || Oskari.util.isDarkColor(value) ? '#FFFFFF' :'#000000'
+    };
+    const chooseTooltip = disabled ? '' : <Message messageKey={`ColorPicker.tooltip`}/>;
     return (
         <React.Fragment>
             <Popover
@@ -82,16 +77,19 @@ export const ColorPicker = (props) => {
                 zIndex={zIndex}
                 onVisibleChange = {setVisible}
                 >
-            <Tooltip title={<Message messageKey='ColorPicker.tooltip' />}>
-                <ChooseColor style={{background: value}} icon={getIcon(value)}/>
+            <Tooltip title={chooseTooltip}>
+                <ChooseColor style={{ background: value }} disabled={disabled} >
+                    <BgColorsOutlined style={chooseIconStyle}/>
+                </ChooseColor>
             </Tooltip>
             </Popover>
-            <ColorTextInput { ...props }/>
+            {!disabled && <ColorTextInput { ...props }/> }
         </React.Fragment>
     );
 }
 
 ColorPicker.propTypes = {
     value: PropTypes.string,
-    onChange: PropTypes.func
+    onChange: PropTypes.func,
+    disabled: PropTypes.bool
 };

--- a/src/react/components/StyleEditor.jsx
+++ b/src/react/components/StyleEditor.jsx
@@ -7,6 +7,8 @@ import styled from 'styled-components';
 import { constants, PointTab, LineTab, AreaTab, OSKARI_BLANK_STYLE, PreviewButton } from './StyleEditor/';
 import { FormToOskariMapper } from './StyleEditor/FormToOskariMapper';
 
+const { TRANSPARENT_FILL } = constants;
+
 const TabSelector = styled(Radio.Group)`
     &&& {
         display: flex;
@@ -45,9 +47,9 @@ const FormSpace = styled(Space)`
  const styleExceptionHandler = (exceptionStyle) => {
     // if fill pattern is set to null, set color as empty
     if (typeof exceptionStyle.fill.area.pattern !== 'undefined') {
-        if (exceptionStyle.fill.area.pattern === 4) {
+        if (exceptionStyle.fill.area.pattern === TRANSPARENT_FILL) {
             exceptionStyle.fill.color = '';
-        } else if (exceptionStyle.fill.area.pattern !== 4 && exceptionStyle.fill.color === '') {
+        } else if (exceptionStyle.fill.area.pattern !== TRANSPARENT_FILL && exceptionStyle.fill.color === '') {
             exceptionStyle.fill.color = OSKARI_BLANK_STYLE.fill.color;
         }
     }

--- a/src/react/components/StyleEditor/AreaTab.jsx
+++ b/src/react/components/StyleEditor/AreaTab.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ColorPicker, Message } from 'oskari-ui';
+import { ColorPicker, Message, Tooltip } from 'oskari-ui';
 import { SvgRadioButton, SizeControl, constants } from './index';
 import { Form, Row, Col } from 'antd';
 
@@ -98,7 +98,10 @@ export const AreaTab = ({oskariStyle}) => {
             ...item,
             data: item.data(counter)
     }});
+    const isTransparentFill = Oskari.util.keyExists(oskariStyle, 'fill.area.pattern')
+        && oskariStyle.fill.area.pattern === constants.TRANSPARENT_FILL;
 
+    const fillColorTooltip = isTransparentFill ? <Message messageKey='StyleEditor.tooltips.noFillColor' /> : '';
     return (
         <React.Fragment>
             <Row>
@@ -113,13 +116,15 @@ export const AreaTab = ({oskariStyle}) => {
                 </Col>
 
                 <Col span={ 10 } offset={ 2 }>
-                    <Form.Item
-                        { ...constants.ANTD_FORMLAYOUT }
-                        name='fill.color'
-                        label={ <Message messageKey='StyleEditor.fill.color' /> }
-                        >
-                        <ColorPicker />
-                    </Form.Item>
+                    <Tooltip title={fillColorTooltip} placement='topLeft'>
+                        <Form.Item
+                            { ...constants.ANTD_FORMLAYOUT }
+                            name='fill.color'
+                            label={ <Message messageKey='StyleEditor.fill.color' /> }
+                            >
+                            <ColorPicker disabled={isTransparentFill} />
+                        </Form.Item>
+                    </Tooltip>
                 </Col>
             </Row>
 

--- a/src/react/components/StyleEditor/constants.js
+++ b/src/react/components/StyleEditor/constants.js
@@ -8,6 +8,8 @@ export const ANTD_FORMLAYOUT = {
 
 export const SUPPORTED_FORMATS = ['point', 'line', 'area'];
 
+export const TRANSPARENT_FILL = 4;
+
 export const LINE_STYLES = {
     "lineDash": [
         {


### PR DESCRIPTION
Antd uses ant-btn-icon-only class if buttons icon property is used. Changed to put icon within Button instead of using icon property to fix vertical-align.

Disable ColorPicker with transparent fill pattern. Tooltip is rendered over FormItem so it isn't attached to ColorPicker button (like choose color tooltip). FormItem binds input and adding tooltip over ColorPicker breaks functionality. Plan is to choose different pattern automatically if user chooses color with transparent fill. So didn't pay more attention to tooltip placing.