### PR TITLE
Use wms-t as type for timeseries layers

### DIFF
--- a/bundles/admin/admin-layeranalytics/instance.js
+++ b/bundles/admin/admin-layeranalytics/instance.js
@@ -230,7 +230,10 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layeranalytics.AdminLayerAnal
                     const itemLayer = this.mapLayerService.findMapLayer(item);
                     const title = itemLayer !== null ? itemLayer.getName() : item;
                     const dataProducer = itemLayer !== null ? itemLayer.getOrganizationName() : '';
-                    const layerType = itemLayer !== null ? itemLayer.getLayerType() : '';
+                    let layerType = itemLayer !== null ? itemLayer.getLayerType() : '';
+                    if (itemLayer.hasTimeseries()) {
+                        layerType += '-t';
+                    }
                     const totalDisplays = result[item].success + result[item].errors;
                     const failurePercentage = Math.round(result[item].errors / totalDisplays * 100);
 


### PR DESCRIPTION
For layer analytics listing (we should only get true for hasTimeSeries() on wms layers, but it's a method in AbstractLayer).