### PR TITLE
Restore map size after exiting publisher

### DIFF
--- a/bundles/framework/publisher2/instance.js
+++ b/bundles/framework/publisher2/instance.js
@@ -277,13 +277,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
             var me = this;
             var map = jQuery('#contentMap');
             data = data || this.getDefaultData();
-            // trigger an event letting other bundles know we require the whole UI
-            var eventBuilder = Oskari.eventBuilder('UIChangeEvent');
-            this.sandbox.notifyAll(eventBuilder(this.mediator.bundleId));
             if (this.getCustomTileRef()) {
                 blnEnabled ? jQuery(this.getCustomTileRef()).addClass('activePublish') : jQuery(this.getCustomTileRef()).removeClass('activePublish');
             }
             if (blnEnabled) {
+                // trigger an event letting other bundles know we require the whole UI
+                var eventBuilder = Oskari.eventBuilder('UIChangeEvent');
+                this.sandbox.notifyAll(eventBuilder(this.mediator.bundleId));
+
                 me.getService().setIsActive(true);
                 var stateRB = Oskari.requestBuilder('StateHandler.SetStateRequest');
                 this.getSandbox().request(this, stateRB(data.configuration));

--- a/bundles/framework/publisher2/view/PanelMapPreview.js
+++ b/bundles/framework/publisher2/view/PanelMapPreview.js
@@ -491,7 +491,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapPreview'
         stop: function () {
             // restore "fill" as default size setting
             this.sizeOptions.forEach(item => {
-                item.selected = item.id === 'fill'
+                item.selected = item.id === 'fill';
             });
             this._unregisterEventHandlers();
 

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -364,7 +364,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
          */
         cancel: function () {
             this.instance.setPublishMode(false);
-            this._editToolLayoutOff();
         },
         /**
          * @private @method _getButtons


### PR DESCRIPTION
Reverts https://github.com/oskariorg/oskari-frontend/pull/1920 and tries another method of restoring map size after exiting publisher.