### PR TITLE
Oskariui primary button types and other small changes

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/LayerBox.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/LayerBox.jsx
@@ -67,12 +67,12 @@ const LayerBox = ({ layer, index, visibilityInfo, controller }) => {
                                             : <EyeShut onClick={handleToggleVisibility} />}
                                     </ColAuto>
                                     <Col>
-                                        <Row style={{ padding: '0px' }}>
-                                            <ColAuto style={{ padding: '0px' }}>
+                                        <Row style={{ padding: '0px', flexWrap: 'nowrap' }}>
+                                            <ColAuto style={{ padding: '0px', flexShrink: 1 }}>
                                                 {getName()}<br/>
                                                 {organizationName}
                                             </ColAuto>
-                                            <ColAutoRight style={{ padding: '0px' }}>
+                                            <ColAutoRight style={{ padding: '0px', alignSelf: 'flex-end' }}>
                                                 {publishable &&
                                                 <Fragment>
                                                     <br/>

--- a/bundles/framework/myplacesimport/service/MyPlacesImportService.js
+++ b/bundles/framework/myplacesimport/service/MyPlacesImportService.js
@@ -10,8 +10,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
     this.urls.create = Oskari.urls.getRoute('CreateUserLayer', { srs: srsName });
     this.urls.get = Oskari.urls.getRoute('GetUserLayers', { srs: srsName });
     this.urls.edit = Oskari.urls.getRoute('EditUserLayer');
-    // negative value for group id means that admin isn't presented with tools for it
-    this.groupId = -1 * Oskari.getSeq('usergeneratedGroup').nextVal();
+    // negative value for group id means that admin isn't presented with tools for it (-1 is reserved for default group)
+    this.groupId = -10 * Oskari.getSeq('usergeneratedGroup').nextVal();
 }, {
     __name: 'MyPlacesImport.MyPlacesImportService',
     __qname: 'Oskari.mapframework.bundle.myplacesimport.MyPlacesImportService',

--- a/bundles/framework/oskariui/resources/locale/en.js
+++ b/bundles/framework/oskariui/resources/locale/en.js
@@ -9,6 +9,8 @@ Oskari.registerLocalization({
             delete: 'Delete',
             edit: 'Edit',
             save: 'Save',
+            submit: 'Submit',
+            import: 'Import',
             yes: 'Yes',
             no: 'No'
         },

--- a/bundles/framework/oskariui/resources/locale/fi.js
+++ b/bundles/framework/oskariui/resources/locale/fi.js
@@ -9,6 +9,8 @@ Oskari.registerLocalization({
             delete: 'Poista',
             edit: 'Muokkaa',
             save: 'Tallenna',
+            submit: 'Lähetä',
+            import: 'Tuo',
             yes: 'Kyllä',
             no: 'Ei'
         },

--- a/bundles/framework/oskariui/resources/locale/fr.js
+++ b/bundles/framework/oskariui/resources/locale/fr.js
@@ -9,6 +9,7 @@ Oskari.registerLocalization({
             delete: 'Supprimer',
             edit: 'Modifier',
             save: 'Enregistrer',
+            submit: 'Envoyer',
             yes: 'Oui',
             no: 'Non'
         },

--- a/bundles/framework/oskariui/resources/locale/is.js
+++ b/bundles/framework/oskariui/resources/locale/is.js
@@ -9,6 +9,7 @@ Oskari.registerLocalization({
             delete: 'Eyða',
             edit: 'Breyta',
             save: 'Vista',
+            submit: 'Senda',
             yes: 'Já',
             no: 'Nei'
         },

--- a/bundles/framework/oskariui/resources/locale/sv.js
+++ b/bundles/framework/oskariui/resources/locale/sv.js
@@ -9,6 +9,8 @@ Oskari.registerLocalization({
             delete: 'Ta bort',
             edit: 'Redigera',
             save: 'Spara',
+            submit: 'Skicka',
+            import: 'Importera',
             yes: 'Ja',
             no: 'Nej'
         },

--- a/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
+++ b/bundles/mapping/mapmyplaces/domain/MyPlacesLayerModelBuilder.js
@@ -27,8 +27,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmyplaces.domain.MyPlacesLayer
                 layer.setOrganizationName(loclayer.organization);
             }
             if (!this.groupId) {
-                // negative value for group id means that admin isn't presented with tools for it
-                this.groupId = -1 * Oskari.getSeq('usergeneratedGroup').nextVal();
+                // negative value for group id means that admin isn't presented with tools for it (-1 is reserved for default group)
+                this.groupId = -10 * Oskari.getSeq('usergeneratedGroup').nextVal();
                 const mapLayerGroup = maplayerService.findLayerGroupById(this.groupId);
                 if (!mapLayerGroup) {
                     const group = {

--- a/src/react/components/FileInput.jsx
+++ b/src/react/components/FileInput.jsx
@@ -31,7 +31,6 @@ const HiddenFileInput = styled('input')`
     display: none;
 `;
 const StyledFileList = styled('div')`
-    display: inline-block;
     padding: 0px 12px;
     margin-top: 8px;
 `;
@@ -42,6 +41,7 @@ const StyledUploadIcon = styled(CloudUploadOutlined)`
 const StyledListItem = styled('span')`
     white-space: nowrap;
     padding-left: 5px;
+    display: inline-block;
 `;
 const StyledName = styled('span')`
     color: #40a9ff;
@@ -62,9 +62,10 @@ export const FileInput = ({
     multiple=true,
     tooltip,
     allowedTypes = [],
-    maxSize = MAX_SIZE
+    maxSize = MAX_SIZE,
+    files = []
 }) => {
-    const [currentFiles, setFiles] = useState([]);
+    const [currentFiles, setFiles] = useState(files);
     const maxCount = multiple ? MAX_COUNT : 1;
 
     const onDrop = event => {

--- a/src/react/components/buttons/PrimaryButton.jsx
+++ b/src/react/components/buttons/PrimaryButton.jsx
@@ -9,5 +9,5 @@ export const PrimaryButton = ({ type, ...other }) => (
 );
 
 PrimaryButton.propTypes = {
-    type: PropTypes.oneOf(['add', 'close', 'delete', 'edit', 'save', 'yes']),
+    type: PropTypes.oneOf(['add', 'close', 'delete', 'edit', 'save', 'yes', 'submit', 'import']),
 };


### PR DESCRIPTION
Add submit and import to PrimaryButton's supported types. Fix FileInput file list styling and allow to init files via props. Change myplaces and userlayer use -10 multiplier to generate group id because -1 group is handled as default group and ignored by layerlist. Fixes issue that layerlist didn't list/show userlayers (or myplaces if it's added before userlayer group). Not sure if this should be fixed by removing default group handling but didn't know what default group's idea is so made this quick fix. Added some css to layerlist's layerbox to avoid long layer or organization name to push 'publishable' tag to new row.