### PR TITLE
DrawTools duplicate overlay fix

### DIFF
--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
@@ -1303,6 +1303,10 @@ Oskari.clazz.define(
        * - creates a new tooltip on drawing
        */
         createDrawingTooltip: function (id) {
+            if (this._overlays[id]) {
+                // already added to map
+                return;
+            }
             const tooltipClass = this._tooltipClassForMeasure + ' ' + this.getCurrentDrawShape() + ' ' + id;
             var tooltipElement = document.createElement('div');
             tooltipElement.className = tooltipClass;

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
@@ -158,13 +158,11 @@ Oskari.clazz.define(
 
             // disable gfi
             me.getMapModule().setDrawingMode(true);
-            // TODO: why not just call the stopDrawing()/_cleanupInternalState() method here?
+
             me.removeInteractions(me._draw, me._id);
             me.removeInteractions(me._modify, me._id);
+            this._cleanupInternalState();
 
-            if (me._sketch) {
-                jQuery('div.' + me._tooltipClassForMeasure + '.' + me._sketch.getId()).remove();
-            }
             me._shape = shape;
 
             // setup functionality id
@@ -455,7 +453,7 @@ Oskari.clazz.define(
         _cleanupInternalState: function () {
             // Remove measure result from map
             if (this._sketch) {
-                jQuery('div.' + this._tooltipClassForMeasure + '.' + this._sketch.getId()).remove();
+                this.removeDrawingTooltip(this._sketch.getId());
             }
             this._sketch = null;
         },
@@ -466,7 +464,6 @@ Oskari.clazz.define(
          */
         clearDrawing: function (id) {
             var me = this;
-
             if (id) {
                 var layer = me.getLayer(me.getLayerIdForFunctionality(id));
                 if (layer) {
@@ -484,8 +481,6 @@ Oskari.clazz.define(
                 me.getMap().removeOverlay(me._overlays[key]);
             });
             me._overlays = {};
-
-            jQuery('.' + me._tooltipClassForMeasure).remove(); // do we need this??
         },
         /**
          * @method sendDrawingEvent
@@ -1320,6 +1315,14 @@ Oskari.clazz.define(
             tooltip.id = id;
             this.getMap().addOverlay(tooltip);
             this._overlays[id] = tooltip;
+        },
+        removeDrawingTooltip: function (id) {
+            const overlay = this._overlays[id];
+            if (!overlay) {
+                return;
+            }
+            this.getMap().removeOverlay(overlay);
+            delete this._overlays[id];
         }
     }, {
         'extend': ['Oskari.mapping.mapmodule.plugin.AbstractMapModulePlugin'],


### PR DESCRIPTION
Skip adding overlay if it's already added to map. Duplicate overlay was added to previous feature when new feature was finished.  This occurs when allowMultipleDrawing, drawControl, modifyControl, showMeasureOnMap are true. For example adding my place or measuring map.

Draw end:
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js#L934
add modify:
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js#L1049

For example editing my place (without draw interaction) measure overlays have to be added to map for all features. So added duplicate check to createDrawingTooltit.

Don't know if sketch could have feature with overlay where jQuery based remove was called but added removeDrawingTooltip to get rid of jQuery based and to be sure that didn't brake anything.

