### PR TITLE
Add frontend validation for groups/dataprovider admin

### DIFF
--- a/bundles/admin/admin-layereditor/instance.js
+++ b/bundles/admin/admin-layereditor/instance.js
@@ -3,6 +3,7 @@ import { LayerEditorFlyout } from './view/Flyout';
 import { ShowLayerEditorRequest } from './request/ShowLayerEditorRequest';
 import { ShowLayerEditorRequestHandler } from './request/ShowLayerEditorRequestHandler';
 import { LocalizingFlyout } from './view/LocalizingFlyout';
+import { Messaging } from 'oskari-ui/util';
 import { EditOutlined, PlusCircleOutlined } from '@ant-design/icons';
 
 const BasicBundle = Oskari.clazz.get('Oskari.BasicBundle');
@@ -364,16 +365,12 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
                             this._getLayerService().addLayerGroup(group, parentId);
                         }
                         // Inform user with popup
-                        const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
-                        dialog.show('', me.loc('messages.saveSuccess'));
-                        dialog.fadeout();
+                        Messaging.success(me.loc('messages.saveSuccess'));
                     },
                     error: (jqXHR, textStatus, errorThrown) => {
                         this.themeFlyout.setLoading(false);
                         // Inform user with popup
-                        const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
-                        dialog.show('', me.loc('messages.saveFailed'));
-                        dialog.fadeout();
+                        Messaging.error(me.loc('messages.saveFailed'));
                         // Log error
                         const errorText = Oskari.util.getErrorTextFromAjaxFailureObjects(jqXHR, errorThrown);
                         Oskari.log('admin-layereditor').error(errorText);
@@ -393,16 +390,12 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
                             this.themeFlyout.hide();
                             this._getLayerService().deleteLayerGroup(response.id, response.parentId, deleteLayers);
                             // Inform user with popup
-                            const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
-                            dialog.show(' ', me.loc('messages.deleteSuccess'));
-                            dialog.fadeout();
+                            Messaging.success(me.loc('messages.deleteSuccess'));
                         },
                         error: (jqXHR, textStatus, errorThrown) => {
                             this.themeFlyout.setLoading(false);
                             // Inform user with popup
-                            const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
-                            dialog.show(' ', me.loc('messages.deleteFailed'));
-                            dialog.fadeout();
+                            Messaging.error(me.loc('messages.deleteFailed'));
                             // Log error
                             const errorText = Oskari.util.getErrorTextFromAjaxFailureObjects(jqXHR, errorThrown);
                             Oskari.log('admin-layereditor').error(errorText);
@@ -475,16 +468,12 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
                         } else {
                             this._getLayerService().addDataProvider(dataProvider);
                         }
-                        const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
-                        dialog.show(' ', me.loc('messages.saveSuccess'));
-                        dialog.fadeout();
+                        Messaging.success(me.loc('messages.saveSuccess'));
                     },
                     error: (jqXHR, textStatus, errorThrown) => {
                         this.dataProviderFlyout.setLoading(false);
                         // Inform user with popup
-                        const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
-                        dialog.show(' ', me.loc('messages.saveFailed'));
-                        dialog.fadeout();
+                        Messaging.error(me.loc('messages.saveFailed'));
                         // Log error
                         const errorText = Oskari.util.getErrorTextFromAjaxFailureObjects(jqXHR, errorThrown);
                         Oskari.log('admin-layereditor').error(errorText);
@@ -504,16 +493,12 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
                             this.dataProviderFlyout.hide();
                             this._getLayerService().deleteDataProvider(response, deleteLayers);
                             // Inform user with popup
-                            const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
-                            dialog.show(' ', me.loc('messages.deleteSuccess'));
-                            dialog.fadeout();
+                            Messaging.success(me.loc('messages.deleteSuccess'));
                         },
                         error: (jqXHR, textStatus, errorThrown) => {
                             this.dataProviderFlyout.setLoading(false);
                             // Inform user with popup
-                            const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
-                            dialog.show(' ', me.loc('messages.deleteFailed'));
-                            dialog.fadeout();
+                            Messaging.error(me.loc('messages.deleteFailed'));
                             // Log error
                             const errorText = Oskari.util.getErrorTextFromAjaxFailureObjects(jqXHR, errorThrown);
                             Oskari.log('admin-layereditor').error(errorText);

--- a/bundles/admin/admin-layereditor/view/LocalizingFlyout.jsx
+++ b/bundles/admin/admin-layereditor/view/LocalizingFlyout.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Spin, LabeledInput, Button, Message, Checkbox, Confirm } from 'oskari-ui';
+import { ButtonContainer, PrimaryButton, SecondaryButton } from 'oskari-ui/components/buttons';
 import { LocalizationComponent } from 'oskari-ui/components/LocalizationComponent';
 import { LocaleProvider, LocaleConsumer, handleBinder, StateHandler, controllerMixin, Controller, Messaging  } from 'oskari-ui/util';
 import styled from 'styled-components';
@@ -161,18 +162,18 @@ const Container = styled('div')`
 const Header = styled('div')`
     font-weight: bold;
 `;
-const Label = styled('div')`
-    margin-top: 8px;
-`;
-const Buttons = styled('div')`
-    display: flex;
-    justify-content: space-between;
-    padding-top: 15px;
-`;
 
 const DeleteLayersCheckbox = styled(Checkbox)`
     padding-top: 15px;
 `;
+const hasMandatoryValues = (current, defaultLang) => {
+    if (!current) {
+        return false;
+    }
+    const langValue = current[defaultLang] || {};
+    const curName = langValue.name || '';
+    return curName.trim().length > 0;
+};
 const LocalizedContent = LocaleConsumer(({ loading, value, headerMessageKey, controller, isNew, deleteMapLayersText, layerCountInGroup, deleteLayers, hasSubgroups, getMessage }) => {
     const RemoveGroupButton = () => {
         if (isNew) {
@@ -194,6 +195,8 @@ const LocalizedContent = LocaleConsumer(({ loading, value, headerMessageKey, con
                 deleteLayers={deleteLayers} />
         );
     };
+    const languages = Oskari.getSupportedLanguages();
+    const isValid = hasMandatoryValues(value, languages[0]);
     const Component = (
         <Container>
             <Header>
@@ -201,21 +204,17 @@ const LocalizedContent = LocaleConsumer(({ loading, value, headerMessageKey, con
             </Header>
             <LocalizationComponent
                 value={value}
-                languages={Oskari.getSupportedLanguages()}
+                languages={languages}
                 onChange={controller.setValue}
             >
                 <LabeledInput type="text" name="name" label={getMessage(`fields.locale.name`)} mandatory={true}/>
                 <LabeledInput type="text" name="desc" label={getMessage(`fields.locale.description`)} />
             </LocalizationComponent>
-            <Buttons>
-                <Button onClick={() => controller.cancel()}>
-                    <Message messageKey='cancel' />
-                </Button>
+            <ButtonContainer>
+                <SecondaryButton type='cancel' onClick={() => controller.cancel()} />
                 <RemoveGroupButton />
-                <Button onClick={() => controller.save()} type='primary'>
-                    <Message messageKey='save' />
-                </Button>
-            </Buttons>
+                <PrimaryButton type='save' onClick={() => controller.save()} disabled={!isValid} />
+            </ButtonContainer>
         </Container>
     );
     if (loading) {

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -482,7 +482,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                 }
             }
             const allLayers = this.getAllLayers();
-            const isLayerInGroup = (layer) => layer.getGroups().filter(g => g.getId() === id).length > 0;
+            const isLayerInGroup = (layer) => layer.getGroups().filter(g => g.id === id).length > 0;
             const layersInDeletedGroup = allLayers.filter(isLayerInGroup).map(l => l.getId());
 
             if (deleteLayers) {


### PR DESCRIPTION
- Disabled save when name is not given for default language
- Replaced jQuery-based status popups "saved" or "failed" with the React-based Messaging API
- Replaced buttons to use the common impl under oskariui
- *Note!* Fixed an issue when removing group (code assumed layer.groups had getters, they don't https://github.com/oskariorg/oskari-frontend/pull/1847/commits/e15b803dc7cf1febf2a8a464556bd3e07a9dcb12)