### PR TITLE
Add ThemeHelper

### DIFF
--- a/src/react/components/window/Banner.jsx
+++ b/src/react/components/window/Banner.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { CloseIcon } from './CloseIcon';
 import { ICON_SIZE } from './constants';
 import { ThemeConsumer } from '../../util/contexts';
+import { getHeaderTheme } from '../../util/ThemeHelper';
 
 const Container = styled('div')`
     position: fixed;
@@ -47,13 +48,14 @@ const IconContainer = styled.span`
 `;
 
 export const Banner = ThemeConsumer(({ children, onClose, options, theme }) => {
+    const headerTheme = getHeaderTheme(theme);
     const containerProps = {
         className: `t_banner t_${options.id}`,
-        color: theme.color.primary
+        color: headerTheme.getBgColor()
     };
     const iconContainerProps = {
-        iconColor: theme.color.icon,
-        hoverColor: theme.color.accent,
+        iconColor: headerTheme.getToolIconColor(),
+        hoverColor: headerTheme.getToolIconHoverColor(),
     };
     return (
         <Container {...containerProps}>

--- a/src/react/components/window/Flyout.jsx
+++ b/src/react/components/window/Flyout.jsx
@@ -5,6 +5,7 @@ import { CloseIcon } from './CloseIcon';
 import { createDraggable } from './util';
 import { ICON_SIZE } from './constants';
 import { ThemeConsumer } from '../../util/contexts';
+import { getHeaderTheme } from '../../util/ThemeHelper';
 
 const Container = styled.div`
     position: absolute;
@@ -79,11 +80,12 @@ export const Flyout = ThemeConsumer(({title = '', children, onClose, bringToTop,
         <div className="oskari-flyouttool-restore"></div>
     Maybe allow passing tools from caller?
     */
+    const headerTheme = getHeaderTheme(theme);
     return (<Container className={containerClass} ref={elementRef} style={{transform: `translate(${position.x}px, ${position.y}px)`}}>
-        <FlyoutHeader color={theme.color.primary} className="oskari-flyouttoolbar" onMouseDown={onMouseDown} onTouchStart={onMouseDown}>
-            <HeaderBand color={theme.color.accent}/>
+        <FlyoutHeader color={headerTheme.getBgColor()} className="oskari-flyouttoolbar" onMouseDown={onMouseDown} onTouchStart={onMouseDown}>
+            <HeaderBand color={headerTheme.getAccentColor()}/>
             <Title>{title}</Title>
-            <ToolsContainer iconColor={theme.color.icon} hoverColor={theme.color.accent}>
+            <ToolsContainer iconColor={headerTheme.getToolIconColor()} hoverColor={headerTheme.getToolIconHoverColor()}>
                 <CloseIcon onClose={onClose}/>
             </ToolsContainer>
         </FlyoutHeader>

--- a/src/react/components/window/Popup.jsx
+++ b/src/react/components/window/Popup.jsx
@@ -6,6 +6,7 @@ import { createDraggable, getPositionForCentering, OUTOFSCREEN_CLASSNAME } from 
 import { monitorResize, unmonitorResize } from './WindowWatcher';
 import { ICON_SIZE } from './constants';
 import { ThemeConsumer } from '../../util/contexts';
+import { getHeaderTheme } from '../../util/ThemeHelper';
 
 const Container = styled.div`
     position: absolute;
@@ -132,10 +133,12 @@ export const Popup = ThemeConsumer(( {title = '', children, onClose, bringToTop,
         <div class="popup-body">content</div>
     </div>
     */
+
+    const headerTheme = getHeaderTheme(theme);
     return (<Container {...containerProps}>
-        <PopupHeader color={theme.color.primary} {...headerProps}>
+        <PopupHeader color={headerTheme.getBgColor()} {...headerProps}>
             <PopupTitle>{title}</PopupTitle>
-            <ToolsContainer iconColor={theme.color.icon} hoverColor={theme.color.accent}>
+            <ToolsContainer iconColor={headerTheme.getToolIconColor()} hoverColor={headerTheme.getToolIconHoverColor()}>
                 <CloseIcon onClose={onClose}/>
             </ToolsContainer>
         </PopupHeader>

--- a/src/react/util/ThemeHelper.js
+++ b/src/react/util/ThemeHelper.js
@@ -1,0 +1,8 @@
+
+export const getHeaderTheme = (theme) => {
+    return {
+        getBgColor: () => theme.color.primary,
+        getToolIconColor: () => theme.color.icon,
+        getToolIconHoverColor: () => theme.color.accent
+    };
+};

--- a/src/react/util/ThemeHelper.js
+++ b/src/react/util/ThemeHelper.js
@@ -2,6 +2,7 @@
 export const getHeaderTheme = (theme) => {
     return {
         getBgColor: () => theme.color.primary,
+        getAccentColor: () => theme.color.accent,
         getToolIconColor: () => theme.color.icon,
         getToolIconHoverColor: () => theme.color.accent
     };


### PR DESCRIPTION
To help determining where and what to get from theme object for different parts of the app. This makes it easier to generate fallback logic for missing values and easier to continue working with theme while changing the structure.