### PR TITLE
Layer analytics: Fix an issue with missing layers

### DIFF
--- a/bundles/admin/admin-layeranalytics/instance.js
+++ b/bundles/admin/admin-layeranalytics/instance.js
@@ -231,7 +231,7 @@ Oskari.clazz.define('Oskari.framework.bundle.admin-layeranalytics.AdminLayerAnal
                     const title = itemLayer !== null ? itemLayer.getName() : item;
                     const dataProducer = itemLayer !== null ? itemLayer.getOrganizationName() : '';
                     let layerType = itemLayer !== null ? itemLayer.getLayerType() : '';
-                    if (itemLayer.hasTimeseries()) {
+                    if (layerType && itemLayer.hasTimeseries()) {
                         layerType += '-t';
                     }
                     const totalDisplays = result[item].success + result[item].errors;


### PR DESCRIPTION
Fixes an issue where the server has data for layers that the current user doesn't have access to. The layer might have been removed or the user just doesn't have permission to see it.