### PR TITLE
Oskariui add labeled action buttons and test class names

### DIFF
--- a/bundles/framework/oskariui/resources/locale/en.js
+++ b/bundles/framework/oskariui/resources/locale/en.js
@@ -2,6 +2,16 @@ Oskari.registerLocalization({
     lang: 'en',
     key: 'oskariui',
     value: {
+        buttons: {
+            add: 'Add',
+            cancel: 'Cancel',
+            close: 'Close',
+            delete: 'Delete',
+            edit: 'Edit',
+            save: 'Save',
+            yes: 'Yes',
+            no: 'No'
+        },
         error: {
             generic: 'Something went wrong'
         },

--- a/bundles/framework/oskariui/resources/locale/fi.js
+++ b/bundles/framework/oskariui/resources/locale/fi.js
@@ -2,6 +2,16 @@ Oskari.registerLocalization({
     lang: 'fi',
     key: 'oskariui',
     value: {
+        buttons: {
+            add: 'Lisää',
+            cancel: 'Peruuta',
+            close: 'Sulje',
+            delete: 'Poista',
+            edit: 'Muokkaa',
+            save: 'Tallenna',
+            yes: 'Kyllä',
+            no: 'Ei'
+        },
         error: {
             generic: 'Tapahtui odottamaton virhe'
         },
@@ -17,11 +27,10 @@ Oskari.registerLocalization({
             moreColors: 'Enemmän värejä'
         },
         StyleEditor: {
-            newtitle: 'Uusi tyyli',
             subheaders: {
                 styleFormat: 'Geometriatyyppi',
                 name: 'Tyylin nimi',
-                style: 'Style',
+                style: 'Esitystapa',
                 pointTab: 'Piste',
                 lineTab: 'Viiva',
                 areaTab: 'Alue'

--- a/bundles/framework/oskariui/resources/locale/fr.js
+++ b/bundles/framework/oskariui/resources/locale/fr.js
@@ -1,0 +1,69 @@
+Oskari.registerLocalization({
+    lang: 'fr',
+    key: 'oskariui',
+    value: {
+        buttons: {
+            add: 'Ajouter',
+            cancel: 'Annuler',
+            close: 'Fermer',
+            delete: 'Supprimer',
+            edit: 'Modifier',
+            save: 'Enregistrer',
+            yes: 'Oui',
+            no: 'Non'
+        },
+        table: {
+            sort: {
+                desc: 'Trier en ordre décroissant',
+                asc: 'Trier en ordre croissant'
+            }
+        },
+        StyleEditor: {
+            subheaders: {
+                pointTab: 'Ponctuelle',
+                lineTab: 'Linéaire',
+                areaTab: 'Surfacique'
+            },
+            fill: {
+                color: 'Couleur de remplissage',
+                area: {
+                    pattern: 'Motif de remplissage'
+                }
+            },
+            image: {
+                shape: 'Icône',
+                size: 'Taille',
+                fill: {
+                    color: 'Couleur'
+                }
+            },
+            stroke: {
+                color: 'Couleur',
+                lineCap: 'Extrémités de ligne',
+                lineDash: 'Tiret',
+                lineJoin: 'Coins',
+                width: 'Largeur',
+                area: {
+                    color: 'Couleur de ligne',
+                    lineDash: 'Trait pointillé',
+                    lineJoin: 'Coins de ligne',
+                    width: 'Largeur de ligne'
+                }
+            }
+        },
+        FileInput: {
+            drag: 'Faites glisser {files, plural, one {un fichier} other {fichiers}} ici ou sélectionnez en naviguant.',
+            noFiles: 'Aucun fichier sélectionné.',
+            error: {
+                invalidType: 'Le format de fichier n\'est pas autorisé.',
+                allowedExtensions: 'Extensions de fichier autorisées: {allowedExtensions}.',
+                multipleNotAllowed: 'On autorise uniquement un fichier unique pour le téléchargement.',
+                fileSize: 'Le fichier sélectionné est trop volumineux. Sa taille maximale doit être de {size, number} Mo.'
+            }
+        },
+        Spin: {
+            loading: 'Chargement en cours...'
+        }
+        
+    }
+});

--- a/bundles/framework/oskariui/resources/locale/is.js
+++ b/bundles/framework/oskariui/resources/locale/is.js
@@ -1,0 +1,52 @@
+Oskari.registerLocalization({
+    lang: 'is',
+    key: 'oskariui',
+    value: {
+        buttons: {
+            add: 'Bæta við',
+            cancel: 'Hætta við',
+            close: 'Loka',
+            delete: 'Eyða',
+            edit: 'Breyta',
+            save: 'Vista',
+            yes: 'Já',
+            no: 'Nei'
+        },
+        StyleEditor: {
+            subheaders: {
+                pointTab: 'Punkti',
+                lineTab: 'Línu',
+                areaTab: 'Fláka'
+            },
+            fill: {
+                color: 'Fylla lit',
+                area: {
+                    pattern: 'Fylla mynstur'
+                }
+            },
+            image: {
+                shape: 'Tákn',
+                size: 'Stærð',
+                fill: {
+                    color: 'Litur'
+                }
+            },
+            stroke: {
+                color: 'Litur',
+                lineCap: 'Endingar',
+                lineDash: 'Dash',
+                lineJoin: 'Horn',
+                width: 'Breidd',
+                area: {
+                    color: 'Litur á línu',
+                    lineDash: 'Brotin lína',
+                    lineJoin: 'Hornlínur',
+                    width: 'Línubreidd'
+                }
+            }
+        },
+        Spin: {
+            loading: 'Hleður...'
+        }
+    }
+});

--- a/bundles/framework/oskariui/resources/locale/ru.js
+++ b/bundles/framework/oskariui/resources/locale/ru.js
@@ -1,0 +1,63 @@
+Oskari.registerLocalization({
+    lang: 'ru',
+    key: 'oskariui',
+    value: {
+        buttons: {
+            add: 'Добавить',
+            cancel: 'Отменить',
+            close: 'Закрыть',
+            delete: 'Удалить',
+            edit: 'Редактировать',
+            save: 'Сохранить',
+            yes: 'Да',
+            no: 'Нет'
+        },
+        table: {
+            sort: {
+                desc: 'Сортировать по убыванию',
+                asc: 'Сортировать по возрастанию'
+            }
+        },
+        StyleEditor: {
+            subheaders: {},
+            fill: {
+                color: 'Цвет заливки',
+                area: {
+                    pattern: 'Образец заливки'
+                }
+            },
+            image: {
+                shape: 'Иконка',
+                size: 'Размер',
+                fill: {
+                    color: 'Цвет'
+                }
+            },
+            stroke: {
+                color: 'Цвет',
+                lineCap: 'Окончания',
+                lineDash: 'Тире',
+                lineJoin: 'Углы',
+                width: 'Ширина',
+                area: {
+                    color: 'Цвет линии',
+                    lineDash: 'Линии, черточки',
+                    lineJoin: 'Углы линии',
+                    width: 'Ширина линии'
+                }
+            }
+        },
+        FileInput: {
+            drag: 'Перетащить {maxCount, plural, one {файл} other {файлы}} сюда или ыбрать путем просмотра.',
+            noFiles: 'Файл не выбран.',
+            error: {
+                invalidType: 'Формат файла не разрешен.',
+                multipleNotAllowed: 'Разрешается загружать только один файл.',
+                fileSize: 'Выбранный файл слишком велик. Файл не может превышать {maxSize, number} Мб'
+            }
+        },
+        Spin: {
+            loading: 'Загрузка...'
+        }
+    }
+});

--- a/bundles/framework/oskariui/resources/locale/sv.js
+++ b/bundles/framework/oskariui/resources/locale/sv.js
@@ -2,6 +2,16 @@ Oskari.registerLocalization({
     lang: 'sv',
     key: 'oskariui',
     value: {
+        buttons: {
+            add: 'Lägg till',
+            cancel: 'Avbryt',
+            close: 'Stäng',
+            delete: 'Ta bort',
+            edit: 'Redigera',
+            save: 'Spara',
+            yes: 'Ja',
+            no: 'Nej'
+        },
         error: {
             generic: 'Something went wrong'
         },

--- a/src/react/components/LocalizationComponent.jsx
+++ b/src/react/components/LocalizationComponent.jsx
@@ -154,10 +154,10 @@ export const LocalizationComponent = ({
         });
 
         return (
-            <React.Fragment key={`${lang}_${index}`}>
+            <div className={`t_localization-${lang}`} key={`${lang}_${index}`}>
                 {addDivider && renderDivider(lang)}
                 {nodes}
-            </React.Fragment>
+            </div>
         );
     });
     if (localizedElements.length === 1 || !collapse) {

--- a/src/react/components/buttons/PrimaryButton.jsx
+++ b/src/react/components/buttons/PrimaryButton.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Message } from 'oskari-ui';
+
+export const PrimaryButton = ({ type, ...other }) => (
+    <Button type='primary' className={`t_button_${type}`} {...other}>
+        <Message bundleKey='oskariui' messageKey={`buttons.${type}`}/>
+    </Button>
+);
+
+PrimaryButton.propTypes = {
+    type: PropTypes.oneOf(['add', 'close', 'delete', 'edit', 'save', 'yes']),
+};

--- a/src/react/components/buttons/SecondaryButton.jsx
+++ b/src/react/components/buttons/SecondaryButton.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Message } from 'oskari-ui';
+
+export const SecondaryButton = ({ type, ...other }) => (
+    <Button className={`t_button_${type}`} {...other}>
+        <Message bundleKey='oskariui' messageKey={`buttons.${type}`}/>
+    </Button>
+);
+
+SecondaryButton.propTypes = {
+    type: PropTypes.oneOf(['close', 'no', 'cancel']),
+};

--- a/src/react/components/buttons/index.js
+++ b/src/react/components/buttons/index.js
@@ -1,0 +1,2 @@
+export { PrimaryButton } from './PrimaryButton';
+export { SecondaryButton } from './SecondaryButton';

--- a/src/react/components/window/Flyout.jsx
+++ b/src/react/components/window/Flyout.jsx
@@ -55,9 +55,10 @@ const ToolsContainer = styled.div`
 `;
 
 
-export const Flyout = ({title = '', children, onClose, bringToTop}) => {
+export const Flyout = ({title = '', children, onClose, bringToTop, options = {}}) => {
     const [position, setPosition] = useState({ x: 210, y: 30 });
     const elementRef = useRef();
+    const containerClass = options.id ? `t_flyout t_${options.id}` : 't_flyout'
     const onMouseDown = useCallback(() => {
         if (typeof bringToTop === 'function') {
             bringToTop();
@@ -73,7 +74,7 @@ export const Flyout = ({title = '', children, onClose, bringToTop}) => {
         <div className="oskari-flyouttool-restore"></div>
     Maybe allow passing tools from caller?
     */
-    return (<Container ref={elementRef} style={{transform: `translate(${position.x}px, ${position.y}px)`}}>
+    return (<Container className={containerClass} ref={elementRef} style={{transform: `translate(${position.x}px, ${position.y}px)`}}>
         <FlyoutHeader className="oskari-flyouttoolbar" onMouseDown={onMouseDown} onTouchStart={onMouseDown}>
             <HeaderBand />
             <Title>{title}</Title>
@@ -91,5 +92,6 @@ Flyout.propTypes = {
     children: PropTypes.any,
     title: PropTypes.string,
     onClose: PropTypes.func.isRequired,
-    bringToTop: PropTypes.func
+    bringToTop: PropTypes.func,
+    options: PropTypes.object
 };

--- a/src/react/components/window/Popup.jsx
+++ b/src/react/components/window/Popup.jsx
@@ -64,13 +64,14 @@ const ToolsContainer = styled.div`
 `;
 
 
-export const Popup = ({title = '', children, onClose, bringToTop, opts = {}}) => {
+export const Popup = ({title = '', children, onClose, bringToTop, options = {}}) => {
     // hide before we can calculate centering coordinates
     const [position, setPosition] = useState({ x: -10000, y: 0, centered: false });
     const containerProps = {
         style: {
             transform: `translate(${position.x}px, ${position.y}px)`
-        }
+        },
+        className: options.id ? `t_popup t_${options.id}` : 't_popup'
     };
     const elementRef = useRef();
     const headerProps = {};
@@ -78,7 +79,7 @@ export const Popup = ({title = '', children, onClose, bringToTop, opts = {}}) =>
     if (typeof bringToTop === 'function') {
         headerFuncs.push(bringToTop);
     }
-    if (opts.isDraggable === true) {
+    if (options.isDraggable === true) {
         containerProps.ref = elementRef;
         headerFuncs.push(useCallback(() => createDraggable(position, setPosition, elementRef), [position, setPosition, elementRef]));
     }
@@ -140,5 +141,6 @@ Popup.propTypes = {
     children: PropTypes.any,
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     onClose: PropTypes.func.isRequired,
-    bringToTop: PropTypes.func
+    bringToTop: PropTypes.func,
+    options: PropTypes.object
 };

--- a/src/react/components/window/index.js
+++ b/src/react/components/window/index.js
@@ -6,6 +6,9 @@ import { Popup } from './Popup';
 /* ************************************************
  * Note! The API is not finalized and can change unexpectedly!!
  * ************************************************ */
+const DEFAULT_POPUP_OPTIONS = {
+    isDraggable: true
+};
 
 /**
  * Creates a root element to render a flyout/popup window into
@@ -71,15 +74,17 @@ const createBringToTop = (element) => {
  * @param {String} title title for flyout
  * @param {String|ReactElement} content content for flyout
  * @param {Function} onClose callback that is called when the window closes
+ * @param {Object} options (optional) to override default options
  * @returns {Object} that provides functions that can be used to close/update the flyout
  */
-export const showPopup = (title, content, onClose) => {
+export const showPopup = (title, content, onClose, options = {}) => {
     const element = createTmpContainer();
     const removeWindow = createRemoveFn(element, onClose);
     const bringToTop = createBringToTop(element);
+    const opts = {...DEFAULT_POPUP_OPTIONS, ...options };
     const render = (title, content) => {
         ReactDOM.render(
-            <Popup title={title} onClose={removeWindow} bringToTop={bringToTop} opts={{isDraggable: true}}>
+            <Popup title={title} onClose={removeWindow} bringToTop={bringToTop} options={opts}>
                 {content}
             </Popup>, element);
     };
@@ -110,15 +115,16 @@ export const showPopup = (title, content, onClose) => {
  * @param {String} title title for flyout
  * @param {String|ReactElement} content content for flyout
  * @param {Function} onClose callback that is called when the window closes
+ * @param {Object} options (optional) to override default options
  * @returns {Object} that provides functions that can be used to close/update the flyout
  */
-export const showFlyout = (title, content, onClose) => {
+export const showFlyout = (title, content, onClose, options = {}) => {
     const element = createTmpContainer();
     const removeWindow = createRemoveFn(element, onClose);
     const bringToTop = createBringToTop(element);
     const render = (title, content) => {
         ReactDOM.render(
-            <Flyout title={title} onClose={removeWindow} bringToTop={bringToTop}>
+            <Flyout title={title} onClose={removeWindow} bringToTop={bringToTop} options={options}>
                 {content}
             </Flyout>, element);
     };


### PR DESCRIPTION
Labeled buttons added to oskariui to import buttons without need to copy localization to implementing bundle.  Added Primary and Secondary action buttons for now (close can be both). Buttons doesn't allow to pass children and type but other props are allowed.  

Copied some localization from divmanazer to oskariui and added fr,is,ru.

Added 't_'-prefixed class names for popup and flyout and t_localization-[lang] to divide LocalizationComponent inputs.