### PR TITLE
Fix table layout issues with long td content

### DIFF
--- a/src/react/components/Table.jsx
+++ b/src/react/components/Table.jsx
@@ -19,7 +19,12 @@ const StyledToolsContainer = styled('div')`
     }
 `;
 
+// AntD defines overflow-wrap: break word for tr td
+//  but for some reason we still need word-break so long texts in the table don't break layout
 const StyledTable = styled(AntTable)`
+    tr td {
+        word-break: break-word;
+    }
     a {
         cursor: pointer;
     }


### PR DESCRIPTION
Fixes an issue where long texts without breaks in table content broke the layout more or less  completely.

## Before
![image](https://user-images.githubusercontent.com/2210335/175303253-dbffc4ea-772a-40b7-8ea5-5f187e763813.png)
## After
![image](https://user-images.githubusercontent.com/2210335/175303330-1794ce02-f4f2-413d-8aa2-2db256bc8876.png)
