### PR TITLE
Fix multiple html popups.

### DIFF
--- a/bundles/framework/mydata/handler/PublishedMapsHandler.js
+++ b/bundles/framework/mydata/handler/PublishedMapsHandler.js
@@ -27,6 +27,9 @@ class MapsHandler extends StateHandler {
     }
 
     showHtml (view) {
+        if (this.popupControls) {
+            this.popupCleanup();
+        }
         this.popupControls = showSnippetPopup(view, () => this.popupCleanup());
     }
 


### PR DESCRIPTION
Prevent opening multiple html popups for published maps, instead close popup & open another one.