### PR TITLE
Fix Jest tests to work with latest ol/geotiff

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
     timers: 'fake',
     verbose: true,
     transformIgnorePatterns: [
-        'node_modules/(?!(ol|jsts|geotiff)).+\\.js$'
+        'node_modules/(?!(ol|jsts|geotiff|quick-lru)).+\\.js$'
     ]
     /*
     ,transform: {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "file-loader": "4.2.0",
     "fs-extra": "8.1.0",
     "geostats": "1.8.0",
-    "geotiff": "2.0.4",
     "gm": "1.23.1",
     "imports-loader": "0.8.0",
     "intl-messageformat": "9.11.4",


### PR DESCRIPTION
Add quick-lru for Jest transformIgnorePatterns so we can use the latest geotiff (transitive dependency through OpenLayers).

Related to: #1779