### PR TITLE
LayerPlugin update layer events

### DIFF
--- a/bundles/framework/maplegend/instance.js
+++ b/bundles/framework/maplegend/instance.js
@@ -169,6 +169,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.MapLegendBundleInstanc
             'MapLayerEvent': function (event) {
                 if (event.getOperation() === 'update') {
                     this.refreshUI();
+                    return;
                 }
 
                 if (event.getOperation() !== 'add') {

--- a/bundles/framework/publisher2/view/PanelMapLayers.js
+++ b/bundles/framework/publisher2/view/PanelMapLayers.js
@@ -125,8 +125,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapLayers',
              *
              * Calls flyouts handleLayerSelectionChanged() and handleDrawLayerSelectionChanged() functions
              */
-            MapLayerEvent: function (event) {
-                this.handleLayerSelectionChanged();
+            'MapLayerEvent': function (event) {
+                if (event.getOperation() === 'update') {
+                    this.handleLayerSelectionChanged();
+                }
             },
 
             /**

--- a/bundles/mapping/mapmodule/AbstractMapLayerPlugin.js
+++ b/bundles/mapping/mapmodule/AbstractMapLayerPlugin.js
@@ -116,9 +116,11 @@ Oskari.clazz.define(
          */
         mapLayerEventHandlers: {
             MapLayerEvent: function (event) {
-                var layer = this.getSandbox().getMap().getSelectedLayer(event.getLayerId());
-
-                if (event.getOperation() === 'update' && layer) {
+                if (event.getOperation() !== 'update') {
+                    return;
+                }
+                const layer = this.getSandbox().findMapLayerFromSelectedMapLayers(event.getLayerId());
+                if (layer && this.isLayerSupported(layer)) {
                     this._updateLayer(layer);
                 }
             },

--- a/bundles/mapping/mapmodule/plugin/layers/BackgroundLayerSelectionPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/layers/BackgroundLayerSelectionPlugin.js
@@ -118,18 +118,6 @@ Oskari.clazz.define(
                 },
 
                 /**
-                 * @method AfterMapMoveEvent
-                 * @param {Oskari.mapframework.event.common.AfterMapMoveEvent} event
-                 *
-                 * Adds the layer to selection
-                 */
-                MapLayerEvent: function (event) {
-                    // TODO add check for event.getMapLayer().getId() here?
-                    // this._createLayerSelectionElements();
-                    this.refresh();
-                },
-
-                /**
                  * @method MapSizeChangedEvent
                  *
                  * Changes selector into dropdown if map is too narrow to fit buttons

--- a/bundles/mapping/mapmodule/plugin/layers/BackgroundLayerSelectionPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/layers/BackgroundLayerSelectionPlugin.js
@@ -118,6 +118,18 @@ Oskari.clazz.define(
                 },
 
                 /**
+                 * @method AfterMapMoveEvent
+                 * @param {Oskari.mapframework.event.common.AfterMapMoveEvent} event
+                 *
+                 * Adds the layer to selection
+                 */
+                MapLayerEvent: function (event) {
+                    // TODO add check for event.getMapLayer().getId() here?
+                    // this._createLayerSelectionElements();
+                    this.refresh();
+                },
+
+                /**
                  * @method MapSizeChangedEvent
                  *
                  * Changes selector into dropdown if map is too narrow to fit buttons

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -76,7 +76,6 @@ Oskari.clazz.define(
          * @return {Object.<string, Function>} EventHandlers
          */
         _createEventHandlers: function () {
-            // TODO: listen to MapLayerEvent and if(event.getOperation() === 'update') -> update layer name in ui?
             return {
                 AfterMapLayerRemoveEvent: function (event) {
                     var service = this.getService();

--- a/bundles/mapping/mapmodule/plugin/realtime/RealtimePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/realtime/RealtimePlugin.js
@@ -64,23 +64,19 @@ Oskari.clazz.define(
                     }
                 },
                 MapLayerEvent: function (event) {
-                    var op = event.getOperation(),
-                        layer = this.getSandbox().findMapLayerFromSelectedMapLayers(
-                            event.getLayerId()
-                        );
-
-                    if (op === 'update' && layer && layer.isRealtime() && this._isNotIgnored(layer)) {
+                    if (event.getOperation() !== 'update') {
+                        return;
+                    }
+                    const layer = this.getSandbox().findMapLayerFromSelectedMapLayers(event.getLayerId());
+                    if (layer && layer.isRealtime() && this._isNotIgnored(layer)) {
                         this._resetInterval(layer);
                     }
                 },
                 MapLayerVisibilityChangedEvent: function (event) {
-                    var layer = event.getMapLayer(),
-                        isVisible = layer.isVisible(),
-                        inScale = event.isInScale(),
-                        inViewPort = event.isGeometryMatch(),
-                        clearOnly = (!isVisible || !inScale || !inViewPort);
+                    const layer = event.getMapLayer();
 
                     if (layer.isRealtime() && this._isNotIgnored(layer)) {
+                        const clearOnly = !layer.isVisible() || !event.isInScale() || !event.isGeometryMatch();
                         this._resetInterval(layer, clearOnly);
                     }
                 },

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -596,7 +596,6 @@ Oskari.clazz.define(
             }
             const sandbox = this.getSandbox();
             const mapLayerService = sandbox.getService('Oskari.mapframework.service.MapLayerService');
-            let layerUpdate = false;
 
             if (options.remove) {
                 const request = Oskari.requestBuilder('RemoveMapLayerRequest')(layer.getId());
@@ -609,12 +608,18 @@ Oskari.clazz.define(
 
                 return layer;
             }
-            if (options.layerName) {
-                layer.setName(options.layerName);
+            let layerUpdate = false;
+            const { layerName, layerOrganizationName, layerDescription } = options;
+            if (layerName && layer.getName() !== layerName) {
+                layer.setName(layerName);
                 layerUpdate = true;
             }
-            if (options.layerOrganizationName) {
-                layer.setOrganizationName(options.layerOrganizationName);
+            if (layerOrganizationName && layer.getOrganizationName() !== layerOrganizationName) {
+                layer.setOrganizationName(layerOrganizationName);
+                layerUpdate = true;
+            }
+            if (layerDescription && layer.getDescription() !== layerDescription) {
+                layer.setDescription(layerDescription);
                 layerUpdate = true;
             }
             if (typeof options.opacity !== 'undefined') {
@@ -623,10 +628,6 @@ Oskari.clazz.define(
                 this._getOlLayer(layer);
             }
             this._setHoverOptions(layer, options);
-            if (options.layerDescription) {
-                layer.setDescription(options.layerDescription);
-                layerUpdate = true;
-            }
             var lyrInService = mapLayerService.findMapLayer(layer.getId());
             if (lyrInService && layerUpdate) {
                 // Send layer updated notification

--- a/bundles/mapping/mapmyplaces/plugin/MyPlacesLayerPlugin.ol.js
+++ b/bundles/mapping/mapmyplaces/plugin/MyPlacesLayerPlugin.ol.js
@@ -63,6 +63,9 @@ Oskari.clazz.define(
                 // Update min max Resolutions
                 zoomLevelHelper.setOLZoomLimits(olLayer, layer.getMinScale(), layer.getMaxScale());
             });
+        },
+        _afterChangeMapLayerStyleEvent: function () {
+            // WFS plugin handles
         }
     }, {
         'extend': ['Oskari.mapping.mapmodule.AbstractMapLayerPlugin'],

--- a/bundles/mapping/mapuserlayers/plugin/UserLayersLayerPlugin.ol.js
+++ b/bundles/mapping/mapuserlayers/plugin/UserLayersLayerPlugin.ol.js
@@ -132,6 +132,9 @@ Oskari.clazz.define(
                 // Update min max Resolutions
                 zoomLevelHelper.setOLZoomLimits(olLayer, layer.getMinScale(), layer.getMaxScale());
             });
+        },
+        _afterChangeMapLayerStyleEvent: function () {
+            // WFS plugin handles
         }
 
     }, {


### PR DESCRIPTION
VectorLayerPlugin add check if values updates before triggering update event. For example statsgrid sends regionset name as layer description and it sends update requests when style is updated. 

AbstractMapLayerPlugin add isLayerSupported to avoid calling other layer plugins. For example analysis layer can't be updated so analysis plugin doesn't have _updateLayer which causes 'TODO...' logging. Another solution is to override method with no op.

Override _afterChangeMapLayerStyleEvent in Userlayer and Myplaces plugins to reduce 'TODO..' logging when selected layer is updated.