### PR TITLE
Change stroke width to be consistent with server default

### DIFF
--- a/src/react/components/StyleEditor/OskariDefaultStyle.js
+++ b/src/react/components/StyleEditor/OskariDefaultStyle.js
@@ -9,13 +9,13 @@ export const OSKARI_BLANK_STYLE = {
     },
     stroke: { // stroke styles
         color: '#000000', // stroke color
-        width: 3, // stroke width
+        width: 1, // stroke width
         lineDash: 'solid', // line dash, supported: dash, dashdot, dot, longdash, longdashdot and solid
         lineCap: 'round', // line cap, supported: butt, round and square
         lineJoin: 'round', // line corner, supported: bevel, round and miter
         area: {
             color: '#000000', // area stroke color
-            width: 3, // area stroke width
+            width: 1, // area stroke width
             lineDash: 'solid', // area line dash
             lineJoin: 'round' // area line corner, supported: bevel, round and miter
         }


### PR DESCRIPTION
Server change: https://github.com/oskariorg/oskari-server/pull/820

The map uses it's own default that is 1 so it makes sense to init the style editor with what the user sees on screen.  The server default should also match so when printing with default style the line width is consistent what is shown on screen.

TODO: use just one default for frontend (and maybe even server).