### PR TITLE
Marker size workaround for backwards compatibility'ish

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -9,12 +9,25 @@ Some extra tags:
 - [rpc] tag indicates that the change affects RPC API
 - [breaking] tag indicates that the change is not backwards compatible
 
+## 2.9.0 [mod] [rpc] [breaking] MapModulePlugin.AddMarkerRequest
+
+For built-in symbols everything stays the same.
+
+For external graphic symbols in markers the size of the marker is:
+- when below 10 is calculated as size * 10 + 40 for actual size (while hack'ish this is for backwards compatibility reasons)
+- 10 + values are now considered as a pixel value (as documented on the API page)
+
 ## 2.8.0
 
 ### [add] [rpc] StateChangedEvent
 
 Event is sent when a massive application state change occurs like user clicks on the "reset map to default".
 This allows RPC-based apps to detect such occurance and re-add for example markers that they need after such reset.
+
+## 2.7.0 [mod] [rpc] [breaking] MapModulePlugin.AddMarkerRequest
+
+The size value is now considered as a pixel value instead of abstracted WHEN using external graphic for marker symbol.
+For built-in symbols everything stays the same.
 
 ## 2.6.0
 

--- a/api/mapping/mapmodule/request/addmarkerrequest.md
+++ b/api/mapping/mapmodule/request/addmarkerrequest.md
@@ -66,7 +66,7 @@ Recognized keys in data-object:
 </tr>
 <tr>
   <td> size </td><td> Number </td><td> size of the marker. For built-in symbols this is usually between `1` and `5` (actual size calculated with `size * 10 + 40`). 
-  For symbols that are NOT built-in the size is assumed to be in pixels (defaults to 32x32px, only square icons supported) </td><td> 1 </td>
+  For symbols that are NOT built-in the size is assumed to be in pixels (defaults to 32x32px, only square icons supported). Exception is when the pixel size is below 10 - Then the above formula is used for size calculation (for backwards compatibility). </td><td> 1 </td>
 </tr>
 
 <tr>

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
@@ -299,6 +299,21 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
             });
             return sanitized;
         },
+        /**
+         * Close enough "backwards compatibility" workaround for marker size when using external graphic/svg as icon.
+         * If the requested size is below 10 -> use the formula used pre-2.7 to calculate size.
+         * Otherwise keep the requested size (documented as pixel size).
+         * @param {Number} requestedSize pixel value or previously supported value of 1-5 like for built-in symbols. Cut off point for logic is at 10.
+         */
+        __workaroundForBackwardsCompatibilitySize: function (requestedSize) {
+            if (typeof requestedSize === 'number' && requestedSize < 10) {
+                const mapmodule = this.getMapModule();
+                if (mapmodule && typeof mapmodule.getPixelForSize === 'function') {
+                    return mapmodule.getPixelForSize(requestedSize);
+                }
+            }
+            return requestedSize;
+        },
         _getStyleFromMarkerData: function (markerData) {
             const style = jQuery.extend(true, {}, DEFAULT_STYLE);
             const { color, shape, size, msg, offsetX, offsetY } = markerData;
@@ -307,7 +322,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
             style.text.labelText = msg;
             // use pixel size if shape is svg or url
             if (typeof shape === 'string') {
-                style.image.sizePx = size;
+                style.image.sizePx = this.__workaroundForBackwardsCompatibilitySize(size);
             } else {
                 style.image.size = size;
             }

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.test.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.test.js
@@ -60,6 +60,14 @@ const markers = [{
     transient: true,
     offsetX: 12,
     offsetY: 8
+}, {
+    x: 4,
+    y: 4,
+    shape: 'image_url',
+    size: 9,
+    transient: true,
+    offsetX: 12,
+    offsetY: 8
 }];
 
 describe('MarkersPlugin', () => {
@@ -173,6 +181,20 @@ describe('MarkersPlugin', () => {
             // looks like getter returns top-left anchor even it is set and stored as bottom-left
             expect(style.getAnchor()).toEqual([offsetX, size - offsetY]);
             expect(style.getSize()).toEqual([size, size]);
+        });
+        test('external with lower than expected size (workaround backwards compatibility)', () => {
+            const id = 'marker2workaround';
+            const marker = markers[4];
+            plugin.addMapMarker(marker, id);
+            const style = getImageStyle(id);
+            const { size, offsetX, offsetY, shape } = marker;
+            // size is 9 here, but with external graphic values under 10 are multiplied -> should result in 130 actual size
+            expect(size).toEqual(9);
+            expect(style.getSrc()).toEqual(shape);
+            const expectedSize = 130;
+            expect(style.getSize()).toEqual([expectedSize, expectedSize]);
+            // looks like getter returns top-left anchor even it is set and stored as bottom-left
+            expect(style.getAnchor()).toEqual([offsetX, expectedSize - offsetY]);
         });
         afterAll(() => {
             // remove markers to normalize state for other tests


### PR DESCRIPTION
Pre-2.7.0 Oskari marker sizes were always given as values between 1-5 and calculated to actual size with `size * 10 + 40`. In 2.7.0 the size for markers changed to actual pixel values WHEN using external graphic instead of the built-in shapes (since the size is easier to know for developer experience when using external graphics). Since there are RPC-based apps using the small values with external graphics those markers are too tiny to see. Any "real" value for marker size is most probably at least 10 with the new API. So this is a hack' ish kind of workaround to restore outdated RPC-based apps to have usable markers while still maintaining the new API.

Kinda weird and wonky, but in practice this should fix any compatibility issues that people might have.