### PR TITLE
Markers react

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -168,6 +168,7 @@ Oskari.clazz.define(
 
         // mapcontrols assumes this to be present before init or start
         me._localization = null;
+        this._loc = Oskari.getMsg.bind(null, 'MapModule');
 
         me._defaultMarker = {
             shape: 2,
@@ -1755,6 +1756,13 @@ Oskari.clazz.define(
                 return this._localization[key];
             }
             return this._localization;
+        },
+        getPluginMsg: function (plugin, path, args) {
+            // return whole Object if path isn't given
+            if (!path) {
+                return this._loc(`plugin.${plugin}`);
+            }
+            return this._loc(`plugin.${plugin}.${path}`, args);
         },
         /**
          * @method onEvent

--- a/bundles/mapping/mapmodule/oskariStyle/generator.ol.js
+++ b/bundles/mapping/mapmodule/oskariStyle/generator.ol.js
@@ -470,6 +470,7 @@ const getImageStyle = (mapModule, styleDef, requestedStyle) => {
             anchorYUnits: 'pixels',
             anchorXUnits: 'pixels',
             anchorOrigin: 'bottom-left',
+            size: [size, size],
             anchor: [offsetX, offsetY],
             opacity
         };

--- a/bundles/mapping/mapmodule/plugin/AbstractMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/AbstractMapModulePlugin.js
@@ -78,6 +78,9 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.AbstractMapModulePlugin',
                 }
             }
         },
+        getMsg: function (path, args) {
+            return this.getMapModule().getPluginMsg(this._name, path, args);
+        },
         /**
          * Returns path to image resources
          * @param fileName

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersForm.jsx
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersForm.jsx
@@ -5,7 +5,7 @@ import { showPopup } from 'oskari-ui/components/window';
 import { Message, TextInput, Tooltip, Divider } from 'oskari-ui';
 import { SecondaryButton, PrimaryButton, ButtonContainer } from 'oskari-ui/components/buttons';
 import { StyleEditor } from 'oskari-ui/components/StyleEditor';
-import { PLUGIN_NAME, BUNDLE_KEY, DEFAULT_STYLE } from './constants';
+import { PLUGIN_NAME, BUNDLE_KEY, DEFAULT_STYLE, STYLE_TYPE } from './constants';
 
 const Content = styled('div')`
     padding: 24px;
@@ -43,7 +43,7 @@ const Form = ({ onAdd, onClose }) => {
             <StyleEditor
                 oskariStyle={state.style}
                 onChange={ updateStyle }
-                tabs = {['point']}
+                tabs = {[STYLE_TYPE]}
             />
             <ButtonContainer>
                 <SecondaryButton type='close' onClick={onClose}/>

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersForm.jsx
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersForm.jsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { showPopup } from 'oskari-ui/components/window';
+import { Message, TextInput, Tooltip, Divider } from 'oskari-ui';
+import { SecondaryButton, PrimaryButton, ButtonContainer } from 'oskari-ui/components/buttons';
+import { StyleEditor } from 'oskari-ui/components/StyleEditor';
+import { PLUGIN_NAME, BUNDLE_KEY, DEFAULT_STYLE } from './constants';
+
+const Content = styled('div')`
+    padding: 24px;
+    width: 400px;
+`;
+
+const getMessage = path => <Message messageKey={ `plugin.${PLUGIN_NAME}.${path}` } bundleKey={BUNDLE_KEY} />;
+
+const updateTextStyle = (style, msg) => {
+    style.text.offsetX = 8 + 2 * style.image.size;
+    style.text.textLabel = msg;
+};
+
+const Form = ({ onAdd, onClose }) => {
+    const [state, setState] = useState({
+        style: DEFAULT_STYLE,
+        msg: ''
+    });
+
+    const updateStyle = (style) => setState({ ...state, style: updateTextStyle(style, state.msg) });
+    const updateMsg = (msg) => setState({ ...state, msg });
+
+    return (
+        <Content>
+            <Tooltip title={getMessage('form.message.label')}>
+                <TextInput
+                    placeholder={ Oskari.getMsg(BUNDLE_KEY, `plugin.${PLUGIN_NAME}.form.message.label`) }
+                    value={ state.text }
+                    onChange={ (event) => updateMsg(event.target.value) }
+                />
+            </Tooltip>
+            <Divider orientation="left">{getMessage('form.style')}</Divider>
+            <StyleEditor
+                oskariStyle={state.style}
+                onChange={ updateStyle }
+                tabs = {['point']}
+            />
+            <ButtonContainer>
+                <SecondaryButton type='close' onClick={onClose}/>
+                <PrimaryButton type='add' onClick={() => onAdd(state) }/>
+            </ButtonContainer>
+        </Content>
+    );
+};
+Form.propTypes = {
+    onAdd: PropTypes.func.isRequired,
+    onClose: PropTypes.func.isRequired
+};
+export const showAddMarkerPopup = (onAdd, onClose) => {
+    const content = (
+        <Form onAdd= { onAdd } onClose={ onClose }/>
+    );
+    return showPopup(getMessage('title'), content, onClose, { id: PLUGIN_NAME });
+};

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersForm.jsx
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersForm.jsx
@@ -14,9 +14,11 @@ const Content = styled('div')`
 
 const getMessage = path => <Message messageKey={ `plugin.${PLUGIN_NAME}.${path}` } bundleKey={BUNDLE_KEY} />;
 
-const updateTextStyle = (style, msg) => {
+const getMarkerStyle = state => {
+    const style = { ...state.style };
     style.text.offsetX = 8 + 2 * style.image.size;
-    style.text.textLabel = msg;
+    style.text.labelText = Oskari.util.sanitize(state.msg);
+    return style;
 };
 
 const Form = ({ onAdd, onClose }) => {
@@ -25,7 +27,7 @@ const Form = ({ onAdd, onClose }) => {
         msg: ''
     });
 
-    const updateStyle = (style) => setState({ ...state, style: updateTextStyle(style, state.msg) });
+    const updateStyle = (style) => setState({ ...state, style });
     const updateMsg = (msg) => setState({ ...state, msg });
 
     return (
@@ -45,7 +47,7 @@ const Form = ({ onAdd, onClose }) => {
             />
             <ButtonContainer>
                 <SecondaryButton type='close' onClick={onClose}/>
-                <PrimaryButton type='add' onClick={() => onAdd(state) }/>
+                <PrimaryButton type='add' onClick={() => onAdd(getMarkerStyle(state)) }/>
             </ButtonContainer>
         </Content>
     );

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
@@ -132,15 +132,6 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
             this._registerTools();
         },
         /**
-         * Creates a marker layer
-         * @private
-         */
-        _createMapMarkerLayer: function () {
-            const markerLayer = new olLayerVector({ title: 'Markers', source: new olSourceVector() });
-            this.getMap().addLayer(markerLayer);
-            return markerLayer;
-        },
-        /**
          * Handles generic map click
          * @private
          * @param  {Oskari.mapframework.bundle.mapmodule.event.MapClickedEvent} event map click
@@ -180,7 +171,8 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
         },
         getMarkersLayer: function () {
             if (!this._layer) {
-                this._layer = this._createMapMarkerLayer();
+                this._layer = new olLayerVector({ title: 'Markers', source: new olSourceVector() });
+                this.getMap().addLayer(this._layer);
             }
             return this._layer;
         },

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
@@ -353,32 +353,21 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
          * @param  {String} id  optional marker id for marker to change it's visibility, all markers visibility changed if not given.
          */
         changeMapMarkerVisibility: function (visible, id) {
-            const layerSource = this.getMarkersLayer().getSource();
-            if (id) {
-                if (visible) {
-                    const feature = this._hiddenMarkers[id];
-                    layerSource.addFeature(feature);
-                    delete this._hiddenMarkers[id];
-                } else {
-                    const feature = layerSource.getFeatureById(id);
-                    this._hiddenMarkers[id] = feature;
-                    layerSource.removeFeature(feature);
-                }
+            if (!id) {
+                this.getMarkersLayer().setVisible(visible);
                 return;
             }
-
+            const layerSource = this.getMarkersLayer().getSource();
             if (visible) {
-                const features = Object.values(this._hiddenMarkers);
-                layerSource.addFeatures(features);
-                this._hiddenMarkers = {};
+                const feature = this._hiddenMarkers[id];
+                layerSource.addFeature(feature);
+                delete this._hiddenMarkers[id];
             } else {
-                layerSource.forEachFeature(feat => {
-                    this._hiddenMarkers[feat.getId()] = feat;
-                });
-                this.layerSource.clear();
+                const feature = layerSource.getFeatureById(id);
+                this._hiddenMarkers[id] = feature;
+                layerSource.removeFeature(feature);
             }
         },
-
         /**
          * Raises the marker layer above the other layers
          *
@@ -500,6 +489,9 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
          * @return {Object} bundle state as JSON
          */
         getState: function () {
+            if (!this.getMarkersLayer().isVisible()) {
+                return {};
+            }
             const markers = this.getMarkersLayer().getSource().getFeatures()
                 .map(feat => this._featureToMarkerData(feat))
                 .filter(markerData => !markerData.transient);

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
@@ -345,7 +345,9 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
 
             if (layerSource.hasFeature(feature)) {
                 // ol doesn't add features with same id, update existing
-                layerSource.getFeatureById(id).setGeometry(new olGeom.Point(coord));
+                const existing = layerSource.getFeatureById(id);
+                existing.setGeometry(new olGeom.Point(coord));
+                existing.setStyle(olStyle);
             } else {
                 layerSource.addFeature(feature);
             }

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
@@ -123,7 +123,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
             this.buttons = {
                 addMarker: {
                     iconCls: 'marker-share',
-                    tooltip: this.getMsg('buttons.add'),
+                    tooltip: this.getMsg('tooltip'),
                     sticky: true,
                     callback: () => this.startMarkerAdd()
                 }
@@ -231,9 +231,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
                 this.getMsg('dialog.message'),
                 [clearBtn, closeBtn]
             );
-            this.getMapModule().getMapEl().addClass(
-                'cursor-crosshair'
-            );
+            this.getMapModule().setCursorStyle('crosshair');
             this.dialog.moveTo(
                 '#toolbar div.toolrow[tbgroup=default-selectiontools]',
                 'bottom'
@@ -249,7 +247,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
                 this.dialog.close(true);
             }
             this.popupCleanup();
-            this.getMapModule().getMapEl().removeClass('cursor-crosshair');
+            this.getMapModule().setCursorStyle('');
             if (!selectDefault) {
                 return;
             }

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
@@ -269,7 +269,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
             // Remove null values to get defaults
             Object.keys(markerData).forEach(key => markerData[key] === null && delete markerData[key]);
 
-            if (markerData.color.charAt(0) === '#') {
+            if (markerData.color && markerData.color.charAt(0) === '#') {
                 markerData.color = markerData.color.substring(1);
             }
 
@@ -337,11 +337,12 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
             feature.setStyle(olStyle);
 
             if (layerSource.hasFeature(feature)) {
-                // if layer has marker with same id remove feature to add with new data
-                layerSource.removeFeature(feature);
+                // ol doesn't add features with same id, update existing
+                layerSource.getFeatureById(id).setGeometry(new olGeom.Point(coord));
+            } else {
+                layerSource.addFeature(feature);
             }
 
-            layerSource.addFeature(feature);
             this.raiseMarkerLayer();
             const data = this._featureToMarkerData(feature);
             const addEvent = Oskari.eventBuilder('AfterAddMarkerEvent')(data, id);

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.test.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.test.js
@@ -4,6 +4,7 @@ import './MarkersPlugin.ol';
 // mapmodule
 import '../../mapmodule.ol';
 import '../../resources/locale/en.js';
+import { DEFAULT_DATA } from './constants';
 
 // for mapmodule
 // defaults from mapfull
@@ -25,9 +26,6 @@ sandbox.registerService(layerService);
 
 const mapModule = Oskari.clazz.create('Oskari.mapframework.ui.module.common.MapModule', 'Test');
 
-// override impl that uses require() as it doesn't work out-of-the-box with Jest
-mapModule.getImageUrl = () => '/testing';
-
 Oskari.setMarkers(getMarkers());
 sandbox.register(mapModule);
 mapModule.registerPlugin(plugin);
@@ -38,16 +36,32 @@ afterAll(() => {
     mapModule.stop();
 });
 
+const getImageStyle = id => plugin.getMarkersLayer().getSource().getFeatureById(id).getStyle()[0].getImage();
+const getTextOnMap = id => plugin.getMarkersLayer().getSource().getFeatureById(id).getStyle()[0].getText().getText();
+
 const markers = [{
     x: 1,
     y: 1
 }, {
     x: 100,
     y: 200
+}, {
+    x: 3,
+    y: 3,
+    color: '#ff0000',
+    shape: 3,
+    size: 3,
+    msg: 'test?'
+}, {
+    x: 4,
+    y: 4,
+    shape: 'image_url',
+    size: 40,
+    transient: true,
+    offsetX: 12,
+    offsetY: 8
 }];
-// addMapMarker(markerData, id, suppressEvent)
-// getStateParameters()
-// changeMapMarkerVisibility(visible, markerId)
+
 describe('MarkersPlugin', () => {
     describe('getStateParameters', () => {
         test('without markers', () => {
@@ -85,6 +99,80 @@ describe('MarkersPlugin', () => {
             plugin.changeMapMarkerVisibility(true, 'my marker');
             // looks like marker order is changed when toggling visibility. Probably not a problem but something to note
             expect(plugin.getStateParameters()).toEqual('&markers=2|1|ffde00|1_1|___2|1|ffde00|100_200|');
+            // hide all
+            expect(plugin.getMarkersLayer().getVisible()).toBe(true);
+            plugin.changeMapMarkerVisibility(false);
+            expect(plugin.getStateParameters()).toEqual('');
+            expect(plugin.getMarkersLayer().getVisible()).toBe(false);
+        });
+        afterAll(() => {
+            // remove markers to normalize state for other tests
+            plugin.removeMarkers();
+            plugin.changeMapMarkerVisibility(true);
+        });
+    });
+    describe('getSanitizedMarker', () => {
+        test('without markers', () => {
+            expect(plugin.getState().markers.length).toEqual(0);
+        });
+        test('sanitized data', () => {
+            const marker = markers[2];
+            plugin.addMapMarker(marker);
+            const markerData = plugin.getState().markers[0];
+            Object.keys(marker).forEach(key => {
+                let value = marker[key];
+                if (key === 'color') {
+                    // sanitize removes #
+                    value = value.substring(1);
+                }
+                expect(markerData[key]).toEqual(value);
+            });
+        });
+        test('default data', () => {
+            plugin.addMapMarker(markers[1]);
+            const markerData = plugin.getState().markers[1];
+            Object.keys(DEFAULT_DATA).forEach(key => {
+                expect(markerData[key]).toEqual(DEFAULT_DATA[key]);
+            });
+        });
+        test('setState', () => {
+            const state = plugin.getState();
+            plugin.removeMarkers();
+            expect(plugin.getStateParameters()).toEqual('');
+            plugin.setState(state);
+            expect(plugin.getStateParameters()).toEqual('&markers=3|3|ff0000|3_3|test%3F___2|1|ffde00|100_200|');
+        });
+        test('transient', () => {
+            expect(plugin.getState().markers.length).toEqual(2);
+            plugin.addMapMarker(markers[3]);
+            expect(plugin.getState().markers.length).toEqual(2);
+        });
+
+        afterAll(() => {
+            // remove markers to normalize state for other tests
+            plugin.removeMarkers();
+        });
+    });
+    describe('rendered style', () => {
+        test('oskari marker', () => {
+            const id = 'marker1';
+            const marker = markers[2];
+            plugin.addMapMarker(marker, id);
+            expect(getTextOnMap(id)).toEqual(marker.msg);
+            const style = getImageStyle(id);
+            const sizePx = mapModule.getPixelForSize(marker.size);
+            expect(style.getSize()).toEqual([sizePx, sizePx]);
+        });
+        test('external', () => {
+            const id = 'marker2';
+            const marker = markers[3];
+            plugin.addMapMarker(marker, id);
+            const style = getImageStyle(id);
+            const { size, offsetX, offsetY, shape } = marker;
+            expect(style.getSrc()).toEqual(shape);
+            // looks like getter returns top-left anchor even it is set and stored as bottom-left
+            expect(style.getAnchor()).toEqual([offsetX, size - offsetY]);
+            expect(style.getSize()).toEqual([size, size]);
         });
         afterAll(() => {
             // remove markers to normalize state for other tests

--- a/bundles/mapping/mapmodule/plugin/markers/constants.js
+++ b/bundles/mapping/mapmodule/plugin/markers/constants.js
@@ -1,0 +1,71 @@
+export const ID_PREFIX = 'M_';
+export const TRANSIENT = false;
+export const BUNDLE_KEY = 'MapModule';
+export const PLUGIN_NAME = 'MarkersPlugin';
+export const TOOL_GROUP = 'selectiontools';
+export const STYLE_TYPE = 'point';
+// export const SVGIconUrl = 'data:image/svg+xml;base64,';
+
+// offsetX: 8 + 2 * size,
+export const DEFAULT_STYLE = {
+    image: {
+        shape: 2,
+        size: 1,
+        fill: {
+            color: '#ffde00'
+        }
+    },
+    text: {
+        font: 'bold 16px Arial',
+        textAlign: 'left',
+        textBaseline: 'middle',
+        offsetX: 8 + 2 * 1,
+        offsetY: 8,
+        fill: {
+            color: '#000000'
+        },
+        stroke: {
+            color: '#ffffff',
+            width: 3
+        }
+    }
+};
+
+export const DEFAULT_DATA = {
+    color: 'ffde00',
+    stroke: 'b4b4b4',
+    msg: '',
+    shape: 2,
+    size: 1,
+    transient: false
+};
+
+/*
+    me._font = {
+        name: 'dot-markers',
+        baseIndex: 57344
+    };
+    me._defaultData = {
+        x: 0,
+        y: 0,
+        color: 'ffde00',
+        stroke: 'b4b4b4',
+        msg: '',
+        shape: 2,
+        size: 1,
+        transient: false
+    }; 
+
+    me._strokeStyle = {
+        'stroke-width': 1,
+        'stroke': '#b4b4b4'
+    };
+
+          // Is SVG supported?
+            // DOMImplementation.hasFeature
+            // Deprecated This feature is no longer recommended
+            me._svg = document.implementation.hasFeature(
+                'http://www.w3.org/TR/SVG11/feature#Image',
+                '1.1'
+            );
+*/

--- a/bundles/mapping/mapmodule/plugin/markers/constants.js
+++ b/bundles/mapping/mapmodule/plugin/markers/constants.js
@@ -4,22 +4,34 @@ export const BUNDLE_KEY = 'MapModule';
 export const PLUGIN_NAME = 'MarkersPlugin';
 export const TOOL_GROUP = 'selectiontools';
 export const STYLE_TYPE = 'point';
-// export const SVGIconUrl = 'data:image/svg+xml;base64,';
 
-// offsetX: 8 + 2 * size,
+export const SEPARATORS = {
+    FIELD: '|',
+    MARKER: '___',
+    COORD: '_'
+};
+
+export const DEFAULT_DATA = {
+    color: 'ffde00',
+    msg: '',
+    shape: 2,
+    size: 1,
+    transient: false
+};
+
 export const DEFAULT_STYLE = {
     image: {
-        shape: 2,
-        size: 1,
+        shape: DEFAULT_DATA.shape,
+        size: DEFAULT_DATA.size,
         fill: {
-            color: '#ffde00'
+            color: '#' + DEFAULT_DATA.color
         }
     },
     text: {
         font: 'bold 16px Arial',
         textAlign: 'left',
         textBaseline: 'middle',
-        offsetX: 8 + 2 * 1,
+        offsetX: 8 + 2 * DEFAULT_DATA.size,
         offsetY: 8,
         fill: {
             color: '#000000'
@@ -30,42 +42,3 @@ export const DEFAULT_STYLE = {
         }
     }
 };
-
-export const DEFAULT_DATA = {
-    color: 'ffde00',
-    stroke: 'b4b4b4',
-    msg: '',
-    shape: 2,
-    size: 1,
-    transient: false
-};
-
-/*
-    me._font = {
-        name: 'dot-markers',
-        baseIndex: 57344
-    };
-    me._defaultData = {
-        x: 0,
-        y: 0,
-        color: 'ffde00',
-        stroke: 'b4b4b4',
-        msg: '',
-        shape: 2,
-        size: 1,
-        transient: false
-    }; 
-
-    me._strokeStyle = {
-        'stroke-width': 1,
-        'stroke': '#b4b4b4'
-    };
-
-          // Is SVG supported?
-            // DOMImplementation.hasFeature
-            // Deprecated This feature is no longer recommended
-            me._svg = document.implementation.hasFeature(
-                'http://www.w3.org/TR/SVG11/feature#Image',
-                '1.1'
-            );
-*/

--- a/bundles/mapping/mapmodule/plugin/markers/constants.js
+++ b/bundles/mapping/mapmodule/plugin/markers/constants.js
@@ -1,5 +1,4 @@
 export const ID_PREFIX = 'M_';
-export const TRANSIENT = false;
 export const BUNDLE_KEY = 'MapModule';
 export const PLUGIN_NAME = 'MarkersPlugin';
 export const TOOL_GROUP = 'selectiontools';

--- a/bundles/mapping/mapmodule/request/AddMarkerRequestHandler.js
+++ b/bundles/mapping/mapmodule/request/AddMarkerRequestHandler.js
@@ -17,7 +17,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.AddMarkerReque
         // Else format old data to new form and inform user about this
         else {
             this._log.warn('AddMarkerRequest data is in deprecated format. Modifying data format before processing request. Please check your request!');
-            var shape = null;
+            var shape;
             if (data.iconUrl) {
                 shape = data.iconUrl;
             } else if (data.shape && data.shape.data) {
@@ -35,8 +35,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.AddMarkerReque
                 stoke: data.stroke,
                 // Converted properties
                 shape: shape,
-                offsetX: (data.shape && data.shape.x && !isNaN(data.shape.x)) ? data.shape.x : null,
-                offsetY: (data.shape && data.shape.y && !isNaN(data.shape.y)) ? data.shape.y : null
+                offsetX: (data.shape && data.shape.x && !isNaN(data.shape.x)) ? data.shape.x : undefined,
+                offsetY: (data.shape && data.shape.y && !isNaN(data.shape.y)) ? data.shape.y : undefined
             };
         }
 

--- a/bundles/mapping/mapmodule/request/AddMarkerRequestHandler.js
+++ b/bundles/mapping/mapmodule/request/AddMarkerRequestHandler.js
@@ -16,7 +16,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.AddMarkerReque
         }
         // Else format old data to new form and inform user about this
         else {
-            this.sandbox.printWarn('AddMarkerRequest data is debricated format, formatted this to the new format before processing request. Please check your request!');
+            this._log.warn('AddMarkerRequest data is debricated format, formatted this to the new format before processing request. Please check your request!');
             var shape = null;
             if (data.iconUrl) {
                 shape = data.iconUrl;

--- a/bundles/mapping/mapmodule/request/AddMarkerRequestHandler.js
+++ b/bundles/mapping/mapmodule/request/AddMarkerRequestHandler.js
@@ -16,7 +16,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.AddMarkerReque
         }
         // Else format old data to new form and inform user about this
         else {
-            this._log.warn('AddMarkerRequest data is debricated format, formatted this to the new format before processing request. Please check your request!');
+            this._log.warn('AddMarkerRequest data is in deprecated format. Modifying data format before processing request. Please check your request!');
             var shape = null;
             if (data.iconUrl) {
                 shape = data.iconUrl;

--- a/bundles/mapping/mapmodule/request/RemoveMarkersRequestHandler.js
+++ b/bundles/mapping/mapmodule/request/RemoveMarkersRequestHandler.js
@@ -5,7 +5,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.RemoveMarkersR
 }, {
     handleRequest: function (core, request) {
         this._log.debug('Remove markers');
-        this.markersPlugin.removeMarkers(false, request.getId());
+        this.markersPlugin.removeMarkers(request.getId());
     }
 }, {
     protocol: ['Oskari.mapframework.core.RequestHandler']

--- a/bundles/mapping/mapmodule/resources/locale/en.js
+++ b/bundles/mapping/mapmodule/resources/locale/en.js
@@ -83,46 +83,29 @@ Oskari.registerLocalization(
                 }
             },
             "MarkersPlugin": {
-                "buttons": {
-                    "add": "Map marker",
-                    "clear": "Delete all markers"
-                },
+                "title": "Map Marker",
+                "tooltip": "Add map marker",
                 "form": {
-                    "title": "Map Marker Style",
-                    "tooltip": "Define a style for map markers.",
-                    "symbol": {
-                        "label": "Icon"
-                    },
-                    "size": {
-                        "label": "Size"
-                    },
-                    "color": {
-                        "label": "Colour",
-                        "labelOr": "or",
-                        "labelCustom": "Custom colour (RGB 0-255)"
-                    },
-                    "preview": {
-                        "label": "Preview"
-                    },
+                    "style": "Map Marker Style",
                     "message": {
-                        "label": "Text on map",
+                        "label": "Text on the map",
                         "hint": "Name or description"
                     }
                 },
                 "dialog": {
-                    "title": "Map Marker",
                     "message": "Select a new location for your map marker by clicking the map.",
-                    "error": {
-                        "title": "Error for getting location!",
-                        "timeout": "Getting a location takes longer than excepted...",
-                        "denied": "The site has blocked location. Please enable location and try again",
-                        "noLocation": "Failed to determine location",
-                        "close": "Close"
-                    }
+                    "clear": "Delete all markers"
                 }
             },
             "MyLocationPlugin": {
-                "tooltip": "Center map to your location"
+                "tooltip": "Center map to your location",
+                "error": {
+                    "title": "Error for getting location!",
+                    "timeout": "Getting a location takes longer than excepted...",
+                    "denied": "The site has blocked location. Please enable location and try again",
+                    "noLocation": "Failed to determine location",
+                    "close": "Close"
+                }
             },
             "PanButtonsPlugin": {
                 "center" : {

--- a/bundles/mapping/mapmodule/resources/locale/fi.js
+++ b/bundles/mapping/mapmodule/resources/locale/fi.js
@@ -82,12 +82,12 @@ Oskari.registerLocalization(
             },
             "MarkersPlugin": {
                 "title": "Karttamerkintä",
+                "tooltip": "Tee karttamerkintä",
                 "form": {
                     "style": "Karttamerkinnän esitystapa",
-                    "add": "Tee karttamerkintä",
                     "message": {
                         "label": "Teksti kartalla",
-                        "hint": "Nimi tai kuvaus",
+                        "hint": "Nimi tai kuvaus"
                     }
                 },
                 "dialog": {

--- a/bundles/mapping/mapmodule/resources/locale/fi.js
+++ b/bundles/mapping/mapmodule/resources/locale/fi.js
@@ -81,35 +81,18 @@ Oskari.registerLocalization(
                 }
             },
             "MarkersPlugin": {
-                "buttons": {
-                    "add": "Tee karttamerkintä.",
-                    "clear": "Poista kaikki merkinnät"
-                },
+                "title": "Karttamerkintä",
                 "form": {
-                    "title": "Karttamerkinnän esitystapa",
-                    "tooltip": "",
-                    "symbol": {
-                        "label": "Symboli"
-                    },
-                    "size": {
-                        "label": "Koko"
-                    },
-                    "color": {
-                        "label": "Väri",
-                        "labelOr": "tai",
-                        "labelCustom": "Oma RGB-väri (0-255)"
-                    },
-                    "preview": {
-                        "label": "Esikatselu"
-                    },
+                    "style": "Karttamerkinnän esitystapa",
+                    "add": "Tee karttamerkintä",
                     "message": {
                         "label": "Teksti kartalla",
-                        "hint": "Nimi tai kuvaus"
+                        "hint": "Nimi tai kuvaus",
                     }
                 },
                 "dialog": {
-                    "title": "Karttamerkintä",
-                    "message": "Valitse karttamerkinnälle uusi sijainti klikkaamalla pistettä kartalla."
+                    "message": "Valitse karttamerkinnälle uusi sijainti klikkaamalla pistettä kartalla.",
+                    "clear": "Poista kaikki merkinnät"
                 }
             },
             "MyLocationPlugin": {

--- a/bundles/mapping/mapmodule/resources/locale/sv.js
+++ b/bundles/mapping/mapmodule/resources/locale/sv.js
@@ -83,35 +83,18 @@ Oskari.registerLocalization(
                 }
             },
             "MarkersPlugin": {
-                "buttons": {
-                    "add": "Kartmarkör",
-                    "clear": "Ta bort alla markörer"
-                },
+                "title": "Kartmarkör",
+                "tooltip": "Kartmarkör",
                 "form": {
-                    "title": "Punktens stil",
-                    "tooltip": "",
-                    "symbol": {
-                        "label": "Ikon"
-                    },
-                    "size": {
-                        "label": "Storlek"
-                    },
-                    "color": {
-                        "label": "Färg",
-                        "labelOr": "eller",
-                        "labelCustom": "Egen färg (RGB 0-255)"
-                    },
-                    "preview": {
-                        "label": "Förhandsgranskning"
-                    },
+                    "style": "Punktens stil",
                     "message": {
                         "label": "Texten på kartan",
                         "hint": "Skriv ett meddelande"
                     }
                 },
                 "dialog": {
-                    "title": "Kartmarkör",
-                    "message": "Välj en ny plats för markören genom att klicka på kartan."
+                    "message": "Välj en ny plats för markören genom att klicka på kartan.",
+                    "clear": "Ta bort alla markörer"
                 }
             },
             "MyLocationPlugin": {

--- a/src/react/components/ColorPicker.jsx
+++ b/src/react/components/ColorPicker.jsx
@@ -60,7 +60,7 @@ const getContent = (props) => {
 };
 
 export const ColorPicker = (props) => {
-    const { value = '#000000', disabled = false } = props;
+    const { value = '#FFFFFF', disabled = false } = props;
     const [visible, setVisible] = useState(false);
     const chooseIconStyle = {
         fontSize: '20px',

--- a/src/react/components/StyleEditor.jsx
+++ b/src/react/components/StyleEditor.jsx
@@ -84,7 +84,7 @@ export const StyleEditor = ({ oskariStyle, onChange, format, tabs }) => {
 
     useEffect(() => {
         form.setFieldsValue(convertedStyleValues);
-    }, [oskariStyle]);
+    }, [style]);
 
     const formats = tabs || constants.SUPPORTED_FORMATS;
 

--- a/src/react/components/StyleEditor.jsx
+++ b/src/react/components/StyleEditor.jsx
@@ -87,17 +87,27 @@ export const StyleEditor = ({ oskariStyle, onChange, format, tabs }) => {
     }, [oskariStyle]);
 
     const formats = tabs || constants.SUPPORTED_FORMATS;
+
+    // Don't render tab selector and show preview in tab if there is only one format
+    const showSelector = formats.length > 1;
+    const showPreview = !showSelector;
+
+    const renderTab = () => {
+        return (
+            <TabSelector { ...constants.ANTD_FORMLAYOUT } value={selectedTab} onChange={(event) => setSelectedTab(event.target.value) } >
+                { formats.map(format => <PreviewButton key={format} oskariStyle = { style } format = {format} /> ) }
+            </TabSelector>
+        );
+    }
     return (
         <LocaleProvider value={{ bundleKey: constants.LOCALIZATION_BUNDLE }}>
             <FormSpace direction='vertical'>
-                <TabSelector { ...constants.ANTD_FORMLAYOUT } value={selectedTab} onChange={(event) => setSelectedTab(event.target.value) } >
-                    { formats.map(format => <PreviewButton key={format} oskariStyle = { style } format = {format} /> ) }
-                </TabSelector>
+                {showSelector  && renderTab() }
                 <Card>
                     <StaticForm form={ form } onValuesChange={ onUpdate }>
-                        { selectedTab === 'point' && <PointTab oskariStyle={ style } /> }
-                        { selectedTab === 'line' && <LineTab oskariStyle={ style } /> }
-                        { selectedTab === 'area' && <AreaTab oskariStyle={  style } /> }
+                        { selectedTab === 'point' && <PointTab oskariStyle={ style } showPreview={showPreview}/> }
+                        { selectedTab === 'line' && <LineTab oskariStyle={ style } showPreview={showPreview} /> }
+                        { selectedTab === 'area' && <AreaTab oskariStyle={  style } showPreview={showPreview} /> }
                     </StaticForm>
                 </Card>
             </FormSpace>

--- a/src/react/components/StyleEditor.jsx
+++ b/src/react/components/StyleEditor.jsx
@@ -66,11 +66,12 @@ export const StyleEditor = ({ oskariStyle, onChange, format, tabs }) => {
         ...OSKARI_BLANK_STYLE,
         ...oskariStyle
     };
+    const formats = tabs || constants.SUPPORTED_FORMATS;
 
     // initialize state with propvided style settings to show preview correctly and set default format as point
     const fieldValuesForForm = FormToOskariMapper.createFlatFormObjectFromStyle(style);
     const convertedStyleValues = FormToOskariMapper.convertFillPatternToForm(fieldValuesForForm);
-    const [selectedTab, setSelectedTab] = useState(format || 'point');
+    const [selectedTab, setSelectedTab] = useState(format || formats[0]);
     const updateStyle = FormToOskariMapper.createStyleAdjuster(style);
 
     const onUpdate = (values) => {
@@ -86,11 +87,8 @@ export const StyleEditor = ({ oskariStyle, onChange, format, tabs }) => {
         form.setFieldsValue(convertedStyleValues);
     }, [style]);
 
-    const formats = tabs || constants.SUPPORTED_FORMATS;
-
     // Don't render tab selector and show preview in tab if there is only one format
     const showSelector = formats.length > 1;
-    const showPreview = !showSelector;
 
     const renderTab = () => {
         return (
@@ -105,9 +103,9 @@ export const StyleEditor = ({ oskariStyle, onChange, format, tabs }) => {
                 {showSelector  && renderTab() }
                 <Card>
                     <StaticForm form={ form } onValuesChange={ onUpdate }>
-                        { selectedTab === 'point' && <PointTab oskariStyle={ style } showPreview={showPreview}/> }
-                        { selectedTab === 'line' && <LineTab oskariStyle={ style } showPreview={showPreview} /> }
-                        { selectedTab === 'area' && <AreaTab oskariStyle={  style } showPreview={showPreview} /> }
+                        { selectedTab === 'point' && <PointTab oskariStyle={ style } showPreview={!showSelector} /> }
+                        { selectedTab === 'line' && <LineTab oskariStyle={ style } showPreview={!showSelector} /> }
+                        { selectedTab === 'area' && <AreaTab oskariStyle={  style } showPreview={!showSelector} /> }
                     </StaticForm>
                 </Card>
             </FormSpace>

--- a/src/react/components/StyleEditor/AreaTab.jsx
+++ b/src/react/components/StyleEditor/AreaTab.jsx
@@ -105,7 +105,7 @@ export const AreaTab = ({oskariStyle}) => {
     return (
         <React.Fragment>
             <Row>
-                <Col span={ 10 }>
+                <Col span={ 12 }>
                     <Form.Item
                         { ...constants.ANTD_FORMLAYOUT }
                         name='stroke.area.color'
@@ -115,7 +115,7 @@ export const AreaTab = ({oskariStyle}) => {
                     </Form.Item>
                 </Col>
 
-                <Col span={ 10 } offset={ 2 }>
+                <Col span={ 12 } >
                     <Tooltip title={fillColorTooltip} placement='topLeft'>
                         <Form.Item
                             { ...constants.ANTD_FORMLAYOUT }

--- a/src/react/components/StyleEditor/AreaTab.jsx
+++ b/src/react/components/StyleEditor/AreaTab.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ColorPicker, Message, Tooltip } from 'oskari-ui';
-import { SvgRadioButton, SizeControl, constants } from './index';
+import { SvgRadioButton, SizeControl, constants, PreviewCol } from './index';
 import { Form, Row, Col } from 'antd';
 
 const getFillIconTransparent = (id) => {
@@ -91,7 +91,7 @@ export const getFillOption = name => {
 
 // counter is used to generate changing ids for SVG to workaround conflicting ids when hard coded
 let counter = 0;
-export const AreaTab = ({oskariStyle}) => {
+export const AreaTab = ({oskariStyle, showPreview}) => {
     counter++;
     const areaFillOptions = areaFills.map(item => {
         return {
@@ -155,11 +155,14 @@ export const AreaTab = ({oskariStyle}) => {
             </Row>
 
             <Row>
-                <SizeControl
-                    format={ 'area' }
-                    name='stroke.area.width'
-                    localeKey={ 'StyleEditor.stroke.area.width' }
-                />
+                <Col span={ 16 }>
+                    <SizeControl
+                        format={ 'area' }
+                        name='stroke.area.width'
+                        localeKey={ 'StyleEditor.stroke.area.width' }
+                    />
+                </Col>
+                { showPreview && <PreviewCol oskariStyle={ oskariStyle } format='area' /> }
             </Row>
         </React.Fragment>
     );
@@ -167,5 +170,6 @@ export const AreaTab = ({oskariStyle}) => {
 
 
 AreaTab.propTypes = {
-    oskariStyle: PropTypes.object.isRequired
+    oskariStyle: PropTypes.object.isRequired,
+    showPreview: PropTypes.bool
 };

--- a/src/react/components/StyleEditor/LineTab.jsx
+++ b/src/react/components/StyleEditor/LineTab.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ColorPicker, Message } from 'oskari-ui';
-import { SvgRadioButton, SizeControl, constants } from './index';
+import { SvgRadioButton, SizeControl, constants, PreviewCol } from './index';
 import { Form, Row, Col } from 'antd';
 
-export const LineTab = (props) => {
+export const LineTab = ({ oskariStyle, showPreview }) => {
     return (
         <React.Fragment>
             <Row>
-                <Col span={ 12 }>
+                <Col span={ 16 }>
                     <Form.Item
                         { ...constants.ANTD_FORMLAYOUT }
                         name='stroke.color'
@@ -17,6 +17,7 @@ export const LineTab = (props) => {
                         <ColorPicker />
                     </Form.Item>
                 </Col>
+                { showPreview && <PreviewCol oskariStyle={ oskariStyle } format='line' /> }
             </Row>
 
             <Row>
@@ -57,5 +58,6 @@ export const LineTab = (props) => {
 };
 
 LineTab.propTypes = {
-    oskariStyle: PropTypes.object.isRequired
+    oskariStyle: PropTypes.object.isRequired,
+    showPreview: PropTypes.bool
 };

--- a/src/react/components/StyleEditor/LineTab.jsx
+++ b/src/react/components/StyleEditor/LineTab.jsx
@@ -8,7 +8,7 @@ export const LineTab = (props) => {
     return (
         <React.Fragment>
             <Row>
-                <Col span={ 10 }>
+                <Col span={ 12 }>
                     <Form.Item
                         { ...constants.ANTD_FORMLAYOUT }
                         name='stroke.color'

--- a/src/react/components/StyleEditor/PointTab.jsx
+++ b/src/react/components/StyleEditor/PointTab.jsx
@@ -1,16 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ColorPicker, Message } from 'oskari-ui';
-import { SvgRadioButton, SizeControl, constants } from './index';
+import { SvgRadioButton, SizeControl, Preview, constants } from './index';
 import { Form, Row, Col } from 'antd';
 
 
 
-export const PointTab = ({ oskariStyle }) => {
+const PreviewCol = ({ oskariStyle }) => {
+    return (
+        <Col span={ 8 }>
+            <Preview
+                oskariStyle={ oskariStyle }
+                format={ 'point' }
+                style={{ border: '1px solid #d9d9d9' }}
+            />
+        </Col>
+    );
+};
+
+export const PointTab = ({ oskariStyle, showPreview }) => {
     return (
         <React.Fragment>
             <Row>
-                <Col span={ 10 }>
+                <Col span={ 16 }>
                     <Form.Item
                         { ...constants.ANTD_FORMLAYOUT }
                         name='image.fill.color'
@@ -19,6 +31,7 @@ export const PointTab = ({ oskariStyle }) => {
                         <ColorPicker />
                     </Form.Item>
                 </Col>
+                { showPreview && <PreviewCol oskariStyle={ oskariStyle }/> }
             </Row>
 
             <Row>
@@ -43,5 +56,6 @@ export const PointTab = ({ oskariStyle }) => {
 };
 
 PointTab.propTypes = {
-    oskariStyle: PropTypes.object.isRequired
+    oskariStyle: PropTypes.object.isRequired,
+    showPreview: PropTypes.bool
 };

--- a/src/react/components/StyleEditor/PointTab.jsx
+++ b/src/react/components/StyleEditor/PointTab.jsx
@@ -1,22 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ColorPicker, Message } from 'oskari-ui';
-import { SvgRadioButton, SizeControl, Preview, constants } from './index';
+import { SvgRadioButton, SizeControl, PreviewCol, constants } from './index';
 import { Form, Row, Col } from 'antd';
-
-
-
-const PreviewCol = ({ oskariStyle }) => {
-    return (
-        <Col span={ 8 }>
-            <Preview
-                oskariStyle={ oskariStyle }
-                format={ 'point' }
-                style={{ border: '1px solid #d9d9d9' }}
-            />
-        </Col>
-    );
-};
 
 export const PointTab = ({ oskariStyle, showPreview }) => {
     return (
@@ -31,7 +17,7 @@ export const PointTab = ({ oskariStyle, showPreview }) => {
                         <ColorPicker />
                     </Form.Item>
                 </Col>
-                { showPreview && <PreviewCol oskariStyle={ oskariStyle }/> }
+                { showPreview && <PreviewCol oskariStyle={ oskariStyle } format='point' /> }
             </Row>
 
             <Row>

--- a/src/react/components/StyleEditor/Preview.jsx
+++ b/src/react/components/StyleEditor/Preview.jsx
@@ -40,13 +40,14 @@ const getSVGContent = (format, propsForSVG) => {
  * @example <caption>Basic usage</caption>
  * <Preview }/>
  */
-export const Preview = ({markers, areaFills, format, oskariStyle}) => {
+export const Preview = ({markers, areaFills, format, oskariStyle, style = {}}) => {
     const propsForSVG = StyleMapper.getPropsForFormat(format, oskariStyle);
     const flagsForSelenium = StyleMapper.getAsDataAttributes(format, propsForSVG);
     const svgIcon = getSVGContent(format, propsForSVG, markers, areaFills);
     const size = format === 'point' ? propsForSVG.size : undefined;
+    const mergedStyle = { ...previewWrapperStyle, ...style };
     return (
-        <div style={ previewWrapperStyle } className="t_preview" { ...flagsForSelenium } >
+        <div style={ mergedStyle } className="t_preview" { ...flagsForSelenium } >
             <SVGWrapper
                 width={ previewSize }
                 height={ previewSize }

--- a/src/react/components/StyleEditor/PreviewCol.jsx
+++ b/src/react/components/StyleEditor/PreviewCol.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types'
+import { Preview } from './index';
+import { Col } from 'antd';
+
+export const PreviewCol = ({ oskariStyle, format }) => {
+    return (
+        <Col span={ 8 }>
+            <Preview
+                oskariStyle={ oskariStyle }
+                format={ format }
+                style={{ border: '1px solid #d9d9d9' }}
+            />
+        </Col>
+    );
+};
+
+PreviewCol.propTypes = {
+    oskariStyle: PropTypes.object.isRequired,
+    format: PropTypes.string.isRequired
+};

--- a/src/react/components/StyleEditor/index.js
+++ b/src/react/components/StyleEditor/index.js
@@ -7,6 +7,7 @@ export { LineTab } from './LineTab';
 export { PointTab } from './PointTab';
 export { Preview } from './Preview';
 export { PreviewButton } from './PreviewButton';
+export { PreviewCol } from './PreviewCol';
 export { SizeControl } from './SizeControl';
 export { StyleSelector } from './StyleSelector';
 export { SvgRadioButton } from './SvgRadioButton';


### PR DESCRIPTION
Add react form for creating map markers. Updated style editor to handle one format case by adding preview component inside tab (implemented only for point) and removing tab selector. 

Tried to remove old stuff from plugin and clarify marker handling (add, remove, visibility) but now when I look changes it seems more like 'tolppakuti' than success (too much changes to be sure that didn't brake anything). New form's output is oskari style which can be used via mapmodule getstyle straight to feature so it didn't make sense that plugin request itself to add marker (oskaristyle -> markerdata -> request -> markerdata -> oskaristyle -> olstyle). Also storing markers(data) to four different places (_markers, _unVisibleMarkers, _markerFeatures, layer source) adds complexity. Tried to store markers only to layer source but it seemed that getting color, size and shape from feature style is complicated (needed for event and state). So stored them to _styleData (maybe them can also be added to feature properties because properties aren't used to GFI etc.). Invisible markers are handled by storing them to _hiddenMarkers (could also set null style and store ol style to visibility changes), so markers doesn't change on layer.

Added common message getters to AbstractMapModule and AbtstractMapModulePlugin to use new localization methods for mapplugins. Same way than plugin.getLocalization to avoid binding getmsg in every plugin.

Created draft pr to review that does plugin changes (gains vs. risks to break things) make any sense or should leave plugin as it was and add only oskaristyle <-> markerdata converters and use new form. At least I have to test more (state, link, add/hide/remove requests) and add junit tests. Also implement line and polygon preview in tab.