### PR TITLE
Metadata icon based on theme colors

### DIFF
--- a/bundles/framework/maplegend/Flyout.js
+++ b/bundles/framework/maplegend/Flyout.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Message } from 'oskari-ui';
-import { LocaleProvider } from 'oskari-ui/util';
+import { LocaleProvider, ThemeProvider } from 'oskari-ui/util';
 import { MapLegendList } from './MapLegendList';
 
 /**
@@ -134,10 +134,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.Flyout',
 
             ReactDOM.render(
                 <LocaleProvider value={{ bundleKey: 'maplegend' }}>
-                    { legends.length === 0
-                        ? <Message messageKey='noLegendsText' />
-                        : <MapLegendList legendList={ legends } />
-                    }
+                    <ThemeProvider>
+                        { legends.length === 0
+                            ? <Message messageKey='noLegendsText' />
+                            : <MapLegendList legendList={ legends } />
+                        }
+                    </ThemeProvider>
                 </LocaleProvider>,
                 this.container
             );

--- a/src/react/components/icons/Metadata.jsx
+++ b/src/react/components/icons/Metadata.jsx
@@ -1,16 +1,35 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { InfoCircleOutlined } from '@ant-design/icons';
-import { Tooltip } from 'oskari-ui';
+import { ThemeConsumer } from '../../util';
 import styled from 'styled-components';
 
+const getThemeColors = theme => {
+    let color = theme?.color?.accent;
+    if (!color || Oskari.util.isLightColor(color)) {
+        // default to light blue if:
+        // - accent color is missing
+        // - color is too light to be readable
+        return {
+            main: '#0290ff',
+            hover: 'rgba(24,144,255, 0.25)'
+        };
+    }
+    // hover = accent with 25% opacity
+    const components = Oskari.util.hexToRgb(color);
+    return {
+        main: color,
+        //hover
+        hover: `rgba(${components.r},${components.g},${components.b}, 0.25)`
+    };
+};
 
 const StyledMetadataIcon = styled(InfoCircleOutlined)`
     cursor: pointer;
-    color: #0290ff;
+    color: ${props => props.theme.main};
     border-radius: 50%;
     &:hover {
-        background-color: rgba(24,144,255, 0.25);
+        background-color: ${props => props.theme.hover};
     }
 `;
 
@@ -20,24 +39,25 @@ const StyledMetadataIcon = styled(InfoCircleOutlined)`
  * @param {Object} style Additional styles
  * @returns 
  */
-export const Metadata = ({ metadataId, size = 16, style }) => {
-
-    if (!metadataId) return null;
+export const Metadata = ThemeConsumer(({ metadataId, size = 16, style, theme }) => {
+    if (!metadataId) {
+        return null;
+    }
 
     const onClick = () => {
-        Oskari.getSandbox().postRequestByName('catalogue.ShowMetadataRequest', [
-            {uuid: metadataId}
-    ]);
+        Oskari.getSandbox()
+            .postRequestByName('catalogue.ShowMetadataRequest', [{ uuid: metadataId }]);
     };
 
     return (
         <StyledMetadataIcon
             className='t_icon t_metadata'
+            theme={getThemeColors(theme)}
             style={{ fontSize: `${size}px`, ...style }}
             onClick={onClick}
         />
     );
-};
+});
 
 Metadata.propTypes = {
     metadataId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),


### PR DESCRIPTION
For light colors now uses the same hard coded blue colors. For dark theme accent color the icon color is from theme with hover background in 25% opacity.