### PR TITLE
Oskari-ui changes for myplacesimport react form

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -217,7 +217,6 @@ Oskari.registerLocalization(
                 "errorFetchLayerEnduserFailed": "Fetching layer details for the layer listing failed. Did you add 'View' permission for a role that you have?",
                 "deleteErrorGroupHasSubgroups": "The group you are trying to remove contains subgroups. Delete the subgroups first."
             },
-            "otherLanguages": "Other languages",
             "stylesJSON": "Style definitions (JSON)",
             "externalStylesJSON": "3rd party style definitions (JSON)",
             "externalStyleFormats": "Supported formats: 3D Tiles, Mapbox",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -218,7 +218,6 @@ Oskari.registerLocalization(
                 "errorFetchLayerEnduserFailed": "Tason tietojen haku listauksen päivittämistä varten epäonnistui. Tallensithan katseluoikeuden roolille joka sinulla on?",
                 "deleteErrorGroupHasSubgroups": "Ryhmä jota yrität poistaa sisältää aliryhmiä. Poista ensin aliryhmät."
             },
-            "otherLanguages": "Muut kielet",
             "stylesJSON": "Tyylimääritykset (JSON)",
             "externalStylesJSON": "Kolmannen osapuolen tyylimääritykset (JSON)",
             "externalStyleFormats": "Tuetut muodot: 3D Tiles, Mapbox",

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -215,7 +215,6 @@ Oskari.registerLocalization(
                 "errorFetchLayerEnduserFailed": "Listan över kartlagren kan inte uppdateras, eftersom kartlagret inte returnerar någon data. Du kom väl ihåg att uppdatera rättigheterna som tillhör din användarroll?",
                 "deleteErrorGroupHasSubgroups": "Gruppen du försöker ta bort innehåller undergrupper. Ta bort undergrupperna först."
             },
-            "otherLanguages": "Andra språk",
             "stylesJSON": "Stildefinitioner (JSON)",
             "externalStylesJSON": "Stildefinitioner av tredjeparts (JSON)",
             "externalStyleFormats": "Stödda format: 3D Tiles, Mapbox",

--- a/bundles/framework/oskariui/resources/locale/en.js
+++ b/bundles/framework/oskariui/resources/locale/en.js
@@ -47,6 +47,26 @@ Oskari.registerLocalization({
                     width: 'Line width'
                 }
             }
-        }        
+        },
+        FileInput: {
+            drag: 'Drag {maxCount, plural, one {a file} other {files}} here or select by browsing.',
+            noFiles: 'No file selected.',
+            error: {
+                invalidType: 'File format is not allowed.',
+                allowedExtensions: 'Allowed file extensions: {allowedExtensions}.',
+                multipleNotAllowed: 'Only single file is allowed to be uploaded.',
+                fileSize: 'The selected file is too large. It can be at most {maxSize, number} Mb.'
+            }
+        },
+        LocalizationComponent: {
+            locale: {
+                fi: 'in Finnish',
+                en: 'in English',
+                sv: 'in Swedish'
+            }
+        },
+        Spin: {
+            loading: 'Loading...'
+        }
     }
 });

--- a/bundles/framework/oskariui/resources/locale/en.js
+++ b/bundles/framework/oskariui/resources/locale/en.js
@@ -59,7 +59,10 @@ Oskari.registerLocalization({
             }
         },
         LocalizationComponent: {
+            otherLanguages: 'Other languages',
+            othersTip: 'Translations will be shown when using the service in different languages.',
             locale: {
+                generic: 'in ({0})',
                 fi: 'in Finnish',
                 en: 'in English',
                 sv: 'in Swedish'

--- a/bundles/framework/oskariui/resources/locale/fi.js
+++ b/bundles/framework/oskariui/resources/locale/fi.js
@@ -48,6 +48,26 @@ Oskari.registerLocalization({
                     width: 'Viivan paksuus'
                 }
             }
+        },
+        FileInput: {
+            drag: 'Raahaa {maxCount, plural, one {tiedosto} other {tiedostot}} tähän tai valitse selaamalla.',
+            noFiles: 'Ei tiedostoja.',
+            error: {
+                invalidType: 'Tiedostomuoto ei ole sallittu.',
+                allowedExtensions: 'Sallitut tiedostopäätteet: {allowedExtensions}.',
+                multipleNotAllowed: 'Anna vain yksi tiedosto.',
+                fileSize: 'Tiedoston koko on liian suuri. Suurin sallittu koko yksittäiselle tiedostolle on {maxSize, number} Mt.'
+            }
+        },
+        LocalizationComponent: {
+            locale: {
+                fi: 'suomeksi',
+                en: 'englanniksi',
+                sv: 'ruotsiksi'
+            }
+        },
+        Spin: {
+            loading: 'Ladataan...'
         }
     }
 });

--- a/bundles/framework/oskariui/resources/locale/fi.js
+++ b/bundles/framework/oskariui/resources/locale/fi.js
@@ -60,7 +60,10 @@ Oskari.registerLocalization({
             }
         },
         LocalizationComponent: {
+            otherLanguages: 'Muut kielet',
+            othersTip: 'Käännökset näytetään käytettäessä palvelua eri kielillä.',
             locale: {
+                generic: 'kielellä ({0})',
                 fi: 'suomeksi',
                 en: 'englanniksi',
                 sv: 'ruotsiksi'

--- a/bundles/framework/oskariui/resources/locale/sv.js
+++ b/bundles/framework/oskariui/resources/locale/sv.js
@@ -59,7 +59,10 @@ Oskari.registerLocalization({
             }
         },
         LocalizationComponent: {
+            otherLanguages: 'Andra språk',
+            othersTip: '',
             locale: {
+                generic: 'på ({0})',
                 fi: 'på finska',
                 en: 'på engelska',
                 sv: 'på svenska'

--- a/bundles/framework/oskariui/resources/locale/sv.js
+++ b/bundles/framework/oskariui/resources/locale/sv.js
@@ -47,6 +47,26 @@ Oskari.registerLocalization({
                     width: 'Linjens bredd'
                 }
             }
-        }        
+        },
+        FileInput: {
+            drag: 'Dra {maxCount, plural, one {fil} other {filerna}} hit, eller välj genom att bläddra.',
+            noFiles: 'Ingen fil vald.',
+            error: {
+                invalidType: 'Filformatet är inte tillåtet.',
+                allowedExtensions: 'Tillåtna filändelser: {allowedExtensions}.',
+                multipleNotAllowed: 'Endast en fil kan laddas upp.',
+                fileSize: 'Den valda filen är för stor. Den högsta tillåtna storleken är {maxSize, number} Mb.'
+            }
+        },
+        LocalizationComponent: {
+            locale: {
+                fi: 'på finska',
+                en: 'på engelska',
+                sv: 'på svenska'
+            }
+        },
+        Spin: {
+            loading:'Laddar...'
+        }
     }
 });

--- a/src/react/components/FileInput.jsx
+++ b/src/react/components/FileInput.jsx
@@ -1,118 +1,150 @@
-import React from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Message, Tooltip } from 'oskari-ui';
 import { Messaging } from 'oskari-ui/util';
-import Upload from 'antd/es/upload/Upload';
 import { CloudUploadOutlined, CloseCircleOutlined  } from '@ant-design/icons';
 
 const MAX_SIZE = 10; //MB
 const MAX_COUNT = 5;
 
-const Padding = styled('div')`
-    padding: 12px 24px;
-`;
-
 const Border = styled('div')`
+    display: block;
+    width: 100%;
+    min-height: 70px;
+    padding: 12px;
     background: #fafafa;
     border: 1px dashed #d9d9d9;
-    width: 100%;
-    cursor: pointer;
     transition: border-color .3s;
-    margin-bottom: 10px;
-    display: inline-block;
     &:hover{
         border-color: #40a9ff;
     }
 `;
-const Icon = styled(CloudUploadOutlined)`
+const StyledLabel = styled('label')`
+    cursor: pointer;
+    padding: 12px;
+    &:hover{
+        color: #40a9ff;
+    }
+`;
+const HiddenFileInput = styled('input')`
+    display: none;
+`;
+const StyledFileList = styled('div')`
+    display: inline-block;
+    padding: 0px 12px;
+    margin-top: 8px;
+`;
+const StyledUploadIcon = styled(CloudUploadOutlined)`
     padding-right: 10px;
+`;
+
+const StyledListItem = styled('span')`
+    white-space: nowrap;
+    padding-left: 5px;
+`;
+const StyledName = styled('span')`
+    color: #40a9ff;
+    padding-right: 5px;
 `;
 
 const getMsg = (path, args) => <Message messageKey={`FileInput.${path}`} bundleKey='oskariui' messageArgs={args}/>;
 
-const uploadListOptions = {
-    showPreviewIcon: false, 
-    removeIcon: <CloseCircleOutlined /> // override default trash icon to get rid of hard coded title
-};
-
-const uploadListItemIconRenderer = () => null; // remove paper clipper (needs some styling)
-
-// Another way to avoid uploadin files
-const fakeRequest = ({ file, onSuccess }) => {
-    setTimeout(() => {
-      onSuccess('ok');
-    }, 0);
-  };
+const prevent = e => e.preventDefault();
 
 const showError = (key, args) => {
     const content = getMsg(`error.${key}`, args);
     Messaging.error({ content, duration: 5 });
 }
 
-
-const onChange = (info, onFiles) => {
-    const { fileList } = info; // { file, fileList }
-    const files = fileList
-        .map(f => f.originFileObj)
-        .filter(f => {
-            if (typeof f !== 'undefined'){
-                return true;
-            }
-            Oskari.log('FileInput').warn('Could not find original File object');
-        });
-        
-    onFiles(files);
-};
-
-const validate = (file, fileList, maxCount, maxSize, allowedTypes  ) => {
-    if (fileList.length > maxCount) {
-        const errorKey = maxCount === 1 ? 'multipleNotAllowed' : 'maxCountExceeded';
-        showError(errorKey);
-        return Upload.LIST_IGNORE;
-    }
-    const validType = Array.isArray(allowedTypes) && allowedTypes.length ? allowedTypes.includes(file.type) : true;
-    if (!validType) {
-        showError('invalidType');
-    }
-    const validSize = file.size < (maxSize * 1024 * 1024);
-    if(!validSize) {
-        showError('fileSize', { maxSize });
-    }
-    // to avoid uploading files return false (Uploading will be stopped with false), LIST_IGNORE doesn't add file
-    // FIXME: LIST_IGNORE doesn't seem to work. Maybe use customized file listing or crate own (and get rid of antd)
-    return validType && validSize ? false : Upload.LIST_IGNORE;
-};
-
 export const FileInput = ({ 
     onFiles,
     multiple=true,
     tooltip,
-    allowedTypes,
-    maxSize = MAX_SIZE 
+    allowedTypes = [],
+    maxSize = MAX_SIZE
 }) => {
+    const [currentFiles, setFiles] = useState([]);
     const maxCount = multiple ? MAX_COUNT : 1;
+
+    const onDrop = event => {
+        event.preventDefault();
+        handleInputFiles(event.dataTransfer.files);
+    };
+    const handleInputFiles = inputFiles => {
+        // Special case for single option to override existing file
+        if (!multiple && inputFiles.length === 1) {
+            const file = inputFiles[0];
+            if(validate(file)){
+                onFiles([file]);
+                setFiles([file]);
+            }
+            return;
+        }
+        if (inputFiles.length + currentFiles.length > maxCount) {
+            const errorKey = maxCount === 1 ? 'multipleNotAllowed' : 'maxCountExceeded';
+            showError(errorKey);
+            return;
+        }
+        const validFiles = [];
+        //FileList doesn't have filter
+        inputFiles.forEach(file => validate(file) && validFiles.push(file));
+        const files = [...currentFiles, ...validFiles];
+        onFiles(files);
+        setFiles(files);
+    };
+
+    const validate = file => {
+        const validType = allowedTypes.length ? allowedTypes.includes(file.type) : true;
+        if (!validType) {
+            showError('invalidType');
+        }
+        const validSize = file.size < (maxSize * 1024 * 1024);
+        if(!validSize) {
+            showError('fileSize', { maxSize });
+        }
+        return validType && validSize;
+    };
+
+    const onFileRemove = name => {
+        const files = currentFiles.filter(file => file.name !== name);
+        setFiles(files);
+        onFiles(files);
+    };
 
     return (
         <Tooltip title={ tooltip } trigger={ ['focus', 'hover'] }>
-            <Border>
-                <Upload
-                    multiple = {multiple}
-                    maxCount = {maxCount}
-                    onChange = {info => onChange(info, onFiles)}
-                    className="upload-list-inline"
-                    beforeUpload = {(file, fileList) => validate(file, fileList, maxCount, maxSize, allowedTypes)} 
-                    showUploadList = {uploadListOptions}
-                    iconRender = {uploadListItemIconRenderer}
-                    customRequest = {fakeRequest}
-                >
-                    <Padding>
-                        <Icon style={{ fontSize: '30px', color: '#006ce8'}}/>
-                        { getMsg('drag',{ maxCount }) }
-                    </Padding>
-                </Upload>
+            <Border
+                className="t_fileinput_dropzone"
+                onDrop={onDrop}
+                onDragOver={prevent}
+                onDragEnter={prevent}
+                onDragLeave={prevent}
+            >
+                <StyledLabel>
+                    <HiddenFileInput
+                        type="file"
+                        multiple= {multiple}
+                        accept={allowedTypes.join(',')}
+                        onChange={e => handleInputFiles(e.target.files)}
+                    />
+                    <StyledUploadIcon className="t_fileinput_btn" style={{ fontSize: '30px', color: '#006ce8'}}/>
+                    { getMsg('drag',{ maxCount }) }
+                </StyledLabel>
+                <StyledFileList className="t_fileinput_list">
+                    { currentFiles.map( ({name}) => <FileListItem name={name} onRemoveClick={onFileRemove} key={name} />) }
+                </StyledFileList>
             </Border>
         </Tooltip>
+    );
+};
+
+const FileListItem = ({name, onRemoveClick}) => {
+    return (
+        <StyledListItem>
+            <StyledName>{ name }</StyledName>
+            <CloseCircleOutlined className="t_fileinput_remove" onClick={()=>onRemoveClick(name)}/>
+        </StyledListItem>
     );
 };
 

--- a/src/react/components/FileInput.jsx
+++ b/src/react/components/FileInput.jsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Message, Tooltip } from 'oskari-ui';
+import { Messaging } from 'oskari-ui/util';
+import Upload from 'antd/es/upload/Upload';
+import { CloudUploadOutlined, CloseCircleOutlined  } from '@ant-design/icons';
+
+const MAX_SIZE = 10; //MB
+const MAX_COUNT = 5;
+
+const Padding = styled('div')`
+    padding: 12px 24px;
+`;
+
+const Border = styled('div')`
+    background: #fafafa;
+    border: 1px dashed #d9d9d9;
+    width: 100%;
+    cursor: pointer;
+    transition: border-color .3s;
+    margin-bottom: 10px;
+    display: inline-block;
+    &:hover{
+        border-color: #40a9ff;
+    }
+`;
+const Icon = styled(CloudUploadOutlined)`
+    padding-right: 10px;
+`;
+
+const getMsg = (path, args) => <Message messageKey={`FileInput.${path}`} bundleKey='oskariui' messageArgs={args}/>;
+
+const uploadListOptions = {
+    showPreviewIcon: false, 
+    removeIcon: <CloseCircleOutlined /> // override default trash icon to get rid of hard coded title
+};
+
+const uploadListItemIconRenderer = () => null; // remove paper clipper (needs some styling)
+
+// Another way to avoid uploadin files
+const fakeRequest = ({ file, onSuccess }) => {
+    setTimeout(() => {
+      onSuccess('ok');
+    }, 0);
+  };
+
+const showError = (key, args) => {
+    const content = getMsg(`error.${key}`, args);
+    Messaging.error({ content, duration: 5 });
+}
+
+
+const onChange = (info, onFiles) => {
+    const { fileList } = info; // { file, fileList }
+    const files = fileList
+        .map(f => f.originFileObj)
+        .filter(f => {
+            if (typeof f !== 'undefined'){
+                return true;
+            }
+            Oskari.log('FileInput').warn('Could not find original File object');
+        });
+        
+    onFiles(files);
+};
+
+const validate = (file, fileList, maxCount, maxSize, allowedTypes  ) => {
+    if (fileList.length > maxCount) {
+        const errorKey = maxCount === 1 ? 'multipleNotAllowed' : 'maxCountExceeded';
+        showError(errorKey);
+        return Upload.LIST_IGNORE;
+    }
+    const validType = Array.isArray(allowedTypes) && allowedTypes.length ? allowedTypes.includes(file.type) : true;
+    if (!validType) {
+        showError('invalidType');
+    }
+    const validSize = file.size < (maxSize * 1024 * 1024);
+    if(!validSize) {
+        showError('fileSize', { maxSize });
+    }
+    // to avoid uploading files return false (Uploading will be stopped with false), LIST_IGNORE doesn't add file
+    // FIXME: LIST_IGNORE doesn't seem to work. Maybe use customized file listing or crate own (and get rid of antd)
+    return validType && validSize ? false : Upload.LIST_IGNORE;
+};
+
+export const FileInput = ({ 
+    onFiles,
+    multiple=true,
+    tooltip,
+    allowedTypes,
+    maxSize = MAX_SIZE 
+}) => {
+    const maxCount = multiple ? MAX_COUNT : 1;
+
+    return (
+        <Tooltip title={ tooltip } trigger={ ['focus', 'hover'] }>
+            <Border>
+                <Upload
+                    multiple = {multiple}
+                    maxCount = {maxCount}
+                    onChange = {info => onChange(info, onFiles)}
+                    className="upload-list-inline"
+                    beforeUpload = {(file, fileList) => validate(file, fileList, maxCount, maxSize, allowedTypes)} 
+                    showUploadList = {uploadListOptions}
+                    iconRender = {uploadListItemIconRenderer}
+                    customRequest = {fakeRequest}
+                >
+                    <Padding>
+                        <Icon style={{ fontSize: '30px', color: '#006ce8'}}/>
+                        { getMsg('drag',{ maxCount }) }
+                    </Padding>
+                </Upload>
+            </Border>
+        </Tooltip>
+    );
+};
+
+FileInput.propTypes = {
+    onFiles: PropTypes.func.isRequired,
+    multiple: PropTypes.bool,
+    allowedTypes: PropTypes.array,
+    tooltip: PropTypes.string,
+    maxSize: PropTypes.number
+};

--- a/src/react/components/FileInput.jsx
+++ b/src/react/components/FileInput.jsx
@@ -75,7 +75,7 @@ export const FileInput = ({
         // Special case for single option to override existing file
         if (!multiple && inputFiles.length === 1) {
             const file = inputFiles[0];
-            if(validate(file)){
+            if (validate(file)) {
                 onFiles([file]);
                 setFiles([file]);
             }
@@ -87,7 +87,7 @@ export const FileInput = ({
             return;
         }
         const validFiles = [];
-        //FileList doesn't have filter
+        // FileList (not array) doesn't have filter, use forEach to filter valid files
         inputFiles.forEach(file => validate(file) && validFiles.push(file));
         const files = [...currentFiles, ...validFiles];
         onFiles(files);
@@ -95,12 +95,12 @@ export const FileInput = ({
     };
 
     const validate = file => {
-        const validType = allowedTypes.length ? allowedTypes.includes(file.type) : true;
+        const validType = !allowedTypes.length || allowedTypes.includes(file.type);
         if (!validType) {
             showError('invalidType');
         }
         const validSize = file.size < (maxSize * 1024 * 1024);
-        if(!validSize) {
+        if (!validSize) {
             showError('fileSize', { maxSize });
         }
         return validType && validSize;

--- a/src/react/components/LocalizationComponent.jsx
+++ b/src/react/components/LocalizationComponent.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Collapse, CollapsePanel, Message, Divider, Tooltip } from 'oskari-ui';
 import styled from 'styled-components';
-import { QuestionCircleOutlined } from '@ant-design/icons';
+import { QuestionCircleOutlined, StarTwoTone } from '@ant-design/icons';
 
 const Label = styled('div')`
     display: inline-block;
@@ -149,13 +149,15 @@ export const LocalizationComponent = ({
             let elementValue = single ? internalValue[lang] : internalValue[lang][name];
             let label = getLabel(labels, lang, name, single);
             const placeholder = getPlaceholder(placeholders, lang, name, single);
+            const { validate, ...rest } = element.props; // don't pass validate to element node
+            const suffix = typeof validate === 'function' && !validate(lang, elementValue) ? <StarTwoTone twoToneColor={'#da5151'}/> : '';
             return (
                 <React.Fragment key={`${lang}_${index}`}>
                     { label &&
                         <LabelComponent>{ label }</LabelComponent>
                     }
                     <Tooltip key={ `${lang}_${index}_tooltip` } title={ placeholder } trigger={ ['focus', 'hover'] }>
-                        <element.type {...element.props} value={elementValue} onChange={onElementValueChange} placeholder={placeholder} autoComplete='off' />
+                        <element.type {...rest} value={elementValue} onChange={onElementValueChange} placeholder={placeholder} autoComplete='off' suffix={suffix}/>
                     </Tooltip>
                 </React.Fragment>
             );

--- a/src/react/components/LocalizationComponent.jsx
+++ b/src/react/components/LocalizationComponent.jsx
@@ -98,14 +98,13 @@ const getCollapseHeader = () => {
     );
 };
 
-
+const validateMandatory = value => typeof value === 'string' && value.trim().length > 0;
 
 export const LocalizationComponent = ({
     languages,
     onChange,
     value,
     labels,
-    placeholders,
     LabelComponent = Label,
     collapse = true,
     defaultOpen = false,
@@ -135,9 +134,13 @@ export const LocalizationComponent = ({
             let elementValue = single ? internalValue[lang] : internalValue[lang][name];
             let label = getLabel(labels, lang, name, single);
 
-            const { required = [], placeholder = '', ...restProps } = element.props; // don't pass required and placeholder to element node
+            const { mandatory = [], placeholder = '', ...restProps } = element.props; // don't pass mandatory and placeholder to element node
             const placeholderWithSuffix = isDefaultLang ? placeholder : getPlaceholderWithLangSuffix(placeholder, lang);
-            const suffix = required.includes(lang) ? <StarTwoTone twoToneColor={'#da5151'}/> : '';
+            let suffix;
+            if (mandatory.includes(lang)) {
+                const isValid = validateMandatory(elementValue);
+                suffix = <StarTwoTone twoToneColor={isValid ? '#52c41a' : '#da5151'}/>;
+            }
             return (
                 <React.Fragment key={`${lang}_${index}`}>
                     { label &&
@@ -183,7 +186,6 @@ LocalizationComponent.propTypes = {
     onChange: PropTypes.func,
     value: PropTypes.object,
     labels: PropTypes.object,
-    placeholders: PropTypes.object,
     LabelComponent: PropTypes.elementType,
     collapse: PropTypes.bool,
     single: PropTypes.bool,

--- a/src/react/components/LocalizationComponent.jsx
+++ b/src/react/components/LocalizationComponent.jsx
@@ -12,6 +12,26 @@ const StyledTooltip = styled(Tooltip)`
     float: right;
 `;
 
+export const createLocalizedLabels = (fields, languages = Oskari.getSupportedLanguages()) => {
+    const labels = {};
+    languages.forEach((lang, index) => {
+        if (index === 0 && lang === Oskari.getLang()) {
+            labels[lang] = fields;
+            return;
+        }
+        const path = `LocalizationComponent.locale.${lang}`;
+        let locale = Oskari.getMsg('oskariui', path);
+        if (path === locale) {
+            locale = Oskari.getMsg('oskariui', 'LocalizationComponent.locale.generic', [lang]);
+        }
+        labels[lang] = Object.keys(fields).reduce((langLabels,field) => {
+            langLabels[field]=`${fields[field]} ${locale}`;
+            return langLabels;
+        }, {});
+    });
+    return labels;
+};
+
 const getMsg = path => <Message messageKey={`LocalizationComponent.${path}`} bundleKey='oskariui'/>;
 
 const getInitialValue = (languages, value, isSingle) => {
@@ -142,7 +162,7 @@ export const LocalizationComponent = ({
         });
 
         return (
-            <React.Fragment>
+            <React.Fragment key={`${lang}_${index}`}>
                 {addDivider && renderDivider(lang)}
                 {nodes}
             </React.Fragment>

--- a/src/react/components/Message.jsx
+++ b/src/react/components/Message.jsx
@@ -38,10 +38,10 @@ const Message = ({ bundleKey, messageKey, messageArgs, defaultMsg, getMessage, c
 
     let message = messageKey;
 
-    if (typeof getMessage === 'function') {
-        message = getMessage(messageKey, messageArgs);
-    } else {
+    if (bundleKey) {
         message = getMessageUsingOskariGlobal(bundleKey, messageKey, messageArgs);
+    } else if (typeof getMessage === 'function') {
+        message = getMessage(messageKey, messageArgs);
     }
 
     // If we didn't find localization AND we have default value -> use it

--- a/src/react/components/Spin.jsx
+++ b/src/react/components/Spin.jsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Spin as AntSpin } from 'antd';
+import { Message } from 'oskari-ui';
 import 'antd/es/spin/style/index.js';
 
-export const Spin = ({ children, ...other }) => (
-    <AntSpin {...other}>{children}</AntSpin>
-);
+export const Spin = ({ children, showTip = false, ...other }) => {
+    const tip = showTip ? <Message messageKey='Spin.loading' bundleKey='oskariui'/> : null;
+    return (
+        <AntSpin tip={tip} {...other}>{children}</AntSpin>
+    );
+};
 
 Spin.propTypes = {
-    children: PropTypes.any
+    children: PropTypes.any,
+    showTip: PropTypes.bool
 };


### PR DESCRIPTION
Changes for LocalizationComponent which are needed to localize name (,source and desc) for myplace and userlayer:
- placeholders can be given as input elements (child) props. Placeholders are lang suffixed (except default language). Maybe some hint could be added to ?-mark header tooltip if user doesn't use default language or yellow !-mark.
`<Input namplaceholder={Name}> => languages = [en,fi,sv] => Name, Name in Finnish, Name in Swedish`
- showDivider adds dividers between languages in collapse (like 'in Finnish').  Placeholders + multiple elements looks messy without divider (or at least some padding must be added)
- ?-icon with tooltip is added to more languages collapse header
- required can be passed with element props if input doesn't have required value. This is little ugly but in most cases value has  to be validated in parent component to disable button etc. So haven't to check existing value twice. Required contains languages which values are still required from user.
`<Input required=['en']>`


See: https://github.com/oskariorg/oskari-frontend/pull/1730 how myplaces is intended to use this

Add FileInput with clumsy styling (for myplacesimport). 

Possibility to show 'Loading...' text in Spin.

If Message is used by other bundle with LocaleProvider. Message gets localization from that bundle even using bundleKey='oskariui'. Changed to use bundleKey if provided. Not sure if it's better to wrap ui components inside LocaleProvider instead of changing Message's bundleKey handling.