### PR TITLE
Internal vector layer handling

### DIFF
--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
@@ -749,7 +749,7 @@ Oskari.clazz.define(
                 source: new olSourceVector({ features: new olCollection() }),
                 style: me._styles.draw
             });
-            me.getMap().addLayer(vector);
+            me.getMapModule().addInternalLayer(vector);
             me._drawLayers[layerId] = vector;
         },
         /**

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
@@ -749,7 +749,7 @@ Oskari.clazz.define(
                 source: new olSourceVector({ features: new olCollection() }),
                 style: me._styles.draw
             });
-            me.getMapModule().addInternalLayer(vector);
+            me.getMapModule().addOverlayLayer(vector);
             me._drawLayers[layerId] = vector;
         },
         /**

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -514,7 +514,7 @@ Oskari.clazz.define(
         /* Impl specific - found in ol2, ol3 and olCesium modules BUT parameters and/or return value differ!!
 ------------------------------------------------------------------> */
         addLayer: Oskari.AbstractFunc('addLayer'),
-        addInternalLayer: Oskari.AbstractFunc('addInternalLayer'),
+        addOverlayLayer: Oskari.AbstractFunc('addOverlayLayer'),
         removeLayer: Oskari.AbstractFunc('removeLayer'),
         bringToTop: Oskari.AbstractFunc('bringToTop'),
         getLayerIndex: Oskari.AbstractFunc('getLayerIndex'),

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -514,6 +514,7 @@ Oskari.clazz.define(
         /* Impl specific - found in ol2, ol3 and olCesium modules BUT parameters and/or return value differ!!
 ------------------------------------------------------------------> */
         addLayer: Oskari.AbstractFunc('addLayer'),
+        addInternalLayer: Oskari.AbstractFunc('addInternalLayer'),
         removeLayer: Oskari.AbstractFunc('removeLayer'),
         bringToTop: Oskari.AbstractFunc('bringToTop'),
         getLayerIndex: Oskari.AbstractFunc('getLayerIndex'),
@@ -1905,7 +1906,6 @@ Oskari.clazz.define(
             var marker = this._markerTemplate.clone();
             var svgObject = null;
             var isWellknownMarker = false;
-
             // marker shape is number --> find it from Oskari.getMarkers()
             if (!isNaN(style.shape)) {
                 var markers = Oskari.getMarkers();

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -30,6 +30,7 @@ import './AbstractMapModule';
 import './plugin/BasicMapModulePlugin';
 
 const AbstractMapModule = Oskari.clazz.get('Oskari.mapping.mapmodule.AbstractMapModule');
+const INTERNAL_LAYER_Z_INDEX = 1;
 
 if (!window.proj4) {
     window.proj4 = proj4;
@@ -1124,7 +1125,7 @@ export class MapModule extends AbstractMapModule {
 ------------------------------------------------------------------> */
 
     /**
-     * @param {ol/layer/Layer} layer ol3 specific!
+     * @param {ol/layer/Layer} layer ol specific!
      * @param {Boolean} toBottom if false or missing adds the layer to the top, if true adds it to the bottom of the layer stack
      */
     addLayer (layerImpl, toBottom) {
@@ -1136,6 +1137,19 @@ export class MapModule extends AbstractMapModule {
         if (toBottom === true) {
             this.setLayerIndex(layerImpl, 0);
         }
+    }
+
+    /**
+     * Adds internal layer to map. Internal layers aren't listed in selected layers and are always above those.
+     * @method bringToTop
+     * @param {ol/layer/Layer} layer ol specific!
+     */
+    addInternalLayer (layerImpl) {
+        if (!layerImpl) {
+            return;
+        }
+        layerImpl.setZIndex(INTERNAL_LAYER_Z_INDEX);
+        this.getMap().addLayer(layerImpl);
     }
 
     /**

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -1140,11 +1140,11 @@ export class MapModule extends AbstractMapModule {
     }
 
     /**
-     * Adds internal layer to map. Internal layers aren't listed in selected layers and are always above those.
-     * @method bringToTop
+     * Adds overlay layer to map. These layers aren't listed in selected layers and are always above those.
+     * @method addOverlayLayer
      * @param {ol/layer/Layer} layer ol specific!
      */
-    addInternalLayer (layerImpl) {
+    addOverlayLayer (layerImpl) {
         if (!layerImpl) {
             return;
         }

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -1137,6 +1137,7 @@ export class MapModule extends AbstractMapModule {
         if (toBottom === true) {
             this.setLayerIndex(layerImpl, 0);
         }
+        this.orderLayersByZIndex();
     }
 
     /**
@@ -1176,6 +1177,7 @@ export class MapModule extends AbstractMapModule {
         var list = map.getLayers();
         list.remove(layer);
         list.push(layer);
+        this.orderLayersByZIndex();
     }
 
     /**

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
@@ -65,7 +65,6 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
             return {
                 MapClickedEvent: event => this._mapClick(event),
                 'Toolbar.ToolbarLoadedEvent': () => this._registerTools(),
-                AfterRearrangeSelectedMapLayerEvent: () => this.raiseMarkerLayer(),
                 'Toolbar.ToolSelectedEvent': event => {
                     if (event.getToolId() !== 'addMarker' && event.getSticky()) {
                         this.stopMarkerAdd(false);
@@ -183,16 +182,10 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
             const clickEvent = Oskari.eventBuilder('MarkerClickEvent')(markerId);
             this.getSandbox().notifyAll(clickEvent);
         },
-        addMapLayerToMap: function () {
-            return () => this.raiseMarkerLayer();
-        },
-        raiseMarkerLayer: function () {
-            this.getMapModule().bringToTop(this.getMarkersLayer());
-        },
         getMarkersLayer: function () {
             if (!this._layer) {
                 this._layer = new olLayerVector({ title: 'Markers', source: new olSourceVector() });
-                this.getMap().addLayer(this._layer);
+                this.getMapModule().addInternalLayer(this._layer);
             }
             return this._layer;
         },
@@ -351,7 +344,6 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
             } else {
                 layerSource.addFeature(feature);
             }
-            this.raiseMarkerLayer();
             const data = this._featureToMarkerData(feature);
             const addEvent = Oskari.eventBuilder('AfterAddMarkerEvent')(data, id);
             this.getSandbox().notifyAll(addEvent);

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
@@ -185,7 +185,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
         getMarkersLayer: function () {
             if (!this._layer) {
                 this._layer = new olLayerVector({ title: 'Markers', source: new olSourceVector() });
-                this.getMapModule().addInternalLayer(this._layer);
+                this.getMapModule().addOverlayLayer(this._layer);
             }
             return this._layer;
         },

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -126,8 +126,7 @@ Oskari.clazz.define(
                     olLayer.set(LAYER_ID, layerId, true);
                     olLayer.setOpacity(opacity);
 
-                    me._map.addLayer(olLayer);
-                    me.raiseVectorLayer(olLayer);
+                    me.getMapModule().addLayer(olLayer);
                     me._olLayers[layerId] = olLayer;
                     me._layerStyles[layerId] = layerStyle;
                 }
@@ -454,8 +453,7 @@ Oskari.clazz.define(
                 const zoomLevelHelper = getZoomLevelHelper(this.getMapModule().getScaleArray());
                 // Set min max zoom levels that layer should be visible in
                 zoomLevelHelper.setOLZoomLimits(olLayer, layer.getMinScale(), layer.getMaxScale());
-                me._map.addLayer(olLayer);
-                me.raiseVectorLayer(olLayer);
+                me.getMapModule().addLayer(olLayer);
             }
             olLayer.setOpacity(layer.getOpacity() / 100);
             olLayer.setVisible(layer.isVisible());
@@ -960,15 +958,6 @@ Oskari.clazz.define(
             }
             // Start animation
             map.render();
-        },
-        /**
-         * Raises the marker layer above the other layers
-         *
-         * @param markerLayer
-         */
-        raiseVectorLayer: function (layer) {
-            this.getMapModule().bringToTop(layer);
-            layer.setVisible(true);
         },
         /**
          * @method _createRequestHandlers

--- a/bundles/mapping/mapmodule/service/HoverHandler.js
+++ b/bundles/mapping/mapmodule/service/HoverHandler.js
@@ -26,7 +26,6 @@ export class HoverHandler {
         this._styleFactory = this._mapmodule.getGeomTypedStyles.bind(this._mapmodule);
         const olLayer = new olLayerVector({ source: new olSourceVector() });
         olLayer.set(LAYER_HOVER, true, true);
-        olLayer.setZIndex(1); // TODO: how to handle layer ordering
         this._mapmodule.addLayer(olLayer);
         this._hoverLayer = olLayer;
     }
@@ -70,14 +69,7 @@ export class HoverHandler {
             return;
         }
         if (layerChanged) {
-            const layer = Oskari.getSandbox().findMapLayerFromSelectedMapLayers(layerId);
-            if (!layer) {
-                // this happens when reseting the map state while a feature is being hovered on
-                return;
-            }
-            this._hoverLayer.setOpacity(layer.getOpacity() / 100);
-            this._hoverLayer.setStyle(this.getCachedStyle(layerId));
-            this._hoverLayer.changed();
+            this.onLayerChange(layerId);
         }
         this._hoverLayer.getSource().addFeature(feature);
     }
@@ -98,6 +90,24 @@ export class HoverHandler {
         this._hoverLayer.setOpacity(layer.getOpacity() / 100);
     }
 
+    onLayerChange (layerId) {
+        const layer = Oskari.getSandbox().findMapLayerFromSelectedMapLayers(layerId);
+        if (!layer) {
+            // this happens when reseting the map state while a feature is being hovered on
+            return;
+        }
+        const mapmodule = this._mapmodule;
+        const hoverLayer = this._hoverLayer;
+        const olLayers = mapmodule.getOLMapLayers(layerId);
+        // assumes that first layer is main layer and others are straight over main layer
+        const topLayer = olLayers[olLayers.length - 1];
+        const index = mapmodule.getLayerIndex(topLayer);
+        mapmodule.setLayerIndex(hoverLayer, index + 1);
+        hoverLayer.setOpacity(layer.getOpacity() / 100);
+        hoverLayer.setStyle(this.getCachedStyle(layerId));
+        hoverLayer.changed();
+    }
+
     // VectorTile uses lightweight and read-only RenderFeature
     // create copy with same source and hover style
     createVectorTileLayer (layer, source) {
@@ -106,7 +116,6 @@ export class HoverHandler {
         olLayer.setVisible(layer.isVisible());
         olLayer.set(LAYER_HOVER, true, true);
         olLayer.setStyle(this._styleGenerator(layer, true));
-        olLayer.setZIndex(1);
         this._vectorTileLayers[layer.getId()] = olLayer;
         this.setTooltipContent(layer);
         return olLayer;


### PR DESCRIPTION
Remove z index from hover layer and add/move hover layer one step above hovered layer.

Add addInternalLayer method for mapmodule which sets z index for layer to keep internal layer above 'normal' layers. Mapmodule has method for ordering layers by z index which is used AfterRearrangeSelectedMapLayerEvent. 
https://github.com/oskariorg/oskari-frontend/blob/develop/bundles/mapping/mapmodule/MapModuleClass.ol.js#L971

Don't know if z indexes were used but at least didn't find current usage. Maybe it could be removed or order layers also on addLayer. Layers could be also added directly to ol map which isn't handled by mapmodule. So the order in map's layer collection/array may vary (even mapmodule addLayer sorts array by z index).
"At rendering time, the layers will be ordered, first by Z-index and then by position"

Removed bringToTop from vectorlayerplugin because it was used only after addLayer which already adds it on top.