### PR TITLE
Drawtools code cleaning

### DIFF
--- a/bundles/mapping/drawtools/instance.js
+++ b/bundles/mapping/drawtools/instance.js
@@ -2,25 +2,16 @@
  * @class Oskari.mapping.drawtools.DrawToolsBundleInstance
  *
  * Main component and starting point for the "drawtools" functionality.
- * Provides functionality for other bundles (my places/analysis/measuretools)
- * for drawing on the map.
+ * Provides functionality for other bundles for drawing on the map.
  *
- * Drawing can be started with a request (DrawTools.StartDrawingRequest).
- * The request specifies:
- *  - an id for the drawing (like 'myplaces')
- *  - type of shape to be drawn or a geojson that should be opened for editing
- *  - options that might include buffer (for dot/line), style, etc
- *  Drawing can be forced to complete/canceled with DrawTools.StopDrawingRequest.
- *  Other components are notified that a drawing has been completed by DrawingEvent.
- *  The event includes:
- *   - id for the drawing
- *   - the geometry as geojson
- *   - possible additional info like area size/line length
+ * Drawing can be started with a DrawTools.StartDrawingRequest.
  *
- * Bundle config can be used to define draw style. Requests can also specify
- * styles in the same format to be used instead of the default for that specific drawing.
+ * Drawing can be forced to complete/canceled with DrawTools.StopDrawingRequest.
+ * Other components are notified that a drawing has been completed by DrawingEvent.
  *
- * See Oskari.mapframework.bundle.infobox.InfoBoxBundle for bundle definition.
+ * Bundle config can be used to define default style.
+ * Requests can specify draw, modify and/or invalid styles to override default style used for drawing.
+ *
  */
 Oskari.clazz.define('Oskari.mapping.drawtools.DrawToolsBundleInstance',
 

--- a/bundles/mapping/drawtools/request/StartDrawingRequest.js
+++ b/bundles/mapping/drawtools/request/StartDrawingRequest.js
@@ -14,14 +14,9 @@ Oskari.clazz.define('Oskari.mapping.drawtools.request.StartDrawingRequest',
      * @method create called automatically on construction
      * @static
      *
-     * @param {String} id drawing id as given in StartDrawingRequest
-     * @param {String|Object} shape [dot|line|circle|box|polygon] or geojson object to set for editing
-     * @param {Object} options options like
-     *                         - buffer [0 to disable dragging a buffer or 1-n for fixed buffer]
-     *                         - styles
-     *                         - clear drawing after finished
-     *                         - show area/line length on map for drawing
-     *                         - show text next to the drawing(?)
+     * @param {String} id
+     * @param {String} shape
+     * @param {Object} options
      */
     function (id, shape, options) {
         this._id = id;
@@ -39,30 +34,23 @@ Oskari.clazz.define('Oskari.mapping.drawtools.request.StartDrawingRequest',
         },
         /**
          * @method getId
-         * @return {String} Id for the feature that is being drawn,
-         *                     this will be referenced by the event that will be
-         *                     triggered when drawing is finished.
+         * @return {String} Id
          */
         getId: function () {
             return this._id;
         },
         /**
          * @method getShape
-         * @return {String|Object} [dot|line|circle|box|polygon] or geojson object to set for editing
+         * @return {String}
          */
         getShape: function () {
             return this._shape;
         },
         /**
          * @method getOptions
-         * @param {String} key optional key for options
-         * @return {Object} if key is given returns the key value from options,
-         *                     otherwise returns the whole options
+         * @return {Object} options
          */
-        getOptions: function (key) {
-            if (key) {
-                return this._options[key];
-            }
+        getOptions: function () {
             return this._options;
         }
     }, {


### PR DESCRIPTION
Remove API documentation from code. These were outdated and we have own files for API documentation which are updated more  often.

Remove unused code.