### PR TITLE
Proxy url contains already id parameter

### DIFF
--- a/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol.js
@@ -106,7 +106,6 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.WmsLayerPlugin',
                 const defaultParams = {
                     LAYERS: _layer.getLayerName(),
                     TRANSPARENT: true,
-                    ID: _layer.getId(),
                     STYLES: _layer.getCurrentStyle().getName(),
                     FORMAT: 'image/png',
                     VERSION: _layer.getVersion() || '1.3.0'


### PR DESCRIPTION
Remove unnecessary ID parameter.

* Proxy url already contains id parameter --> not necessary
* Normal non proxy WMS url not know what to do with id parameter