### PR TITLE
Fix null query (opening layerlist with filter using request)

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
@@ -117,15 +117,19 @@ class ViewHandler extends StateHandler {
     }
     setFilter (activeId, searchText = '') {
         const previousSearchText = this.filter.searchText;
-        // generate search terms by splitting by * and space
-        const terms = searchText
+        // Generate search terms by splitting by * and space
+        // Opening layerlist with request might send searchText as null
+        //  so we need to make sure it's string before processing it.
+        //  Nulls are not changed to function param default values, this is required even with default value.
+        const normalizedQuery = searchText || '';
+        const terms = normalizedQuery
             .replaceAll('*', ' ')
             .replaceAll(',', ' ')
             .split(' ')
             .filter(item => item !== '');
         this.filter = {
             activeId,
-            searchText,
+            normalizedQuery,
             terms
         };
 


### PR DESCRIPTION
Fixes an issue where clicking "Add map layers" button in publisher functionality broke the layerlist for end-user.