### PR TITLE
Admin announcements refactor

### DIFF
--- a/bundles/admin/admin-announcements/Flyout.js
+++ b/bundles/admin/admin-announcements/Flyout.js
@@ -54,11 +54,16 @@ Oskari.clazz.define('Oskari.admin.bundle.admin-announcements.Flyout',
             if (!this.container) {
                 return;
             }
+            const edit = (announcement) => {
+                const controller = this.announcementsListHandler.getController();
+                this.instance.showEditPopup(controller, announcement);
+            };
             const content = (
                 <LocaleProvider value={{ bundleKey: this.instance.getName() }}>
                     <AnnouncementsList
                         {...this.announcementsListHandler.getState()}
                         controller={this.announcementsListHandler.getController()}
+                        edit = {edit}
                     />
                 </LocaleProvider>
             );

--- a/bundles/admin/admin-announcements/instance.js
+++ b/bundles/admin/admin-announcements/instance.js
@@ -1,3 +1,4 @@
+import { showEditPopup } from './view/AnnouncementsPopup';
 /**
  * @class Oskari.framework.bundle.admin-announcements.AdminAnnouncementsBundleInstance
  *
@@ -15,9 +16,24 @@ Oskari.clazz.define('Oskari.admin.bundle.admin-announcements.AdminAnnouncementsB
         var conf = this.getConfiguration();
         conf.name = 'admin-announcements';
         conf.flyoutClazz = 'Oskari.admin.bundle.admin-announcements.Flyout';
+        this.popupControls = null;
     }, {
 
         afterStart: function () {
+        },
+
+        showEditPopup: function (controller, announcement) {
+            if (this.popupControls) {
+                this.popupCleanup();
+            }
+            const onClose = () => this.popupCleanup();
+            this.popupControls = showEditPopup(controller, announcement, onClose);
+        },
+        popupCleanup: function () {
+            if (this.popupControls) {
+                this.popupControls.close();
+            }
+            this.popupControls = null;
         }
 
     }, {

--- a/bundles/admin/admin-announcements/resources/locale/en.js
+++ b/bundles/admin/admin-announcements/resources/locale/en.js
@@ -31,21 +31,27 @@ Oskari.registerLocalization(
             },
             "locale": {
                 "generic": {
-                    "name": "Name in {0}",
+                    "name": "Title in {0}",
                     "content": "Content in {0}"
                 },
                 "en": {
-                    "name": "Name in English",
+                    "name": "Title in English",
                     "content": "Content in English"
                 },
                 "fi": {
-                    "name": "Name in Finnish",
+                    "name": "Title in Finnish",
                     "content": "Content in Finnish"
                 },
                 "sv": {
-                    "name": "Name in Swedish",
+                    "name": "Title in Swedish",
                     "content": "Content in Swedish"
                 }
+            },
+            "validate": {
+                "name": "Add title",
+                "content": "Add content!",
+                "link": "Add external link!",
+                "date": "Add daterange!"
             }
         },
         "messages": {
@@ -67,9 +73,6 @@ Oskari.registerLocalization(
             },
             "announcementsName": "Name",
             "announcementsTime": "Valid"
-        },
-        "titleError": "Add title",
-        "contentError": "Add content!",
-        "dateError": "Add daterange!"
+        }
     }
 });

--- a/bundles/admin/admin-announcements/resources/locale/en.js
+++ b/bundles/admin/admin-announcements/resources/locale/en.js
@@ -11,16 +11,24 @@ Oskari.registerLocalization(
         "tile": {
             "title": "A: Announcements"
         },
-        "addNewForm": "New Announcement",
-        "delete": "Delete",
-        "save": "Save",
-        "yes": "Yes",
-        "cancel": "Cancel",
+        "popup": {
+            "title": "Announcement"
+        },
         "fields": {
             "title": "Title",
             "content": "Content",
-            "date-range": "Date range",
-            "show-popup": "Show pop-up",
+            "date": "Date range",
+            "show": {
+                "label": "Show as",
+                "popup": "Popup-window",
+                "banner": "Banner"
+            },
+            "type": {
+                "label": "Type",
+                "title": "Title only",
+                "content": "Contents",
+                "link": "External link"
+            },
             "locale": {
                 "generic": {
                     "name": "Name in {0}",
@@ -40,7 +48,6 @@ Oskari.registerLocalization(
                 }
             }
         },
-        "otherLanguages": "Other languages",
         "messages": {
             "saveSuccess": "Announcement saved",
             "saveFailed": "Saving announcement failed",

--- a/bundles/admin/admin-announcements/resources/locale/fi.js
+++ b/bundles/admin/admin-announcements/resources/locale/fi.js
@@ -31,21 +31,27 @@ Oskari.registerLocalization(
                 },
                 "locale": {
                     "generic": {
-                        "name": "Nimi kielellä {0}",
+                        "name": "Otsikko kielellä {0}",
                         "content": "Sisältö kielellä {0}"
                     },
                     "en": {
-                        "name": "Nimi englanniksi",
+                        "name": "Otsikko englanniksi",
                         "content": "Sisältö englanniksi"
                     },
                     "fi": {
-                        "name": "Nimi suomeksi",
+                        "name": "Otsikko suomeksi",
                         "content": "Sisältö suomeksi"
                     },
                     "sv": {
-                        "name": "Nimi ruotsiksi",
+                        "name": "Otsikko ruotsiksi",
                         "content": "Sisältö ruotsiksi"
                     }
+                },
+                "validate": {
+                    "name": "Lisää otsikko!",
+                    "content": "Lisää sisältö!",
+                    "link": "Lisää lisätietolinkki!",
+                    "date": "Lisää aikaväli!"
                 }
             },
             "messages": {
@@ -67,9 +73,6 @@ Oskari.registerLocalization(
                 },
                 "announcementsName": "Nimi",
                 "announcementsTime": "Voimasssa"
-            },
-            "titleError": "Lisää otsikko!",
-            "contentError": "Lisää sisältö!",
-            "dateError": "Lisää aikaväli!"
+            }
         }
     });

--- a/bundles/admin/admin-announcements/resources/locale/fi.js
+++ b/bundles/admin/admin-announcements/resources/locale/fi.js
@@ -11,16 +11,24 @@ Oskari.registerLocalization(
             "tile": {
                 "title": "A: Ilmoitukset"
             },
-            "addNewForm": "Uusi Ilmoitus",
-            "delete": "Poista",
-            "save": "Tallenna",
-            "yes": "Kyllä",
-            "cancel": "Peruuta",
+            "popup": {
+                "title": "Ilmoitus"
+            },
             "fields": {
                 "title": "Otsikko",
                 "content": "Sisältö",
-                "date-range": "Aikaväli",
-                "show-popup": "Näytä ponnahdusikkuna",
+                "date": "Aikaväli",
+                "show": {
+                    "label": "Näytä",
+                    "popup": "Ponnahdusikkunassa",
+                    "banner": "Yläpalkissa"
+                },
+                "type": {
+                    "label": "Ilmoituksen tyyppi",
+                    "title": "Vain otsikko",
+                    "content": "Sisältö",
+                    "link": "Lisätietolinkki"
+                },
                 "locale": {
                     "generic": {
                         "name": "Nimi kielellä {0}",
@@ -40,7 +48,6 @@ Oskari.registerLocalization(
                     }
                 }
             },
-            "otherLanguages": "Muut kielet",
             "messages": {
                 "saveSuccess": "Ilmoitus tallennettu.",
                 "saveFailed": "Ilmoituksen tallennus epäonnistui.",

--- a/bundles/admin/admin-announcements/resources/locale/sv.js
+++ b/bundles/admin/admin-announcements/resources/locale/sv.js
@@ -11,16 +11,24 @@ Oskari.registerLocalization(
             "tile": {
                 "title": "A: Aviseringar"
             },
-            "addNewForm": "Ny avisering",
-            "delete": "Ta bort",
-            "save": "Spara",
-            "yes": "Ja",
-            "cancel": "Annullera",
+            "popup": {
+                "title": "Avisering"
+            },
             "fields": {
                 "title": "Titel",
                 "content": "Innehåll",
-                "date-range": "Datumintervall",
-                "show-popup": "Visa popup",
+                "date": "Datumintervall",
+                "show": {
+                    "label": "Visa i",
+                    "popup": "Popupfönster",
+                    "banner": "Webannons"
+                },
+                "type": {
+                    "label": "Typ",
+                    "title": "Bara rubrik",
+                    "content": "Popupens innehåll",
+                    "link": "Extern länk"
+                },
                 "locale": {
                     "generic": {
                         "name": "Namn på {0}",
@@ -40,7 +48,6 @@ Oskari.registerLocalization(
                     }
                 }
             },
-            "otherLanguages": "Andra språk",
             "messages": {
                 "saveSuccess": "Avisering sparat",
                 "saveFailed": "Sparar avisering misslyckades",

--- a/bundles/admin/admin-announcements/resources/locale/sv.js
+++ b/bundles/admin/admin-announcements/resources/locale/sv.js
@@ -31,21 +31,27 @@ Oskari.registerLocalization(
                 },
                 "locale": {
                     "generic": {
-                        "name": "Namn på {0}",
+                        "name": "Titel på {0}",
                         "content": "Innehåll på {0}"
                     },
                     "en": {
-                        "name": "Namn på engelska",
+                        "name": "Titel på engelska",
                         "content": "Innehåll på engelska"
                     },
                     "fi": {
-                        "name": "Namn på finska",
+                        "name": "Titel på finska",
                         "content": "Innehåll på finska"
                     },
                     "sv": {
-                        "name": "Namn på svenska",
+                        "name": "Titel på svenska",
                         "content": "Innehåll på svenska"
                     }
+                },
+                "validate": {
+                    "name": "Lägg till en titel!",
+                    "content": "Lägg till innehåll!",
+                    "link": "Lägg till extern länk",
+                    "date": "Lägg till intervall!"
                 }
             },
             "messages": {
@@ -67,9 +73,6 @@ Oskari.registerLocalization(
                 },
                 "announcementsName": "Namn",
                 "announcementsTime": "Datumintervall"
-            },
-            "titleError": "Lägg till en titel!",
-            "contentError": "Lägg till innehåll!",
-            "dateError": "Lägg till intervall!"
+            }
         }
     });

--- a/bundles/admin/admin-announcements/view/AnnouncementsForm.jsx
+++ b/bundles/admin/admin-announcements/view/AnnouncementsForm.jsx
@@ -78,18 +78,19 @@ export const AnnouncementsForm = ({
     onClose
 }) => {
     const [state, setState] = useState(initState(announcement));
-    console.log(state);
+
     const isEdit = !!state.id;
     const onSave = () => {
-        const { date, ...other } = state;
         // TODO: should link or/and content be removed from locale??
         // Should format date value before submit.
         const values = {
-            beginDate: date[0].format(DATEFORMAT),
-            endDate: date[1].format(DATEFORMAT),
-            ...other
+            beginDate: state.date[0].format(),
+            endDate: state.date[1].format(),
+            locale: JSON.stringify(state.locale),
+            options: JSON.stringify(state.options)
         };
         if (isEdit) {
+            values.id = state.id;
             controller.updateAnnouncement(values);
         } else {
             controller.saveAnnouncement(values);
@@ -117,7 +118,7 @@ export const AnnouncementsForm = ({
             <Radio.Group
                 value={state.options.showAs}
                 buttonStyle="solid"
-                onChange={(evt) => onOptionChange('showAs', evt.target.value)}
+                onChange={(evt) => onOptionChange('showAsPopup', evt.target.value)}
             >
                 {getRadioButtons('show', SHOW_AS)}
             </Radio.Group>

--- a/bundles/admin/admin-announcements/view/AnnouncementsList.jsx
+++ b/bundles/admin/admin-announcements/view/AnnouncementsList.jsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { AnnouncementsForm } from './AnnouncementsForm';
 import PropTypes from 'prop-types';
 import { Collapse } from "antd";
-import { PlusOutlined } from '@ant-design/icons';
+import { PlusOutlined, EditOutlined } from '@ant-design/icons';
 import { Button } from 'oskari-ui';
 import { Controller, LocaleConsumer } from 'oskari-ui/util';
 import styled from 'styled-components';
@@ -16,8 +15,17 @@ const { Panel } = Collapse;
 const StyledButton = styled(Button)`
     margin-top: 10px;
 `;
-const AnnouncementsList = ({controller,  announcements, activeKey }) => {
 
+const getEditIcon = (edit, announcement) => (
+    <EditOutlined
+        onClick={event => {
+            edit(announcement);
+            event.stopPropagation();
+        }}
+    />
+);
+
+const AnnouncementsList = ({controller,  announcements, activeKey, edit }) => {
   const callback = (key) => {
     controller.openCollapse(key);
   }
@@ -29,20 +37,15 @@ const AnnouncementsList = ({controller,  announcements, activeKey }) => {
             const loc = Oskari.getLocalized(announcement.locale) || {};
             const title = loc.name ||  Oskari.getMsg('admin-announcements', 'addNewForm');
             return (
-              <Panel header={title} key={index}>
-              <AnnouncementsForm
-                controller={controller}
-                announcement={announcement}
-                index={index}
-                key={index}
-              />
+              <Panel header={title} key={index} extra={getEditIcon(edit, announcement)}>
+                <div dangerouslySetInnerHTML={{ __html: loc.content }}/>
               </Panel>
             );
           })}
           </Collapse>
         </div>
 
-        <StyledButton type="primary" onClick={() => controller.addForm()}>
+        <StyledButton type="primary" onClick={() => edit()}>
           <PlusOutlined />
         </StyledButton>
     </div>

--- a/bundles/admin/admin-announcements/view/AnnouncementsListHandler.js
+++ b/bundles/admin/admin-announcements/view/AnnouncementsListHandler.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StateHandler, controllerMixin, Messaging } from 'oskari-ui/util';
 import { Message } from 'oskari-ui';
-import { ANNOUNCEMENTS_LOCALSTORAGE } from '../../../framework/announcements/view/Constants';
+import { LOCAL_STORAGE_KEY } from '../../../framework/announcements/view/Constants';
 
 /*
 Handler for admin-announcements forms.
@@ -33,21 +33,21 @@ class ViewHandler extends StateHandler {
     constructor (sandbox) {
         super();
         this.service = sandbox.getService('Oskari.framework.announcements.service.AnnouncementsService');
-        this.fetchAdminAnnouncements();
+        this.fetchAnnouncements();
         this.state = {
             announcements: [],
-            active: true,
             activeKey: []
         };
     }
 
-    fetchAdminAnnouncements () {
-        this.service.fetchAdminAnnouncements(function (err, data) {
+    fetchAnnouncements () {
+        this.service.fetchAnnouncements(function (err, data) {
             if (err) {
                 Messaging.error(getMessage('messages.getAdminAnnouncementsFailed'));
             } else {
                 this.updateState({
-                    announcements: data
+                    announcements: data,
+                    activeKey: null
                 });
             }
         }.bind(this));
@@ -59,10 +59,7 @@ class ViewHandler extends StateHandler {
                 Messaging.error(getMessage('messages.saveFailed'));
             } else {
                 Messaging.success(getMessage('messages.saveSuccess'));
-                this.updateState({
-                    activeKey: []
-                });
-                this.fetchAdminAnnouncements();
+                this.fetchAnnouncements();
             }
         }.bind(this));
     }
@@ -75,11 +72,8 @@ class ViewHandler extends StateHandler {
                 return false;
             } else {
                 Messaging.success(getMessage('messages.updateSuccess'));
-                removeFromLocalStorageArray(ANNOUNCEMENTS_LOCALSTORAGE, data.id);
-                this.updateState({
-                    activeKey: []
-                });
-                this.fetchAdminAnnouncements();
+                removeFromLocalStorageArray(LOCAL_STORAGE_KEY, data.id);
+                this.fetchAnnouncements();
             }
         }.bind(this));
     }
@@ -91,10 +85,7 @@ class ViewHandler extends StateHandler {
             } else {
                 Messaging.success(getMessage('messages.deleteSuccess'));
                 // Update accordion with announcements and keep all closed
-                this.updateState({
-                    activeKey: []
-                });
-                this.fetchAdminAnnouncements();
+                this.fetchAnnouncements();
             }
         }.bind(this));
     }

--- a/bundles/admin/admin-announcements/view/AnnouncementsListHandler.js
+++ b/bundles/admin/admin-announcements/view/AnnouncementsListHandler.js
@@ -98,33 +98,8 @@ class ViewHandler extends StateHandler {
             }
         }.bind(this));
     }
-    // Cancel creating a new announcement or editing one. Close all panels.
-    cancel (id) {
-        if (id !== undefined) {
-            this.updateState({
-                activeKey: []
-            });
-        } else {
-            const newList = [...this.state.announcements];
-            newList.splice(-1, 1);
-            this.updateState({
-                announcements: newList,
-                activeKey: []
-            });
-        }
-    }
 
-    addForm () {
-        const newList = [...this.state.announcements];
-        const lang = Oskari.getLang();
-        newList.push({
-            locale: { [lang]: { name: Oskari.getMsg('admin-announcements', 'addNewForm') } }
-        });
-        this.updateState({
-            announcements: newList
-        });
-    }
-
+    // TODO: remnove
     openCollapse (key) {
         this.updateState({
             activeKey: key
@@ -133,5 +108,5 @@ class ViewHandler extends StateHandler {
 }
 
 export const AnnouncementsListHandler = controllerMixin(ViewHandler, [
-    'addForm', 'deleteAnnouncement', 'saveAnnouncement', 'updateAnnouncement', 'cancel', 'openCollapse'
+    'deleteAnnouncement', 'saveAnnouncement', 'updateAnnouncement', 'openCollapse'
 ]);

--- a/bundles/admin/admin-announcements/view/AnnouncementsPopup.jsx
+++ b/bundles/admin/admin-announcements/view/AnnouncementsPopup.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Message } from 'oskari-ui';
+import { showPopup } from 'oskari-ui/components/window';
+import { Controller, LocaleProvider } from 'oskari-ui/util';
+import { AnnouncementsForm } from './AnnouncementsForm';
+import { BUNDLE_KEY } from './constants';
+
+const Content = styled.div`
+    margin: 12px 24px 24px;
+`;
+
+export const showEditPopup = (controller, announcement, onClose) => {
+    const title = <Message messageKey="popup.title" bundleKey={BUNDLE_KEY} />;
+    const content = (
+        <LocaleProvider value={{ bundleKey: BUNDLE_KEY }}>
+            <Content>
+                <AnnouncementsForm
+                    controller={controller}
+                    announcement={announcement}
+                    onClose={onClose} />
+            </Content>
+        </LocaleProvider>
+    );
+    return showPopup(title, content, onClose, { id: BUNDLE_KEY });
+};
+
+showEditPopup.propTypes = {
+    controller: PropTypes.instanceOf(Controller).isRequired,
+    announcement: PropTypes.object,
+    onClose: PropTypes.func.isRequired
+};

--- a/bundles/admin/admin-announcements/view/constants.js
+++ b/bundles/admin/admin-announcements/view/constants.js
@@ -1,0 +1,2 @@
+export const BUNDLE_KEY = 'admin-announcements';
+export const DATEFORMAT = 'YYYY-MM-DD HH:mm';

--- a/bundles/admin/admin-announcements/view/constants.js
+++ b/bundles/admin/admin-announcements/view/constants.js
@@ -1,2 +1,15 @@
 export const BUNDLE_KEY = 'admin-announcements';
-export const DATEFORMAT = 'YYYY-MM-DD HH:mm';
+// Format for range inputs
+export const DATE_FORMAT = 'YYYY-MM-DD HH:mm';
+// Format for time picker
+export const TIME_FORMAT = 'HH';
+
+export const TYPE = {
+    TITLE: 'title',
+    CONTENT: 'content',
+    LINK: 'link'
+};
+
+export const OPTIONS = {
+    showAsPopup: true
+};

--- a/bundles/framework/announcements/service/AnnouncementsService.js
+++ b/bundles/framework/announcements/service/AnnouncementsService.js
@@ -29,41 +29,21 @@ Oskari.clazz.define('Oskari.framework.announcements.service.AnnouncementsService
         },
 
         /**
-        * @method fetchAdminAnnouncements
+        * @method fetchAnnouncements
         *
-        * Makes an ajax call to get admin announcements (all announcements)
+        * Makes an ajax call to get active announcements.
+        * For admin user all announcements are returned.
         */
-        fetchAdminAnnouncements: function (handler) {
+        fetchAnnouncements: function (handler) {
             if (typeof handler !== 'function') {
                 return;
             }
-
-            jQuery.ajax({
-                type: 'GET',
-                dataType: 'json',
-                data: { all: true },
-                url: Oskari.urls.getRoute('Announcements'),
-                success: function (pResp) {
-                    handler(null, pResp.data);
-                },
-                error: function (jqXHR, textStatus) {
-                    handler('Error', []);
-                }
-            });
-        },
-
-        /**
-        * @method fetchAnnouncements
-        *
-        * Makes an ajax call to get announcements (all except expired ones)
-        */
-        fetchAnnouncements: function (handler) {
             jQuery.ajax({
                 type: 'GET',
                 dataType: 'json',
                 url: Oskari.urls.getRoute('Announcements'),
                 success: (pResp) => {
-                    handler(null, pResp.data);
+                    handler(null, pResp.announcements);
                 },
                 error: function (jqXHR, textStatus) {
                     handler('Error', []);

--- a/src/react/ant-theme.less
+++ b/src/react/ant-theme.less
@@ -8,6 +8,7 @@
 @zindex-notification: 30010;
 @zindex-popover: 30030;
 @zindex-dropdown: 30050;
+@zindex-picker: 30050;
 @zindex-tooltip: 30060;
 
 @tooltip-max-width: 400px;


### PR DESCRIPTION
Refactor add/edit announcement to use popup instead of collapse item. Remove form and use state for all fields (localizedcomponent used state and other values were inside form).

Add radio buttons for announcement type selection.
Add field for external link. 
Add time to beginDate and endDate (only hours are shown)
Remove clear from date range input.
Clean locale before submit.

Not sure if announcement type should be stored to options. Now it is stored only in components internal state and used for showing/hiding inputs and cleaning locale before submit.