### PR TITLE
React test classes

### DIFF
--- a/bundles/framework/announcements/instance.js
+++ b/bundles/framework/announcements/instance.js
@@ -88,18 +88,18 @@ Oskari.clazz.define('Oskari.framework.bundle.announcements.AnnouncementsBundleIn
                 controller.onBannerClose();
                 this.bannerCleanup();
             };
-            this.bannerControls = showAnnouncementsBanner(state, controller, onClose, (title, description) => this.renderDescriptionPopup(title, description));
+            const renderDescriptionPopup = (announcement) => this.renderDescriptionPopup(announcement);
+            this.bannerControls = showAnnouncementsBanner(state, controller, onClose, renderDescriptionPopup);
         },
-        renderDescriptionPopup: function (title, description) {
+        renderDescriptionPopup: function (announcement) {
             if (this.descriptionPopupControls) {
-                this.descriptionPopupControls.update(title, description);
-                return;
+                this.descriptionPopupControls.close();
             }
 
             const onClose = () => {
                 this.descriptionPopupCleanup();
             };
-            this.descriptionPopupControls = showBannerDescriptionPopup(title, description, onClose);
+            this.descriptionPopupControls = showBannerDescriptionPopup(announcement, onClose);
         },
         popupCleanup: function () {
             if (this.popupControls) {

--- a/bundles/framework/announcements/view/AnnouncementsBanner.jsx
+++ b/bundles/framework/announcements/view/AnnouncementsBanner.jsx
@@ -22,6 +22,7 @@ const InfoIcon = styled(InfoCircleOutlined)`
 
 const StyledCheckbox = styled(Checkbox)`
     margin-left: 10px;
+    white-space: nowrap;
 `;
 const StyledTitle = styled.span`
     font-weight: bold;

--- a/bundles/framework/announcements/view/AnnouncementsBanner.jsx
+++ b/bundles/framework/announcements/view/AnnouncementsBanner.jsx
@@ -1,22 +1,9 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { showBanner } from 'oskari-ui/components/window';
 import { Checkbox, Message, Pagination, Link } from 'oskari-ui';
 import { BUNDLE_KEY } from '../constants';
 import styled from 'styled-components';
-import { SecondaryButton, PrimaryButton, ButtonContainer } from 'oskari-ui/components/buttons';
 import { InfoCircleOutlined, SelectOutlined } from '@ant-design/icons';
-
-const StyledPagination = styled(Pagination)`
-    li.ant-pagination-next {
-        min-width: 0;
-    }
-`;
-
-const ActionContainer = styled('div')`
-    display: flex;
-    flex-direction: inherit;
-    align-items: end;
-`;
 
 const LinkIcon = styled(SelectOutlined)`
     margin-left: 6px;
@@ -27,80 +14,83 @@ const PopupLink = styled('span')`
     cursor: pointer;
 `;
 
-const getContent = (state, controller, onClose, renderDescriptionPopup) => {
+const InfoIcon = styled(InfoCircleOutlined)`
+    color: #3c3c3c;
+    font-size: 24px;
+    margin-right: 10px;
+`;
+
+const StyledCheckbox = styled(Checkbox)`
+    margin-left: 10px;
+`;
+const StyledTitle = styled.span`
+    font-weight: bold;
+    color: #3c3c3c;
+`;
+const Column = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+const Margin = styled.div`
+    margin-right: auto;
+`;
+
+const getContent = (state, controller, renderDescriptionPopup) => {
     const { bannerAnnouncements, currentBanner = 1 } = state;
     const announcement = bannerAnnouncements[currentBanner - 1];
 
     if (!announcement) return null;
 
     const { title, link, content } = Oskari.getLocalized(announcement.locale);
+    const count = bannerAnnouncements.length;
     const setShowAgain = (e) => controller.setShowAgain(announcement.id, e.target.checked);
-
     const onPageChange = (page) => controller.onBannerChange(page);
-    const isLast = currentBanner === bannerAnnouncements.length;
 
-    const itemRender = (current, type, originalElement) => {
-        if (type === 'prev') {
-            return <SecondaryButton type='previous'/>;
-        }
-        if (type === 'next') {
-            return isLast ? null : <PrimaryButton type='next' style={{ color: '#ffffff' }}/>;
-        }
-        return originalElement;
-    };
-
-    let description;
+    let description = <span/>;
 
     if (link) {
-        description = <Link url={link}>
-            <Message messageKey={'externalLink'} bundleKey={BUNDLE_KEY} />
-        </Link>;
+        description = (
+            <Link url={link}>
+                <Message messageKey={'externalLink'} bundleKey={BUNDLE_KEY} />
+            </Link>
+        );
     } else if (content) {
-        const contentHtml = <div dangerouslySetInnerHTML={{ __html: content }}/>;
-        description = <PopupLink onClick={() => renderDescriptionPopup(title, contentHtml)}>
+        description = (
+            <PopupLink onClick={() => renderDescriptionPopup(announcement)}>
                 <Message messageKey={'externalLink'} bundleKey={BUNDLE_KEY} />
                 <LinkIcon/>
-        </PopupLink>;
+            </PopupLink>
+        );
     }
-
-    const action = <ActionContainer>
-        <Checkbox checked={state.dontShowAgain.includes(announcement.id)} onChange={setShowAgain}>
-            <Message messageKey='dontShow' bundleKey={BUNDLE_KEY} />
-        </Checkbox>
-        {bannerAnnouncements.length > 1 && (
-            <ButtonContainer>
-                <StyledPagination current={currentBanner} total={bannerAnnouncements.length} defaultPageSize={1} hideOnSinglePage onChange={onPageChange} itemRender={itemRender}/>
-                {isLast && <PrimaryButton type='close' onClick={() => onClose()}/>}
-            </ButtonContainer>
-        )}
-    </ActionContainer>;
-
-    return {
-        title,
-        action,
-        closable: bannerAnnouncements.length > 1 ? false : true,
-        content: description,
-        icon: <InfoCircleOutlined style={{color: '#3c3c3c'}} />
-    }
+    return (
+        <Fragment>
+            <InfoIcon/>
+            <Column>
+                <StyledTitle>{title}</StyledTitle>
+                <span>
+                    {description}
+                    <Margin/>
+                </span>
+            </Column>
+            <Margin/>
+            <Column>
+                <StyledCheckbox checked={state.dontShowAgain.includes(announcement.id)} onChange={setShowAgain}>
+                    <Message messageKey='dontShow' bundleKey={BUNDLE_KEY} />
+                </StyledCheckbox>
+                <Pagination simple hideOnSinglePage current={currentBanner} total={count} defaultPageSize={1} onChange={onPageChange}/>
+            </Column>
+        </Fragment>
+    );
 };
 
 export const showAnnouncementsBanner = (state, controller, onClose, renderDescriptionPopup) => {
-    const content = getContent(state, controller, onClose, renderDescriptionPopup);
-    if (content === null) return null;
-    const controls = showBanner(content.icon, content.title, content.content, onClose, content.closable, content.action);
+    const content = getContent(state, controller, renderDescriptionPopup);
+    const controls = showBanner(content, onClose, { id: BUNDLE_KEY });
     return {
         ...controls,
         update: (state) => {
-            const content = getContent(state, controller, onClose, renderDescriptionPopup);
-            if (content === null) return null;
-            controls.update({
-                icon: content.icon,
-                title: content.title,
-                content: content.content,
-                onClose,
-                closable: content.closable,
-                action: content.action
-            });
+            const content = getContent(state, controller, renderDescriptionPopup);
+            controls.update(content);
         }
     };
 };

--- a/bundles/framework/announcements/view/AnnouncementsContent.jsx
+++ b/bundles/framework/announcements/view/AnnouncementsContent.jsx
@@ -12,10 +12,13 @@ export const AnnouncementsContent = ({ announcement }) => {
             </Link>
         );
     }
-    return (
-        <div className="announcements-content"
-            dangerouslySetInnerHTML={{ __html: content }}/>
-    );
+    if (content) {
+        return (
+            <div className="announcements-content"
+                dangerouslySetInnerHTML={{ __html: content }}/>
+        );
+    }
+    return null;
 };
 AnnouncementsContent.propTypes = {
     announcement: PropTypes.object.isRequired

--- a/bundles/framework/announcements/view/banner/BannerDescription.jsx
+++ b/bundles/framework/announcements/view/banner/BannerDescription.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { showPopup } from 'oskari-ui/components/window';
 import { BUNDLE_KEY } from '../../constants';
+import { AnnouncementsContent } from '../AnnouncementsContent';
 import styled from 'styled-components';
 
 const StyledContent = styled.div`
@@ -8,17 +9,12 @@ const StyledContent = styled.div`
     min-width: 300px;
 `;
 
-export const showBannerDescriptionPopup = (title, description, onClose) => {
-
-    const content = <StyledContent>
-        {description}
-    </StyledContent>;
-
-    const controls = showPopup(title, content, onClose, { id: BUNDLE_KEY });
-    return {
-        ...controls,
-        update: (title, description) => {
-            controls.update(title, description);
-        }
-    };
-}
+export const showBannerDescriptionPopup = (announcement, onClose) => {
+    const content = (
+        <StyledContent>
+            <AnnouncementsContent announcement={announcement}/>
+        </StyledContent>
+    );
+    const { title } = Oskari.getLocalized(announcement.locale);
+    return showPopup(title, content, onClose, { id: BUNDLE_KEY });
+};

--- a/src/react/components/Link.jsx
+++ b/src/react/components/Link.jsx
@@ -12,13 +12,12 @@ export const Link = ({
     url,
     external = true,
     label,
-    tooltip,
+    tooltip = url,
     children
 }) => {
     const target = external ? '_blank' : '_self';
-    const title = typeof tooltip === 'undefined' ? url : tooltip;
     return (
-        <Tooltip title={title}>
+        <Tooltip title={tooltip}>
             {label}
             <a href={url} target={target} rel="noreferrer noopener">
                 {children}

--- a/src/react/components/buttons/DeleteButton.jsx
+++ b/src/react/components/buttons/DeleteButton.jsx
@@ -41,11 +41,15 @@ export const DeleteButton = ({
     const placement = tooltip ? 'bottom' : 'top';
     return (
         <Confirm
+            overlayClassName='t_popover t_confirm'
             title={title}
             onConfirm={onConfirm}
             disabled={disabled}
             okText={<Message messageKey='buttons.delete' bundleKey='oskariui'/>}
             cancelText={<Message messageKey='buttons.cancel' bundleKey='oskariui'/>}
+            okButtonProps={{className: 't_button t_delete'}}
+            cancelButtonProps={{className: 't_button t_cancel'}}
+            okType='danger'
             placement={placement}>
             <Tooltip title={tooltip}>
                 {getButton(type, disabled)}

--- a/src/react/components/buttons/DeleteButton.jsx
+++ b/src/react/components/buttons/DeleteButton.jsx
@@ -41,7 +41,7 @@ export const DeleteButton = ({
     const placement = tooltip ? 'bottom' : 'top';
     return (
         <Confirm
-            overlayClassName='t_popover t_confirm'
+            overlayClassName='t_confirm'
             title={title}
             onConfirm={onConfirm}
             disabled={disabled}

--- a/src/react/components/buttons/DeleteButton.jsx
+++ b/src/react/components/buttons/DeleteButton.jsx
@@ -14,13 +14,17 @@ const DeleteIcon = styled(DeleteOutlined)`
 
 
 const getButton = (type, disabled ) => {
+    const props = {
+        className: 't_button t_delete',
+        disabled
+    }
     if (type === 'icon') {
-        return <DeleteIcon/>;
+        return <DeleteIcon {...props}/>;
     }
     if (type === 'button') {
-        return <Button disabled={disabled}><DeleteIcon/></Button>;
+        return <Button  {...props}><DeleteIcon/></Button>;
     }
-    return <SecondaryButton disabled={disabled} danger type="delete"/>;
+    return <SecondaryButton {...props} danger type="delete"/>;
 };
 const getMsg = key => <Message messageKey={key} bundleKey='oskariui'/>
 

--- a/src/react/components/buttons/PrimaryButton.jsx
+++ b/src/react/components/buttons/PrimaryButton.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Button, Message } from 'oskari-ui';
 
 export const PrimaryButton = ({ type, ...other }) => (
-    <Button type='primary' className={`t_button_${type}`} {...other}>
+    <Button type='primary' className={`t_button t_${type}`} {...other}>
         <Message bundleKey='oskariui' messageKey={`buttons.${type}`}/>
     </Button>
 );

--- a/src/react/components/buttons/SecondaryButton.jsx
+++ b/src/react/components/buttons/SecondaryButton.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Button, Message } from 'oskari-ui';
 
 export const SecondaryButton = ({ type, ...other }) => (
-    <Button className={`t_button_${type}`} {...other}>
+    <Button className={`t_button t_${type}`} {...other}>
         <Message bundleKey='oskariui' messageKey={`buttons.${type}`}/>
     </Button>
 );

--- a/src/react/components/window/Banner.jsx
+++ b/src/react/components/window/Banner.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { CloseCircleOutlined } from '@ant-design/icons';
+import { CloseCircleFilled } from '@ant-design/icons';
 
 const COLOR = '#fdf8d9'
 
@@ -27,16 +27,18 @@ const Container = styled('div')`
 const Content = styled('div')`
     margin-right: auto;
     width: 100%;
+    display: flex;
     @media only screen and (max-width: 1025px) {
         flex-direction: column;
     }
 `;
 
-const CloseIcon = styled(CloseCircleOutlined)`
+const CloseIcon = styled(CloseCircleFilled)`
     cursor: pointer;
     color: #3c3c3c;
     font-size: 18px;
     align-self: center;
+    margin-left: 10px;
 `;
 
 export const Banner = ({ children, onClose, options }) => {
@@ -48,7 +50,7 @@ export const Banner = ({ children, onClose, options }) => {
             <Content>
                 {children}
             </Content>
-            <CloseIcon className='t_button t_close' onClick={onClose} />
+            <CloseIcon className='t_icon t_close' onClick={onClose} />
         </Container>
     );
 };

--- a/src/react/components/window/Banner.jsx
+++ b/src/react/components/window/Banner.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { CloseCircleOutlined } from '@ant-design/icons';
 
 const COLOR = '#fdf8d9'
 
-const StyledBanner = styled('div')`
+const Container = styled('div')`
     position: fixed;
     top: 0;
     background-color: ${COLOR};
@@ -19,11 +20,12 @@ const StyledBanner = styled('div')`
         width: 100%
     }
     z-index: 999999;
-`;
-
-const Container = styled('div')`
     display: flex;
     flex-direction: row;
+`;
+
+const Content = styled('div')`
+    margin-right: auto;
     width: 100%;
     @media only screen and (max-width: 1025px) {
         flex-direction: column;
@@ -37,28 +39,22 @@ const CloseIcon = styled(CloseCircleOutlined)`
     align-self: center;
 `;
 
-const Content = styled('div')`
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
-`;
-
-
-
-
-
-export const Banner = ({ content, onClose, options }) => {
+export const Banner = ({ children, onClose, options }) => {
     const containerProps = {
         className: `t_banner t_${options.id}`
     };
     return (
-        <StyledBanner>
-            <Container {...containerProps}>
-                <Content>
-                    {content}
-                </Content>
-                <CloseIcon className='t_button t_close' onClick={onClose} />
-            </Container>
-        </StyledBanner>
+        <Container {...containerProps}>
+            <Content>
+                {children}
+            </Content>
+            <CloseIcon className='t_button t_close' onClick={onClose} />
+        </Container>
     );
+};
+
+Banner.propTypes = {
+    children: PropTypes.any,
+    onClose: PropTypes.func.isRequired,
+    options: PropTypes.object
 };

--- a/src/react/components/window/Banner.jsx
+++ b/src/react/components/window/Banner.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 import styled from 'styled-components';
 import { CloseCircleOutlined } from '@ant-design/icons';
 
+const COLOR = '#fdf8d9'
+
 const StyledBanner = styled('div')`
     position: fixed;
     top: 0;
-    background-color: #fdf8d9;
+    background-color: ${COLOR};
     box-shadow: 0 5px 10px 0 #888888;
     height: auto;
     padding: 10px 15px 10px 15px;
@@ -28,11 +30,6 @@ const Container = styled('div')`
     }
 `;
 
-const StyledTitle = styled('span')`
-    font-weight: bold;
-    color: #3c3c3c;
-`;
-
 const CloseIcon = styled(CloseCircleOutlined)`
     cursor: pointer;
     color: #3c3c3c;
@@ -46,38 +43,21 @@ const Content = styled('div')`
     flex-grow: 1;
 `;
 
-const Actions = styled('div')`
-    display: flex;
-    flex-direction: column;
-    margin: 0 20px 0 10px;
-    @media only screen and (max-width: 1025px) {
-        flex-direction: column;
-    }
-`;
 
-const Icon = styled('div')`
-    font-size: 24px;
-    margin-right: 10px;
-`;
 
-export const Banner = ({ icon, title, content, action, onClose, closable }) => {
 
+
+export const Banner = ({ content, onClose, options }) => {
+    const containerProps = {
+        className: `t_banner t_${options.id}`
+    };
     return (
         <StyledBanner>
-            <Container>
-                <Icon>
-                    {icon}
-                </Icon>
+            <Container {...containerProps}>
                 <Content>
-                    <StyledTitle>{title}</StyledTitle>
-                    <Content>{content}</Content>
+                    {content}
                 </Content>
-                <Actions>
-                    {action}
-                </Actions>
-                {closable && (
-                    <CloseIcon onClick={onClose} />
-                )}
+                <CloseIcon className='t_button t_close' onClick={onClose} />
             </Container>
         </StyledBanner>
     );

--- a/src/react/components/window/Popup.jsx
+++ b/src/react/components/window/Popup.jsx
@@ -129,10 +129,10 @@ export const Popup = ({title = '', children, onClose, bringToTop, options}) => {
         <PopupHeader {...headerProps}>
             <PopupTitle>{title}</PopupTitle>
             <ToolsContainer>
-                <CloseCircleFilled className="t_popup-close" onClick={onClose}/>
+                <CloseCircleFilled className="t_icon t_close" onClick={onClose}/>
             </ToolsContainer>
         </PopupHeader>
-        <PopupBody className="t_popup-body">
+        <PopupBody className="t_body">
             {children}
         </PopupBody>
     </Container>)

--- a/src/react/components/window/index.js
+++ b/src/react/components/window/index.js
@@ -1,6 +1,5 @@
 import ReactDOM, { unmountComponentAtNode } from 'react-dom';
 import React from 'react';
-import styled from 'styled-components';
 import { Flyout } from './Flyout';
 import { Popup } from './Popup';
 import { Banner } from './Banner';
@@ -191,15 +190,13 @@ export const showFlyout = (title, content, onClose, options = {}) => {
 
 /**
  * 
- * @param {ReactElement} icon
- * @param {String} title
  * @param {ReactNode} content
- * @param {ReactNode} action
  * @param {Function} onClose 
  * @param {boolean} closable 
  * @returns {object} that provides functions that can be used to close/update the banner
  */
-export const showBanner = (icon, title, content, onClose, closable, action) => {
+export const showBanner = (content, onClose, options = {}) => {
+    validate(options);
     const element = createTmpContainer();
     const removeWindow = createRemoveFn(element, onClose);
     const bringToTop = createBringToTop(element);
@@ -210,7 +207,7 @@ export const showBanner = (icon, title, content, onClose, closable, action) => {
                 {...props}
             />, element);
     };
-    render({icon, title, content, action, onClose, closable});
+    render({content, onClose, options});
     return  {
         update: render,
         close: removeWindow,

--- a/src/react/components/window/index.js
+++ b/src/react/components/window/index.js
@@ -201,13 +201,13 @@ export const showBanner = (content, onClose, options = {}) => {
     const removeWindow = createRemoveFn(element, onClose);
     const bringToTop = createBringToTop(element);
 
-    const render = (props) => {
+    const render = (content) => {
         ReactDOM.render(
             <Banner onClose={removeWindow} options={options}>
                 {content}
             </Banner>, element);
     };
-    render({content, onClose, options});
+    render(content);
     return  {
         update: render,
         close: removeWindow,

--- a/src/react/components/window/index.js
+++ b/src/react/components/window/index.js
@@ -203,9 +203,9 @@ export const showBanner = (content, onClose, options = {}) => {
 
     const render = (props) => {
         ReactDOM.render(
-            <Banner
-                {...props}
-            />, element);
+            <Banner onClose={removeWindow} options={options}>
+                {content}
+            </Banner>, element);
     };
     render({content, onClose, options});
     return  {


### PR DESCRIPTION
Refactor window showBanner to provide container and move other content rendering to announcement banner.
Use same AnnouncementContent for banner show more click than announcement popup uses.
Use simple paginate in banner (in my opinion it looks nicer than buttons also close icon is always shown for now)
Add empty div (margin-right: auto) after show more link to avoid clicks in empty space (long title increases whole column)
