### PR TITLE
Fix 'show on map' on published maps.

### DIFF
--- a/bundles/framework/mydata/handler/PublishedMapsHandler.js
+++ b/bundles/framework/mydata/handler/PublishedMapsHandler.js
@@ -269,7 +269,9 @@ class MapsHandler extends StateHandler {
                 const req = setStateRequestBuilder(data.state);
                 req.setCurrentViewId(data.id);
                 sandbox.request(this.instance, req);
+                return true;
             }
+            return false;
         }
         this.confirmSetState(confirmCallback, resp.msg === 'missing');
     }


### PR DESCRIPTION
Fixed published maps "show on map" always showing error message.