### PR TITLE
Drawtools modify

### DIFF
--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
@@ -1044,6 +1044,7 @@ Oskari.clazz.define(
                 me._modify[me._id] = new olInteractionModify({
                     features: layer.getSource().getFeaturesCollection(),
                     style: me._styles.modify,
+                    insertVertexCondition: isModifyLimited(shape) ? olEventsCondition.never : olEventsCondition.always,
                     deleteCondition: function (event) {
                         return olEventsCondition.shiftKeyOnly(event) && olEventsCondition.singleClick(event);
                     }


### PR DESCRIPTION
Limit modify for Circle, Box and Square. Disable add vertices and keep geometry shape on modify.

Modify doesn't trigger pointer drag so had to add pointerdrag to map while modifying.

Modify interaction edits feature's geometry so original feature's geometry can't be edited. Added temp feature and style for rendering original feature with edited geometry and temp feature to update measurements and create geojson.

For Box finding drag coord/index from coordinates fails sometimes (double precision?, timing issue?) so had to calculate distances to find opposite corner.