### PR TITLE
Reset list before populating with new data

### DIFF
--- a/bundles/admin/admin-layeranalytics/instance.js
+++ b/bundles/admin/admin-layeranalytics/instance.js
@@ -225,6 +225,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layeranalytics.AdminLayerAnal
          */
         produceAnalyticsListData () {
             this.fetchLayerAnalytics(null, (result) => {
+                this.analyticsListData = []
                 for (const item in result) {
                     const itemLayer = this.mapLayerService.findMapLayer(item);
                     const title = itemLayer !== null ? itemLayer.getName() : item;

--- a/bundles/admin/admin-layeranalytics/instance.js
+++ b/bundles/admin/admin-layeranalytics/instance.js
@@ -225,7 +225,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layeranalytics.AdminLayerAnal
          */
         produceAnalyticsListData () {
             this.fetchLayerAnalytics(null, (result) => {
-                this.analyticsListData = []
+                this.analyticsListData = [];
                 for (const item in result) {
                     const itemLayer = this.mapLayerService.findMapLayer(item);
                     const title = itemLayer !== null ? itemLayer.getName() : item;


### PR DESCRIPTION
Fixes an issue where re-opening the flyout duplicated the data on each re-open.