### PR TITLE
Fix IconButton clipping the icon on Safari

### DIFF
--- a/src/react/components/Table.jsx
+++ b/src/react/components/Table.jsx
@@ -13,6 +13,10 @@ const StyledToolsContainer = styled('div')`
     a {
         cursor: pointer;
     }
+    button {
+        width: 24px;
+        height: 24px;
+    }
 `;
 
 const StyledTable = styled(AntTable)`

--- a/src/react/components/buttons/IconButton.jsx
+++ b/src/react/components/buttons/IconButton.jsx
@@ -6,11 +6,12 @@ import { ThemeConsumer } from '../../util';
 import { getColorEffect } from '../../theme/ThemeHelper';
 import styled from 'styled-components';
 
+// Note! AntD buttons default at 32x32px
+//  If the font-size of the icon is > 32px it will be clipped by at least Safari
+//  Let the user of this component define the size of the button instead of doing it here.
 const StyledButton = styled(Button)`
     border: none;
     background: none;
-    width: 16px;
-    height: 16px;
     &:hover {
         color: ${props => props.color};
         background: none;

--- a/src/react/components/window/Flyout.jsx
+++ b/src/react/components/window/Flyout.jsx
@@ -65,13 +65,14 @@ const Title = styled.h3`
 `;
 const ToolsContainer = styled.div`
     float: right;
-    margin-right: 25px;
+    margin-right: 15px;
     height: 16px;
     display: inline-block;
-    margin-top: 12px;
+    margin-top: 6px;
     /* Size and color for tool icons from AntD: */
     font-size: ${ICON_SIZE}px;
     > button {
+        margin-top: -5px;
         color: ${props => props.iconColor};
     }
     > button:hover {

--- a/src/react/components/window/Popup.jsx
+++ b/src/react/components/window/Popup.jsx
@@ -64,6 +64,7 @@ const ToolsContainer = styled.div`
     /* Size and color for tool icons from AntD: */
     font-size: ${ICON_SIZE}px;
     > button {
+        margin-top: -5px;
         color: ${props => props.iconColor};
     }
     > button:hover {


### PR DESCRIPTION
Fix an issue where React-based popup/flyout/banner close icons were visually clipped on Safari. This was because IconButton declared a size of 16x16px while the code using the button defined a font-size of 18px for the icons. This resulted in the icon clipping. It works with Chrome on Windows properly even without this but the problem occured on MacOS/Safari. This hopefully fixes that.