### PR TITLE
Timeseries publishing fix

### DIFF
--- a/bundles/framework/timeseries/instance.js
+++ b/bundles/framework/timeseries/instance.js
@@ -205,6 +205,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesToolBundleI
         handleRequest: function (core, request) {
             if (request.getName() === 'Timeseries.ConfigurationRequest') {
                 this._setControlPluginConfiguration(request.getConfiguration());
+                const active = this._timeseriesService.getActiveTimeseries();
+                this._updateControl(active);
             }
         },
         /**

--- a/bundles/framework/timeseries/publisher/TimeseriesTool.js
+++ b/bundles/framework/timeseries/publisher/TimeseriesTool.js
@@ -84,10 +84,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesTool',
             // Set control visibility by updating it's config.
             this.controlConfig.showControl = enabled;
             this._updateTimeseriesPluginConfig();
-
-            // Apply changed configuration.
-            var active = this._getTimeseriesService().getActiveTimeseries();
-            this.service.trigger('activeChanged', active);
         },
         /**
         * Is this tool disabled.

--- a/bundles/framework/timeseries/view/TimeSeriesRangeControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeSeriesRangeControlPlugin.js
@@ -13,7 +13,7 @@ class TimeSeriesRangeControlPlugin extends BasicMapModulePlugin {
         super(conf);
         this._clazz = 'Oskari.mapframework.bundle.timeseries.TimeSeriesRangeControlPlugin';
         this._name = 'TimeSeriesRangeControlPlugin';
-        this._defaultLocation = 'top left';
+        this._defaultLocation = conf.location || 'top left';
         this._log = Oskari.log(this._name);
         this._toolOpen = false;
         this._element = null;
@@ -23,6 +23,11 @@ class TimeSeriesRangeControlPlugin extends BasicMapModulePlugin {
 
         this.stateHandler = new TimeSeriesRangeControlHandler(delegate, () => this.updateUI());
         this._updateCurrentViewportBbox();
+    }
+
+    hasUI () {
+        // prevent publisher to stop this plugin and start it again when leaving the publisher
+        return false;
     }
 
     getControlState () {

--- a/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
@@ -91,6 +91,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
             { key: 'week', value: 'weeks' },
             { key: 'month', value: 'months' }
         ],
+        hasUI: function () {
+            // prevent publisher to stop this plugin and start it again when leaving the publisher
+            return false;
+        },
         /**
          * @method getCurrentTimeFormatted
          * return current time in timeseries in same format as shown in timeseries control


### PR DESCRIPTION
Publisher stop and starts plugins which have ui component. Timeseries plugin seems to lost controlled layer when publisher is closed. After visiting publisher hide + show timesieries layer duplicates timeseries control plugin. Tried to handle start/stop plugin correctly but the timeseries instance is handling plugins (instead of plugins itself). So made the same solution than statistics classification plugin has and prevent publisher to stop plugin with hasUI false. 

Also fixed to use TimeseriesTools's top-center (default location from conf) and hidden/removed (checkbox in publisher) controller to show again when publisher is closed by updating controller on ConfigurationRequest.