### PR TITLE
OskariStyle generator thicker patterns

### DIFF
--- a/bundles/mapping/mapmodule/oskariStyle/constants.js
+++ b/bundles/mapping/mapmodule/oskariStyle/constants.js
@@ -55,7 +55,7 @@ export const FILL_STYLE = {
 
 export const PATTERN_STROKE = {
     THIN: 2,
-    THICK: 3
+    THICK: 4
 };
 
 export const FILTER = {

--- a/bundles/mapping/mapmodule/oskariStyle/generator.ol.js
+++ b/bundles/mapping/mapmodule/oskariStyle/generator.ol.js
@@ -350,31 +350,29 @@ export const getFillPatternPath = (size, fillCode) => {
 };
 
 const getDiagonalPattern = (size, lineWidth) => {
-    const numberOfStripes = lineWidth > 2 ? 12 : 18;
-    const bandWidth = size / numberOfStripes;
+    const whiteSpace = lineWidth * 2 + 2;
+    const bandWidth = lineWidth + whiteSpace;
+    const transition = size / Math.floor(size / bandWidth);
     const path = [];
-    for (let i = 0; i < numberOfStripes * 2 + 2; i++) {
-        if (i % 2 === 0) {
-            continue;
-        }
-        const a = i * bandWidth + bandWidth / 2;
-        path.push(`M${a},0`);
-        path.push(`L${a - size},${size}`);
+    for (let t = transition / 2; t < size; t += transition) {
+        path.push(`M${t},0`);
+        path.push(`L0,${t}`);
+    }
+    for (let t = transition / 2; t < size; t += transition) {
+        path.push(`M${t},${size}`);
+        path.push(`L${size},${t}`);
     }
     return path.join(' ');
 };
 
 const getHorizontalPattern = (size, lineWidth) => {
-    const numberOfStripes = lineWidth > 2 ? 16 : 18;
-    const bandWidth = size / numberOfStripes;
+    const whiteSpace = lineWidth + 2;
+    const bandWidth = lineWidth + whiteSpace;
+    const transition = size / Math.floor(size / bandWidth);
     const path = [];
-    for (let i = 0; i < numberOfStripes; i++) {
-        if (i % 2 === 0) {
-            continue;
-        }
-        const b = i * bandWidth + bandWidth / 2;
-        path.push(`M0,${b}`);
-        path.push(`L${size},${b}`);
+    for (let y = transition / 2; y < size; y += transition) {
+        path.push(`M0,${y}`);
+        path.push(`L${size},${y}`);
     }
     return path.join(' ');
 };

--- a/src/react/components/StyleEditor/AreaTab.jsx
+++ b/src/react/components/StyleEditor/AreaTab.jsx
@@ -20,7 +20,7 @@ const getFillIcon = (name, fillCode) => {
          // use tooltip from antd because oskari-ui tooltip wraps children inside span which has height issue with svg
         <Tooltip title={<Message messageKey={`StyleEditor.tooltips.${lowerName}`}/>}>
             <svg width={SIZE} height={SIZE}>
-                { !solid && <FillPattern id={id} fillCode={fillCode} color={COLOR}/> }
+                { !solid && <FillPattern id={id} fillCode={fillCode} color={COLOR} size={SIZE}/> }
                 <rect width={SIZE} height={SIZE} fill={fillPattern} />
             </svg>
         </Tooltip>

--- a/src/react/components/StyleEditor/FillPattern.jsx
+++ b/src/react/components/StyleEditor/FillPattern.jsx
@@ -3,27 +3,30 @@ import PropTypes from 'prop-types';
 import { getFillPatternPath } from '../../../../bundles/mapping/mapmodule/oskariStyle/generator.ol';
 import { FILLS } from './constants';
 
-const PATTERN_SIZE = 64;
+const OVERFLOW = 4;
 
 export const isSolid = id => {
     return id === FILLS.SOLID || id < 0;
 }
 
-export const FillPattern = ({ id, fillCode, color })=> {
+export const FillPattern = ({ id, fillCode, color, size: svgSize })=> {
+    // create little bigger pattern to get diagonal corners look nice
+    const size = svgSize + OVERFLOW;
     if (fillCode === FILLS.TRANSPARENT) {
         return (
             <defs>
-                <pattern id={id} x="0" y="0" width="16" height="16" patternUnits="userSpaceOnUse">
+                <pattern id={id} width="16" height="16" patternUnits="userSpaceOnUse">
                     <rect fill="#eee" x="0" width="8" height="8" y="0"/>
                     <rect fill="#eee" x="8" width="8" height="8" y="8"/>
                 </pattern>
             </defs>
         );
     }
-    const { strokeWidth, path } = getFillPatternPath(PATTERN_SIZE, fillCode);
+    const { strokeWidth, path } = getFillPatternPath(size, fillCode);
+    const anchor = -OVERFLOW / 2;
     return (
         <defs>
-            <pattern id={id} width={PATTERN_SIZE} height={PATTERN_SIZE}>
+            <pattern id={id} x={anchor} y={anchor} width={size} height={size} patternUnits="userSpaceOnUse">
                 <path d={path} stroke={color} strokeWidth={strokeWidth}/>
             </pattern>
         </defs>
@@ -33,5 +36,6 @@ export const FillPattern = ({ id, fillCode, color })=> {
 FillPattern.propTypes = {
     id: PropTypes.string.isRequired,
     fillCode: PropTypes.number.isRequired,
+    size: PropTypes.number.isRequired,
     color: PropTypes.string.isRequired
 };

--- a/src/react/components/StyleEditor/Preview/AreaPreview.jsx
+++ b/src/react/components/StyleEditor/Preview/AreaPreview.jsx
@@ -18,7 +18,7 @@ export const AreaPreview = ({ previewSize, propsForSVG }) => {
     const fillPattern = solid ? color : `url(#${id})`;
     return (
         <svg width={previewSize} height={previewSize}>
-            { !solid && <FillPattern id={id} fillCode={pattern} color={color}/> }
+            { !solid && <FillPattern id={id} fillCode={pattern} color={color} size={previewSize}/> }
             <path d={PATH}
                 stroke={strokecolor}
                 strokeWidth={size}


### PR DESCRIPTION
Increase thick pattern width from 3 to 4 and increase white space for both thick and thin. Refactor get patterns to use size to calculate how many lines are drawn instead of line width. And make line width and white space easier to update. Start pattern with 1/2 transition and calculate transition based on lines drawn to get same white space for beginning and ending.

Change StyleEditor to use svg size for pattern. Request pattern 4 px wider/higher than svg to get complete lines (corners) for diagonal icons.