### PR TITLE
Fix markers plugin ol layer

### DIFF
--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
@@ -197,7 +197,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
             return this._layer;
         },
         getOLMapLayers: function () {
-            return [this.getMarkersLayer()];
+            return [];
         },
         getMapMarkerBounds: function () {
             return this.getMarkersLayer().getSource().getExtent();


### PR DESCRIPTION
Return empty array to avoid adding markers ol layer on mapmodule.getOLMapLayers(layerId).