### PR TITLE
Statsgrid classification for one unique count

### DIFF
--- a/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
@@ -128,7 +128,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
         },
         getEditOptions: function (state, uniqueCount, minMax) {
             const { activeIndicator } = state;
-            const { type, count, reverseColors, mapStyle, base } = activeIndicator.classification;
+            const { type, count, reverseColors, mapStyle, base, method } = activeIndicator.classification;
             const { count: { min, max }, methods, modes, mapStyles, types, fractionDigits } = this.service.getClassificationService().getLimits(mapStyle, type);
 
             const colorCount = mapStyle === 'points' ? 2 + count % 2 : count;
@@ -137,6 +137,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
             const disabled = [];
             if (uniqueCount < 3) {
                 disabled.push('jenks');
+                // only jenks breaks with small unique count, show at least count 2 for others
+                if (method !== 'jenks') {
+                    uniqueCount = 2;
+                }
             }
 
             // if dataset has negative and positive values it can be divided, base !== 0 has to be given in metadata

--- a/bundles/statistics/statsgrid2016/service/ClassificationService.js
+++ b/bundles/statistics/statsgrid2016/service/ClassificationService.js
@@ -74,7 +74,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationService',
             const dataAsList = Object.values(indicatorData).filter(val => val !== null && val !== undefined);
             const dataSize = uniqueCount || new Set(dataAsList).size;
             // geostats fails with jenks if there isn't at least one more unique values than count
-            const minData = opts.method === 'jenks' ? Math.max(opts.count + 1, 3) : 2;
+            const minData = opts.method === 'jenks' ? Math.max(opts.count + 1, 3) : 1;
             if ((groupStats && groupStats.serie.length < 3) || dataSize < minData) {
                 return { error: 'noEnough' };
             }

--- a/bundles/statistics/statsgrid2016/view/SearchFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/SearchFlyout.js
@@ -415,8 +415,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.SearchFlyout', function (t
                             resolve();
                             return;
                         }
-                        let counter = 0;
-                        const enoughData = Object.values(data).some(val => !isNaN(val) && ++counter > 1);
+                        const enoughData = Object.values(data).some(val => !isNaN(val));
                         if (!enoughData) {
                             searchFailed(search);
                             resolve();


### PR DESCRIPTION
Only `jenks` breaks with small unique count. Allow other methods to use one unique value for classification and show at least count 2 option.

Not sure why counter was used for search flyout enough data. Changed to check that at least one region has number value.