### PR TITLE
Divmanazer remove visuform

### DIFF
--- a/packages/framework/bundle/divmanazer/bundle.js
+++ b/packages/framework/bundle/divmanazer/bundle.js
@@ -207,9 +207,6 @@ Oskari.clazz.define("Oskari.userinterface.bundle.ui.UserInterfaceBundle", functi
                 "src": "../../../../bundles/framework/divmanazer/component/TextAreaInput.js"
             }, {
                 "type": "text/javascript",
-                "src": "../../../../bundles/framework/divmanazer/component/VisualizationForm.js"
-            }, {
-                "type": "text/javascript",
                 "src": "../../../../bundles/framework/divmanazer/component/buttons/AddButton.js"
             }, {
                 "type": "text/javascript",
@@ -238,15 +235,6 @@ Oskari.clazz.define("Oskari.userinterface.bundle.ui.UserInterfaceBundle", functi
             }, {
                 "type": "text/javascript",
                 "src": "../../../../bundles/framework/divmanazer/component/buttons/SearchButton.js"
-            }, {
-                "type": "text/javascript",
-                "src": "../../../../bundles/framework/divmanazer/component/visualization-form/AreaForm.js"
-            }, {
-                "type": "text/javascript",
-                "src": "../../../../bundles/framework/divmanazer/component/visualization-form/LineForm.js"
-            }, {
-                "type": "text/javascript",
-                "src": "../../../../bundles/framework/divmanazer/component/visualization-form/DotForm.js"
             }, {
                 "type": "text/javascript",
                 "src": "../../../../bundles/framework/divmanazer/extension/DefaultTile.js"
@@ -308,9 +296,6 @@ Oskari.clazz.define("Oskari.userinterface.bundle.ui.UserInterfaceBundle", functi
             }, {
                 "type": "text/css",
                 "src": "../../../../bundles/framework/divmanazer/resources/scss/overlay.scss"
-            }, {
-                "type": "text/css",
-                "src": "../../../../bundles/framework/divmanazer/resources/scss/visualizationform.scss"
             }, {
                 "type": "text/css",
                 "src": "../../../../bundles/framework/divmanazer/resources/scss/popover.scss"

--- a/packages/framework/bundle/ui-components/bundle.js
+++ b/packages/framework/bundle/ui-components/bundle.js
@@ -113,22 +113,7 @@ Oskari.clazz.define("Oskari.userinterface.bundle.ui.ComponentsBundle", function(
             "src" : "../../../../bundles/framework/divmanazer/component/ProgressBar.js"
         }, {
             "type" : "text/javascript",
-            "src" : "../../../../bundles/framework/divmanazer/component/VisualizationForm.js"
-        }, {
-            "type" : "text/javascript",
-            "src" : "../../../../bundles/framework/divmanazer/component/visualization-form/AreaForm.js"
-        }, {
-            "type" : "text/javascript",
-            "src" : "../../../../bundles/framework/divmanazer/component/visualization-form/LineForm.js"
-        }, {
-            "type" : "text/javascript",
-            "src" : "../../../../bundles/framework/divmanazer/component/visualization-form/DotForm.js"
-        }, {
-            "type" : "text/javascript",
             "src" : "../../../../libraries/jquery/plugins/jquery-placeholder/jquery.placeholder.js"
-        }, {
-            "type" : "text/css",
-            "src" : "../../../../bundles/framework/divmanazer/resources/scss/visualizationform.scss"
         }, {
             "type" : "text/css",
             "src" : "../../../../bundles/framework/divmanazer/resources/scss/divman.scss"


### PR DESCRIPTION
Remove VisualizationForm components from divmanazer and ui-components. As Oskari core frontend doesn't use these components anymore them aren't linked/packed and aren't available to use with other bundles. To use divamazer's VisualizationForm in your own bundle, components have to be part of that bundle or linked in another way.

See: https://github.com/oskariorg/oskari-frontend-contrib/pull/73
