### PR TITLE
Clear button state when popup is closed

### DIFF
--- a/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPlugin.js
@@ -44,7 +44,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionP
     }, {
         _toggleToolState: function () {
             if (this.popupControls) {
-                this.getSandbox().postRequestByName('Toolbar.SelectToolButtonRequest', [null, 'mobileToolbar-mobile-toolbar']);
                 this.popupCleanup();
             } else {
                 this.showPopup();
@@ -87,6 +86,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionP
         },
         popupCleanup: function () {
             if (this.popupControls) {
+                this.getSandbox().postRequestByName('Toolbar.SelectToolButtonRequest', [null, 'mobileToolbar-mobile-toolbar']);
                 this.popupControls.close();
             }
             this.popupControls = null;


### PR DESCRIPTION
Fixes button state on map "mobile mode" toolbar if the popup is closed from the [x] icon on the popup header instead of clicking on the toolbar icon.

![image](https://user-images.githubusercontent.com/2210335/190643815-1dd8fd12-e624-453a-8ee0-340f6e683b83.png)
