### PR TITLE
Common Form/FormItem wrapper for AntD

### DIFF
--- a/src/react/components/Form.jsx
+++ b/src/react/components/Form.jsx
@@ -1,0 +1,11 @@
+import { Form as AntForm } from 'antd';
+import 'antd/es/form/style/index.js';
+import styled from 'styled-components';
+
+export const FormItem = styled(AntForm.Item)`
+ > .ant-form-item-label {
+     padding: 0;
+ }
+`;
+
+export const Form = AntForm;

--- a/src/react/components/StyleEditor/AreaTab.jsx
+++ b/src/react/components/StyleEditor/AreaTab.jsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import { ColorPicker } from '../ColorPicker';
 import { Message } from '../Message';
 import { SvgRadioButton, SizeControl, constants, PreviewCol } from './index';
-import { Form, Row, Col, Tooltip } from 'antd';
+import { Row, Col, Tooltip } from 'antd';
+import { FormItem } from '../Form';
 import { FillPattern, isSolid } from './FillPattern';
 
 const { FILLS, FILL_ORDER } = constants;
@@ -48,50 +49,50 @@ export const AreaTab = ({oskariStyle, showPreview}) => {
         <React.Fragment>
             <Row>
                 <Col span={ 12 }>
-                    <Form.Item
+                    <FormItem
                         { ...constants.ANTD_FORMLAYOUT }
                         name='stroke.area.color'
                         label={ <Message messageKey='StyleEditor.stroke.area.color' /> }
                         >
                         <ColorPicker />
-                    </Form.Item>
+                    </FormItem>
                 </Col>
 
                 <Col span={ 12 } >
-                    <Form.Item
+                    <FormItem
                         { ...constants.ANTD_FORMLAYOUT }
                         name='fill.color'
                         label={ <Message messageKey='StyleEditor.fill.color' /> }
                         >
                         <ColorPicker />
-                    </Form.Item>
+                    </FormItem>
                 </Col>
             </Row>
 
             <Row>
-                <Form.Item
+                <FormItem
                     { ...constants.ANTD_FORMLAYOUT }
                     name='stroke.area.lineDash'
                     label={ <Message messageKey='StyleEditor.stroke.area.lineDash' /> }
                 >
                     <SvgRadioButton options={ constants.LINE_STYLES.lineDash } />
-                </Form.Item>
+                </FormItem>
 
-                <Form.Item
+                <FormItem
                     { ...constants.ANTD_FORMLAYOUT }
                     name='stroke.area.lineJoin'
                     label={ <Message messageKey='StyleEditor.stroke.area.lineJoin' /> }
                 >
                     <SvgRadioButton options={ constants.LINE_STYLES.corners } />
-                </Form.Item>
+                </FormItem>
 
-                <Form.Item
+                <FormItem
                     { ...constants.ANTD_FORMLAYOUT }
                     name='fill.area.pattern'
                     label={ <Message messageKey='StyleEditor.fill.area.pattern' /> }
                 >
                     <SvgRadioButton options={ areaFillOptions } />
-                </Form.Item>
+                </FormItem>
             </Row>
 
             <Row>

--- a/src/react/components/StyleEditor/LineTab.jsx
+++ b/src/react/components/StyleEditor/LineTab.jsx
@@ -3,48 +3,49 @@ import PropTypes from 'prop-types';
 import { ColorPicker } from '../ColorPicker';
 import { Message } from '../Message';
 import { SvgRadioButton, SizeControl, constants, PreviewCol } from './index';
-import { Form, Row, Col } from 'antd';
+import { Row, Col } from 'antd';
+import { FormItem } from '../Form';
 
 export const LineTab = ({ oskariStyle, showPreview }) => {
     return (
         <React.Fragment>
             <Row>
                 <Col span={ 16 }>
-                    <Form.Item
+                    <FormItem
                         { ...constants.ANTD_FORMLAYOUT }
                         name='stroke.color'
                         label={ <Message messageKey='StyleEditor.stroke.color' /> }
                     >
                         <ColorPicker />
-                    </Form.Item>
+                    </FormItem>
                 </Col>
                 { showPreview && <PreviewCol oskariStyle={ oskariStyle } format='line' /> }
             </Row>
 
             <Row>
-                <Form.Item
+                <FormItem
                     { ...constants.ANTD_FORMLAYOUT }
                     name='stroke.lineDash'
                     label={ <Message messageKey='StyleEditor.stroke.lineDash' /> }
                 >
                     <SvgRadioButton options={ constants.LINE_STYLES.lineDash } />
-                </Form.Item>
+                </FormItem>
 
-                <Form.Item
+                <FormItem
                     { ...constants.ANTD_FORMLAYOUT }
                     name='stroke.lineCap'
                     label={ <Message messageKey='StyleEditor.stroke.lineCap' /> }
                 >
                     <SvgRadioButton options={ constants.LINE_STYLES.linecaps } />
-                </Form.Item>
+                </FormItem>
 
-                <Form.Item
+                <FormItem
                     { ...constants.ANTD_FORMLAYOUT }
                     name='stroke.lineJoin'
                     label={ <Message messageKey='StyleEditor.stroke.lineJoin' /> }
                 >
                     <SvgRadioButton options={ constants.LINE_STYLES.corners } />
-                </Form.Item>
+                </FormItem>
             </Row>
 
             <Row>

--- a/src/react/components/StyleEditor/PointTab.jsx
+++ b/src/react/components/StyleEditor/PointTab.jsx
@@ -2,33 +2,34 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ColorPicker } from '../ColorPicker';
 import { Message } from '../Message';
+import { Form, FormItem } from '../Form';
 import { SvgRadioButton, SizeControl, PreviewCol, constants } from './index';
-import { Form, Row, Col } from 'antd';
+import { Row, Col } from 'antd';
 
 export const PointTab = ({ oskariStyle, showPreview }) => {
     return (
         <React.Fragment>
             <Row>
                 <Col span={ 16 }>
-                    <Form.Item
+                    <FormItem
                         { ...constants.ANTD_FORMLAYOUT }
                         name='image.fill.color'
                         label={ <Message messageKey='StyleEditor.image.fill.color' /> }
                     >
                         <ColorPicker />
-                    </Form.Item>
+                    </FormItem>
                 </Col>
                 { showPreview && <PreviewCol oskariStyle={ oskariStyle } format='point' /> }
             </Row>
 
             <Row>
-                <Form.Item
+                <FormItem
                     { ...constants.ANTD_FORMLAYOUT }
                     name='image.shape'
                     label={ <Message messageKey='StyleEditor.image.shape' /> }
                 >
                     <SvgRadioButton options={ Oskari.getMarkers() } />
-                </Form.Item>
+                </FormItem>
             </Row>
 
             <Row>

--- a/src/react/components/StyleEditor/SizeControl.jsx
+++ b/src/react/components/StyleEditor/SizeControl.jsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Message } from 'oskari-ui';
-import { Form, InputNumber } from 'antd';
+import { InputNumber } from 'antd';
 import { ANTD_FORMLAYOUT } from './constants';
+import { FormItem } from '../Form';
 
 const sizeFormatter = (number) => Math.abs(number); 
 
 
 export const SizeControl = (props) => {
     return (
-        <Form.Item
+        <FormItem
             name={ props.name }
             label={
                 <Message messageKey={ props.localeKey }/>
@@ -22,7 +23,7 @@ export const SizeControl = (props) => {
                 formatter={ sizeFormatter }
                 parser={ sizeFormatter }
             />
-        </Form.Item>
+        </FormItem>
     );
 };
 

--- a/src/react/components/StyleEditor/StyleSelector.jsx
+++ b/src/react/components/StyleEditor/StyleSelector.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Select, Message } from 'oskari-ui';
-import { Form, Card } from 'antd';
+import { Card } from 'antd';
+import { Form, FormItem } from '../Form';
 import { ANTD_FORMLAYOUT, LOCALIZATION_BUNDLE } from './constants';
 import styled from 'styled-components';
 
@@ -18,7 +19,7 @@ export const StyleSelector = (props) => {
     return (
         <SelectorForm>
             <Card>
-                <Form.Item label={<Message bundleKey={ LOCALIZATION_BUNDLE } messageKey='StyleEditor.subheaders.name' />} { ...ANTD_FORMLAYOUT } name={ 'styleListSelector' }>
+                <FormItem label={<Message bundleKey={ LOCALIZATION_BUNDLE } messageKey='StyleEditor.subheaders.name' />} { ...ANTD_FORMLAYOUT } name={ 'styleListSelector' }>
                     <Select onChange={ (name) => props.onChange(name) }>
                         { props.styleList.map((singleOption) => {
                             return (
@@ -31,7 +32,7 @@ export const StyleSelector = (props) => {
                             );
                         }) }
                     </Select>
-                </Form.Item>
+                </FormItem>
             </Card>
         </SelectorForm>
     );


### PR DESCRIPTION
Added common form wrapper for AntD Form that can be used with:
```
import { Form, FormItem } from 'oskari-ui/components/Form';
```
`FormItem` replaces the `Form.Item` from AntD-component with custom styling by removing some of the padding that goes between a form field and label of the field.

Changed StyleEditor to use this new component for having the labels closer to fields.