### PR TITLE
My places: Fix finish drawing button while sketch is incomplete

### DIFF
--- a/api/ui/toolbar/request/Toolbar.SelectToolButtonRequest.md
+++ b/api/ui/toolbar/request/Toolbar.SelectToolButtonRequest.md
@@ -1,3 +1,28 @@
 # Toolbar.SelectToolButtonRequest
 
 Requests for toolbar to act as if user had clicked a button or returns a default tool if create params aren't given.
+
+## Use cases
+
+- Programmatically "click" a button on toolbar
+
+## Description
+
+Can be used to programmatically select buttons on the toolbar like user clicked on them or reset toolbar state to
+show the default tool (panning) when functionalities with toolbar buttons are stopped.
+
+## Parameters
+
+(* means the parameter is required)
+
+<table class="table">
+<tr>
+  <th> Name</th><th> Type</th><th> Description</th><th> Default value</th>
+</tr>
+<tr>
+  <td> buttonId </td><td> String </td><td> Id for button to click </td><td> Defaults to panning tool if omitted.</td>
+</tr>
+<tr>
+  <td> groupId </td><td> String </td><td> Id for group where button is located in. Required if button id is given. Note! This needs to include the toolbar id before the group. As an example when adding the button with group 'test' and id 'my', selecting the button in the "default" toolbar requires the group id be 'default-test' with buttonId remaining as 'my'. This is not intuitive, but it is the way the request works currently. </td><td></td>
+</tr>
+</table>

--- a/bundles/framework/myplaces3/ButtonHandler.js
+++ b/bundles/framework/myplaces3/ButtonHandler.js
@@ -159,12 +159,16 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.ButtonHandler',
                 this.drawMode = null;
                 this.instance.getDrawHandler().stopDrawing();
                 // Select default tool
-                this.instance.getSandbox().request(this, Oskari.requestBuilder('Toolbar.SelectToolButtonRequest')());
+                this.instance.getSandbox().postRequestByName('Toolbar.SelectToolButtonRequest', []);
                 return;
             }
             // finish sketch and proceed with saving
             this.instance.getDrawHandler().finishDrawing((geojson) => {
                 this.instance.getMyPlacesHandler().addPlace(geojson);
+                if (!geojson) {
+                    // geometry error, reset toolbar to default tool
+                    this.instance.getSandbox().postRequestByName('Toolbar.SelectToolButtonRequest', []);
+                }
             });
         },
         /**

--- a/bundles/framework/myplaces3/ButtonHandler.js
+++ b/bundles/framework/myplaces3/ButtonHandler.js
@@ -156,20 +156,43 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.ButtonHandler',
         stopDrawing: function (isCancel) {
             this.closeDialog();
             if (isCancel) {
+                this.drawMode = null;
                 this.instance.getDrawHandler().stopDrawing();
-            } else {
-                this.instance.getDrawHandler().finishDrawing();
-                this.instance.getMyPlacesHandler().addPlace();
+                // Select default tool
+                this.instance.getSandbox().request(this, Oskari.requestBuilder('Toolbar.SelectToolButtonRequest')());
+                return;
             }
-            // Select default tool
-            this.instance.getSandbox().request(this, Oskari.requestBuilder('Toolbar.SelectToolButtonRequest')());
+            // finish sketch and proceed with saving
+            this.instance.getDrawHandler().finishDrawing((geojson) => {
+                this.instance.getMyPlacesHandler().addPlace(geojson);
+            });
         },
-        toolSelected: function () {
-            // changed tool -> cancel any drawing and close helper
+        /**
+         * Setup state and UI-buttons when editing a myplaces feature
+         * @param {String} type the draw mode that we are starting based on feature geometry type
+         */
+        setupModifyMode: function (type) {
+            // set drawMode so we know to reset functionality when another toolbar buttons is pressed while editing
+            this.drawMode = type;
+            if (this.drawMode) {
+                // make the button for myplaces draw functionality go "selected" when editing a feature
+                const buttonId = this.drawMode;
+                const buttonGroup = 'default-' + this.buttonGroup;
+                this.instance.getSandbox().postRequestByName('Toolbar.SelectToolButtonRequest', [buttonId, buttonGroup]);
+            }
+        },
+        someOtherToolSelected: function () {
+            // changed tool -> cancel any drawing and close popups
+            this.drawMode = null;
             this.closeDialog();
+            this.instance.getMyPlacesHandler().placePopupCleanup(false);
             this.instance.getDrawHandler().stopDrawing();
         },
         startDrawing: function (drawMode, shape) {
+            if (this.drawMode === drawMode) {
+                // already in progress
+                return;
+            }
             this.drawMode = drawMode;
             this.instance.getDrawHandler().startDrawing(shape);
             this.showDrawHelper();
@@ -241,14 +264,15 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.ButtonHandler',
              * @method Toolbar.ToolSelectedEvent
              */
             'Toolbar.ToolSelectedEvent': function (event) {
-                if (this.drawMode === event.getToolId() || !event.getSticky()) {
+                if (['point', 'area', 'line'].includes(event.getToolId())) {
+                    // it's me
                     return;
                 }
-                if (this.instance.getMyPlacesHandler().isPlacePopupActive()) {
-                    // do not trigger when placeform is shown
-                    return;
+                if (this.drawMode) {
+                    // draw mode is set when functionality is activated
+                    // reset tool if user was drawing and clicked on another tool
+                    this.someOtherToolSelected();
                 }
-                this.toolSelected();
             },
 
             /**

--- a/bundles/framework/myplaces3/handler/MyPlacesHandler.js
+++ b/bundles/framework/myplaces3/handler/MyPlacesHandler.js
@@ -43,12 +43,16 @@ class PlaceHandler extends StateHandler {
         this.layerControls = null;
     }
 
-    placePopupCleanup () {
+    placePopupCleanup (resetTool = true) {
         if (this.placeControls) {
             this.placeControls.close();
         }
         this.instance.getDrawHandler().stopDrawing();
         this.placeControls = null;
+        if (resetTool) {
+            // Select default tool
+            this.instance.getSandbox().postRequestByName('Toolbar.SelectToolButtonRequest', []);
+        }
     }
 
     openLayerDialog (categoryId, locale, style) {
@@ -134,17 +138,16 @@ class PlaceHandler extends StateHandler {
         this.addLayerAndFocus(place);
     }
 
-    addPlace () {
-        const place = Oskari.clazz.create('Oskari.mapframework.bundle.myplaces3.model.MyPlace');
-        // init category from selected
-        place.setCategoryId(this.state.selectedCategoryId);
-        const drawHandler = this.instance.getDrawHandler();
-        if (!drawHandler.hasValidGeometry()) {
+    addPlace (geojson) {
+        if (!geojson) {
             // no features, user clicks save my new place without valid geometry drawn
             Messaging.error(this.loc('error.savePlace'));
             drawHandler.stopDrawing();
             return;
         }
+        const place = Oskari.clazz.create('Oskari.mapframework.bundle.myplaces3.model.MyPlace');
+        // init category from selected
+        place.setCategoryId(this.state.selectedCategoryId);
         this.openPlacePopup(place);
     }
 

--- a/bundles/framework/myplaces3/handler/MyPlacesHandler.js
+++ b/bundles/framework/myplaces3/handler/MyPlacesHandler.js
@@ -142,7 +142,7 @@ class PlaceHandler extends StateHandler {
         if (!geojson) {
             // no features, user clicks save my new place without valid geometry drawn
             Messaging.error(this.loc('error.savePlace'));
-            drawHandler.stopDrawing();
+            this.instance.getDrawHandler().stopDrawing();
             return;
         }
         const place = Oskari.clazz.create('Oskari.mapframework.bundle.myplaces3.model.MyPlace');

--- a/bundles/framework/myplaces3/instance.js
+++ b/bundles/framework/myplaces3/instance.js
@@ -150,7 +150,9 @@ Oskari.clazz.define(
         stop: function () {
             this.sandbox = null;
         },
-
+        setupModifyMode: function (type) {
+            this.buttons.setupModifyMode(type);
+        },
         addTab: function (appStarted) {
             const sandbox = Oskari.getSandbox();
             let myDataService = sandbox.getService('Oskari.mapframework.bundle.mydata.service.MyDataService');


### PR DESCRIPTION
Pressing the button while sketch was not completed resulted in an error message to user. Now the sketch is finished if possible instead of showing an error message. Also added code to select buttons on toolbar when editing a my places feature so the edit can be canceled by selecting another tool on the toolbar.