### PR TITLE
Metadata search results fix for server error result

### DIFF
--- a/bundles/catalogue/metadatacatalogue/instance.js
+++ b/bundles/catalogue/metadatacatalogue/instance.js
@@ -803,6 +803,8 @@ Oskari.clazz.define(
          */
         _showResults: function (results) {
             var me = this;
+            // make sure we have an array as results. Otherwise the UI breaks when we check for length etc
+            results = results || [];
             me.lastResult = results;
             var resultPanel = me.metadataCatalogueContainer.find('.metadataResults');
             var searchPanel = me.metadataCatalogueContainer.find('.metadataSearching');


### PR DESCRIPTION
Make sure we have a results array to parse even if we get an error from server.