### PR TITLE
Tune ThemeContext reducing change listeners

### DIFF
--- a/src/react/components/window/Banner.jsx
+++ b/src/react/components/window/Banner.jsx
@@ -54,8 +54,8 @@ export const Banner = ThemeConsumer(({ children, onClose, options, theme }) => {
         color: headerTheme.getBgColor()
     };
     const iconContainerProps = {
-        iconColor: headerTheme.getToolIconColor(),
-        hoverColor: headerTheme.getToolIconHoverColor(),
+        iconColor: headerTheme.getToolColor(),
+        hoverColor: headerTheme.getToolHoverColor(),
     };
     return (
         <Container {...containerProps}>

--- a/src/react/components/window/Flyout.jsx
+++ b/src/react/components/window/Flyout.jsx
@@ -50,7 +50,7 @@ const FlyoutHeader = styled.div`
 const HeaderBand = styled.div`
     background-color: ${props => props.theme.getAccentColor()};
     border-top: 1px solid ${props => props.theme.getBgBorderColor()};
-    border-bottom: 1px solid ${props => props.theme.getAccentBottomColor()};
+    border-bottom: 1px solid ${props => props.theme.getBgBorderBottomColor()};
     height: 14px;
     width: 100%;
 `;
@@ -104,7 +104,7 @@ export const Flyout = ThemeConsumer(({title = '', children, onClose, bringToTop,
         <FlyoutHeader theme={headerTheme} className="oskari-flyouttoolbar" onMouseDown={onMouseDown} onTouchStart={onMouseDown}>
             <HeaderBand theme={headerTheme}/>
             <Title className='flyout-title'>{title}</Title>
-            <ToolsContainer iconColor={headerTheme.getToolIconColor()} hoverColor={headerTheme.getToolIconHoverColor()}>
+            <ToolsContainer iconColor={headerTheme.getToolColor()} hoverColor={headerTheme.getToolHoverColor()}>
                 <CloseIcon onClose={onClose}/>
             </ToolsContainer>
         </FlyoutHeader>

--- a/src/react/components/window/Popup.jsx
+++ b/src/react/components/window/Popup.jsx
@@ -43,7 +43,8 @@ const Container = styled.div`
 `;
 
 const PopupHeader = styled.h3`
-    background-color: ${props => props.color};
+    background-color: ${props => props.theme.getBgColor()};
+    color:  ${props => props.theme.getTextColor()};
     padding: 8px 10px;
     display: flex;
     cursor: ${props => props.isDraggable ? 'grab' : undefined}
@@ -136,9 +137,9 @@ export const Popup = ThemeConsumer(( {title = '', children, onClose, bringToTop,
 
     const headerTheme = getHeaderTheme(theme);
     return (<Container {...containerProps}>
-        <PopupHeader color={headerTheme.getBgColor()} {...headerProps}>
+        <PopupHeader theme={headerTheme} {...headerProps}>
             <PopupTitle>{title}</PopupTitle>
-            <ToolsContainer iconColor={headerTheme.getToolIconColor()} hoverColor={headerTheme.getToolIconHoverColor()}>
+            <ToolsContainer iconColor={headerTheme.getToolColor()} hoverColor={headerTheme.getToolHoverColor()}>
                 <CloseIcon onClose={onClose}/>
             </ToolsContainer>
         </PopupHeader>

--- a/src/react/components/window/index.js
+++ b/src/react/components/window/index.js
@@ -130,10 +130,9 @@ export const showPopup = (title, content, onClose, options = {}) => {
     const removeWindow = () => REGISTER.clear(key);
     const bringToTop = createBringToTop(element);
     const opts = {...DEFAULT_POPUP_OPTIONS, ...options };
-    const THEMING = Oskari.app.getTheming();
     const render = (title, content) => {
         ReactDOM.render(
-            <ThemeProvider value={THEMING.getTheme()}>
+            <ThemeProvider>
                 <Popup title={title} onClose={removeWindow} bringToTop={bringToTop} options={opts}>
                     {content}
                 </Popup>
@@ -177,9 +176,11 @@ export const showFlyout = (title, content, onClose, options = {}) => {
     const bringToTop = createBringToTop(element);
     const render = (title, content) => {
         ReactDOM.render(
-            <Flyout title={title} onClose={removeWindow} bringToTop={bringToTop} options={options}>
-                {content}
-            </Flyout>, element);
+            <ThemeProvider>
+                <Flyout title={title} onClose={removeWindow} bringToTop={bringToTop} options={options}>
+                    {content}
+                </Flyout>
+            </ThemeProvider>, element);
     };
     render(title, content);
     return  {
@@ -206,9 +207,11 @@ export const showBanner = (content, onClose, options = {}) => {
 
     const render = (content) => {
         ReactDOM.render(
-            <Banner onClose={removeWindow} options={options}>
-                {content}
-            </Banner>, element);
+            <ThemeProvider>
+                <Banner onClose={removeWindow} options={options}>
+                    {content}
+                </Banner>
+            </ThemeProvider>, element);
     };
     render(content);
     return  {

--- a/src/react/theme/ThemeHelper.js
+++ b/src/react/theme/ThemeHelper.js
@@ -2,14 +2,18 @@
 import { EFFECT } from './constants';
 
 export const getHeaderTheme = (theme) => {
-    return {
+    const isDark = Oskari.util.isDarkColor(theme.color.primary);
+    const headerColor = isDark ? "#FFFFFF" : '#000000';
+    const funcs = {
         getBgColor: () => theme.color.primary,
-        getBgBorderColor: () => getColorEffect(theme.color.accent, -10),
         getAccentColor: () => theme.color.accent,
-        getAccentBottomColor: () => getColorEffect(theme.color.accent, 20),
-        getToolIconColor: () => theme.color.icon,
-        getToolIconHoverColor: () => theme.color.accent
+        getBgBorderColor: () => getColorEffect(theme.color.accent, -10),
+        getBgBorderBottomColor: () => getColorEffect(theme.color.accent, 20),
+        getTextColor: () => theme.color.header?.text || headerColor,
+        getToolColor: () => theme.color.header?.icon || funcs.getTextColor(),
+        getToolHoverColor: () => theme.color.accent
     };
+    return funcs;
 };
 
 /* ------------------------------------------------------------------------------ */

--- a/src/react/theme/ThemeHelper.js
+++ b/src/react/theme/ThemeHelper.js
@@ -2,18 +2,24 @@
 import { EFFECT } from './constants';
 
 export const getHeaderTheme = (theme) => {
-    const isDark = Oskari.util.isDarkColor(theme.color.primary);
-    const headerColor = isDark ? "#FFFFFF" : '#000000';
+    const headerTextColor = getTextColor(theme.color.primary);
     const funcs = {
         getBgColor: () => theme.color.primary,
         getAccentColor: () => theme.color.accent,
         getBgBorderColor: () => getColorEffect(theme.color.accent, -10),
         getBgBorderBottomColor: () => getColorEffect(theme.color.accent, 20),
-        getTextColor: () => theme.color.header?.text || headerColor,
+        getTextColor: () => theme.color.header?.text || headerTextColor,
         getToolColor: () => theme.color.header?.icon || funcs.getTextColor(),
         getToolHoverColor: () => theme.color.accent
     };
     return funcs;
+};
+
+export const getTextColor = (bgColor) => {
+    if (Oskari.util.isDarkColor(bgColor)) {
+        return '#FFFFFF';
+    };
+    return '#000000';
 };
 
 /* ------------------------------------------------------------------------------ */

--- a/src/react/util/contexts/ThemeContext.jsx
+++ b/src/react/util/contexts/ThemeContext.jsx
@@ -15,6 +15,9 @@ const ThemeContext = React.createContext();
  *         <SomeThemeConsumerComponent />
  *     </ThemeProvider>
  * );
+ * 
+ * The value can be omitted for provider. 
+ * This makes the provider use Oskari.app.getTheming().getTheme() AND listen to changes at runtime.
  */
 export const ThemeProvider = ({value, children}) => {
     if (value) {

--- a/src/react/util/index.js
+++ b/src/react/util/index.js
@@ -4,5 +4,5 @@
  */
 export { StateHandler, Controller, controllerMixin } from './state';
 export { Timeout, Messaging, handleBinder } from './extras';
-export { GenericContext, withContext, LocaleProvider, LocaleConsumer } from './contexts';
+export { GenericContext, withContext, LocaleProvider, LocaleConsumer, ThemeProvider, ThemeConsumer } from './contexts';
 export { ErrorBoundary } from './ErrorBoundary';


### PR DESCRIPTION
Make provider to listen to changes at runtime IF value is not given. This way we only get change listeners for providers and not the consumers which reduces the amount of listeners a lot. Also makes provider actually useful since it's now needed for providing the theme instead of consumer just getting it from Oskari.app.getTheming().

Changed some of the names of the getters. Still thinking if provider should provide the theme helper functions in addition to the "raw" theme.