### PR TITLE
Change close icon to button/add cursor css

### DIFF
--- a/bundles/framework/divmanazer/resources/scss/divman.scss
+++ b/bundles/framework/divmanazer/resources/scss/divman.scss
@@ -33,6 +33,7 @@ body {
     background-color: #fdf8d9;
     border-top: #fdfdfd;
     border-bottom: #fef2ba;
+    cursor: grab;
 }
 
 .oskari-flyout-title {
@@ -58,6 +59,9 @@ body {
     height: 16px;
     display: inline-block;
     margin-top: 15px;
+    > div {
+        cursor: pointer;
+    }
 }
 
 .oskari-flyouttool-detach {

--- a/bundles/framework/divmanazer/resources/scss/popup.scss
+++ b/bundles/framework/divmanazer/resources/scss/popup.scss
@@ -36,6 +36,10 @@
     border-radius: 7px;
     z-index: 50000;
 
+    &.ui-draggable h3.popupHeader {
+        cursor: grab;
+    }
+
     &.no_resize div.content textarea {
         resize: none;
     }

--- a/src/react/components/buttons/IconButton.jsx
+++ b/src/react/components/buttons/IconButton.jsx
@@ -10,6 +10,7 @@ const StyledButton = styled(Button)`
     width: 16px;
     height: 16px;
     &:hover {
+        color: #ffd400;
         background: none;
     }
 `;

--- a/src/react/components/window/Banner.jsx
+++ b/src/react/components/window/Banner.jsx
@@ -37,7 +37,7 @@ const Content = styled('div')`
 const IconContainer = styled.span`
     font-size: ${ICON_SIZE}px;
     color: ${ICON_COLOR};
-    > span:hover {
+    > button:hover {
         color: ${ICON_COLOR_HOVER};
     }
     align-self: center;

--- a/src/react/components/window/CloseIcon.jsx
+++ b/src/react/components/window/CloseIcon.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { IconButton } from 'oskari-ui/components/buttons';
 import { CloseCircleFilled } from '@ant-design/icons';
-import styled from 'styled-components';
-
-// Note! Colors/hover and size are configured for tools container on popup/flyout and separately for banner
-const StyledCloseIcon = styled(CloseCircleFilled)`
-    cursor: pointer;
-`;
 
 /**
  * Close icon for popups and flyouts.
@@ -15,10 +10,12 @@ const StyledCloseIcon = styled(CloseCircleFilled)`
 // Otherwise a draggable operation is started that we DON'T want if the user does mousedown/touchstart ON THE ICON.
 // Doing the draggable on mousedown seems to create problems with clickhandler IF the window has been updated AFTER rendering (doing showPopup(title, content).update(newTitle, newContent)).
 // For some reason this problem doesn't seem to trigger right after showing/before updating.
+// Note! Colors/hover and size are configured for tools container on popup/flyout and separately for banner
 export const CloseIcon = ({onClose}) => {
     return (
-        <StyledCloseIcon
-            className="t_icon t_close"
+        <IconButton
+            className="t_close"
+            icon={<CloseCircleFilled />}
             onMouseDown={e => e.stopPropagation()}
             onTouchStart={e => e.stopPropagation()}
             onClick={onClose}/>);

--- a/src/react/components/window/Flyout.jsx
+++ b/src/react/components/window/Flyout.jsx
@@ -51,7 +51,7 @@ const ToolsContainer = styled.div`
     /* Size and color for tool icons from AntD: */
     font-size: ${ICON_SIZE}px;
     color: ${ICON_COLOR};
-    > span:hover {
+    > button:hover {
         color: ${ICON_COLOR_HOVER};
     }
 `;

--- a/src/react/components/window/Flyout.jsx
+++ b/src/react/components/window/Flyout.jsx
@@ -24,6 +24,7 @@ const FlyoutHeader = styled.div`
     background-color: ${HEADER_COLOR};
     border-top: #fdfdfd;
     border-bottom: #fef2ba;
+    cursor: grab;
 `;
 const HeaderBand = styled.div`
     background-color: ${ICON_COLOR_HOVER};

--- a/src/react/components/window/Popup.jsx
+++ b/src/react/components/window/Popup.jsx
@@ -61,7 +61,7 @@ const ToolsContainer = styled.div`
     /* Size and color for tool icons from AntD: */
     font-size: ${ICON_SIZE}px;
     color: ${ICON_COLOR};
-    > span:hover {
+    > button:hover {
         color: ${ICON_COLOR_HOVER};
     }
 `;

--- a/src/react/components/window/Popup.jsx
+++ b/src/react/components/window/Popup.jsx
@@ -44,6 +44,7 @@ const PopupHeader = styled.h3`
     background-color: ${HEADER_COLOR};
     padding: 8px 10px;
     display: flex;
+    cursor: ${props => props.isDraggable ? 'grab' : undefined}
 `;
 const PopupTitle = styled.span`
     margin-right: auto;
@@ -76,7 +77,9 @@ export const Popup = ({title = '', children, onClose, bringToTop, options}) => {
         className: `t_popup t_${options.id}`
     };
     const elementRef = useRef();
-    const headerProps = {};
+    const headerProps = {
+        isDraggable: !!options.isDraggable
+    };
     const headerFuncs = [];
     if (typeof bringToTop === 'function') {
         headerFuncs.push(bringToTop);


### PR DESCRIPTION
- Changed close icon on React-based windows from clickable div to a button.
- Also added `cursor: grab` for both new and old flyouts/popups that are draggable and `pointer` for close icons