### PR TITLE
Statsgrid geostats update

### DIFF
--- a/bundles/statistics/statsgrid2016/components/manualClassification/HistogramForm.jsx
+++ b/bundles/statistics/statsgrid2016/components/manualClassification/HistogramForm.jsx
@@ -30,12 +30,15 @@ const Form = ({
     useEffect(() => {
         // editor appends content to ref element, clear content
         ref.current.innerHTML = '';
+        if (error) {
+            return;
+        }
         manualClassificationEditor(ref.current, bounds, dataAsList, colors, activeBound, onBoundChange, fractionDigits);
     });
     const { activeIndicator: { classification }, seriesStats, controller } = state;
     const { method, fractionDigits } = classification;
     const { methods } = editOptions;
-    const { groups, bounds } = classifiedDataset;
+    const { groups = [], bounds, error } = classifiedDataset;
 
     const colors = groups.map(group => group.color);
     const dataAsList = Object.values(seriesStats ? seriesStats.serie : data);
@@ -62,6 +65,7 @@ const Form = ({
                 ))}
             </StyledSelect>
             <div ref={ref} className="manual-class-view"/>
+            {error && <Message messageKey={'legend.noEnough' } bundleKey={BUNDLE_KEY} />}
             <ButtonContainer>
                 <PrimaryButton type='close' onClick={onClose}/>
             </ButtonContainer>

--- a/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
@@ -73,7 +73,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
             const { data, status, uniqueCount, minMax } = this.getIndicatorData(state);
             if (status === 'PENDING') return;
             const editOptions = this.getEditOptions(state, uniqueCount, minMax);
-            const classifiedDataset = this.classifyDataset(state, data);
+            const classifiedDataset = this.classifyDataset(state, data, uniqueCount);
             // Histogram doesn't need to be updated on every events but props are gathered here
             // and histogram is updated only if it's opened, so update here for now
             this.updateHistogram(state, classifiedDataset, data, editOptions);
@@ -162,9 +162,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
                 colorsets
             };
         },
-        classifyDataset: function (state, data) {
+        classifyDataset: function (state, data, uniqueCount) {
             const { activeIndicator: { classification }, seriesStats } = state;
-            return this.service.getClassificationService().getClassification(data, classification, seriesStats);
+            return this.service.getClassificationService().getClassification(data, classification, seriesStats, uniqueCount);
         },
         startHistogramView: function (state, classifiedDataset, data, editOptions) {
             if (this.histogramControls) {

--- a/bundles/statistics/statsgrid2016/service/ClassificationService.js
+++ b/bundles/statistics/statsgrid2016/service/ClassificationService.js
@@ -64,15 +64,18 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationService',
          * @param  {geostats} groupStats precalculated geostats | optional
          * @return {Object}               result with classified values
          */
-        getClassification: function (indicatorData, opts, groupStats) {
+        getClassification: function (indicatorData, opts, groupStats, uniqueCount) {
             if (typeof indicatorData !== 'object') {
                 this.log.warn('Data expected as object with region/value as keys/values.');
                 return { error: 'noData' };
             }
-            // TODO: data should be validated in one place (stateservice?)
+            // TODO: data should be validated and unique values counted in one place
+            // stateservice.getState() => returns or service triggers state for all components
             const dataAsList = Object.values(indicatorData).filter(val => val !== null && val !== undefined);
-            const minData = opts.method === 'jenks' ? 3 : 2;
-            if ((groupStats && groupStats.serie.length < 3) || dataAsList.length < minData) {
+            const dataSize = uniqueCount || new Set(dataAsList).size;
+            // geostats fails with jenks if there isn't at least one more unique values than count
+            const minData = opts.method === 'jenks' ? Math.max(opts.count + 1, 3) : 2;
+            if ((groupStats && groupStats.serie.length < 3) || dataSize < minData) {
                 return { error: 'noEnough' };
             }
             const isDivided = opts.type === 'div';

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "expose-loader": "0.7.5",
     "file-loader": "4.2.0",
     "fs-extra": "8.1.0",
-    "geostats": "1.8.0",
+    "geostats": "2.0.0",
     "gm": "1.23.1",
     "imports-loader": "0.8.0",
     "intl-messageformat": "9.11.4",


### PR DESCRIPTION
Update geostats 1.8.0 -> 2.0.0

Use unique values for min data check before passing data to geostats. Jenks method requires count + 1 unique values to create classification (less causes js errors). Fixes issue where adding dataset/indicator which has less than 6 unique values (default: jenks and 5) didn't show anything to user. Now classification plugin is shown with warning message.