### PR TITLE
HoverHandler stroke width

### DIFF
--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/util/style.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/util/style.js
@@ -22,29 +22,9 @@ const defaults = {
             }
         }
     },
-    selected: {
-        inherit: true,
-        effect: 'auto major',
-        stroke: {
-            area: {
-                effect: 'none',
-                color: '#000000',
-                width: 4
-            },
-            width: 3
-        }
-    },
     hover: {
         inherit: true,
-        effect: 'auto minor',
-        stroke: {
-            area: {
-                effect: 'none',
-                color: '#000000',
-                width: 2
-            },
-            width: 2
-        }
+        effect: 'auto minor'
     }
 };
 export const DEFAULT_STYLES = { ...defaults };


### PR DESCRIPTION
Handle inherited stroke and area stroke width in HoverHandler and remove hard coded widths from wfs plugin style.

Removed also polygons effect and black stroke. WFS plugin's hover style means only that wfs layers (and additional layers that plugin handles) have hover style by default which is inherited from layer's default (from plugin) or defined feature style. If polygon effect has to be removed or stroke color forced to black, then them should be added to HoverHandler getInheritedStyle to avoid layer/plugin specific handling. 

Also registering plugin/layer specific styles to mapmodule might be removed and add default vector style straight to mapmodule. Then WFS layer's getHoverOptions could be overrided to get hover style OR add hover style for all vector layer types by default.
