### PR TITLE
Determine system default view when removing a personal one

### DIFF
--- a/bundles/framework/mydata/handler/MyViewsHandler.js
+++ b/bundles/framework/mydata/handler/MyViewsHandler.js
@@ -170,14 +170,13 @@ class ViewsHandler extends StateHandler {
     }
 
     getDefaultViewUrlWithCurrentMapParams (srsName) {
-        let uuid;
-        const defaultViews = Oskari.app.getSystemDefaultViews();
-        defaultViews.forEach((defaultView) => {
-            if (defaultView.srsName === srsName) {
-                uuid = defaultView.uuid;
-            }
-        });
-        let url = this.sandbox.createURL('/?uuid=' + uuid, true);
+        const systemDefault = Oskari.app.getSystemDefaultViews()
+            .find((defaultView) => defaultView.srsName === srsName);
+        let url = this.sandbox.createURL('/?', true);
+        if (systemDefault) {
+            // use uuid if available so server doesn't need to provide the global default
+            url += 'uuid=' + systemDefault.uuid + '&';
+        }
         url += this.sandbox.generateMapLinkParameters();
         return url;
     }


### PR DESCRIPTION
Use the first default view with same srs instead of last one. Since the first one is probably "more correct"/"more default" than the last one. Fixes an issue in the sample-application where removing a customized 2D-view that is the users personalized default makes the map reload with the default 3D-geoportal instead of the 2D-geoportal that is "more default".