### PR TITLE
Enable problem tracking for map layers

### DIFF
--- a/api/admin/admin-layeranalytics/bundle.md
+++ b/api/admin/admin-layeranalytics/bundle.md
@@ -1,0 +1,42 @@
+# admin-layeranalytics
+
+Admin UI for map layer problem tracker
+
+## Description
+
+This admin user-interface lists map layers that have received (anonymized) reports of problems from end-users browser.
+The admin UI shows total number of loading events and error rate for the problematic layers.
+The intention is to help admins notice configuration issues with layers registered on the Oskari instance.
+
+*Note!* The data is collected by another bundle `layeranalytics` and it only collects data when an end-user encounters an error.
+This bundle is only used to help admins analyze the collected data and is of no use if the data is not collected by the `layeranalytics` bundle (or some other means).
+
+### Analyzing the data
+
+From the listing the admin can see aggregated request count with error rate.
+A detailed view is shown by clicking on the layer name.
+
+The details include listing with:
+- success/error counts per problem report
+- when the issues have been reported
+- link with the map location/zoom level the user used and other layers that were shown on the map when problems were encountered
+
+These allow admins to try and reproduce the problem in an effort to understand what caused the issue.
+
+#### High total count, low error rate
+
+The layer configuration is probably ok. The service providing the layer might respond with an error if the user is looking at locations with no data on the layer/zoomed out of range etc.
+Things to check:
+- are zoom limits for the layer properly configured?
+- does the layer have coverage bbox or is it correct?
+
+#### High error rate
+
+There's probably something wrong with the configuration.
+Things to check:
+- is the layer still available on the service it was registered from?
+- if the layer is available, try using it on the map and errors from browsers console/network requests
+- are zoom limits for the layer properly configured?
+
+If the total count is high, end-users are trying to see this data but can't so this could be considered critical.
+If the total count is low, end-users are trying to see this data but there's not much of them or most don't have problems so it's not as critical.

--- a/api/framework/layeranalytics/bundle.md
+++ b/api/framework/layeranalytics/bundle.md
@@ -7,3 +7,4 @@ Map layer problem tracker
 Listens to map layer loading events from the map module to make an effort for detecting problems with layer configurations.
 If there is an error when a map layer is being loaded for the end-user the bundle collects a dataset consisting of ids of used layers and map location.
 The dataset is sent to the server when the user exits the page so the issue can be further analysed by admins and possible issue in layer configuration can be corrected for other users.
+Also collects usage data for map layers when there are no errors but additional data like map location/other layers are collected only when there is an error.

--- a/api/framework/layeranalytics/bundle.md
+++ b/api/framework/layeranalytics/bundle.md
@@ -1,0 +1,9 @@
+# layeranalytics
+
+Map layer problem tracker
+
+## Description
+
+Listens to map layer loading events from the map module to make an effort for detecting problems with layer configurations.
+If there is an error when a map layer is being loaded for the end-user the bundle collects a dataset consisting of ids of used layers and map location.
+The dataset is sent to the server when the user exits the page so the issue can be further analysed by admins and possible issue in layer configuration can be corrected for other users.

--- a/bundles/admin/admin-layeranalytics/Flyout.js
+++ b/bundles/admin/admin-layeranalytics/Flyout.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { LocaleProvider } from 'oskari-ui/util';
+import { LayerAnalyticsList } from './LayerAnalyticsList';
+import { LayerAnalyticsDetails } from './LayerAnalyticsDetails';
+
+Oskari.clazz.define('Oskari.framework.bundle.admin-layeranalytics.Flyout',
+
+    function (instance) {
+        this.instance = instance;
+        this.container = null;
+        this.flyout = null;
+        this.selectedLayerId = null;
+    }, {
+        __name: 'Oskari.framework.bundle.admin-layeranalytics.Flyout',
+        getName () {
+            return this.__name;
+        },
+        getTitle () {
+            return this.instance.getLocalization('flyout').title;
+        },
+        setEl (el, flyout, width, height) {
+            this.container = el[0];
+            this.flyout = flyout;
+            this.container.classList.add('admin-layeranalytics');
+            this.flyout.addClass('admin-layeranalytics');
+        },
+        /**
+         * Renders content for flyout UI
+         * @method createContent
+         */
+        createContent () {
+            const root = this.container;
+            if (!root) {
+                return;
+            }
+
+            this.updateUI();
+        },
+        updateUI () {
+            ReactDOM.render(
+                <LocaleProvider value={{ bundleKey: this.instance.getName() }}>
+                    { !this.selectedLayerId
+                        ? <LayerAnalyticsList
+                            analyticsData={[...this.instance.getAnalyticsListData()]}
+                            isLoading={ this.instance.getLoadingState() }
+                            layerEditorCallback={ this.openLayerEditor }
+                            removeAnalyticsCallback={ (id) => this.instance.removeAnalyticsData(id) }
+                            layerDetailsCallback={ (id) => this.toggleLayerDetails(id) }
+                        />
+                        : <LayerAnalyticsDetails
+                            layerData={ this.instance.getAnalyticsDetailsData() }
+                            isLoading={ this.instance.getLoadingState() }
+                            closeDetailsCallback={ () => this.toggleLayerDetails() }
+                            removeAnalyticsCallback={ (id, dataId) => this.instance.removeAnalyticsData(id, dataId) }
+                        />
+                    }
+                </LocaleProvider>,
+                this.container
+            );
+        },
+        openLayerEditor (id) {
+            if (typeof id !== 'undefined') {
+                Oskari.getSandbox().postRequestByName('ShowLayerEditorRequest', [id]);
+            }
+        },
+        toggleLayerDetails (selectedId) {
+            if (typeof selectedId !== 'undefined') {
+                this.selectedLayerId = selectedId;
+                this.instance.produceAnalyticsDetailsData(selectedId);
+            } else {
+                this.selectedLayerId = null;
+            }
+            this.updateUI();
+        },
+        getSelectedLayerId () {
+            return this.selectedLayerId;
+        },
+        startPlugin () {}
+    }
+);

--- a/bundles/admin/admin-layeranalytics/LayerAnalyticsDetails.jsx
+++ b/bundles/admin/admin-layeranalytics/LayerAnalyticsDetails.jsx
@@ -1,11 +1,9 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Button, Table, Space, Spin } from 'antd';
-import { Confirm, Message, Tooltip } from 'oskari-ui';
+import { Table } from 'oskari-ui/components/Table';
+import { Button, Confirm, Message, Space, Spin, Tooltip } from 'oskari-ui';
 import { ArrowLeftOutlined, DeleteOutlined } from '@ant-design/icons';
 import { red } from '@ant-design/colors'
-
-import 'antd/es/table/style/index.js';
 
 const dateLocale = 'fi-FI';
 const localeDateOptions = {

--- a/bundles/admin/admin-layeranalytics/LayerAnalyticsDetails.jsx
+++ b/bundles/admin/admin-layeranalytics/LayerAnalyticsDetails.jsx
@@ -1,0 +1,156 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { Button, Table, Space, Spin } from 'antd';
+import { Confirm, Message, Tooltip } from 'oskari-ui';
+import { ArrowLeftOutlined, DeleteOutlined } from '@ant-design/icons';
+import { red } from '@ant-design/colors'
+
+import 'antd/es/table/style/index.js';
+
+const dateLocale = 'fi-FI';
+const localeDateOptions = {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+};
+
+export const DELETE_ICON_STYLE = {
+    color: red.primary
+};
+
+const sorterTooltipOptions = {
+    title: <Message messageKey='flyout.sorterTooltip' />
+};
+
+// timestamp formatting copied from admin-layereditor in oskari-frontend
+// TO-DO: Move both to helper class
+const formatTimestamp = (timestamp) => {
+    let date;
+    if (typeof timestamp !== 'undefined') {
+        date = new Date(timestamp);
+    }
+    return  formatDate(date) + ' ' + formatTime(date);
+};
+const formatDate = (date) => {
+    if (typeof date === 'undefined') {
+        return '--.--.----';
+    }
+    return date.toLocaleDateString(dateLocale, localeDateOptions);
+};
+
+const formatTime = (date) => {
+    if (typeof date === 'undefined') {
+        return '--:--:--';
+    }
+    return date.toLocaleTimeString(dateLocale).replace(/\./g, ':');
+};
+
+const generateLink = (item) => {
+    let toScaleURL = '/?coord=' + item.x + '_' + item.y;
+    
+    toScaleURL += '&mapLayers=';
+    for (const [index, value] of item.layers.entries()) {
+        toScaleURL += value; // add layer id
+        toScaleURL += '+100'; // add layer opacity
+        toScaleURL += '+'; // add layer default style as empty string
+        if (index !== (item.layers.length - 1)) {
+            toScaleURL += ','; // add layer separator if not last layer in item
+        }
+    }
+
+    toScaleURL += '&zoomLevel=' + item.z;
+
+    return toScaleURL;
+};
+
+export const LayerAnalyticsDetails = ({ layerData, isLoading, closeDetailsCallback, removeAnalyticsCallback }) => {
+
+    const columnSettings = [
+        {
+            title: <b><Message messageKey='flyout.successTitle' /></b>,
+            dataIndex: 'success',
+            sortDirections: ['descend', 'ascend', 'descend'],
+            sorter: (a, b) => a.success - b.success,
+            showSorterTooltip: sorterTooltipOptions
+        },
+        {
+            title: <b><Message messageKey='flyout.failureTitle' /></b>,
+            dataIndex: 'errors',
+            sortDirections: ['descend', 'ascend', 'descend'],
+            sorter: (a, b) => a.errors - b.errors,
+            showSorterTooltip: sorterTooltipOptions
+        },
+        {
+            title: 'Aika',
+            dataIndex: 'time',
+            defaultSortOrder: 'descend',
+            sortDirections: ['descend', 'ascend', 'descend'],
+            sorter: (a, b) => a.time - b.time,
+            showSorterTooltip: sorterTooltipOptions,
+            render: (text) => <Space>{ formatTimestamp(text) }</Space>
+        },
+        {
+            title: '',
+            key: 'movetoscale',
+            render: (text, entry) => entry.stack.map((item, index) => {
+                const link = generateLink(item);
+                return (
+                    <Fragment key={ link }>
+                        <Tooltip title={ <Message messageKey='flyout.moveToScaleTooltip' /> }>
+                            <a href={ link } target='_blank'><Message messageKey='flyout.moveToScale' /> { index + 1 }</a><br/>
+                        </Tooltip>
+                    </Fragment>
+                )})
+        },
+        {
+            title: '',
+            key: 'remove',
+            render: (text, entry, index) => (
+                <Confirm
+                    title={<Message messageKey='flyout.removeSingleDataForLayer' />}
+                    onConfirm={() => removeAnalyticsCallback(layerData.id, entry.time)}
+                    okText={<Message messageKey='flyout.delete' />}
+                    cancelText={<Message messageKey='flyout.cancel' />}
+                    placement='bottomLeft'>
+                    <DeleteOutlined style={ DELETE_ICON_STYLE } />
+                </Confirm>)
+        }
+    ];
+
+    if (isLoading) {
+        return ( <Spin/> );
+    }
+
+    return (
+        <Space direction='vertical' style={{ width: '100%' }}>
+            <Button onClick={ () => closeDetailsCallback() } >
+                <ArrowLeftOutlined /> <Message messageKey='flyout.backToList' />
+            </Button>
+            <b>{ layerData.title }</b>
+            { layerData.layerOrganization && 
+                <div><Message messageKey='flyout.layerDataProvider' />: { layerData.layerOrganization }</div>
+            }
+            <div><Message messageKey='flyout.successTitle' />: { layerData.success } ({ layerData.successPercentage }%)</div>
+            <div><Message messageKey='flyout.failureTitle' />: { layerData.errors }</div>
+            { layerData.details.length > 0 &&
+                <Table
+                    columns={ columnSettings }
+                    dataSource={ layerData.details.map(item => {
+                        return {
+                            key: item.time,
+                            ...item
+                        };
+                    }) }
+                    pagination={{ position: ['none', 'none'] }}
+                />
+            }
+        </Space>
+    );
+};
+
+LayerAnalyticsDetails.propTypes = {
+    layerData: PropTypes.object.isRequired,
+    isLoading: PropTypes.bool.isRequired,
+    closeDetailsCallback: PropTypes.func.isRequired,
+    removeAnalyticsCallback: PropTypes.func.isRequired
+};

--- a/bundles/admin/admin-layeranalytics/LayerAnalyticsList.jsx
+++ b/bundles/admin/admin-layeranalytics/LayerAnalyticsList.jsx
@@ -1,12 +1,10 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Table } from 'antd';
+import { Table, getSorterFor } from 'oskari-ui/components/Table';
 import { Confirm, Message, Space, Spin, Tooltip } from 'oskari-ui';
 import { EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import { DELETE_ICON_STYLE } from './LayerAnalyticsDetails';
 import styled from 'styled-components';
-
-import 'antd/es/table/style/index.js';
 
 const TitleArea = styled.span`
     & {
@@ -34,7 +32,7 @@ export const LayerAnalyticsList = ({ analyticsData, isLoading, layerEditorCallba
             dataIndex: 'title',
             defaultSortOrder: 'ascend',
             sortDirections: ['descend', 'ascend', 'descend'],
-            sorter: (a, b) => Oskari.util.naturalSort(a.title, b.title),
+            sorter: getSorterFor('title'),
             showSorterTooltip: sorterTooltipOptions,
             render: (title, item) => {
                 return (
@@ -52,7 +50,7 @@ export const LayerAnalyticsList = ({ analyticsData, isLoading, layerEditorCallba
             dataIndex: 'dataProducer',
             defaultSortOrder: 'ascend',
             sortDirections: ['descend', 'ascend', 'descend'],
-            sorter: (a, b) => Oskari.util.naturalSort(a.dataProducer, b.dataProducer),
+            sorter: getSorterFor('dataProducer'),
             showSorterTooltip: sorterTooltipOptions,
             render: (title, item) => {
                 return (<TitleArea>{ title }</TitleArea>);
@@ -64,7 +62,7 @@ export const LayerAnalyticsList = ({ analyticsData, isLoading, layerEditorCallba
             dataIndex: 'layerType',
             defaultSortOrder: 'ascend',
             sortDirections: ['descend', 'ascend', 'descend'],
-            sorter: (a, b) => Oskari.util.naturalSort(a.layerType, b.layerType),
+            sorter: getSorterFor('layerType'),
             showSorterTooltip: sorterTooltipOptions,
             render: (title, item) => {
                 return (<TitleArea>{ title }</TitleArea>);

--- a/bundles/admin/admin-layeranalytics/LayerAnalyticsList.jsx
+++ b/bundles/admin/admin-layeranalytics/LayerAnalyticsList.jsx
@@ -1,0 +1,152 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { Table } from 'antd';
+import { Confirm, Message, Space, Spin, Tooltip } from 'oskari-ui';
+import { EditOutlined, DeleteOutlined } from '@ant-design/icons';
+import { DELETE_ICON_STYLE } from './LayerAnalyticsDetails';
+import styled from 'styled-components';
+
+import 'antd/es/table/style/index.js';
+
+const TitleArea = styled.span`
+    & {
+        display: flex;
+        justify-content: space-between;
+    }
+`;
+
+const StyledTable = styled(Table)`
+    .ant-table-column-sorter {
+        margin: 0 0 0 5px;
+    }
+`;
+
+const sorterTooltipOptions = {
+    title: <Message messageKey='flyout.sorterTooltip' />
+};
+
+export const LayerAnalyticsList = ({ analyticsData, isLoading, layerEditorCallback, layerDetailsCallback, removeAnalyticsCallback }) => {
+    
+    const columnSettings = [
+        {
+            align: 'left',
+            title: <Message messageKey='flyout.idTitle' />,
+            dataIndex: 'title',
+            defaultSortOrder: 'ascend',
+            sortDirections: ['descend', 'ascend', 'descend'],
+            sorter: (a, b) => Oskari.util.naturalSort(a.title, b.title),
+            showSorterTooltip: sorterTooltipOptions,
+            render: (title, item) => {
+                return (
+                    <TitleArea>
+                        <Tooltip title={ <Message messageKey='flyout.showDetailsTooltip' /> }>
+                            <a onClick={ () => layerDetailsCallback(item.id) } >{ title }</a>
+                        </Tooltip>
+                    </TitleArea>
+                );
+            }
+        },
+        {
+            align: 'left',
+            title: <Message messageKey='flyout.layerDataProvider' />,
+            dataIndex: 'dataProducer',
+            defaultSortOrder: 'ascend',
+            sortDirections: ['descend', 'ascend', 'descend'],
+            sorter: (a, b) => Oskari.util.naturalSort(a.dataProducer, b.dataProducer),
+            showSorterTooltip: sorterTooltipOptions,
+            render: (title, item) => {
+                return (<TitleArea>{ title }</TitleArea>);
+            }
+        },
+        {
+            align: 'left',
+            title: 'Type',
+            dataIndex: 'layerType',
+            defaultSortOrder: 'ascend',
+            sortDirections: ['descend', 'ascend', 'descend'],
+            sorter: (a, b) => Oskari.util.naturalSort(a.layerType, b.layerType),
+            showSorterTooltip: sorterTooltipOptions,
+            render: (title, item) => {
+                return (<TitleArea>{ title }</TitleArea>);
+            }
+        },
+        {
+            align: 'left',
+            title: <Message messageKey='flyout.totalDisplaysTitle' />,
+            dataIndex: 'total',
+            sortDirections: ['descend', 'ascend', 'descend'],
+            sorter: (a, b) => a.total - b.total,
+            showSorterTooltip: sorterTooltipOptions
+        },
+        {
+            align: 'left',
+            title: <Message messageKey='flyout.failurePercentage' />,
+            dataIndex: 'failurePercentage',
+            sortDirections: ['descend', 'ascend', 'descend'],
+            sorter: (a, b, sortOrder) => {
+                const rate = a.failurePercentage - b.failurePercentage;
+                if (rate !== 0) {
+                    return rate;
+                }
+                if (sortOrder === 'ascend') {
+                    // most used, least failures
+                    return b.total - a.total;
+                }
+                // most used, most failures
+                return a.total - b.total;
+            },
+            showSorterTooltip: sorterTooltipOptions,
+            render: (title) => <Fragment>{ title }%</Fragment>
+        },
+        {
+            align: 'left',
+            key: 'tools',
+            render: (title, item) => {
+                return (
+                    <React.Fragment>
+                        <TitleArea>
+                            <Space>
+                                <Tooltip title={ <Message messageKey='flyout.editLayerTooltip' /> }>
+                                    <EditOutlined onClick={ () => layerEditorCallback(item.id) } />
+                                </Tooltip>
+                                <Confirm
+                                    title={<Message messageKey='flyout.removeAllDataForLayer' />}
+                                    onConfirm={() => removeAnalyticsCallback(item.id)}
+                                    okText={<Message messageKey='flyout.delete' />}
+                                    cancelText={<Message messageKey='flyout.cancel' />}
+                                    placement='bottomLeft'>
+                                    <DeleteOutlined style={ DELETE_ICON_STYLE } />
+                                </Confirm>
+                            </Space>
+                        </TitleArea>
+                    </React.Fragment>
+                );
+            }
+        }
+    ];
+
+    if (isLoading) {
+        return ( <Spin/> );
+    }
+
+    return (
+        <StyledTable
+            columns={ columnSettings }
+            dataSource={ analyticsData.map(item => {
+                return {
+                    key: item.id,
+                    ...item
+                };
+            }) }
+            pagination={{ position: ['none', 'bottomCenter'] }}
+        />
+    );
+};
+
+LayerAnalyticsList.propTypes = {
+    analyticsData: PropTypes.array.isRequired,
+    isLoading: PropTypes.bool.isRequired,
+    layerEditorCallback: PropTypes.func.isRequired,
+    layerDetailsCallback: PropTypes.func.isRequired,
+    removeAnalyticsCallback: PropTypes.func.isRequired
+};

--- a/bundles/admin/admin-layeranalytics/Tile.js
+++ b/bundles/admin/admin-layeranalytics/Tile.js
@@ -1,0 +1,109 @@
+/**
+ * @class Oskari.framework.bundle.admin-layeranalytics.Tile
+ * Renders the "layer analytics admin" tile.
+ */
+Oskari.clazz.define('Oskari.framework.bundle.admin-layeranalytics.Tile',
+    /**
+     * @method create called automatically on construction
+     * @static
+     * @param {Oskari.mapframework.bundle.admin-layeranalytics.AdminLayerAnalyticsBundleInstance} instance
+     *     reference to component that created the tile
+     */
+
+    function (instance) {
+        this.instance = instance;
+        this.container = null;
+    }, {
+        /**
+         * @method getName
+         * @return {String} the name for the component
+         */
+        getName: function () {
+            return 'Oskari.framework.bundle.admin-layeranalytics.Tile';
+        },
+        /**
+         * @method setEl
+         * @param {Object} el
+         *      reference to the container in browser
+         * @param {Number} width
+         *      container size(?) - not used
+         * @param {Number} height
+         *      container size(?) - not used
+         *
+         * Interface method implementation
+         */
+        setEl: function (el) {
+            this.container = jQuery(el);
+        },
+        /**
+         * @method startPlugin
+         * Interface method implementation, calls #refresh()
+         */
+        startPlugin: function () {
+            this._addTileStyleClasses();
+            this.refresh();
+        },
+        _addTileStyleClasses: function () {
+            var isContainer = !!((this.container && this.instance.mediator));
+            var isBundleId = !!((isContainer && this.instance.mediator.bundleId));
+            var isInstanceId = !!((isContainer && this.instance.mediator.instanceId));
+
+            if (isInstanceId && !this.container.hasClass(this.instance.mediator.instanceId)) {
+                this.container.addClass(this.instance.mediator.instanceId);
+            }
+            if (isBundleId && !this.container.hasClass(this.instance.mediator.bundleId)) {
+                this.container.addClass(this.instance.mediator.bundleId);
+            }
+        },
+        /**
+         * @method stopPlugin
+         * Interface method implementation, clears the container
+         */
+        stopPlugin: function () {
+            this.container.empty();
+        },
+        /**
+         * @method getTitle
+         * @return {String} localized text for the title of the tile
+         */
+        getTitle: function () {
+            return this.instance.getLocalization('title');
+        },
+        /**
+         * @method getDescription
+         * @return {String} localized text for the description of the tile
+         */
+        getDescription: function () {
+            return this.instance.getLocalization('desc');
+        },
+        /**
+         * @method getOptions
+         * Interface method implementation, does nothing atm
+         */
+        getOptions: function () {
+
+        },
+        /**
+         * @method setState
+         * @param {Object} state
+         *      state that this component should use
+         * Interface method implementation, does nothing atm
+         */
+        setState: function (state) {
+
+        },
+        /**
+         * @method refresh
+         * Refresh UI. Does nothing atm
+         */
+        refresh: function () {
+
+        }
+    }, {
+        /**
+         * @property {String[]} protocol
+         * @static
+         */
+        protocol: ['Oskari.userinterface.Tile']
+    }
+);

--- a/bundles/admin/admin-layeranalytics/bundle.js
+++ b/bundles/admin/admin-layeranalytics/bundle.js
@@ -1,0 +1,79 @@
+/**
+ * Definition for bundle. See source for details.
+ *
+ * @class Oskari.framework.admin-layeranalytics.AdminLayerAnalyticsBundle
+ */
+Oskari.clazz.define('Oskari.framework.admin-layeranalytics.AdminLayerAnalyticsBundle',
+    /**
+     * Called automatically on construction. At this stage bundle sources have been
+     * loaded, if bundle is loaded dynamically.
+     *
+     * @contructor
+     * @static
+     */
+    function () {
+
+    }, {
+        /*
+        * called when a bundle instance will be created
+        *
+        * @method create
+        */
+        create: function () {
+            return Oskari.clazz.create(
+                'Oskari.framework.bundle.admin-layeranalytics.AdminLayerAnalyticsBundleInstance'
+            );
+        },
+        /**
+         * Called by Bundle Manager to provide state information to
+         *
+         * @method update
+         * bundle
+         */
+        update: function (manager, bundle, bi, info) {
+        }
+    },
+
+    /**
+     * metadata
+     */
+    {
+        protocol: ['Oskari.bundle.Bundle', 'Oskari.mapframework.bundle.extension.ExtensionBundle'],
+        source: {
+            scripts: [
+                {
+                    type: 'text/javascript',
+                    src: './instance.js'
+                },
+                {
+                    type: 'text/javascript',
+                    src: './Tile.js'
+                },
+                {
+                    type: 'text/javascript',
+                    src: './Flyout.js'
+                }
+            ],
+            locales: [
+                {
+                    lang: 'fi',
+                    type: 'text/javascript',
+                    src: './resources/locale/fi.js'
+                },
+                {
+                    lang: 'en',
+                    type: 'text/javascript',
+                    src: './resources/locale/en.js'
+                },
+                {
+                    lang: 'sv',
+                    type: 'text/javascript',
+                    src: './resources/locale/sv.js'
+                }
+            ]
+        }
+    }
+);
+
+// Install this bundle by instantating the Bundle Class
+Oskari.bundle_manager.installBundleClass('admin-layeranalytics', 'Oskari.framework.admin-layeranalytics.AdminLayerAnalyticsBundle');

--- a/bundles/admin/admin-layeranalytics/instance.js
+++ b/bundles/admin/admin-layeranalytics/instance.js
@@ -1,0 +1,303 @@
+import { Messaging } from 'oskari-ui/util';
+import { Message } from 'oskari-ui';
+import React from 'react';
+
+const getMessage = (key, args) => <Message messageKey={key} messageArgs={args} bundleKey='admin-layeranalytics' />;
+
+/**
+ * @class Oskari.framework.bundle.admin-layeranalytics.AdminLayerAnalyticsBundleInstance
+ *
+ * See Oskari.framework.bundle.admin-layeranalytics.AdminLayerAnalyticsBundleInstance for bundle definition.
+ */
+Oskari.clazz.define('Oskari.framework.bundle.admin-layeranalytics.AdminLayerAnalyticsBundleInstance',
+
+    /**
+    * @method create called automatically on construction
+    * @static
+    */
+    function () {
+        this.localization = null;
+        this.plugins = {};
+        this.sandbox = null;
+        this.isLoading = true;
+        this.analyticsListData = [];
+        this.selectedLayerData = {};
+        this.mapLayerService = Oskari.getSandbox().getService('Oskari.mapframework.service.MapLayerService');
+    }, {
+        __name: 'admin-layeranalytics',
+        /**
+         * @method setSandbox
+         * @param {Oskari.Sandbox} sandbox
+         * Sets the sandbox reference to this component
+         */
+        setSandbox (sandbox) {
+            this.sandbox = sandbox;
+        },
+
+        /**
+         * @method getSandbox
+         * @return {Oskari.Sandbox}
+         */
+        getSandbox () {
+            return this.sandbox;
+        },
+        eventHandlers: {
+            'userinterface.ExtensionUpdatedEvent': function (event) {
+                // Not handle other extension update events
+                if (event.getExtension().getName() !== this.getName()) {
+                    return;
+                }
+
+                if (event.getViewState() !== 'close') {
+                    this.produceAnalyticsListData();
+                }
+            }
+        },
+        /**
+         * @method getLocalization
+         * Returns JSON presentation of bundles localization data for
+         * current language.
+         * If key-parameter is not given, returns the whole localization
+         * data.
+         *
+         * @param {String} key (optional) if given, returns the value for
+         *         key
+         * @return {String/Object} returns single localization string or
+         *      JSON object for complete data depending on localization
+         *      structure and if parameter key is given
+         */
+        getLocalization (key) {
+            if (!this.localization) {
+                this.localization = Oskari.getLocalization(this.getName());
+            }
+            if (key) {
+                return this.localization[key];
+            }
+            return this.localization;
+        },
+        /**
+         * @method start
+         * implements BundleInstance protocol start method
+         */
+        start () {
+            const me = this;
+
+            const sandboxName = 'sandbox';
+            const sandbox = Oskari.getSandbox(sandboxName);
+
+            this.sandbox = sandbox;
+            this.sandbox.register(me);
+
+            // Let's extend UI
+            const reqName = 'userinterface.AddExtensionRequest';
+            const reqBuilder = Oskari.requestBuilder(reqName);
+            const request = reqBuilder(this);
+            sandbox.request(this, request);
+
+            Object.keys(this.eventHandlers).forEach(eventName => sandbox.registerForEventByName(this, eventName));
+
+            me.createUi();
+        },
+        /**
+         * @memberof BasicBundle
+         * @param {Oskari.mapframework.event.Event} event A Oskari event object.
+         */
+        onEvent (event) {
+            const handler = this.eventHandlers[event.getName()];
+            if (!handler) {
+                return;
+            }
+            return handler.call(this, event);
+        },
+        /**
+         * @method init
+         * implements Module protocol init method - does nothing atm
+         */
+        init () {
+            return null;
+        },
+        /**
+         * @method update
+         * implements BundleInstance protocol update method - does nothing atm
+         */
+        update () {
+
+        },
+        getName () {
+            return this.__name;
+        },
+        /**
+         * @method startExtension
+         * implements Oskari.userinterface.Extension protocol
+         * startExtension method
+         * Creates a flyout and a tile:
+         * Oskari.mapframework.bundle.publisher.Flyout
+         * Oskari.mapframework.bundle.publisher.Tile
+         */
+        startExtension () {
+            this.plugins['Oskari.userinterface.Flyout'] = Oskari.clazz.create('Oskari.framework.bundle.admin-layeranalytics.Flyout', this);
+            this.plugins['Oskari.userinterface.Tile'] = Oskari.clazz.create('Oskari.framework.bundle.admin-layeranalytics.Tile', this);
+        },
+
+        /**
+         * @method stopExtension
+         * implements Oskari.userinterface.Extension protocol
+         * stopExtension method
+         * Clears references to flyout and tile
+         */
+        stopExtension () {
+            this.plugins['Oskari.userinterface.Tile'] = null;
+        },
+
+        /**
+         * @method getPlugins
+         * implements Oskari.userinterface.Extension protocol getPlugins
+         * method
+         * @return {Object} references to flyout and tile
+         */
+        getPlugins () {
+            return this.plugins;
+        },
+
+        createUi () {
+            this.plugins['Oskari.userinterface.Tile'].refresh();
+            this.plugins['Oskari.userinterface.Flyout'].createContent();
+        },
+
+        /**
+         * @method fetchLayerAnalytics
+         * Fetches data for layer analytics
+         * @param {*} layerId null or layerId as a number. If null only list view data will be fetched
+         * @param {*} callback
+         * @returns
+         */
+        fetchLayerAnalytics (layerId, callback) {
+            this.updateLoadingState(true);
+            const route = layerId ? Oskari.urls.getRoute('LayerStatus', { id: layerId }) : Oskari.urls.getRoute('LayerStatus');
+
+            return fetch(route, {
+                method: 'GET',
+                headers: {
+                    Accept: 'application/json'
+                }
+            }).then(response => {
+                if (!response.ok) {
+                    Messaging.error(getMessage('messages.errorFetchingLayerAnalytics'));
+                }
+                return response.json();
+            }).then(json => {
+                if (callback) {
+                    callback(json);
+                }
+            });
+        },
+
+        removeAnalyticsData (layerId, dataId) {
+            this.updateLoadingState(true);
+            this.plugins['Oskari.userinterface.Flyout'].updateUI(); // show spinner
+            const route = dataId ? Oskari.urls.getRoute('LayerStatus', { id: layerId, dataId: dataId }) : Oskari.urls.getRoute('LayerStatus', { id: layerId });
+
+            fetch(route, {
+                method: 'DELETE',
+                headers: {
+                    Accept: 'application/json'
+                }
+            }).then(response => {
+                if (!response.ok) {
+                    Messaging.error(getMessage('messages.errorDeletingLayerAnalytics'));
+                }
+
+                this.updateLoadingState();
+                if (!dataId) {
+                    // removed whole layer data
+                    this.analyticsListData = this.analyticsListData.filter(item => item.id !== layerId);
+                    this.plugins['Oskari.userinterface.Flyout'].updateUI();
+                } else {
+                    // removed single usage data
+                    this.produceAnalyticsDetailsData(this.plugins['Oskari.userinterface.Flyout'].getSelectedLayerId());
+                }
+            });
+        },
+
+        /**
+         * @method produceAnalyticsListData
+         * Produce data for analytics list view
+         */
+        produceAnalyticsListData () {
+            this.fetchLayerAnalytics(null, (result) => {
+                for (const item in result) {
+                    const itemLayer = this.mapLayerService.findMapLayer(item);
+                    const title = itemLayer !== null ? itemLayer.getName() : item;
+                    const dataProducer = itemLayer !== null ? itemLayer.getOrganizationName() : '';
+                    const layerType = itemLayer !== null ? itemLayer.getLayerType() : '';
+                    const totalDisplays = result[item].success + result[item].errors;
+                    const failurePercentage = Math.round(result[item].errors / totalDisplays * 100);
+
+                    this.analyticsListData.push({
+                        ...result[item],
+                        total: totalDisplays,
+                        failurePercentage: failurePercentage,
+                        id: item,
+                        title: title,
+                        dataProducer,
+                        layerType
+                    });
+                }
+                this.updateLoadingState();
+                this.plugins['Oskari.userinterface.Flyout'].updateUI();
+            });
+        },
+
+        /**
+         * @method produceAnalyticsDetailsData
+         * Produce analytics details view data by fetching data with id as parameter
+         */
+        produceAnalyticsDetailsData (id) {
+            this.updateLoadingState(true);
+
+            this.fetchLayerAnalytics(id, (itemData) => {
+                const itemLayer = this.mapLayerService.findMapLayer(id);
+                const layerOrganization = itemLayer !== 'undefined' && itemLayer !== null ? itemLayer.getOrganizationName() : null;
+                const title = typeof itemLayer !== 'undefined' && itemLayer !== null ? itemLayer.getName() : id;
+                const totalDisplays = itemData.success + itemData.errors;
+                const successPercentage = Math.round(itemData.success / totalDisplays * 100);
+
+                this.selectedLayerData = {
+                    ...itemData,
+                    id: id,
+                    successPercentage: successPercentage,
+                    title: title,
+                    layerOrganization: layerOrganization
+                };
+                this.updateLoadingState();
+                this.plugins['Oskari.userinterface.Flyout'].updateUI();
+            });
+        },
+
+        getAnalyticsListData () {
+            return this.analyticsListData;
+        },
+
+        getAnalyticsDetailsData () {
+            return this.selectedLayerData;
+        },
+
+        /**
+         * @method updateLoadingState
+         * Updates loading state of bundle for progress spinner usage
+         */
+        updateLoadingState (loadingState = false) {
+            this.isLoading = loadingState;
+        },
+
+        getLoadingState () {
+            return this.isLoading;
+        }
+    }, {
+        protocol: [
+            'Oskari.bundle.BundleInstance',
+            'Oskari.mapframework.module.Module',
+            'Oskari.userinterface.Extension'
+        ]
+    }
+);

--- a/bundles/admin/admin-layeranalytics/resources/locale/en.js
+++ b/bundles/admin/admin-layeranalytics/resources/locale/en.js
@@ -1,0 +1,35 @@
+Oskari.registerLocalization(
+    {
+        "lang": "en",
+        "key": "admin-layeranalytics",
+        "value": {
+            "title": "A: Layer monitor",
+            "desc": "",
+            "tile": {
+                "title": "A: Layer monitor"
+            },
+            "flyout": {
+                "title": "Layer monitor",
+                "totalDisplaysTitle": "Total displays",
+                "failurePercentage": "Failed displays %",
+                "successTitle": "Successes",
+                "failureTitle": "Failures",
+                "idTitle": "Id",
+                "moveToScale": "Situation",
+                "moveToScaleTooltip": "Open the map view in which the problem occured.",
+                "backToList": "Back to list",
+                "layerDataProvider": "Dataprovider",
+                "sorterTooltip": "Click to sort descending/ascending",
+                "showDetailsTooltip": "Open detailed view",
+                "editLayerTooltip": "Edit layer",
+                "removeAllDataForLayer": "Remove all tracking data for layer",
+                "removeSingleDataForLayer": "Remove tracking data from single user report",
+                "delete": "Delete",
+                "cancel": "Cancel"
+            },
+            "messages": {
+                "errorFetchingLayerAnalytics": "Layer monitor data couldn't be fetched.",
+                "errorDeletingLayerAnalytics": "Layer monitor data couldn't be deleted."
+            }
+        }
+    });

--- a/bundles/admin/admin-layeranalytics/resources/locale/fi.js
+++ b/bundles/admin/admin-layeranalytics/resources/locale/fi.js
@@ -1,0 +1,35 @@
+Oskari.registerLocalization(
+    {
+        "lang": "fi",
+        "key": "admin-layeranalytics",
+        "value": {
+            "title": "A: Tasoseuranta",
+            "desc": "",
+            "tile": {
+                "title": "A: Tasoseuranta"
+            },
+            "flyout": {
+                "title": "Tasoseuranta",
+                "totalDisplaysTitle": "Näytöt yhteensä",
+                "failurePercentage": "Virheelliset näytöt %",
+                "successTitle": "Onnistuneet näytöt",
+                "failureTitle": "Virheelliset näytöt",
+                "idTitle": "Nimi",
+                "moveToScale": "Tilanne",
+                "moveToScaleTooltip": "Avaa karttanäkymä jossa virhetilanne syntyi.",
+                "backToList": "Paluu listausnäkymään",
+                "layerDataProvider": "Tiedontuottaja",
+                "sorterTooltip": "Järjestä laskevasti/nousevasti",
+                "showDetailsTooltip": "Avaa yksityiskohtaiset tiedot",
+                "editLayerTooltip": "Muokkaa tasoa",
+                "removeAllDataForLayer": "Poista tason kaikki seurantatiedot",
+                "removeSingleDataForLayer": "Poista yksittäisen käyttäjän raportoimat seurantatiedot",
+                "delete": "Poista",
+                "cancel": "Peruuta"
+            },
+            "messages": {
+                "errorFetchingLayerAnalytics": "Tason analytiikka tietoja ei voitu hakea.",
+                "errorDeletingLayerAnalytics": "Taso analytiikan tietoja ei voitu poistaa."
+            }
+        }
+    });

--- a/bundles/admin/admin-layeranalytics/resources/locale/sv.js
+++ b/bundles/admin/admin-layeranalytics/resources/locale/sv.js
@@ -1,0 +1,31 @@
+Oskari.registerLocalization(
+    {
+        "lang": "sv",
+        "key": "admin-layeranalytics",
+        "value": {
+            "title": "A: Övervakning för kartlager",
+            "desc": "",
+            "tile": {
+                "title": "A: Övervakning för kartlager"
+            },
+            "flyout": {
+                "title": "Övervakning för kartlager",
+                "totalDisplaysTitle": "Totala vyn",
+                "failurePercentage": "Misslyckade vyn %",
+                "successTitle": "Framgångsrika vyn",
+                "failureTitle": "Misslyckade vyn",
+                "idTitle": "Id",
+                "moveToScale": "Situation",
+                "moveToScaleTooltip": "Öppna kartvy som förorsakade misslyckad funktion.",
+                "backToList": "Återgå till listvyn",
+                "layerDataProvider": "Dataproducent",
+                "sorterTooltip": "Sortera fallande / stigande",
+                "showDetailsTooltip": "Öppna detaljvyn",
+                "editLayerTooltip": "Editera kartlager"
+            },
+            "messages": {
+                "errorFetchingLayerAnalytics": "Layer analytics couldn't be fetched.",
+                "errorDeletingLayerAnalytics": "Layer monitor data couldn't be deleted."
+            }
+        }
+    });

--- a/bundles/framework/layeranalytics/bundle.js
+++ b/bundles/framework/layeranalytics/bundle.js
@@ -1,0 +1,21 @@
+/**
+ * @class Oskari.layeranalytics.StatusBundle
+ *
+ * Definition for bundle. See source for details.
+ */
+Oskari.clazz.define('Oskari.layeranalytics.StatusBundle', function () { }, {
+    create: function () {
+        return Oskari.clazz.create('Oskari.layeranalytics.StatusBundleInstance');
+    },
+    update: function (manager, bundle, bi, info) { }
+}, {
+    protocol: ['Oskari.bundle.Bundle'],
+    source: {
+        scripts: [{
+            type: 'text/javascript',
+            src: './instance.js'
+        }]
+    }
+});
+
+Oskari.bundle_manager.installBundleClass('layeranalytics', 'Oskari.layeranalytics.StatusBundle');

--- a/bundles/framework/layeranalytics/instance.js
+++ b/bundles/framework/layeranalytics/instance.js
@@ -1,0 +1,103 @@
+// state values for layer loading statuses
+const STATE = {
+    ERROR: 'error',
+    SUCCESS: 'success'
+};
+
+/**
+ * @class Oskari.pti.layerstatus.StatusBundleInstance
+ */
+Oskari.clazz.define('Oskari.layeranalytics.StatusBundleInstance', function () {
+    // no-op
+}, {
+    __name: 'LayerStatusBundleInstance',
+    __loadingStatus: {},
+    _startImpl: function (sandbox) {
+        const map = sandbox.findRegisteredModuleInstance('MainMapModule');
+        map.on('layer.loading', (event) => {
+            // event: {layer: 801, started: true, errored: false}
+            if (event.started) {
+                // don't care about start events
+                return;
+            }
+            this._handleLoadingEvent(event.layer, event.errored);
+        });
+
+        window.addEventListener('beforeunload', () => {
+            // just fire and forget when the user leaves the page
+            this._sendStatus();
+        });
+    },
+    _handleLoadingEvent: function (layer, wasError) {
+        const stats = this._getLayerStatus(layer);
+        let currentState = STATE.SUCCESS;
+        if (wasError) {
+            stats.errors++;
+            currentState = STATE.ERROR;
+        } else {
+            stats.success++;
+        }
+
+        if (stats.previous !== currentState) {
+            stats.previous = currentState;
+            // for the first 10 state changes:
+            // save stack for current state with center coord and zoom level
+            if (stats.stack.length < 10) {
+                const mapState = this.sandbox.getMap();
+                stats.stack.push({
+                    x: mapState.getX(),
+                    y: mapState.getY(),
+                    z: mapState.getZoom(),
+                    state: currentState,
+                    layers: mapState.getLayers().map(l => l.getId())
+                });
+            }
+        }
+    },
+    _getLayerStatus: function (layerId, includeVector = false) {
+        const NON_TRACKED_LAYER = 'runtimeVector';
+        if (!layerId) {
+            const status = {
+                ...this.__loadingStatus
+            };
+            if (!includeVector) {
+                delete status[NON_TRACKED_LAYER];
+            }
+            return status;
+        }
+        let id = '' + layerId;
+        // combine results for recognized layer ids from same (internal) service
+        if (typeof layerId !== 'number') {
+            if (id.startsWith('myplaces_') || id.startsWith('userlayer_') || id.startsWith('analysis_')) {
+                id = 'usercontent';
+            } else {
+                // STATS_LAYER and other runtime vector layers
+                id = NON_TRACKED_LAYER;
+            }
+        }
+
+        const stats = this.__loadingStatus[id];
+        if (stats) {
+            return stats;
+        }
+        this.__loadingStatus[id] = {
+            errors: 0,
+            success: 0,
+            stack: [],
+            previous: STATE.SUCCESS
+        };
+        return this.__loadingStatus[id];
+    },
+    _sendStatus: function () {
+        fetch(Oskari.urls.getRoute('LayerStatus'), {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(this._getLayerStatus())
+        });
+    }
+}, {
+    extend: ['Oskari.BasicBundle'],
+    protocol: ['Oskari.bundle.BundleInstance', 'Oskari.mapframework.module.Module']
+});


### PR DESCRIPTION
Frontend impl for layeranalytics (oskariorg/oskari-server#817). Moved from nls-oskari/pti-frontend

# New bundles:

## layeranalytics

New bundle for collecting success/error rate for map layer loading events and pushing the data to the server when user leaves the page

## admin-layeranalytics

New bundle for admins to inspect failure rates for map layers based on end-user experience. This allows admins to see which map layers are not working properly for end-users and make configuration changes to improve the situation or remove the layer from the system if it has been removed from the service it was registered from.