### PR TITLE
Common settings for React-based windows

### DIFF
--- a/src/react/components/window/Banner.jsx
+++ b/src/react/components/window/Banner.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { CloseIcon } from './CloseIcon';
 import { ICON_SIZE, ICON_COLOR, ICON_COLOR_HOVER } from './constants';
-
+// HEADER_COLOR in constants should but we should enable transparency for banner
 const COLOR = '#fdf8d9'
 
 const Container = styled('div')`

--- a/src/react/components/window/Banner.jsx
+++ b/src/react/components/window/Banner.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { CloseCircleFilled } from '@ant-design/icons';
+import { CloseIcon } from './CloseIcon';
+import { ICON_SIZE, ICON_COLOR, ICON_COLOR_HOVER } from './constants';
 
 const COLOR = '#fdf8d9'
 
@@ -33,10 +34,12 @@ const Content = styled('div')`
     }
 `;
 
-const CloseIcon = styled(CloseCircleFilled)`
-    cursor: pointer;
-    color: #3c3c3c;
-    font-size: 18px;
+const StyledCloseIcon = styled(CloseIcon)`
+    font-size: ${ICON_SIZE}px;
+    color: ${ICON_COLOR};
+    :hover {
+        color: ${ICON_COLOR_HOVER};
+    }
     align-self: center;
     margin-left: 10px;
 `;
@@ -50,7 +53,7 @@ export const Banner = ({ children, onClose, options }) => {
             <Content>
                 {children}
             </Content>
-            <CloseIcon className='t_icon t_close' onClick={onClose} />
+            <StyledCloseIcon onClick={onClose} />
         </Container>
     );
 };

--- a/src/react/components/window/CloseIcon.jsx
+++ b/src/react/components/window/CloseIcon.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { CloseCircleFilled } from '@ant-design/icons';
+import styled from 'styled-components';
+
+// Note! Colors/hover and size are configured for tools container on popup/flyout and separately for banner
+const StyledCloseIcon = styled(CloseCircleFilled)`
+    cursor: pointer;
+`;
 
 /**
  * Close icon for popups and flyouts.
@@ -11,7 +17,7 @@ import { CloseCircleFilled } from '@ant-design/icons';
 // For some reason this problem doesn't seem to trigger right after showing/before updating.
 export const CloseIcon = ({onClose}) => {
     return (
-        <CloseCircleFilled
+        <StyledCloseIcon
             className="t_icon t_close"
             onMouseDown={e => e.stopPropagation()}
             onTouchStart={e => e.stopPropagation()}

--- a/src/react/components/window/CloseIcon.jsx
+++ b/src/react/components/window/CloseIcon.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { CloseCircleFilled } from '@ant-design/icons';
+
+/**
+ * Close icon for popups and flyouts.
+ */
+// Requires onMouseDown/onTouchStart to be ignored as events as they are listened by the header of the window components.
+// Otherwise a draggable operation is started that we DON'T want if the user does mousedown/touchstart ON THE ICON.
+// Doing the draggable on mousedown seems to create problems with clickhandler IF the window has been updated AFTER rendering (doing showPopup(title, content).update(newTitle, newContent)).
+// For some reason this problem doesn't seem to trigger right after showing/before updating.
+export const CloseIcon = ({onClose}) => {
+    return (
+        <CloseCircleFilled
+            className="t_icon t_close"
+            onMouseDown={e => e.stopPropagation()}
+            onTouchStart={e => e.stopPropagation()}
+            onClick={onClose}/>);
+};
+
+CloseIcon.propTypes = {
+    onClose: PropTypes.func.isRequired
+};

--- a/src/react/components/window/Flyout.jsx
+++ b/src/react/components/window/Flyout.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { CloseCircleFilled } from '@ant-design/icons';
+import { CloseIcon } from './CloseIcon';
 import { createDraggable } from './util';
 
 const Container = styled.div`
@@ -79,7 +79,7 @@ export const Flyout = ({title = '', children, onClose, bringToTop, options}) => 
             <HeaderBand />
             <Title>{title}</Title>
             <ToolsContainer>
-                <CloseCircleFilled className="oskari-flyouttool-close" onClick={onClose}/>
+                <CloseIcon onClose={onClose}/>
             </ToolsContainer>
         </FlyoutHeader>
         <div>

--- a/src/react/components/window/Flyout.jsx
+++ b/src/react/components/window/Flyout.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { CloseIcon } from './CloseIcon';
 import { createDraggable } from './util';
+import { ICON_SIZE, ICON_COLOR, ICON_COLOR_HOVER } from './constants';
 
 const Container = styled.div`
     position: absolute;
@@ -47,10 +48,10 @@ const ToolsContainer = styled.div`
     display: inline-block;
     margin-top: 12px;
     /* Size and color for tool icons from AntD: */
-    font-size: 18px;
-    color: black;
+    font-size: ${ICON_SIZE}px;
+    color: ${ICON_COLOR};
     > span:hover {
-        color: #ffd400;
+        color: ${ICON_COLOR_HOVER};
     }
 `;
 

--- a/src/react/components/window/Flyout.jsx
+++ b/src/react/components/window/Flyout.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { CloseIcon } from './CloseIcon';
 import { createDraggable } from './util';
-import { ICON_SIZE, ICON_COLOR, ICON_COLOR_HOVER } from './constants';
+import { ICON_SIZE, ICON_COLOR, ICON_COLOR_HOVER, HEADER_COLOR } from './constants';
 
 const Container = styled.div`
     position: absolute;
@@ -21,12 +21,12 @@ const Container = styled.div`
 const FlyoutHeader = styled.div`
     height: 57px;
     width: 100%;
-    background-color: #fdf8d9;
+    background-color: ${HEADER_COLOR};
     border-top: #fdfdfd;
     border-bottom: #fef2ba;
 `;
 const HeaderBand = styled.div`
-    background-color: #ffd400;
+    background-color: ${ICON_COLOR_HOVER};
     border-top: 1px solid #ffdf00;
     border-bottom: 1px solid #ebb819;
     height: 14px;

--- a/src/react/components/window/Popup.jsx
+++ b/src/react/components/window/Popup.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { CloseIcon } from './CloseIcon';
 import { createDraggable, getPositionForCentering, OUTOFSCREEN_CLASSNAME } from './util';
 import { monitorResize, unmonitorResize } from './WindowWatcher';
-import { ICON_SIZE, ICON_COLOR, ICON_COLOR_HOVER } from './constants';
+import { ICON_SIZE, ICON_COLOR, ICON_COLOR_HOVER, HEADER_COLOR } from './constants';
 
 const Container = styled.div`
     position: absolute;
@@ -41,7 +41,7 @@ const Container = styled.div`
 `;
 
 const PopupHeader = styled.h3`
-    background-color: #FDF8D9;
+    background-color: ${HEADER_COLOR};
     padding: 8px 10px;
     display: flex;
 `;

--- a/src/react/components/window/Popup.jsx
+++ b/src/react/components/window/Popup.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { CloseCircleFilled } from '@ant-design/icons';
+import { CloseIcon } from './CloseIcon';
 import { createDraggable, getPositionForCentering, OUTOFSCREEN_CLASSNAME } from './util';
 import { monitorResize, unmonitorResize } from './WindowWatcher';
 
@@ -129,7 +129,7 @@ export const Popup = ({title = '', children, onClose, bringToTop, options}) => {
         <PopupHeader {...headerProps}>
             <PopupTitle>{title}</PopupTitle>
             <ToolsContainer>
-                <CloseCircleFilled className="t_icon t_close" onClick={onClose}/>
+                <CloseIcon onClose={onClose}/>
             </ToolsContainer>
         </PopupHeader>
         <PopupBody className="t_body">

--- a/src/react/components/window/Popup.jsx
+++ b/src/react/components/window/Popup.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { CloseIcon } from './CloseIcon';
 import { createDraggable, getPositionForCentering, OUTOFSCREEN_CLASSNAME } from './util';
 import { monitorResize, unmonitorResize } from './WindowWatcher';
+import { ICON_SIZE, ICON_COLOR, ICON_COLOR_HOVER } from './constants';
 
 const Container = styled.div`
     position: absolute;
@@ -57,10 +58,10 @@ const ToolsContainer = styled.div`
     height: 16px;
     display: inline-block;
     /* Size and color for tool icons from AntD: */
-    font-size: 18px;
-    color: black;
+    font-size: ${ICON_SIZE}px;
+    color: ${ICON_COLOR};
     > span:hover {
-        color: #ffd400;
+        color: ${ICON_COLOR_HOVER};
     }
 `;
 

--- a/src/react/components/window/constants.js
+++ b/src/react/components/window/constants.js
@@ -1,3 +1,5 @@
 export const ICON_SIZE = 18;
 export const ICON_COLOR = '#3c3c3c';
 export const ICON_COLOR_HOVER = '#ffd400';
+
+export const HEADER_COLOR = '#fdf8d9';

--- a/src/react/components/window/constants.js
+++ b/src/react/components/window/constants.js
@@ -1,0 +1,3 @@
+export const ICON_SIZE = 18;
+export const ICON_COLOR = '#3c3c3c';
+export const ICON_COLOR_HOVER = '#ffd400';


### PR DESCRIPTION
Common close icon that prevents mousedown/touchstart from triggering drag-functionality on the header. This fixes an issue where user needs to click the icon twice to get the window to close. The problem doesn't manifest initially when the window is opened BUT after the content has been updated.

Also moved some color choices to a constants file for React-windows so we can see more easily where they are defined/used.