### PR TITLE
Fix an issue with styles when stroke is not drawn

### DIFF
--- a/bundles/mapping/mapmodule/oskariStyle/generator.ol.js
+++ b/bundles/mapping/mapmodule/oskariStyle/generator.ol.js
@@ -272,6 +272,10 @@ export const getOlStyles = (mapModule, styleDef, geomType, requestedStyle = {}) 
 // draw transparent solid stroke to fire hover and click also on gaps with dashed stroke
 // open layers renders only dashes so hover or click aren't fired on gaps
 const getWorkaroundForDash = olStroke => {
+    if (!olStroke) {
+        // stroke with width 0 returns null as olStroke
+        return [];
+    }
     const lineDash = olStroke.getLineDash();
     if (!lineDash || !lineDash.length) {
         return [];


### PR DESCRIPTION
Stylegenerator throws `Cannot read properties of null (reading 'getLineDash')` when using a style with `{ stroke: { width: 0 }}`. This fixes the issue.