### PR TITLE
Drawtools limits

### DIFF
--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
@@ -503,7 +503,6 @@ Oskari.clazz.define(
             }
 
             const geojson = this.getFeaturesAsGeoJSON(features);
-            geojson.crs = this._getSRS();
             const bufferedGeoJson = this.getFeaturesAsGeoJSON(bufferedFeatures);
 
             const measures = this.sumMeasurements(features);
@@ -571,6 +570,7 @@ Oskari.clazz.define(
             var me = this,
                 geoJsonObject = {
                     type: 'FeatureCollection',
+                    crs: this._getSRS(),
                     features: []
                 },
                 measures,

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
@@ -866,10 +866,12 @@ Oskari.clazz.define(
         },
         handleFinishedDrawing: function (feature = this._sketch, suppressEvent) {
             this._mode = '';
-            if (this.validateGeometry(feature)) {
+            if (!this.validateGeometry(feature)) {
                 this.updateTooltip(feature, this.getInvalidReasonMessage(feature.getId()));
-            } else {
+            } else if (this.getOpts('showMeasureOnMap')) {
                 this.updateMeasurementTooltip(feature);
+            } else {
+                this.updateTooltip(feature);
             }
             if (!suppressEvent) {
                 this.sendDrawingEvent(true);
@@ -933,7 +935,7 @@ Oskari.clazz.define(
                 }
             }
             this.setFeatureValidity(id, invalidReason);
-            return !!invalidReason;
+            return !invalidReason;
         },
         /**
          * @method checkIntersection
@@ -979,8 +981,8 @@ Oskari.clazz.define(
             if (!feature || !this.getOpts('showMeasureOnMap')) {
                 return;
             }
-            if (!this.isFeatureValid(feature.getId())) {
-                // remove measurement for invalid feature while drawing/modifying
+            if (this._invalidFeatures[feature.getId()] === INVALID_REASONS.INTERSECTION) {
+                // remove measurement for self intersecting geometries while drawing/modifying
                 if (this.isCurrentlyDrawing() || this.isCurrentlyModifying()) {
                     this.updateTooltip(feature);
                 }

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
@@ -670,9 +670,8 @@ Oskari.clazz.define(
          * @return {Object} object with length and area keys with numbers as values indicating meters/m2.
          */
         sumMeasurements: function (features) {
-            var me = this;
-            var value = {};
-            var mapmodule = this.getMapModule();
+            const value = {};
+            const mapmodule = this.getMapModule();
             features.forEach(function (f) {
                 const geomType = f.getGeometry().getType();
                 if (geomType === 'LineString' || geomType === 'Polygon') {

--- a/bundles/mapping/drawtools/resources/locale/en.js
+++ b/bundles/mapping/drawtools/resources/locale/en.js
@@ -3,6 +3,8 @@ Oskari.registerLocalization(
     "lang": "en",
     "key": "DrawTools",
     "value": {
-        "intersectionNotAllowed": "Polygon self-intersection is not allowed. Edit current polygon or draw a new polygon."
+        "intersectionNotAllowed": "Polygon self-intersection is not allowed. Edit current polygon or draw a new polygon.",
+        "invalidAreaSize": "The area is too large. It can be at most {size}. Edit the area or draw a new polygon.",
+        "invalidLineLenght": "The line is too long. It can be at most {length}. Edit the line or draw a new line."
     }
 });

--- a/bundles/mapping/drawtools/resources/locale/fi.js
+++ b/bundles/mapping/drawtools/resources/locale/fi.js
@@ -3,6 +3,8 @@ Oskari.registerLocalization(
     "lang": "fi",
     "key": "DrawTools",
     "value": {
-        "intersectionNotAllowed": "Alue ei saa muodostaa silmukkaa. Muokkaa aluetta tai piirrä uusi."
+        "intersectionNotAllowed": "Alue ei saa muodostaa silmukkaa. Muokkaa aluetta tai piirrä uusi.",
+        "invalidAreaSize": "Alue on liian suuri. Suurin sallittu koko on {size}. Muokkaa aluetta tai piirrä uusi.",
+        "invalidLineLenght": "Viiva on liian pitkä. Suurin sallittu pituus on {length}. Muokkaa viivaa tai piirrä uusi viiva."
     }
 });

--- a/bundles/mapping/drawtools/resources/locale/sv.js
+++ b/bundles/mapping/drawtools/resources/locale/sv.js
@@ -3,6 +3,8 @@ Oskari.registerLocalization(
     "lang": "sv",
     "key": "DrawTools",
     "value": {
-        "intersectionNotAllowed": "Området får inte forma en öga. Redigera område eller rita ett nytt giltigt område."
+        "intersectionNotAllowed": "Området får inte forma en öga. Redigera område eller rita ett nytt giltigt område.",
+        "invalidAreaSize": "Området är för stort. Redigera området eller rita ett nytt.", // Den högsta tillåtna storleken är {size}.
+        "invalidLineLenght": "Linjen är för lång. Redigera linjen eller rita en ny." // Den högsta tillåtna längden är {length}.
     }
 });


### PR DESCRIPTION
Add limits to StartDrawingRequest options
limits: { area: m2, length: m }

Refactor:
use same handleFinishedDrawing for given geojson, drawend and modifyend.
Init options with defaults and don't pass options (use getOpts)
remove _showIntersectionWarning and use mode.