### PR TITLE
Statsgrid reset state

### DIFF
--- a/bundles/statistics/statsgrid2016/service/StateService.js
+++ b/bundles/statistics/statsgrid2016/service/StateService.js
@@ -155,11 +155,12 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
             this.regionset = null;
             this.indicators = [];
             this.activeRegion = null;
+            this.lastSelectedClassification = {};
             const eventBuilder = Oskari.eventBuilder('StatsGrid.StateChangedEvent');
             this.sandbox.notifyAll(eventBuilder(true));
         },
-        setState: function (state = {}) {
-            const { regionset, indicators = [], active: activeHash, activeRegion } = state;
+        setState: function (state) {
+            const { regionset, indicators = [], active: activeHash, activeRegion } = state || {};
             this.regionset = regionset;
             this.activeRegion = activeRegion;
             // map to keep stored states work properly
@@ -514,7 +515,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.StateService',
                 this.sandbox.notifyAll(eventBuilder(datasrc, indicator, selections, series, true));
             } else {
                 // if no indicators then reset state
-                // last indicator removal should act like all indicators or layer was removed
+                // last indicator removal should act like all indicators was removed
                 this.resetState();
             }
 

--- a/bundles/statistics/statsgrid2016/view/SearchFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/SearchFlyout.js
@@ -33,6 +33,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
         }
         this.uiElement.empty();
     },
+    teardownUI: function () {
+        this.hide();
+        this.uiElement = null;
+    },
     setSpinner: function (spinner) {
         this.spinner = spinner;
     },


### PR DESCRIPTION
Reset state and clear search flyout when new state doesn't have any indicators. User gets rid of statsgrid's flyouts and gets clean search flyout when whole state is reset ("Do you wish to return to the original view?"). 

Changed to clean last used classification on reset (indicators removed or setState without indicators). 

Changed to clean dataprovider and hide classification + series control always when stats layer is removed and removed them from state reset event listener.