### PR TITLE
StopDrawingRequest  documentation update

### DIFF
--- a/api/mapping/drawtools/request/startdrawingrequest.md
+++ b/api/mapping/drawtools/request/startdrawingrequest.md
@@ -27,7 +27,7 @@ Activates draw control on map.
   <td> \* shape</td><td> String</td><td> Point|LineString|Polygon|Circle|Box|Square</td><td> </td>
 </tr>
 <tr>
-  <td> \* options</td><td> Object</td><td> Parameters for options-object are listed in the next table</td><td> null</td>
+  <td> options</td><td> Object</td><td> Parameters for options-object are listed in the next table</td><td> null</td>
 </tr>
 </table>
 

--- a/api/mapping/drawtools/request/stopdrawingrequest.md
+++ b/api/mapping/drawtools/request/stopdrawingrequest.md
@@ -13,17 +13,15 @@ If the user is allowed to draw on the map this request can be used to complete t
 
 ## Parameters
 
-(* means the parameter is required)
-
 <table class="table">
 <tr>
   <th> Name</th><th> Type</th><th> Description</th><th> Default value</th>
 </tr>
 <tr>
-  <td> \* id</td><td> String</td><td> Identifier for request</td><td> </td>
+  <td> id</td><td> String</td><td> Identifier for request. Required for complete drawing. </td><td> </td>
 </tr>
 <tr>
-  <td> clearCurrent</td><td> Boolean</td><td> true - all selection will be removed from the map after stopping plugin.<br> false - will keep selection on the map.</td><td> false</td>
+  <td> clearCurrent</td><td> Boolean</td><td> true - drawings will be removed from the map. If id is given, then id related drawings are removed, otherwise all. <br> false - will keep drawings on the map.</td><td> false</td>
 </tr>
 <tr>
   <td> supressEvent</td><td> Boolean</td><td> true - does not send out an DrawingEvent.<br> false - sends out DrawingEvent.</td><td> false</td>
@@ -34,25 +32,29 @@ If the user is allowed to draw on the map this request can be used to complete t
 
 Complete a draw for 'measure' functionality and keep the drawing on the map:
 ```javascript
-var sb = Oskari.getSandbox();
-sb.postRequestByName('DrawTools.StopDrawingRequest', ['measure']);
+Oskari.getSandbox().postRequestByName('DrawTools.StopDrawingRequest', ['measure']);
 ```
 
 This expects that drawing has been started for id 'measure' and will result in an 'DrawingEvent' where id is 'measure' with the measure data available in event.getData().
 
-Complete a draw for 'myplaces' functionality and clear the drawing from the map:
+Complete a draw for 'myplaces' functionality and clear 'myplaces' drawings from the map:
 ```javascript
-var sb = Oskari.getSandbox();
-sb.postRequestByName('DrawTools.StopDrawingRequest', ['myplaces', true]);
+Oskari.getSandbox().postRequestByName('DrawTools.StopDrawingRequest', ['myplaces', true]);
 ```
 Again, this expects that drawing has been started for id 'myplaces' and will result in an 'DrawingEvent' where id is 'myplaces' with the drawn shape as geojson available in event.getGeoJson().
 
 
-Complete a draw but don't send out an event:
+Clear 'myplaces' drawings and don't send out an event:
 ```javascript
-var sb = Oskari.getSandbox();
-sb.postRequestByName('DrawTools.StopDrawingRequest', ['measure', true, true]);
+Oskari.getSandbox().postRequestByName('DrawTools.StopDrawingRequest', ['measure', true, true]);
 ```
+This is normally used when functionality is stopped to clean own drawings.
+
+Remove all drawings:
+```javascript
+Oskari.getSandbox().postRequestByName('DrawTools.StopDrawingRequest');
+```
+This can be used to be sure that there isn't any previous or other functionalitys' drawings before a new drawing is started.
 
 ## Related api
 


### PR DESCRIPTION
On complete id is required but on clear it depends. If id isn't given, layer wasn't found for given id or current id !== id, all drawings are cleared. Otherwise shape related and id linked layer is cleared.

Don't know why (<2.9.0) supressEvent had to be true to clear drawings.
2.8.0:
https://github.com/oskariorg/oskari-frontend/blob/2.8.0/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js#L376
develop:
https://github.com/oskariorg/oskari-frontend/blob/develop/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js

clearDrawing + id is also weird because it cleans only shape linked draw layer but all overlays.