### PR TITLE
Statsgrid jenks min value count fix

### DIFF
--- a/bundles/statistics/statsgrid2016/service/ClassificationService.js
+++ b/bundles/statistics/statsgrid2016/service/ClassificationService.js
@@ -71,7 +71,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationService',
             }
             // TODO: data should be validated in one place (stateservice?)
             const dataAsList = Object.values(indicatorData).filter(val => val !== null && val !== undefined);
-            if ((groupStats && groupStats.serie.length < 3) || dataAsList.length < 2) {
+            const minData = opts.method === 'jenks' ? 3 : 2;
+            if ((groupStats && groupStats.serie.length < 3) || dataAsList.length < minData) {
                 return { error: 'noEnough' };
             }
             const isDivided = opts.mapStyle === 'points' && opts.type === 'div';


### PR DESCRIPTION
Add min data 3 for jenks. Jenks option is disabled if unique value count < 3. This should be done in StateService validateClassification but it doesn't validate data for now. This is quick and dirty fix for issue where 2 value indicator (e.g. Nuts1) is added with default options (jenks) and classificationplugin crashes.