### PR TITLE
Mobile toolbar handling for plugins/publisher

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1379,7 +1379,7 @@ Oskari.clazz.define(
             plugins.sort((a, b) => getIndex(a) - getIndex(b));
             return plugins;
         },
-
+        // NOTE! This is called from BasicMapModulePlugin so we can hide or show toolbar when buttons are added/removed
         _adjustMobileMapSize: function () {
             var mapDivHeight = this.getMapEl().height();
             var mobileDiv = this.getMobileDiv();

--- a/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
@@ -370,17 +370,17 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
             }
         },
         addToolbarButtons: function (buttons, group) {
-            var sandbox = this.getSandbox();
-            var toolbar = this.getMapModule().getMobileToolbar();
-            var themeColors = this.getMapModule().getThemeColours();
+            const sandbox = this.getSandbox();
+            const toolbar = this.getMapModule().getMobileToolbar();
+            const themeColors = this.getMapModule().getThemeColours();
             if (buttons && !sandbox.hasHandler('Toolbar.AddToolButtonRequest')) {
                 return true;
             }
-            var addToolButtonBuilder = Oskari.requestBuilder('Toolbar.AddToolButtonRequest');
+            const addToolButtonBuilder = Oskari.requestBuilder('Toolbar.AddToolButtonRequest');
 
             if (sandbox.hasHandler('Toolbar.AddToolButtonRequest') && addToolButtonBuilder) {
-                for (var tool in buttons) {
-                    var buttonConf = buttons[tool];
+                for (let tool in buttons) {
+                    const buttonConf = buttons[tool];
                     buttonConf.toolbarid = toolbar;
                     // add active color if sticky and toggleChangeIcon
                     if (buttonConf.sticky === true && buttonConf.toggleChangeIcon === true && !buttonConf.activeColor) {
@@ -388,10 +388,13 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
                     }
                     sandbox.request(this, addToolButtonBuilder(tool, group, buttonConf));
                 }
+                // we need to calculate new size to show toolbar after adding a button
+                // TODO: this should be responsibility of the toolbar instead
+                setTimeout(() => this.getMapModule()._adjustMobileMapSize(), 200);
             }
         },
         removeToolbarButtons: function (buttons, group) {
-            var sandbox = this.getSandbox();
+            const sandbox = this.getSandbox();
             if (!sandbox) {
                 return true;
             }
@@ -401,13 +404,16 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
             if (buttons && !sandbox.hasHandler('Toolbar.RemoveToolButtonRequest')) {
                 return true;
             }
-            var removeToolButtonBuilder = Oskari.requestBuilder('Toolbar.RemoveToolButtonRequest');
-            var toolbar = this.getMapModule().getMobileToolbar();
-            for (var tool in buttons) {
-                var buttonConf = buttons[tool];
+            const removeToolButtonBuilder = Oskari.requestBuilder('Toolbar.RemoveToolButtonRequest');
+            const toolbar = this.getMapModule().getMobileToolbar();
+            for (let tool in buttons) {
+                const buttonConf = buttons[tool];
                 buttonConf.toolbarid = toolbar;
                 sandbox.request(this, removeToolButtonBuilder(tool, group, toolbar));
             }
+            // we need to calculate new size to possibly hide toolbar after removing a button
+            // TODO: this should be responsibility of the toolbar instead
+            setTimeout(() => this.getMapModule()._adjustMobileMapSize(), 200);
         },
 
         /**

--- a/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPlugin.js
@@ -373,55 +373,54 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionP
          * @param {Boolean} forced application has started and ui should be rendered with assets that are available
          */
         redrawUI: function (mapInMobileMode, forced) {
-            var isMobile = mapInMobileMode || Oskari.util.isMobile();
-            if (!this.isVisible()) {
+            if (!this.isVisible() || !this.isEnabled()) {
                 // no point in drawing the ui if we are not visible
                 return;
             }
-            var me = this;
-            var mobileDefs = this.getMobileDefs();
 
+            const mobileDefs = this.getMobileDefs();
             // don't do anything now if request is not available.
             // When returning false, this will be called again when the request is available
-            var toolbarNotReady = this.removeToolbarButtons(mobileDefs.buttons, mobileDefs.buttonGroup);
+            const toolbarNotReady = this.removeToolbarButtons(mobileDefs.buttons, mobileDefs.buttonGroup);
             if (!forced && toolbarNotReady) {
                 return true;
             }
             this.teardownUI();
-            if (!toolbarNotReady && isMobile) {
+            if (!toolbarNotReady && mapInMobileMode) {
                 this.addToolbarButtons(mobileDefs.buttons, mobileDefs.buttonGroup);
             } else {
                 // TODO: redrawUI is basically refresh, move stuff here from refresh if needed
-                me._element = me._createControlElement();
-                me.changeToolStyle(null, me._element);
-                me.refresh();
-                this.addToPluginContainer(me._element);
+                this._element = this._createControlElement();
+                this.changeToolStyle(null, this._element);
+                this.refresh();
+                this.addToPluginContainer(this._element);
             }
         },
 
         refresh: function () {
-            var me = this,
-                conf = me.getConfig(),
-                element = me.getElement();
+            const me = this;
+            const conf = me.getConfig();
+            const element = me.getElement();
             this._updateLayerSelectionPopup();
-            if (conf) {
-                if (conf.toolStyle) {
-                    me.changeToolStyle(conf.toolStyle, element);
-                } else {
-                    // not found -> use the style config obtained from the mapmodule.
-                    var toolStyle = me.getToolStyleFromMapModule();
-                    if (toolStyle !== null && toolStyle !== undefined) {
-                        me.changeToolStyle(toolStyle, me.getElement());
-                    }
+            if (!conf) {
+                return;
+            }
+            if (conf.toolStyle) {
+                me.changeToolStyle(conf.toolStyle, element);
+            } else {
+                // not found -> use the style config obtained from the mapmodule.
+                var toolStyle = me.getToolStyleFromMapModule();
+                if (toolStyle !== null && toolStyle !== undefined) {
+                    me.changeToolStyle(toolStyle, me.getElement());
                 }
+            }
 
-                if (conf.font) {
-                    me.changeFont(conf.font, element);
-                } else {
-                    var font = me.getToolFontFromMapModule();
-                    if (font !== null && font !== undefined) {
-                        me.changeFont(font, element);
-                    }
+            if (conf.font) {
+                me.changeFont(conf.font, element);
+            } else {
+                var font = me.getToolFontFromMapModule();
+                if (font !== null && font !== undefined) {
+                    me.changeFont(font, element);
                 }
             }
         },


### PR DESCRIPTION
Added delayed calls to `mapmodule._adjustMobileMapSize()` for plugins `addToolbarButtons()` and `removeToolbarButtons()` since `_adjustMobileMapSize()` hides or shows the toolbar based on amount of tools in the toolbar. If it is not called when the amount of tools change between 0 and 1 or more the toolbar remains either visible or hidden regardless if buttons are added or removed. This must have changed at some point when since this was not necessary before. Also the responsibility for setting the toolbar size should be either in toolbar impl directly or it should trigger an event for changes so we don't have to use a timeout to check it.