### PR TITLE
Remove auto-exported components to reduce min.js size

### DIFF
--- a/bundles/admin/admin-announcements/view/AnnouncementsForm.jsx
+++ b/bundles/admin/admin-announcements/view/AnnouncementsForm.jsx
@@ -1,9 +1,10 @@
 import React, { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Message, DateRange, Label, LabeledInput, Radio, Tooltip } from 'oskari-ui';
-import { LocaleConsumer } from 'oskari-ui/util';
+import { Message, Label, LabeledInput, Radio, Tooltip } from 'oskari-ui';
 import { SecondaryButton, PrimaryButton, ButtonContainer, DeleteButton } from 'oskari-ui/components/buttons';
 import { LocalizationComponent } from 'oskari-ui/components/LocalizationComponent';
+import { DateRange } from 'oskari-ui/components/DateRange';
+import { LocaleConsumer } from 'oskari-ui/util';
 import styled from 'styled-components';
 import moment from 'moment';
 import { RichEditor } from 'oskari-ui/components/RichEditor';

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VectorStyle.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VectorStyle.jsx
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import { VectorStyleSelect } from './VectorStyle/VectorStyleSelect';
 import { VectorNameInput } from './VectorStyle/VectorNameInput';
 import { LocaleConsumer, Controller } from 'oskari-ui/util';
-import { Button, Message, Modal, Space } from 'oskari-ui';
+import { Button, Message, Space } from 'oskari-ui';
 import { PlusOutlined } from '@ant-design/icons';
+import { Modal } from 'oskari-ui/components/Modal';
 import { StyleEditor } from 'oskari-ui/components/StyleEditor';
 import styled from 'styled-components';
 

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -34,7 +34,3 @@ export { Link } from './components/Link';
 // TODO: consider moving these out of index.js so we don't pack them in for embedded maps
 // or in components that are used on embedded maps we could import the components directly and NOT use this index file for imports
 export { UrlInput } from './components/UrlInput';
-export { GenericForm } from './components/GenericForm';
-export { DateRange } from './components/DateRange';
-export { ColorPicker } from './components/ColorPicker';
-export { Modal } from './components/Modal';


### PR DESCRIPTION
Export by path instead of index.js directly in oskari-ui so we don't package the components for applications that don't need them.