### PR TITLE
Layer getZIndex fix

### DIFF
--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -976,8 +976,10 @@ export class MapModule extends AbstractMapModule {
      * Orders layers by Z-indexes.
      */
     orderLayersByZIndex () {
+        // getZIndex returns undefined if z indez isn't set even default is 0.
+        const layerZ = l => l.getZIndex() || 0;
         this.getMap().getLayers().getArray().sort(function (a, b) {
-            return a.getZIndex() - b.getZIndex();
+            return layerZ(a) - layerZ(b);
         });
     }
 


### PR DESCRIPTION
getZIndex returns undefined if zIndex isn't set. Avoid to return undefined to sort correctly.

`The z-index for layer rendering. At rendering time, the layers will be ordered, first by Z-index and then by position. When undefined, a zIndex of 0 is assumed for layers that are added to the map's layers collection, or Infinity when the layer's setMap() method was used.`

`getZIndex() Return the Z-index of the layer, which is used to order layers before rendering. The default Z-index is 0.`

Not sure if it's fine to sort Collection by sorting array (getMap().getLayers().getArray().sort())

Collection.getArray():
`Get a reference to the underlying Array object. Warning: if the array is mutated, no events will be dispatched by the collection, and the collection's "length" property won't be in sync with the actual length of the array.`