### PR TITLE
Skip empty GFI results

### DIFF
--- a/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetFeatureInfoFormatter.js
@@ -201,7 +201,8 @@ Oskari.clazz.category('Oskari.mapframework.mapmodule.GetInfoPlugin', 'formatter'
                 } else {
                     pretty = me._formatGfiDatum(datum);
                 }
-                if (typeof pretty === 'undefined') {
+                if (pretty === null) {
+                    // if formatter returned null we should skip this result
                     return null;
                 }
 


### PR DESCRIPTION
The formatter returns null, not undefined.