### PR TITLE
Announcements localization update

### DIFF
--- a/bundles/framework/announcements/resources/locale/en.js
+++ b/bundles/framework/announcements/resources/locale/en.js
@@ -7,7 +7,8 @@ Oskari.registerLocalization(
         "desc": "",
         "flyout": {
             "title": "Announcements",
-            "noAnnouncements": "No active announcements",
+            "noAnnouncements": "No announcements",
+            "active": "Current announcements",
             "outdated": "Outdated announcements",
             "upcoming": "Upcoming announcements"
         },

--- a/bundles/framework/announcements/resources/locale/fi.js
+++ b/bundles/framework/announcements/resources/locale/fi.js
@@ -7,7 +7,8 @@ Oskari.registerLocalization(
             "desc": "",
             "flyout": {
                 "title": "Ilmoitukset",
-                "noAnnouncements": "Ei aktiivisia ilmoituksia",
+                "noAnnouncements": "Ei ilmoituksia",
+                "active": "Voimassa olevat ilmoitukset",
                 "outdated": "Vanhentuneet ilmoitukset",
                 "upcoming": "Tulevat ilmoitukset"
             },

--- a/bundles/framework/announcements/resources/locale/sv.js
+++ b/bundles/framework/announcements/resources/locale/sv.js
@@ -7,7 +7,8 @@ Oskari.registerLocalization(
             "desc": "",
             "flyout": {
                 "title": "Aviseringar",
-                "noAnnouncements": "Inga aktiva aviseringar",
+                "noAnnouncements": "Inga aviseringar",
+                "active": "Aktuella aviseringar",
                 "outdated": "Föråldrade aviseringar",
                 "upcoming": "Framtida aviseringar"
             },

--- a/bundles/framework/announcements/view/flyout/FlyoutContent.jsx
+++ b/bundles/framework/announcements/view/flyout/FlyoutContent.jsx
@@ -16,15 +16,21 @@ export const FlyoutContent = ({
     // Flyout content with tools, outdated and upcoming announcements for admin users
     return (
         <div>
-            <FlyoutCollapse announcements={active} toolController={toolController}/>
             <Divider orientation='left'>
-                <Message messageKey='flyout.outdated'/>
+                <Message messageKey='flyout.active'/>
             </Divider>
-            <FlyoutCollapse announcements={outdated} toolController={toolController}/>
+            <FlyoutCollapse announcements={active} toolController={toolController}/>
+
             <Divider orientation='left'>
                 <Message messageKey='flyout.upcoming'/>
             </Divider>
             <FlyoutCollapse announcements={upcoming} toolController={toolController}/>
+
+            <Divider orientation='left'>
+                <Message messageKey='flyout.outdated'/>
+            </Divider>
+            <FlyoutCollapse announcements={outdated} toolController={toolController}/>
+
             <FlyoutFooter toolController={toolController} />
         </div>
     );


### PR DESCRIPTION
Remove 'active' from noAnnouncements localization .
Add 'active' localization and divider for admin.
Move upcoming list/collapse before outdated.