### PR TITLE
Statsgrid test classes

### DIFF
--- a/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
+++ b/bundles/statistics/statsgrid2016/components/RegionsetViewer.js
@@ -19,7 +19,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
         const me = this;
         const { activeIndicator, regionset, error, seriesStats } = this.service.getStateService().getStateForRender();
         if (error) {
-            this.log.warn('Error getting state', error);
+            this.log.debug('Error getting state', error);
             me._clearRegions();
             return;
         }

--- a/bundles/statistics/statsgrid2016/components/classification/editclassification/EditClassification.jsx
+++ b/bundles/statistics/statsgrid2016/components/classification/editclassification/EditClassification.jsx
@@ -64,7 +64,7 @@ export const EditClassification = ({
                 <Message messageKey={`classify.labels.method`}/>
                 <span>: &nbsp;</span>
                 <Message messageKey={`classify.methods.${values.method}`}/>
-                <EditIcon disabled = {disabled} onClick={() => startHistogramView()}/>
+                <EditIcon disabled = {disabled} className='t_button-method' onClick={() => startHistogramView()}/>
             </MethodContainer>
             <LabeledSelect
                 name = 'count'

--- a/bundles/statistics/statsgrid2016/components/classification/editclassification/LabeledSelect.jsx
+++ b/bundles/statistics/statsgrid2016/components/classification/editclassification/LabeledSelect.jsx
@@ -19,8 +19,9 @@ export const LabeledSelect = ({
     return (
         <Fragment>
             <Message messageKey={`classify.labels.${name}`}/>
-            <Margin className={`t_option-${name}`}>
+            <Margin>
                 <Select
+                    className={`t_option-${name}`}
                     onChange={value => handleChange(name, value)}
                     size='small'
                     {...rest}

--- a/bundles/statistics/statsgrid2016/components/manualClassification/HistogramForm.jsx
+++ b/bundles/statistics/statsgrid2016/components/manualClassification/HistogramForm.jsx
@@ -12,9 +12,10 @@ const BUNDLE_KEY = 'StatsGrid';
 const Content = styled.div`
     padding: 24px;
 `;
-const Margin = styled.div`
-    padding-top: 5px;
-    padding-bottom: 10px;
+const StyledSelect = styled(Select)`
+    margin-left: 10px;
+    min-width: 150px;
+    margin-bottom: 10px;
 `;
 
 const Form = ({
@@ -49,18 +50,17 @@ const Form = ({
     };
     return (
         <Content>
-            <Message messageKey={'classify.labels.method' } bundleKey={BUNDLE_KEY} />
-            <Margin>
-                <Select
-                    value = {method}
-                    onChange={value => onMethodChange(value)}>
-                    {methods.map(({ label, ...rest }, i) => (
-                        <Option key={`option-${i}`} {...rest}>
-                            {label}
-                        </Option>
-                    ))}
-                </Select>
-            </Margin>
+            <label><b><Message messageKey={'classify.labels.method' } bundleKey={BUNDLE_KEY} /></b></label>
+            <StyledSelect
+                className='t_option-method'
+                value = {method}
+                onChange={value => onMethodChange(value)}>
+                {methods.map(({ label, ...rest }, i) => (
+                    <Option key={`option-${i}`} {...rest}>
+                        {label}
+                    </Option>
+                ))}
+            </StyledSelect>
             <div ref={ref} className="manual-class-view"/>
             <ButtonContainer>
                 <PrimaryButton type='close' onClick={onClose}/>

--- a/bundles/statistics/statsgrid2016/instance.js
+++ b/bundles/statistics/statsgrid2016/instance.js
@@ -480,12 +480,10 @@ Oskari.clazz.define(
             };
         },
         createClassficationView: function () {
-            var config = jQuery.extend(true, {}, this.getConfiguration());
-            var sandbox = this.getSandbox();
-            var locale = Oskari.getMsg.bind(null, 'StatsGrid');
-            var mapModule = sandbox.findRegisteredModuleInstance('MainMapModule');
+            const config = jQuery.extend(true, {}, this.getConfiguration());
+            const mapModule = this.getSandbox().findRegisteredModuleInstance('MainMapModule');
 
-            this.classificationPlugin = Oskari.clazz.create('Oskari.statistics.statsgrid.ClassificationPlugin', this, config, locale, sandbox);
+            this.classificationPlugin = Oskari.clazz.create('Oskari.statistics.statsgrid.ClassificationPlugin', this, config);
             this.classificationPlugin.on('show', () => this.togglePlugin && this.togglePlugin.toggleTool(TOGGLE_TOOL_CLASSIFICATION, true));
             this.classificationPlugin.on('hide', () => this.togglePlugin && this.togglePlugin.toggleTool(TOGGLE_TOOL_CLASSIFICATION, false));
             mapModule.registerPlugin(this.classificationPlugin);

--- a/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
@@ -9,12 +9,13 @@ import '../resources/scss/classificationplugin.scss';
  */
 Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
 
-    function (instance, config, locale, sandbox) {
-        var me = this;
-        me._locale = locale;
-        me._config = config || {};
-        me._sandbox = sandbox;
+    function (instance, config) {
+        const me = this;
         me._instance = instance;
+        me._config = config || {};
+        me._sandbox = instance.getSandbox();
+        this.service = instance.getStatisticsService();
+        me._locale = Oskari.getMsg.bind(null, 'StatsGrid');
         me._clazz = 'Oskari.statistics.statsgrid.ClassificationPlugin';
         me._index = 9;
         this._defaultLocation = me._config.legendLocation || 'right bottom';
@@ -35,7 +36,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
         me.log = Oskari.log('Oskari.statistics.statsgrid.ClassificationPlugin');
         Oskari.makeObservable(this);
 
-        this.service = sandbox.getService('Oskari.statistics.statsgrid.StatisticsService');
         this.node = null;
         this._overflowedOffset = null;
         this._previousIsEdit = false;


### PR DESCRIPTION
Add test classes for method select and icon.
Move method select to same row than label.
Get service from instance. For some reason classification plugin didn't get events and plugin didn't render.
Didn't trigger render on:
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js#L273
but this was triggered:
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/statistics/statsgrid2016/components/RegionsetViewer.js#L349
Looks like getting service from instance works. Have to look this again if it doesn't solve problem.