### PR TITLE
Accept name in addition to id for layer identification from WMTS capabilities

### DIFF
--- a/bundles/mapping/mapwmts/service/WmtsLayerService.ol.js
+++ b/bundles/mapping/mapwmts/service/WmtsLayerService.ol.js
@@ -154,7 +154,7 @@ Oskari.clazz.define('Oskari.mapframework.wmts.service.WMTSLayerService', functio
         return {
             Contents: {
                 Layer: [{
-                    Identifier: layerCapabilities.id,
+                    Identifier: layerCapabilities.id || layerCapabilities.name,
                     TileMatrixSetLink: [{
                         TileMatrixSet: tileMatrixSet.identifier
                     }],


### PR DESCRIPTION
In preparation for upcoming server-side capabilities rewrite. The layer `id` will be under the `name` key on layer.capabilities and the value should match `layer.name`.