### PR TITLE
Statsgrid validate classification on SetState

### DIFF
--- a/bundles/statistics/statsgrid2016/service/ColorService.js
+++ b/bundles/statistics/statsgrid2016/service/ColorService.js
@@ -131,6 +131,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ColorService',
         },
         validateColor: function (classification) {
             const { mapStyle, color, type } = classification;
+            if (typeof color !== 'string') {
+                return false;
+            }
             if (mapStyle === 'points' && type !== 'div') {
                 return !!Oskari.util.hexToRgb(color);
             }

--- a/bundles/statistics/statsgrid2016/service/StateService.js
+++ b/bundles/statistics/statsgrid2016/service/StateService.js
@@ -165,6 +165,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
             // map to keep stored states work properly
             this.indicators = indicators.map(ind => {
                 const hash = ind.hash || this.getHash(ind.ds, ind.id, ind.selections, ind.series);
+                if (ind.classification) {
+                    this.validateClassification(ind.classification);
+                }
                 return {
                     datasource: Number(ind.ds),
                     indicator: ind.id,


### PR DESCRIPTION
Validate classification on SetState. Check that color is string before validate. Fixes issue where state (cookie, user or published view) contains invalid classification (user gets valid color or count without crashing).