### PR TITLE
Improve layer text filter

### DIFF
--- a/bundles/framework/layerlist/model/LayerGroup.js
+++ b/bundles/framework/layerlist/model/LayerGroup.js
@@ -111,8 +111,12 @@ export class LayerGroup {
         return val.toLowerCase();
     }
     matchesKeyword (layerId, keyword) {
-        var searchableIndex = this.searchIndex[layerId];
-        return searchableIndex.indexOf(keyword.toLowerCase()) !== -1;
+        const searchableIndex = this.searchIndex[layerId];
+        let terms = keyword;
+        if (!Array.isArray(terms)) {
+            terms = [terms];
+        }
+        return terms.every(key => searchableIndex.indexOf(key.toLowerCase()) !== -1);
     }
     clone () {
         const clone = new LayerGroup(this.id, this.groupMethod, this.name, this.description, this.parentId);

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Filter/FilterHandler.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Filter/FilterHandler.js
@@ -11,7 +11,7 @@ class ViewHandler extends StateHandler {
 
         this.state = {
             activeFilterId: FILTER_ALL_LAYERS,
-            searchText: null,
+            searchText: '',
             filters: this.getFiltersProvidingResults(this.initFilters())
         };
         this.layerlistService.on('Layerlist.Filter.Button.Add',

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Filter/FilterHandler.test.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Filter/FilterHandler.test.js
@@ -17,7 +17,7 @@ describe('FilterHandler', () => {
         expect.assertions(3);
         const { searchText, activeFilterId, filters } = handler.getState();
         expect(activeFilterId).toBe(FILTER_ALL_LAYERS);
-        expect(searchText).toBe(null);
+        expect(searchText).toBe('');
         expect(filters[0].id).toBe(FILTER_ALL_LAYERS);
     });
 

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
@@ -119,7 +119,8 @@ class ViewHandler extends StateHandler {
         const previousSearchText = this.filter.searchText;
         // generate search terms by splitting by * and space
         const terms = searchText
-            .replace('*', ' ')
+            .replaceAll('*', ' ')
+            .replaceAll(',', ' ')
             .split(' ')
             .filter(item => item !== '');
         this.filter = {


### PR DESCRIPTION
Continues #1945, but makes the text filter more intuitive to use. For example typing `F*nland` before didn't match `Finland` because star was removed and the query was actually `Fnland`. Now the query is split from `*`, `, ` and ` ` and each part much match the layers "search index" which is built by combining the layer name, data provider and theme/group name.