### PR TITLE
Clarify data provider handling

### DIFF
--- a/bundles/admin/admin-layereditor/instance.js
+++ b/bundles/admin/admin-layereditor/instance.js
@@ -36,7 +36,6 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
         _startImpl () {
             this._setupLayerTools();
             this._setupAdminTooling();
-            this._loadDataProviders();
             this.sandbox.requestHandler(ShowLayerEditorRequest.NAME, new ShowLayerEditorRequestHandler(this));
             const layerService = this._getLayerService();
             layerService.on('availableLayerTypesUpdated', () => this._setupLayerTools());
@@ -278,34 +277,6 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
             return groups;
         }
 
-        /**
-         * @private @method _loadDataProviders
-         * Loads data provider list
-         */
-        _loadDataProviders () {
-            const me = this;
-            jQuery.ajax({
-                type: 'GET',
-                dataType: 'json',
-                contentType: 'application/json; charset=UTF-8',
-                url: Oskari.urls.getRoute('GetMapLayerGroups'),
-                error: function () {
-                    var errorDialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
-                    errorDialog.show(me.locale('errors.dataProvider.title'), me.locale('errors.dataProvider.message'));
-                    errorDialog.fadeout();
-                },
-                success: function (response) {
-                    const dataProviders = [];
-                    response.organization.forEach(function (org) {
-                        dataProviders.push({
-                            id: org.id,
-                            name: Oskari.getLocalized(org.name)
-                        });
-                    });
-                    me._getLayerService().setDataProviders(dataProviders);
-                }
-            });
-        }
         /**
          * @private @method _getFlyout
          * Ensure flyout exists and return it

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
@@ -23,41 +23,29 @@ const getLayerGroups = (groups = []) => {
 };
 
 const providerReducer = (accumulator, currentLayer) => {
-    // TODO: once we have id, use it
-    const org = Oskari.getLocalized(currentLayer.getOrganizationName());
-    if (!org) {
+    const id = currentLayer.getDataProviderId();
+    if (!id) {
         return accumulator;
     }
-    let orgLayers = accumulator[org] || [];
+    const dataProviderId = '' + id;
+    let orgLayers = accumulator[dataProviderId] || [];
     if (!orgLayers.length) {
-        accumulator[org] = orgLayers;
+        accumulator[dataProviderId] = orgLayers;
     }
     orgLayers.push({ id: currentLayer.getId() });
     return accumulator;
 };
 
-const getDataProviders = (fromService = [], layers = []) => {
-    // Note! fromService will be an empty array if admin-layereditor is not started on the appsetup
-    // TODO: determine map provider -> layers list mapping with reduce
-    const providerMapping = layers.reduce(providerReducer, {});
-    if (!fromService.length) {
-        return Object.keys(providerMapping).map(name => {
-            return {
-                // generate an id when we don't have the id (== when admin-layereditor is not on the appsetup)
-                // use negative number just in case to make it "non-editable"
-                id: -Oskari.seq.nextVal('dummyProviders'),
-                name,
-                layers: providerMapping[name] || [],
-                groups: []
-            };
-        });
-    }
-    return fromService.map(dataProvider => {
+const getDataProviders = (providers = [], layers = []) => {
+    // Note! providers will be an empty array before layer listing has been loaded/populated
+    // get layers by provider { providerId: [... list of layer ids for provider...]}
+    const layersByProvider = layers.reduce(providerReducer, {});
+    return providers.map(dataProvider => {
         const name = dataProvider.name;
         return {
             id: dataProvider.id,
             name,
-            layers: providerMapping[name] || [],
+            layers: layersByProvider['' + dataProvider.id] || [],
             groups: []
         };
     });

--- a/bundles/mapping/mapmodule/domain/AbstractLayer.js
+++ b/bundles/mapping/mapmodule/domain/AbstractLayer.js
@@ -67,6 +67,7 @@ Oskari.clazz.define(
         me._isLinkedLayer = null;
 
         me._organizationName = null;
+        me._dataproviderId = null;
         me._dataUrl = null;
 
         /*
@@ -251,6 +252,20 @@ Oskari.clazz.define(
          */
         getDataUrl: function () {
             return this._dataUrl;
+        },
+        /**
+         * Dataprovider id (matching organization name)
+         * @param {Number} id
+         */
+        setDataProviderId: function (id) {
+            this._dataproviderId = id;
+        },
+        /**
+         * Dataprovider id (matching organization name)
+         * @param {Number} id
+         */
+        getDataProviderId: function () {
+            return this._dataproviderId;
         },
         /**
          * @method setOrganizationName

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -736,7 +736,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                     id,
                     name: pResp.providers[id].name
                 };
-            })
+            });
             this.setDataProviders(providers);
 
             const flatLayerGroups = [];
@@ -1194,12 +1194,12 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
             baseLayer.setMetadataIdentifier(baseMapJson.metadataUuid);
 
             // for grouping by dataprovider
-            layer.setDataProviderId(baseMapJson.dataproviderId);
+            baseLayer.setDataProviderId(baseMapJson.dataproviderId);
             const provider = this.getDataProviderById(baseMapJson.dataproviderId);
             if (provider) {
-                layer.setOrganizationName(provider.name || '');
+                baseLayer.setOrganizationName(provider.name || '');
             } else {
-                layer.setOrganizationName(baseMapJson.orgName || '');
+                baseLayer.setOrganizationName(baseMapJson.orgName || '');
             }
 
             baseLayer.setDescription(baseMapJson.info);

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -335,8 +335,14 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                 layer.setDescription(newLayerConf.subtitle);
             }
 
-            if (newLayerConf.orgName) {
-                layer.setOrganizationName(newLayerConf.orgName);
+            if (newLayerConf.dataproviderId) {
+                layer.setDataProviderId(newLayerConf.dataproviderId);
+                const provider = this.getDataProviderById(newLayerConf.dataproviderId);
+                if (provider) {
+                    layer.setOrganizationName(provider.name || '');
+                } else {
+                    layer.setOrganizationName(newLayerConf.orgName || '');
+                }
             }
 
             if (newLayerConf.realtime) {
@@ -643,13 +649,34 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
          */
         updateDataProvider: function (dataProvider) {
             // Update dataProvider to dataProviders
-            const index = this._dataProviders.findIndex(g => g.id === dataProvider.id);
+            const index = this._dataProviders.findIndex(g => '' + g.id === '' + dataProvider.id);
             if (index !== -1) {
                 this._dataProviders[index] = dataProvider;
             }
-            // Update dataProvider to needed layers.
-            this.getAllLayers().filter(l => l.admin && l.admin.organizationId === dataProvider.id).map(l => (l._organizationName = dataProvider.name));
+            // Update dataProvider to layers.
+            this.getAllLayers()
+                .filter(l => l.getDataProviderId() === dataProvider.id)
+                .forEach(l => l.setOrganizationName(dataProvider.name));
             this.trigger('dataProvider.update');
+        },
+        setDataProviders: function (dataProviders) {
+            this._dataProviders = dataProviders;
+            this.trigger('dataProvider.update');
+        },
+
+        getDataProviderById: function (id) {
+            const index = this._dataProviders.findIndex(g => '' + g.id === '' + id);
+            if (index === -1) {
+                return null;
+            }
+            // return a copy
+            return {
+                ...this._dataProviders[index]
+            };
+        },
+
+        getDataProviders: function () {
+            return this._dataProviders;
         },
         /**
          * @method deleteDataProvider
@@ -667,19 +694,16 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
             if (deleteLayers) {
                 // Remove layers
                 const layers = this._loadedLayersList.filter(l => {
-                    if (!l.admin) {
-                        return true;
-                    }
-                    return l.admin.organizationId !== dataProvider.id;
+                    return l.getDataProviderId() !== dataProvider.id;
                 });
                 this._loadedLayersList = layers;
             } else {
                 // Clear data provider from needed layers.
                 this.getAllLayers()
-                    .filter(l => l.admin && l.admin.organizationId === dataProvider.id)
+                    .filter(l => l.getDataProviderId() === dataProvider.id)
                     .forEach(l => {
-                        l._organizationName = '';
-                        delete l.admin.organizationId;
+                        l.setDataProviderId(null);
+                        l.setOrganizationName('');
                     });
             }
             this.trigger('dataProvider.update');
@@ -706,6 +730,14 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
             const groupModels = pResp.groups
                 .map(group => Oskari.clazz.create('Oskari.mapframework.domain.MaplayerGroup', group));
             this._layerGroups.push(...groupModels);
+
+            const providers = Object.keys(pResp.providers).map(id => {
+                return {
+                    id,
+                    name: pResp.providers[id].name
+                };
+            })
+            this.setDataProviders(providers);
 
             const flatLayerGroups = [];
             const gatherFlatGroups = (groups = []) => {
@@ -1117,9 +1149,6 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
             }
 
             // Set additional data
-            if (mapLayer && mapLayerJson.admin !== null && mapLayerJson.admin !== undefined) {
-                mapLayer.admin = mapLayerJson.admin;
-            }
             if (mapLayer && mapLayerJson.names !== null && mapLayerJson.names !== undefined) {
                 mapLayer.names = mapLayerJson.names;
             }
@@ -1164,10 +1193,13 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
 
             baseLayer.setMetadataIdentifier(baseMapJson.metadataUuid);
 
-            if (baseMapJson.orgName) {
-                baseLayer.setOrganizationName(baseMapJson.orgName);
+            // for grouping by dataprovider
+            layer.setDataProviderId(baseMapJson.dataproviderId);
+            const provider = this.getDataProviderById(baseMapJson.dataproviderId);
+            if (provider) {
+                layer.setOrganizationName(provider.name || '');
             } else {
-                baseLayer.setOrganizationName('');
+                layer.setOrganizationName(baseMapJson.orgName || '');
             }
 
             baseLayer.setDescription(baseMapJson.info);
@@ -1186,11 +1218,6 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                     // Notice that we are adding layers to baselayers sublayers array
                     const subLayer = this._createActualMapLayer(baseMapJson.subLayer[i]);
                     subLayer.setParentId(baseMapJson.id);
-
-                    // if (baseMapJson.subLayer[i].admin) {
-                    subLayer.admin = baseMapJson.subLayer[i].admin || {};
-                    // }
-
                     baseLayer.getSubLayers().push(subLayer);
                 }
             }
@@ -1302,11 +1329,13 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                 layer.setBackendStatus(mapLayerJson.backendStatus);
             }
 
-            // for grouping: organisation and inspire
-            if (mapLayerJson.orgName) {
-                layer.setOrganizationName(mapLayerJson.orgName);
+            // for grouping by dataprovider
+            layer.setDataProviderId(mapLayerJson.dataproviderId);
+            const provider = this.getDataProviderById(mapLayerJson.dataproviderId);
+            if (provider) {
+                layer.setOrganizationName(provider.name || '');
             } else {
-                layer.setOrganizationName('');
+                layer.setOrganizationName(mapLayerJson.orgName || '');
             }
 
             layer.setVisible(true);
@@ -1507,15 +1536,6 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
             });
             // return true if all layers were found
             return !missingLayer;
-        },
-
-        setDataProviders: function (dataProviders) {
-            this._dataProviders = dataProviders;
-            this.trigger('dataProvider.update');
-        },
-
-        getDataProviders: function () {
-            return this._dataProviders;
         }
     }, {
         /**


### PR DESCRIPTION
Previously the `getDataProviders()` from `Oskari.mapframework.service.MapLayerService` returned an empty list IF `admin-layereditor` bundle wasn't included (it populated the list). The layer listing by data provider was created based on `layer.getOrganizationName()`.

Now data providers listing is included in `GetHierarchicalMapLayerGroups` response. Layers also have `dataproviderId` in addition to `orgName` in their JSON format. This change populates the `getDataProviders()` in `MapLayerService` based on that response. The  `admin-layereditor` bundle no longer loads it's own list of data providers. 

This allows us to add more information than just the name of the data provider for the UI AND makes it more manageable to reference data providers when we can use an ID for them instead of just distinct names. Continuing https://github.com/oskariorg/oskari-server/pull/850 as a step forward for adding descriptions for data providers.
