### PR TITLE
Statsgrid validations fix

### DIFF
--- a/bundles/statistics/statsgrid2016/service/ClassificationService.js
+++ b/bundles/statistics/statsgrid2016/service/ClassificationService.js
@@ -69,7 +69,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationService',
                 this.log.warn('Data expected as object with region/value as keys/values.');
                 return { error: 'noData' };
             }
-            const dataAsList = Object.values(indicatorData);
+            // TODO: data should be validated in one place (stateservice?)
+            const dataAsList = Object.values(indicatorData).filter(val => val !== null && val !== undefined);
             if ((groupStats && groupStats.serie.length < 3) || dataAsList.length < 2) {
                 return { error: 'noEnough' };
             }
@@ -94,9 +95,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationService',
 
             if (groupStats) {
                 groupStats.silent = true;
-                if (opts.count >= groupStats.serie.length) {
-                    opts.count = groupStats.serie.length - 1;
-                }
                 var groupOpts = groupStats.classificationOptions || {};
                 const calculateBounds =
                     groupOpts.method !== opts.method ||
@@ -108,6 +106,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationService',
                     groupOpts.method = opts.method;
                     groupOpts.count = opts.count;
                     groupStats.classificationOptions = groupOpts;
+                } else {
+                    bounds = groupStats.bounds;
                 }
                 // Set bounds manually.
                 stats.setBounds(groupStats.bounds);

--- a/bundles/statistics/statsgrid2016/service/StateService.js
+++ b/bundles/statistics/statsgrid2016/service/StateService.js
@@ -307,10 +307,15 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
             return result;
         },
         validateClassification: function (classification) {
-            const { mapStyle, color, type } = classification;
             const colorService = this.service.getColorService();
-            if (!colorService.validateColor(color, mapStyle, type)) {
-                classification.color = colorService.getDefaultColorForType(mapStyle, type);
+            if (!colorService.validateColor(classification)) {
+                classification.color = colorService.getDefaultColor(classification);
+            }
+            const { max } = classification.mapStyle === 'points'
+                ? this.service.getClassificationService().getRangeForPoints()
+                : colorService.getRangeForColor(classification.color);
+            if (classification.count > max) {
+                classification.count = max;
             }
         },
         /**


### PR DESCRIPTION
Validate data before passing it to geostat. This fixes issue where geostats/classifiy fails if data has undefined values. 
Set groupstats.bounds to bounds. This fixes issue when adding groupstats (bounds were set only if them were recalculated).
Add default colors for every type. Earlier first type matching color was selected. For 'qual' type first color is 'Accent' which have only 8 colors which caused problems if count was > 8. Also added max count validation which decreases count to max if it was higher.
Fix colorservice getRange which returned max value higher by one than should (user had extra count option which didn't work)