### PR TITLE
Statsgrid divided points

### DIFF
--- a/bundles/statistics/statsgrid2016/components/classification/Legend.jsx
+++ b/bundles/statistics/statsgrid2016/components/classification/Legend.jsx
@@ -22,7 +22,7 @@ export const Legend = ({
     }
     const opacity = transparency / 100 || 1;
     const { groups } = classifiedDataset;
-    const maxSizePx = groups[groups.length - 1].sizePx;
+    const maxSizePx = groups.map(g => g.sizePx).reduce((max, val) => max < val ? val : max);
     return (
         <Container>
             { groups.map((group, i) =>

--- a/bundles/statistics/statsgrid2016/components/classification/editclassification/Color.jsx
+++ b/bundles/statistics/statsgrid2016/components/classification/editclassification/Color.jsx
@@ -13,8 +13,8 @@ const StyledCheckbox = styled(Checkbox)`
 `;
 
 export const Color = ({ colorsets, values, controller, disabled }) => {
-    const { color, mapStyle, reverseColors } = values;
-    const isSimple = mapStyle === 'points';
+    const { color, mapStyle, reverseColors, type } = values;
+    const isSimple = mapStyle === 'points' && type !== 'div';
 
     const handleReverseColors = evt => controller.updateClassification('reverseColors', evt.target.checked);
     const handleColorChange = color => controller.updateClassification('color', color);

--- a/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
@@ -108,7 +108,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
                 if (this.indicatorData.hash !== activeIndicator.hash) return; // not latest active indicator response
                 if (data) {
                     const validData = Object.fromEntries(Object.entries(data).filter(([key, val]) => val !== null && val !== undefined));
-                    const uniqueValues = [...new Set(Object.values(validData))].sort((a,b) => a - b);
+                    const uniqueValues = [...new Set(Object.values(validData))].sort((a, b) => a - b);
                     this.indicatorData.uniqueCount = uniqueValues.length;
                     this.indicatorData.data = data;
                     this.indicatorData.minMax = { min: uniqueValues[0], max: uniqueValues[uniqueValues.length - 1] };

--- a/bundles/statistics/statsgrid2016/service/ColorService.js
+++ b/bundles/statistics/statsgrid2016/service/ColorService.js
@@ -59,6 +59,31 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ColorService',
             }
             return reverseColors ? [...set].reverse() : set;
         },
+        getDividedColors: function (classification, bounds) {
+            const { count, color, reverseColors, base = 0 } = classification;
+            const isEven = count % 2 === 0;
+            const colorCount = isEven ? 2 : 3;
+            const colorset = [...this.getColorset(colorCount, color)];
+            if (reverseColors) {
+                colorset.reverse();
+            }
+            const baseIndex = bounds.findIndex(bound => bound >= base);
+            const colors = [];
+            if (isEven) {
+                for (let i = 0; i < bounds.length - 1; i++) {
+                    colors[i] = i < baseIndex ? colorset[0] : colorset[1];
+                }
+            } else {
+                for (let i = 0; i < bounds.length - 1; i++) {
+                    if (i === baseIndex) {
+                        colors[i] = colorset[1];
+                    } else {
+                        colors[i] = i < baseIndex ? colorset[0] : colorset[2];
+                    }
+                }
+            }
+            return colors;
+        },
         /**
          * Tries to return an array of colors where length equals count parameter.
          * If such set is not available, throws Error
@@ -95,7 +120,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ColorService',
             return { min: 2, max: max + 2 };
         },
         validateColor: function (color, mapStyle, type) {
-            if (mapStyle === 'points') {
+            if (mapStyle === 'points' && type !== 'div') {
                 return !!Oskari.util.hexToRgb(color);
             }
             const colorset = this.colorsets.find(set => set.name === color);
@@ -103,7 +128,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ColorService',
             return setType === type;
         },
         getDefaultColorForType: function (mapStyle, type) {
-            if (mapStyle === 'points') {
+            if (mapStyle === 'points' && type !== 'div') {
                 return this._defaults.color;
             }
             if (!this.getAvailableTypes().includes(type)) {

--- a/bundles/statistics/statsgrid2016/service/StateService.js
+++ b/bundles/statistics/statsgrid2016/service/StateService.js
@@ -278,6 +278,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
             const lastSelected = { ...this.lastSelectedClassification };
             delete lastSelected.manualBounds;
             delete lastSelected.fractionDigits;
+            delete lastSelected.base;
 
             const metadataClassification = {};
             // Note! Assumes that the metadata has been loaded when selecting the indicator from the list to get a sync response
@@ -290,25 +291,18 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
                 const metadata = data.metadata || {};
                 if (typeof metadata.isRatio === 'boolean') {
                     metadataClassification.mapStyle = metadata.isRatio ? 'choropleth' : 'points';
-                } else {
-                    // we have no metadata, default to last used or 'choropleth'
-                    metadataClassification.mapStyle = lastSelected.mapStyle || 'choropleth';
                 }
-                let decimalCount = metadata.decimalCount;
-                if (typeof decimalCount !== 'number') {
-                    decimalCount = lastSelected.fractionDigits;
+                if (typeof metadata.decimalCount === 'number') {
+                    metadataClassification.fractionDigits = metadata.decimalCount;
                 }
-                metadataClassification.fractionDigits = decimalCount;
                 if (typeof metadata.base === 'number') {
                     // if there is a base value the data is divided at base value
                     // TODO: other stuff based on this
+                    metadataClassification.base = metadata.base;
                     metadataClassification.type = 'div';
-                } else {
-                    // we have no metadata, default to last used or 'seq'
-                    metadataClassification.type = lastSelected.type || 'seq';
                 }
             });
-            const result = jQuery.extend({}, this._defaults.classification, lastSelected, metadataClassification, indicator.classification || {});
+            const result = jQuery.extend({}, this._defaults.classification, lastSelected, metadataClassification);
             this.validateClassification(result);
             return result;
         },


### PR DESCRIPTION
If points mapStyle has base (from metadata) or negative and positive values it can be divided. Add functionality to calculate divided points and colors (div colorsets). Force closest bound to base value with even count and force both bounds with odd count to get 'neutral' group.

getClassificationOpts is used like:
`ind.classification || this.getClassificationOpts(hash)`
So removed extending classification from indicator because it should be always {}.
Classification also gets defaults and lastSelected if metadata doesn't override values so changed to set metadataClassification values only if needed.