### PR TITLE
GFI plugin fix

### DIFF
--- a/packages/mapping/olcs/mapmodule/bundle.js
+++ b/packages/mapping/olcs/mapmodule/bundle.js
@@ -85,6 +85,12 @@ Oskari.clazz.define(
                     'type': 'text/javascript',
                     'src': '../../../../bundles/mapping/mapmodule/plugin/getinfo/request/ResultHandlerRequestHandler.js'
                 }, {
+                    'type': 'text/javascript',
+                    'src': '../../../../bundles/mapping/mapmodule/plugin/getinfo/request/SwipeStatusRequest.js'
+                }, {
+                    'type': 'text/javascript',
+                    'src': '../../../../bundles/mapping/mapmodule/plugin/getinfo/request/SwipeStatusRequestHandler.js'
+                }, {
                     'type': 'text/css',
                     'src': '../../../../bundles/mapping/mapmodule/resources/scss/getinfo.scss'
                 },


### PR DESCRIPTION
Add swipe status request and handler for 3d mapmodule. Fixes issue where GFI plugin failed to start in 3D mode. Without GFI plugin publisher crashes also in 3D.