### PR TITLE
Publisher map size reset on cancel

### DIFF
--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -364,6 +364,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
          */
         cancel: function () {
             this.instance.setPublishMode(false);
+            this._editToolLayoutOff();
         },
         /**
          * @private @method _getButtons


### PR DESCRIPTION
This fixes issue where map size is changed and publishing is canceled and geoportal/mainview wasn't reset to full size.

setEnabled(false) should call editToolLayoutOff but don't know if there is some timing issue. However it is called before publishmap on save and in ajax success callback. 
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/framework/publisher2/view/PublisherSidebar.js#L401-L402
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/framework/publisher2/view/PublisherSidebar.js#L484
Didn't refactor or debug deeper because this will be rewritten in React. Just added editToolLayoutOff on cancel.
