### PR TITLE
Improvements to ErrorBoundary component

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
@@ -170,7 +170,7 @@ const LayerCollapsePanel = (props) => {
     // after AntD version 4.9.0 we could disable panels without children:
     // const hasChildren = layerRows.length > 0 || group.getGroups().length > 0;
     return (
-        <ErrorBoundary hideError={true} debug={{group, selectedLayerIds}}>
+        <ErrorBoundary hide={true} debug={{group, selectedLayerIds}}>
             <StyledCollapsePanel {...propsNeededForPanel}
                 // collapsible={hasChildren ? 'header' : 'disabled'}
                 // TODO: remove gid_[id] once data-attributes work for AntD Collapse.Panels

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Collapse, CollapsePanel, List, ListItem, Tooltip } from 'oskari-ui';
 import { QuestionCircleOutlined } from '@ant-design/icons';
-import { Controller } from 'oskari-ui/util';
+import { Controller, ErrorBoundary } from 'oskari-ui/util';
 import { Layer } from './Layer/';
 import { LayerCountBadge } from './LayerCountBadge';
 import { AllLayersSwitch } from './AllLayersSwitch';
@@ -170,33 +170,35 @@ const LayerCollapsePanel = (props) => {
     // after AntD version 4.9.0 we could disable panels without children:
     // const hasChildren = layerRows.length > 0 || group.getGroups().length > 0;
     return (
-        <StyledCollapsePanel {...propsNeededForPanel}
-            // collapsible={hasChildren ? 'header' : 'disabled'}
-            // TODO: remove gid_[id] once data-attributes work for AntD Collapse.Panels
-            className={`t_group gid_${group.getId()}`}
-            // data-attr doesn't seem to work for the panel in AntD-version 4.8.5
-            data-gid={group.getId()}
-            header={group.getTitle()}
-            extra={
-                <PanelToolContainer
-                    group={group}
-                    opts={opts}
-                    layerCount={group.getLayerCount()}
-                    controller={controller}
-                    allLayersOnMap={allLayersOnMap} />
-            }>
-                { isPanelOpen && <React.Fragment>
-                    <SubGroupList
-                        subgroups={group.getGroups()}
-                        selectedLayerIds={selectedLayerIds}
+        <ErrorBoundary hideError={true} debug={{group, selectedLayerIds}}>
+            <StyledCollapsePanel {...propsNeededForPanel}
+                // collapsible={hasChildren ? 'header' : 'disabled'}
+                // TODO: remove gid_[id] once data-attributes work for AntD Collapse.Panels
+                className={`t_group gid_${group.getId()}`}
+                // data-attr doesn't seem to work for the panel in AntD-version 4.8.5
+                data-gid={group.getId()}
+                header={group.getTitle()}
+                extra={
+                    <PanelToolContainer
+                        group={group}
                         opts={opts}
-                        openGroupTitles={openGroupTitles}
+                        layerCount={group.getLayerCount()}
                         controller={controller}
-                        { ...propsNeededForPanel } />
-                    <LayerList
-                        layers={layerRows} />
-                </React.Fragment>}
-        </StyledCollapsePanel>
+                        allLayersOnMap={allLayersOnMap} />
+                }>
+                    { isPanelOpen && <React.Fragment>
+                        <SubGroupList
+                            subgroups={group.getGroups()}
+                            selectedLayerIds={selectedLayerIds}
+                            opts={opts}
+                            openGroupTitles={openGroupTitles}
+                            controller={controller}
+                            { ...propsNeededForPanel } />
+                        <LayerList
+                            layers={layerRows} />
+                    </React.Fragment>}
+            </StyledCollapsePanel>
+        </ErrorBoundary>
     );
 };
 

--- a/src/react/util/ErrorBoundary.jsx
+++ b/src/react/util/ErrorBoundary.jsx
@@ -29,18 +29,27 @@ export class ErrorBoundary extends React.Component {
     constructor(props) {
         super(props);
         this.errorComp = props.errorComponent;
+        this.hideError = !!props.hide;
+        this.debugInfo = props.debug;
         this.state = { hasError: false };
     }
 
     componentDidCatch (error, errorInfo) {
+        const log = Oskari.log('React/ErrorBoundary');
+        log.error(error);
+        if (this.debugInfo) {
+            log.info('Debug info', this.debugInfo);
+        }
         this.setState({
             hasError: true,
             errorInfo });
-        Oskari.log('React/ErrorBoundary').error(error, errorInfo);
     }
 
     render () {
         if (this.state.hasError) {
+            if (this.hideError) {
+                return null;
+            }
             const ErrorComp = this.errorComp || DefaultError;
             return (<ErrorComp info={this.state.errorInfo}/>);
         }
@@ -48,6 +57,12 @@ export class ErrorBoundary extends React.Component {
     }
 }
 ErrorBoundary.propTypes = {
-    children: PropTypes.node,
-    errorComponent: PropTypes.elementType
+    // boolean to just skip without showing an error
+    hide: PropTypes.bool,
+    // info to include in logging if an error occurs
+    debug: PropTypes.object,
+    // custom component for rendering an error message
+    errorComponent: PropTypes.elementType,
+    // children are rendered when there is no error
+    children: PropTypes.node
 };


### PR DESCRIPTION
And wrap layerlist groups to an error boundary in case we have groups that use localized names (after layer list changes for 2.8.0 groups should only use name for current language).