### PR TITLE
Remove refs to capabilities.typeSpecific object for layer admin

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/AdditionalTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/AdditionalTabPane.jsx
@@ -28,9 +28,8 @@ const {
 } = LayerComposingModel;
 
 export const AdditionalTabPane = ({ layer, propertyFields, controller }) => {
-    const { capabilities = {} } = layer;
-    const { typeSpecific = {} } = capabilities;
-    const isQueryable = layer.attributes.isQueryable || capabilities.isQueryable || typeSpecific.isQueryable;
+    const { capabilities = {}, attributes = {}} = layer;
+    const isQueryable = attributes.isQueryable || capabilities.isQueryable || capabilities.queryable;
     return (
         <Fragment>
             { !layer.isNew &&

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/GfiType.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/GfiType.jsx
@@ -6,9 +6,8 @@ import { InfoTooltip } from '../InfoTooltip';
 import { StyledFormField } from '../styled';
 
 export const GfiType = ({ layer, controller }) => {
-    const { capabilities, gfiType } = layer;
-    const { typeSpecific = {} } = capabilities;
-    const options = typeSpecific.infoFormats || [];
+    const { capabilities = {}, gfiType } = layer;
+    const options = capabilities.infoFormats || [];
     const value = gfiType || '';
     if (options.length === 0) {
         return null;

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/SelectedTime.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/SelectedTime.jsx
@@ -7,9 +7,8 @@ import { StyledFormField } from '../styled';
 export const SelectedTime = ({ layer, controller }) => {
     const value = layer.params ? layer.params.selectedTime : '';
     const { capabilities = {} } = layer;
-    const { typeSpecific = {} } = capabilities;
 
-    if (!Array.isArray(typeSpecific.times)) {
+    if (!Array.isArray(capabilities.times)) {
         return null;
     }
     return (
@@ -21,7 +20,7 @@ export const SelectedTime = ({ layer, controller }) => {
                     allowClear
                     value={value}
                     onChange={value => controller.setSelectedTime(value)}>
-                    { typeSpecific.times.map(time => <Option key={time}>{time}</Option>)}
+                    { capabilities.times.map(time => <Option key={time}>{time}</Option>)}
                 </Select>
             </StyledFormField>
         </Fragment>

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/ServiceMetadata.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/ServiceMetadata.jsx
@@ -5,15 +5,14 @@ import { Controller } from 'oskari-ui/util';
 import { MetadataButton } from './styled';
 
 export const ServiceMetadata = ({ capabilities, controller, hasHandler }) => {
-    // as of Oskari server 2.7.0-SNAPSHOT:
+    // as of Oskari server 2.8.0-SNAPSHOT:
     /*
-    "typeSpecific": {
+    "capabilities": {
         "metadataUrl": "the whole url instead of just metadata uuid"
         "metadataId": "uuid from metadata url"
         ...
     */
-    const { typeSpecific = {} } = capabilities;
-    const metadataUuid = typeSpecific.metadataId;
+    const metadataUuid = capabilities.metadataId;
     if (!metadataUuid) {
         return (
             <Fragment>

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VisualizationTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VisualizationTabPane.jsx
@@ -40,7 +40,7 @@ export const VisualizationTabPane = ({ layer, scales, propertyFields, controller
             { propertyFields.includes(OPACITY) &&
                 <Opacity layer={layer} controller={controller} />
             }
-            { (propertyFields.includes(TIMES) && layer.capabilities.typeSpecific && layer.capabilities.typeSpecific.times) &&
+            { (propertyFields.includes(TIMES) && layer.capabilities.times) &&
                 <TimeSeries layer={layer} scales={scales} controller={controller} />
             }
             { propertyFields.includes(CLUSTERING_DISTANCE) &&


### PR DESCRIPTION
The capabilities JSON was adjusted in oskariorg/oskari-server#843 and the "typeSpecific" object was removed in that PR. These are the corresponding adjustments to the layer admin functionalities.