### PR TITLE
Fix flyout reference for embedded maps

### DIFF
--- a/bundles/framework/maplegend/instance.js
+++ b/bundles/framework/maplegend/instance.js
@@ -168,7 +168,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.MapLegendBundleInstanc
              */
             'MapLayerEvent': function (event) {
                 if (event.getOperation() === 'update') {
-                    this.plugins['Oskari.userinterface.Flyout'].refresh();
+                    this.refreshUI();
                 }
 
                 if (event.getOperation() !== 'add') {


### PR DESCRIPTION
MapLayerEvent is rarely used in embedded maps, but timeseries player uses it.

Note! This should be looked at more closely so legend ui is not re-rendered after each change (since timeseries/vector features style update functionality uses this "aggressively"). Maybe checking to re-render only if name/legend changes or something like that.