### PR TITLE
Timeseries "times" are now under typeSpecific object

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VisualizationTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VisualizationTabPane.jsx
@@ -40,7 +40,7 @@ export const VisualizationTabPane = ({ layer, scales, propertyFields, controller
             { propertyFields.includes(OPACITY) &&
                 <Opacity layer={layer} controller={controller} />
             }
-            { propertyFields.includes(TIMES) && layer.capabilities.times &&
+            { (propertyFields.includes(TIMES) && layer.capabilities.typeSpecific && layer.capabilities.typeSpecific.times) &&
                 <TimeSeries layer={layer} scales={scales} controller={controller} />
             }
             { propertyFields.includes(CLUSTERING_DISTANCE) &&


### PR DESCRIPTION
Fixes an issue where timeseries UI was not shown for admin after capabiliities refactoring.