### PR TITLE
Announcement bundle localization

### DIFF
--- a/bundles/admin/admin-announcements/resources/locale/en.js
+++ b/bundles/admin/admin-announcements/resources/locale/en.js
@@ -16,12 +16,31 @@ Oskari.registerLocalization(
         "save": "Save",
         "yes": "Yes",
         "cancel": "Cancel",
-        "newAnnouncement": {
+        "fields": {
             "title": "Title",
             "content": "Content",
             "date-range": "Date range",
-            "show-popup": "Show pop-up"
+            "show-popup": "Show pop-up",
+            "locale": {
+                "generic": {
+                    "name": "Name in {0}",
+                    "content": "Content in {0}"
+                },
+                "en": {
+                    "name": "Name in English",
+                    "content": "Content in English"
+                },
+                "fi": {
+                    "name": "Name in Finnish",
+                    "content": "Content in Finnish"
+                },
+                "sv": {
+                    "name": "Name in Swedish",
+                    "content": "Content in Swedish"
+                }
+            }
         },
+        "otherLanguages": "Other languages",
         "messages": {
             "saveSuccess": "Announcement saved",
             "saveFailed": "Saving announcement failed",

--- a/bundles/admin/admin-announcements/resources/locale/fi.js
+++ b/bundles/admin/admin-announcements/resources/locale/fi.js
@@ -16,12 +16,31 @@ Oskari.registerLocalization(
             "save": "Tallenna",
             "yes": "Kyllä",
             "cancel": "Peruuta",
-            "newAnnouncement": {
+            "fields": {
                 "title": "Otsikko",
                 "content": "Sisältö",
                 "date-range": "Aikaväli",
-                "show-popup": "Näytä ponnahdusikkuna"
+                "show-popup": "Näytä ponnahdusikkuna",
+                "locale": {
+                    "generic": {
+                        "name": "Nimi kielellä {0}",
+                        "content": "Sisältö kielellä {0}"
+                    },
+                    "en": {
+                        "name": "Nimi englanniksi",
+                        "content": "Sisältö englanniksi"
+                    },
+                    "fi": {
+                        "name": "Nimi suomeksi",
+                        "content": "Sisältö suomeksi"
+                    },
+                    "sv": {
+                        "name": "Nimi ruotsiksi",
+                        "content": "Sisältö ruotsiksi"
+                    }
+                }
             },
+            "otherLanguages": "Muut kielet",
             "messages": {
                 "saveSuccess": "Ilmoitus tallennettu.",
                 "saveFailed": "Ilmoituksen tallennus epäonnistui.",

--- a/bundles/admin/admin-announcements/resources/locale/sv.js
+++ b/bundles/admin/admin-announcements/resources/locale/sv.js
@@ -16,12 +16,31 @@ Oskari.registerLocalization(
             "save": "Spara",
             "yes": "Ja",
             "cancel": "Annullera",
-            "newAnnouncement": {
+            "fields": {
                 "title": "Titel",
                 "content": "Innehåll",
                 "date-range": "Datumintervall",
-                "show-popup": "Visa popup"
+                "show-popup": "Visa popup",
+                "locale": {
+                    "generic": {
+                        "name": "Namn på {0}",
+                        "content": "Innehåll på {0}"
+                    },
+                    "en": {
+                        "name": "Namn på engelska",
+                        "content": "Innehåll på engelska"
+                    },
+                    "fi": {
+                        "name": "Namn på finska",
+                        "content": "Innehåll på finska"
+                    },
+                    "sv": {
+                        "name": "Namn på svenska",
+                        "content": "Innehåll på svenska"
+                    }
+                }
             },
+            "otherLanguages": "Andra språk",
             "messages": {
                 "saveSuccess": "Avisering sparat",
                 "saveFailed": "Sparar avisering misslyckades",

--- a/bundles/admin/admin-announcements/view/AnnouncementsForm.jsx
+++ b/bundles/admin/admin-announcements/view/AnnouncementsForm.jsx
@@ -88,10 +88,6 @@ const AnnouncementsForm = ({controller, key, announcement, bundleKey, index}) =>
     }
   }
 
-  const setLocalizedContent = (locale) => {
-    setLocales({ ...locales, ...locale });
-  }
-
     return (
       <div>
             <Form layout="vertical" 
@@ -137,7 +133,7 @@ const AnnouncementsForm = ({controller, key, announcement, bundleKey, index}) =>
                 <Form.Item>
                   <Confirm
                       title={<Message messageKey='messages.deleteAnnouncementConfirm'/>}
-                      onConfirm={() => controller.deleteAnnouncement(announcement.id, announcement.locale[lang].name)}
+                      onConfirm={() => controller.deleteAnnouncement(announcement.id)}
                       okText={<Message messageKey='yes'/>}
                       cancelText={<Message messageKey='cancel'/>}
                       placement='top'

--- a/bundles/admin/admin-announcements/view/AnnouncementsList.jsx
+++ b/bundles/admin/admin-announcements/view/AnnouncementsList.jsx
@@ -18,6 +18,7 @@ const StyledButton = styled(Button)`
 `;
 const AnnouncementsList = ({controller,  announcements, title, activeKey }) => {
 
+  const lang = Oskari.getLang();
   const callback = (key) => {
     controller.openCollapse(key);
   }
@@ -25,14 +26,13 @@ const AnnouncementsList = ({controller,  announcements, title, activeKey }) => {
     <div>
         <div>
         <Collapse accordion activeKey={activeKey} onChange={callback}>
-          {announcements.map((form, index) => {
+          {announcements.map((announcement, index) => {
             return (
-              <Panel header={form.title ? form.title : Oskari.getMsg('admin-announcements', 'addNewForm')} key={index} >
+              <Panel header={announcement.locale[lang] && announcement.locale[lang].name && announcement.locale[lang].name ? announcement.locale[lang].name : Oskari.getMsg('admin-announcements', 'addNewForm')} key={index} >
               <AnnouncementsForm
                 controller={controller}
-                form={form}
+                announcement={announcement}
                 index={index}
-                title={title}
                 key={index}
               />
               </Panel>

--- a/bundles/admin/admin-announcements/view/AnnouncementsListHandler.js
+++ b/bundles/admin/admin-announcements/view/AnnouncementsListHandler.js
@@ -116,8 +116,9 @@ class ViewHandler extends StateHandler {
 
     addForm () {
         const newList = [...this.state.announcements];
+        const lang = Oskari.getLang();
         newList.push({
-            title: Oskari.getMsg('admin-announcements', 'addNewForm')
+            locale: { [lang]: { name: Oskari.getMsg('admin-announcements', 'addNewForm') } }
         });
         this.updateState({
             announcements: newList

--- a/bundles/framework/announcements/resources/locale/en.js
+++ b/bundles/framework/announcements/resources/locale/en.js
@@ -13,6 +13,7 @@ Oskari.registerLocalization(
         },
         "valid": "Valid:",
         "dontShow" : "Don't show this again",
+        "noAnnouncements": "No active announcements",
         "messages": {
             "getFailed":"Fetching announcements failed"
         },

--- a/bundles/framework/announcements/resources/locale/fi.js
+++ b/bundles/framework/announcements/resources/locale/fi.js
@@ -13,6 +13,7 @@ Oskari.registerLocalization(
             },
             "valid": "Voimassa:",
             "dontShow" : "Älä näytä uudelleen",
+            "noAnnouncements": "Ei aktiivisia ilmoituksia",
             "messages": {
                 "getFailed":"Ilmoitusten haku epäonnistui."
             },

--- a/bundles/framework/announcements/resources/locale/sv.js
+++ b/bundles/framework/announcements/resources/locale/sv.js
@@ -13,6 +13,7 @@ Oskari.registerLocalization(
             },
             "valid": "Giltig:",
             "dontShow" : "Visa inte detta igen",
+            "noAnnouncements": "Inga aktiva aviseringar",
             "messages": {
                 "getFailed":"Fetching announcements failed"
             },

--- a/bundles/framework/announcements/view/AnnouncementsCollapse.jsx
+++ b/bundles/framework/announcements/view/AnnouncementsCollapse.jsx
@@ -28,20 +28,24 @@ const AnnouncementsCollapse = ({controller, checked, announcements, modals }) =>
             );
           })}
       <div>
-      <Collapse accordion>
-          { announcements.map((announcement) => {
-            let start = moment(announcement.begin_date).format(DATEFORMAT);
-            let end = moment(announcement.end_date).format(DATEFORMAT);
-              return announcement.locale[lang].name && (
-                <CollapsePanel header={announcement.locale[lang].name} key={announcement.id}>
-                    <h3><b>{announcement.locale[lang].name}</b></h3>
-                    <p>{announcement.locale[lang].content}</p>
-                    <Divider />
-                    <b><Message messageKey={'valid'} /></b>
-                    <p>{start.toString()} - {end.toString()}</p>
-                </CollapsePanel>)
-          })}
-        </Collapse>
+        { announcements.length > 0 ?
+          <Collapse accordion>
+            { announcements.map((announcement) => {
+              let start = moment(announcement.begin_date).format(DATEFORMAT);
+              let end = moment(announcement.end_date).format(DATEFORMAT);
+                return announcement.locale[lang].name && (
+                  <CollapsePanel header={announcement.locale[lang].name} key={announcement.id}>
+                      <h3><b>{announcement.locale[lang].name}</b></h3>
+                      <p>{announcement.locale[lang].content}</p>
+                      <Divider />
+                      <b><Message messageKey={'valid'} /></b>
+                      <p>{start.toString()} - {end.toString()}</p>
+                  </CollapsePanel>)
+            })}
+          </Collapse>
+          :
+          <center><h3><Message messageKey={'noAnnouncements'}/></h3></center>
+        }
       </div>
     </div>
   );

--- a/bundles/framework/announcements/view/AnnouncementsCollapse.jsx
+++ b/bundles/framework/announcements/view/AnnouncementsCollapse.jsx
@@ -10,6 +10,7 @@ import moment from 'moment';
 const DATEFORMAT = 'DD/MM/YYYY';
 
 const AnnouncementsCollapse = ({controller, checked, announcements, modals }) => {
+  const lang = Oskari.getLang();
       
   return (
     <div>
@@ -18,8 +19,8 @@ const AnnouncementsCollapse = ({controller, checked, announcements, modals }) =>
               <AnnouncementsModal
               id={modal.id}
               controller={controller}
-              title={modal.title}
-              content={modal.content}
+              title={modal.locale[lang].name}
+              content={modal.locale[lang].content}
               key={modal.id}
               index={index}
               checked={checked}
@@ -31,10 +32,10 @@ const AnnouncementsCollapse = ({controller, checked, announcements, modals }) =>
           { announcements.map((announcement) => {
             let start = moment(announcement.begin_date).format(DATEFORMAT);
             let end = moment(announcement.end_date).format(DATEFORMAT);
-              return (
-                <CollapsePanel header={announcement.title} key={announcement.id}>
-                    <h3><b>{announcement.title}</b></h3>
-                    <p>{announcement.content}</p>
+              return announcement.locale[lang].name && (
+                <CollapsePanel header={announcement.locale[lang].name} key={announcement.id}>
+                    <h3><b>{announcement.locale[lang].name}</b></h3>
+                    <p>{announcement.locale[lang].content}</p>
                     <Divider />
                     <b><Message messageKey={'valid'} /></b>
                     <p>{start.toString()} - {end.toString()}</p>

--- a/bundles/framework/announcements/view/AnnouncementsHandler.js
+++ b/bundles/framework/announcements/view/AnnouncementsHandler.js
@@ -27,6 +27,7 @@ class ViewHandler extends StateHandler {
                 this.updateState({
                     announcements: data
                 });
+                this.updateModals();
             }
         }.bind(this));
     }


### PR DESCRIPTION
- Integrate localizationComponent to announcements bundle
- New announcement model, "title" is now removed and renamed as "name".
- Instead of separate title and content, these are now localized and are included in "locale" json:
{ fi: { name: "Name", content: "Content"}, en: { } ...}
- Added text to announcements flyout when there are no active announcements

* Also includes fix to announcement modales not being shown