### PR TITLE
React banner z-index

### DIFF
--- a/src/react/components/window/Banner.jsx
+++ b/src/react/components/window/Banner.jsx
@@ -21,7 +21,7 @@ const Container = styled('div')`
         min-width: 0;
         width: 100%
     }
-    z-index: 999999;
+    z-index: 18000;
     display: flex;
     flex-direction: row;
 `;


### PR DESCRIPTION
Adjust banner z-index. Now its above of mapplugins and below of messages, popups, flyouts, progress bar,..

ol popup (gfi info) is below banner. Tried 15000 z-index for banner but ol popup seems to be attached to map somehow so z-index doesn't affect.

Query/divmanazer:
------------------
flyout: 20000
popup: 50000
infobox (olpopupplugin): 16000
overlay: 100000 (modal popup 100001)
progress bar: 25000
spinner: 2e9
.oskari-datasource.link: 100000000

mapplugins: 15000
 - announcements: 15001
 - timeseriescontrolplugin: 15002
 - layerselection: 15001
 - classificationplugin: 15001

.statsgrid-series-control-plugin: 15002
publishedToolbarContainer: 16000

#contentMap:
.oskari-map-window-fullscreen: 3
.basic_printout: 1500
.basic_publisher: 2
.cesium-credit-container + .ol-attribution: 1
.fullscreenDiv: 15000

#maptools: 2

React:
----------
flyout: 20009
popup: 30000
colorpicker: 55500
genericform: 99998
modal: 55500
.ant-tooltip: 999999
.ant-popconfirm: 999998

@zindex-message: 30010;
@zindex-notification: 30010;
@zindex-popover: 30030;
@zindex-dropdown: 30050;
@zindex-picker: 30050;
@zindex-tooltip: 30060;

AllLayerSwitch confirm popup: 999999
3d camera controls: 15000
.ant-select-dropdown (time-control-3d): 2147483647.