### PR TITLE
Fix pinch zooming in Android Chrome

### DIFF
--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -75,6 +75,10 @@ export class MapModule extends AbstractMapModule {
         });
 
         var map = new olMap({
+            // Chrome on Android crashes at times when for example:
+            // - pinchzooming the map out so a WFS-layer scale limit is hit midpinch (layer is hidden while pinching)
+            // Setting pixelRatio:1 seems to fix this ^ See for example https://github.com/openlayers/openlayers/issues/11465
+            pixelRatio: 1,
             keyboardEventTarget: document,
             target: this.getMapElementId(),
             controls: controls,


### PR DESCRIPTION
The map crashed consistently on Android Chrome when pinch zooming out so the scale limit of a WFS-layer was hit (layer hidden mid-pinch). Crashed only when the embedded map was used in an iframe (like it usually is). Couldn't reproduce this when using the embedded map page directly (as normal page/NOT inside an iframe).