### PR TITLE
Myplaces locale name

### DIFF
--- a/bundles/framework/myplaces3/CategoryHandler.js
+++ b/bundles/framework/myplaces3/CategoryHandler.js
@@ -232,12 +232,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.CategoryHandler',
             dialog.show(title, message, [okBtn]);
         },
         saveCategory: function (category, callback) {
-            const id = category.categoryId;
+            const { id, locale, isDefault, style } = category;
             const data = {
                 id,
-                name: category.name,
-                isDefault: category.isDefault,
-                style: JSON.stringify(category.style)
+                isDefault,
+                locale: JSON.stringify(locale),
+                style: JSON.stringify(style)
             };
             this.instance.getService().commitCategory(data, layerJson => {
                 const isNew = !id;

--- a/bundles/framework/myplaces3/CategoryHandler.js
+++ b/bundles/framework/myplaces3/CategoryHandler.js
@@ -92,7 +92,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.CategoryHandler',
             return {
                 categoryId: this.parseCategoryId(layerId),
                 layerId,
-                // TODO: check if we need to sanitize name here or somewhere down the line
                 name: layer.getName(),
                 isDefault: !!layer.getOptions().isDefault,
                 // has only one style default for now
@@ -150,13 +149,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.CategoryHandler',
             return layer;
         },
         updateLayer: function (layerJson) {
-            const { id, name, options } = layerJson;
+            const { id, locale, options } = layerJson;
             const layer = this.mapLayerService.findMapLayer(id);
             if (!layer) {
                 this.log.warn('tried to update layer which does not exist, id: ' + id);
                 return;
             }
-            layer.setName(name);
+            layer.setLocale(locale);
             layer.setOptions(options);
             const evt = Oskari.eventBuilder('MapLayerEvent')(id, 'update');
             this.sandbox.notifyAll(evt);
@@ -189,11 +188,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.CategoryHandler',
                     style
                 });
             };
-            const names = { ...layer._name }; // TODO: getter?
-            const locale = Object.keys(names).reduce((locale, lang) => {
-                locale[lang] = { name: names[lang] };
-                return locale;
-            }, {});
+            const locale = layer.getLocale();
             const style = layer.getCurrentStyle().getFeatureStyle();
             showModal(locale, style, saveLayer);
         },

--- a/bundles/framework/myplaces3/CategoryHandler.js
+++ b/bundles/framework/myplaces3/CategoryHandler.js
@@ -181,15 +181,21 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.CategoryHandler',
             this._notifyUpdate();
         },
         editCategory: function (categoryId) {
-            const layer = this.getCategory(categoryId);
-            const saveLayer = (name, style) => {
+            const layer = this.mapLayerService.findMapLayer(this.getMapLayerId(categoryId));
+            const saveLayer = (locale, style) => {
                 this.saveCategory({
-                    ...layer,
-                    name,
+                    id: categoryId,
+                    locale,
                     style
                 });
             };
-            showModal(layer.name, layer.style, saveLayer);
+            const names = { ...layer._name }; // TODO: getter?
+            const locale = Object.keys(names).reduce((locale, lang) => {
+                locale[lang] = { name: names[lang] };
+                return locale;
+            }, {});
+            const style = layer.getCurrentStyle().getFeatureStyle();
+            showModal(locale, style, saveLayer);
         },
         showValidationErrorMessage: function (errors) {
             var dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');

--- a/bundles/framework/myplaces3/MyPlacesLayerForm.jsx
+++ b/bundles/framework/myplaces3/MyPlacesLayerForm.jsx
@@ -23,6 +23,9 @@ const getMandatory = (defaultLang) => {
     return mandatory;
 };
 
+// name in default language is mandatory
+const validate = (lang, value) => lang !== Oskari.getDefaultLanguage() || (typeof value === 'string' && value.trim().length > 0);
+
 export const MyPlacesLayerForm = ({ locale: initLocale, style: initStyle, onSave, onCancel }) => {
     const [editorState, setEditorState] = useState({
         style: initStyle || OSKARI_BLANK_STYLE,
@@ -53,7 +56,7 @@ export const MyPlacesLayerForm = ({ locale: initLocale, style: initStyle, onSave
                 onChange={ updateLocale }
                 mandatoryFields = { getMandatory(defaultLang) }
             >
-                <PaddedInput type='text' name='name' />
+                <PaddedInput type='text' name='name' validate={validate}/>
             </LocalizationComponent>
             <Divider orientation="left"><Message messageKey={ 'categoryform.styleTitle' } /></Divider>
             <StyleEditor

--- a/bundles/framework/myplaces3/MyPlacesLayerForm.jsx
+++ b/bundles/framework/myplaces3/MyPlacesLayerForm.jsx
@@ -1,38 +1,58 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Message, TextInput, Divider, Modal } from 'oskari-ui';
+import styled from 'styled-components';
+import { Message, Divider, Modal, LocalizationComponent, TextInput } from 'oskari-ui';
+import { createLocalizedLabels } from 'oskari-ui/components/LocalizationComponent';
 
 import { StyleEditor } from 'oskari-ui/components/StyleEditor';
 import { OSKARI_BLANK_STYLE } from 'oskari-ui/components/StyleEditor/index';
+import { LOCALE_KEY } from './constants';
 
-export const MyPlacesLayerForm = ({ name, style, onSave, onCancel }) => {
+const PaddedInput = styled(TextInput)`
+    margin-bottom: 10px;
+`;
+
+const getPlaceholders = (defaultLang) => {
+    const localizedFields = { name: Oskari.getMsg(LOCALE_KEY, 'categoryform.layerName') };
+    const placeholders = createLocalizedLabels(localizedFields);
+    placeholders[defaultLang].name = placeholders[defaultLang].name + ' *'; // add mandatory mark
+    return placeholders;
+};
+
+export const MyPlacesLayerForm = ({ locale: initLocale, style: initStyle, onSave, onCancel }) => {
     const [editorState, setEditorState] = useState({
-        style: style || OSKARI_BLANK_STYLE,
-        name: name
+        style: initStyle || OSKARI_BLANK_STYLE,
+        locale: initLocale || {}
     });
-
+    const { locale, style } = editorState;
     const updateStyle = (style) => setEditorState({ ...editorState, style });
-    const updateName = (name) => setEditorState({ ...editorState, name });
-    const hasName = editorState.name.length > 0;
+    const updateLocale = (locale) => setEditorState({ ...editorState, locale });
+    const defaultLang = Oskari.getDefaultLanguage();
+    const hasName = Oskari.util.keyExists(locale, `${defaultLang}.name`) && locale[defaultLang].name.trim().length > 0;
+    // TODO: show warning in button tooltip
+    // { !hasName && <Message messageKey='validation.categoryName' /> }
     return (
         <Modal
             title={ <Message messageKey={ 'categoryform.title' } /> }
             visible={ true }
-            onOk={ () => onSave(editorState.name, editorState.style) }
+            onOk={ () => onSave(locale, style) }
+            maskClosable = { false }
             okButtonProps={ { disabled: !hasName } }
             onCancel={ onCancel }
             cancelText={ <Message messageKey="buttons.cancel" /> }
             okText={ <Message messageKey="buttons.save" /> }
         >
-            <TextInput
-                addonBefore={ <Message messageKey={ 'categoryform.layerName' } /> }
-                value={ editorState.name }
-                onChange={ (event) => updateName(event.target.value) }
-            />
-            { !hasName && <Message messageKey='validation.categoryName' /> }
+            <LocalizationComponent
+                placeholders={ getPlaceholders(defaultLang) }
+                value={ locale }
+                languages={ Oskari.getSupportedLanguages() }
+                onChange={ updateLocale }
+            >
+                <PaddedInput type='text' name='name' />
+            </LocalizationComponent>
             <Divider orientation="left"><Message messageKey={ 'categoryform.styleTitle' } /></Divider>
             <StyleEditor
-                oskariStyle={ editorState.style }
+                oskariStyle={ style }
                 onChange={ updateStyle }
             />
         </Modal>
@@ -40,7 +60,7 @@ export const MyPlacesLayerForm = ({ name, style, onSave, onCancel }) => {
 };
 
 MyPlacesLayerForm.propTypes = {
-    name: PropTypes.string.isRequired,
+    locale: PropTypes.object,
     style: PropTypes.object,
     onSave: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired

--- a/bundles/framework/myplaces3/MyPlacesLayerForm.jsx
+++ b/bundles/framework/myplaces3/MyPlacesLayerForm.jsx
@@ -24,10 +24,6 @@ export const MyPlacesLayerForm = ({ locale: initLocale, style: initStyle, onSave
     const hasName = Oskari.util.keyExists(locale, `${defaultLang}.name`) && locale[defaultLang].name.trim().length > 0;
 
     const placeholder = Oskari.getMsg(LOCALE_KEY, 'categoryform.layerName');
-    const required = [];
-    if (!hasName) {
-        required.push(defaultLang);
-    }
     // TODO: show warning in button tooltip
     // { !hasName && <Message messageKey='validation.categoryName' /> }
 
@@ -47,7 +43,7 @@ export const MyPlacesLayerForm = ({ locale: initLocale, style: initStyle, onSave
                 languages={ Oskari.getSupportedLanguages() }
                 onChange={ updateLocale }
             >
-                <PaddedInput type='text' name='name' placeholder={placeholder} required={required} />
+                <PaddedInput type='text' name='name' placeholder={placeholder} mandatory={[defaultLang]} />
             </LocalizationComponent>
             <Divider orientation="left"><Message messageKey={ 'categoryform.styleTitle' } /></Divider>
             <StyleEditor

--- a/bundles/framework/myplaces3/MyPlacesLayerForm.jsx
+++ b/bundles/framework/myplaces3/MyPlacesLayerForm.jsx
@@ -12,11 +12,15 @@ const PaddedInput = styled(TextInput)`
     margin-bottom: 10px;
 `;
 
-const getPlaceholders = (defaultLang) => {
+const getPlaceholders = () => {
     const localizedFields = { name: Oskari.getMsg(LOCALE_KEY, 'categoryform.layerName') };
-    const placeholders = createLocalizedLabels(localizedFields);
-    placeholders[defaultLang].name = placeholders[defaultLang].name + ' *'; // add mandatory mark
-    return placeholders;
+    return createLocalizedLabels(localizedFields);
+};
+
+const getMandatory = (defaultLang) => {
+    const mandatory = {};
+    mandatory[defaultLang] = ['name'];
+    return mandatory;
 };
 
 export const MyPlacesLayerForm = ({ locale: initLocale, style: initStyle, onSave, onCancel }) => {
@@ -43,10 +47,11 @@ export const MyPlacesLayerForm = ({ locale: initLocale, style: initStyle, onSave
             okText={ <Message messageKey="buttons.save" /> }
         >
             <LocalizationComponent
-                placeholders={ getPlaceholders(defaultLang) }
+                placeholders={ getPlaceholders() }
                 value={ locale }
                 languages={ Oskari.getSupportedLanguages() }
                 onChange={ updateLocale }
+                mandatoryFields = { getMandatory(defaultLang) }
             >
                 <PaddedInput type='text' name='name' />
             </LocalizationComponent>

--- a/bundles/framework/myplaces3/MyPlacesLayerForm.jsx
+++ b/bundles/framework/myplaces3/MyPlacesLayerForm.jsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Message, Divider, Modal, LocalizationComponent, TextInput } from 'oskari-ui';
-import { createLocalizedLabels } from 'oskari-ui/components/LocalizationComponent';
 
 import { StyleEditor } from 'oskari-ui/components/StyleEditor';
 import { OSKARI_BLANK_STYLE } from 'oskari-ui/components/StyleEditor/index';
@@ -12,20 +11,6 @@ const PaddedInput = styled(TextInput)`
     margin-bottom: 10px;
 `;
 
-const getPlaceholders = () => {
-    const localizedFields = { name: Oskari.getMsg(LOCALE_KEY, 'categoryform.layerName') };
-    return createLocalizedLabels(localizedFields);
-};
-
-const getMandatory = (defaultLang) => {
-    const mandatory = {};
-    mandatory[defaultLang] = ['name'];
-    return mandatory;
-};
-
-// name in default language is mandatory
-const validate = (lang, value) => lang !== Oskari.getDefaultLanguage() || (typeof value === 'string' && value.trim().length > 0);
-
 export const MyPlacesLayerForm = ({ locale: initLocale, style: initStyle, onSave, onCancel }) => {
     const [editorState, setEditorState] = useState({
         style: initStyle || OSKARI_BLANK_STYLE,
@@ -34,10 +19,18 @@ export const MyPlacesLayerForm = ({ locale: initLocale, style: initStyle, onSave
     const { locale, style } = editorState;
     const updateStyle = (style) => setEditorState({ ...editorState, style });
     const updateLocale = (locale) => setEditorState({ ...editorState, locale });
+
     const defaultLang = Oskari.getDefaultLanguage();
     const hasName = Oskari.util.keyExists(locale, `${defaultLang}.name`) && locale[defaultLang].name.trim().length > 0;
+
+    const placeholder = Oskari.getMsg(LOCALE_KEY, 'categoryform.layerName');
+    const required = [];
+    if (!hasName) {
+        required.push(defaultLang);
+    }
     // TODO: show warning in button tooltip
     // { !hasName && <Message messageKey='validation.categoryName' /> }
+
     return (
         <Modal
             title={ <Message messageKey={ 'categoryform.title' } /> }
@@ -50,13 +43,11 @@ export const MyPlacesLayerForm = ({ locale: initLocale, style: initStyle, onSave
             okText={ <Message messageKey="buttons.save" /> }
         >
             <LocalizationComponent
-                placeholders={ getPlaceholders() }
                 value={ locale }
                 languages={ Oskari.getSupportedLanguages() }
                 onChange={ updateLocale }
-                mandatoryFields = { getMandatory(defaultLang) }
             >
-                <PaddedInput type='text' name='name' validate={validate}/>
+                <PaddedInput type='text' name='name' placeholder={placeholder} required={required} />
             </LocalizationComponent>
             <Divider orientation="left"><Message messageKey={ 'categoryform.styleTitle' } /></Divider>
             <StyleEditor

--- a/bundles/framework/myplaces3/instance.js
+++ b/bundles/framework/myplaces3/instance.js
@@ -278,13 +278,13 @@ Oskari.clazz.define(
         openAddLayerDialog: function () {
             // create popup
             const handler = this.categoryHandler;
-            const saveLayer = (name, style) => {
+            const saveLayer = (locale, style) => {
                 handler.saveCategory({
-                    name,
+                    locale,
                     style
                 });
             };
-            showModal(this.loc('tab.addCategoryFormButton'), null, saveLayer);
+            showModal({}, null, saveLayer);
         }
     }, {
         /**

--- a/bundles/framework/myplaces3/reactModalHelper.js
+++ b/bundles/framework/myplaces3/reactModalHelper.js
@@ -11,7 +11,7 @@ import { LOCALE_KEY } from './constants';
  * @param {Object} style Oskari style object for editing
  * @param {Function} saveLayer callback to call when user hits "Save"
  */
-export const showModal = (name, style, saveLayer) => {
+export const showModal = (locale, style, saveLayer) => {
     const element = document.createElement('div');
     document.body.appendChild(element);
 
@@ -23,10 +23,10 @@ export const showModal = (name, style, saveLayer) => {
     ReactDOM.render(
         <LocaleProvider value={{ bundleKey: LOCALE_KEY }}>
             <MyPlacesLayerForm
-                name={ name }
+                locale={ locale }
                 style={ style }
-                onSave={ (name, style) => {
-                    saveLayer(name, style);
+                onSave={ (locale, style) => {
+                    saveLayer(locale, style);
                     removeModal();
                 } }
                 onCancel={ removeModal }

--- a/bundles/mapping/mapmyplaces/domain/MyPlacesLayer.js
+++ b/bundles/mapping/mapmyplaces/domain/MyPlacesLayer.js
@@ -11,8 +11,31 @@ export class MyPlacesLayer extends WFSLayer {
         /* Layer Type */
         this._layerType = 'MYPLACES';
         this._metaType = 'MYPLACES';
+        this._locale = {};
     }
     /* Layer type specific functions */
+
+    // override to get name from locale
+    getName (lang = Oskari.getLang()) {
+        const locale = this.getLocale();
+        let { name } = locale[lang] || {};
+        if (!name) {
+            const defaultLocale = locale[Oskari.getDefaultLanguage()] || {};
+            name = defaultLocale.name;
+        }
+        if (name) {
+            return Oskari.util.sanitize(name);
+        }
+        return '';
+    }
+
+    getLocale () {
+        return this._locale;
+    }
+
+    setLocale (locale) {
+        this._locale = locale;
+    }
 
     isFilterSupported () {
         // this defaults to false in AbstractLayer, but WFSLayer returns true.

--- a/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
+++ b/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
@@ -21,6 +21,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmyplaces.domain.MyPlacesLayer
             var loclayer = me.localization.layer;
             // call parent parseLayerData
             this.wfsBuilder.parseLayerData(layer, mapLayerJson, maplayerService);
+            layer.setLocale(mapLayerJson.locale);
 
             if (loclayer.organization) {
                 layer.setOrganizationName(loclayer.organization);


### PR DESCRIPTION
Change myplaces to use locale object and LocalizationComponent instead of name. For new layer default name isn't used.

TODO: if mandatory is missing show note in button's tooltip => With window.showPopup it is possible to use tooltip + button but changing modal (has only buttonProps) to showpopup should be done in own PR.

AbstractLayer _name can be object but it doesn't have getter for whole object. getName returns `_name[lang || default || some]`. Maybe for userdata layers backend may return only locale (remove name) and getName is overrided to get lang || default name from locale. Will fix/unify this after locale userlayer.

Needs: https://github.com/oskariorg/oskari-frontend/pull/1729 and https://github.com/oskariorg/oskari-server/pull/793


