### PR TITLE
Fix capabilities handling for admin-layereditor

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/AdditionalTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/AdditionalTabPane.jsx
@@ -28,7 +28,9 @@ const {
 } = LayerComposingModel;
 
 export const AdditionalTabPane = ({ layer, propertyFields, controller }) => {
-    const isQueryable = layer.attributes.isQueryable || layer.capabilities.isQueryable;
+    const { capabilities = {} } = layer;
+    const { typeSpecific = {} } = capabilities;
+    const isQueryable = layer.attributes.isQueryable || capabilities.isQueryable || typeSpecific.isQueryable;
     return (
         <Fragment>
             { !layer.isNew &&

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/GfiType.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/GfiType.jsx
@@ -7,8 +7,8 @@ import { StyledFormField } from '../styled';
 
 export const GfiType = ({ layer, controller }) => {
     const { capabilities, gfiType } = layer;
-    const { formats = {} } = capabilities;
-    const options = formats.available || [];
+    const { typeSpecific = {} } = capabilities;
+    const options = typeSpecific.infoFormats || [];
     const value = gfiType || '';
     if (options.length === 0) {
         return null;

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/SelectedTime.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/SelectedTime.jsx
@@ -6,8 +6,10 @@ import { StyledFormField } from '../styled';
 
 export const SelectedTime = ({ layer, controller }) => {
     const value = layer.params ? layer.params.selectedTime : '';
-    const { capabilities } = layer;
-    if (!Array.isArray(capabilities.times)) {
+    const { capabilities = {} } = layer;
+    const { typeSpecific = {} } = capabilities;
+
+    if (!Array.isArray(typeSpecific.times)) {
         return null;
     }
     return (
@@ -19,7 +21,7 @@ export const SelectedTime = ({ layer, controller }) => {
                     allowClear
                     value={value}
                     onChange={value => controller.setSelectedTime(value)}>
-                    { capabilities.times.map(time => <Option key={time}>{time}</Option>)}
+                    { typeSpecific.times.map(time => <Option key={time}>{time}</Option>)}
                 </Select>
             </StyledFormField>
         </Fragment>

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/ServiceMetadata.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/ServiceMetadata.jsx
@@ -5,6 +5,13 @@ import { Controller } from 'oskari-ui/util';
 import { MetadataButton } from './styled';
 
 export const ServiceMetadata = ({ capabilities, controller, hasHandler }) => {
+    // this is currently 2.7.0-SNAPSHOT:
+    /*
+    "typeSpecific": {
+        "metadataUrl": "the whole url instead of just metadata uuid"
+        ...
+    */
+    // FIXME: parse uuid part to be accessible directly from somewhere under capabilities AND update reference here:
     const { metadataUuid } = capabilities;
     if (!metadataUuid) {
         return (


### PR DESCRIPTION
Still need to do something about metadata uuid at least. It was previously:
```
capabilities: { metadataUuid: '83aabfca-92eb-4f5e-8028-71a7c206e0bf' }
```
Now it's the whole url (we should parse the uuid part for the frontend on the server):

```
capabilities: {
    "typeSpecific": {
        "metadataUrl": "http://mydomain.com/geonetwork/srv/fin/csw?Service=CSW&Request=GetRecordById&Version=2.0.2&id=83aabfca-92eb-4f5e-8028-71a7c206e0bf&outputSchema=http://www.isotc211.org/2005/gmd&elementSetName=full"