### PR TITLE
Enable config for external domain for frontend build

### DIFF
--- a/webpack/parseParams.js
+++ b/webpack/parseParams.js
@@ -35,9 +35,7 @@ module.exports = function parseParams (env) {
 };
 
 function getVersion (appdefParts) {
-    // After we upgrade webpack to latest we can use env: https://github.com/webpack/webpack-dev-server/pull/1929
-    // const isDevServer = !!process.env.WEBPACK_DEV_SERVER;
-    const isDevServer = !!process.argv.find(v => v.indexOf('webpack-dev-server') !== -1);
+    const isDevServer = !!process.env.WEBPACK_DEV_SERVER;
     if (appdefParts.length > 1) {
         return appdefParts[0];
     } else if (!isDevServer) {

--- a/webpack/parseParams.js
+++ b/webpack/parseParams.js
@@ -21,10 +21,13 @@ module.exports = function parseParams (env) {
     const version = getVersion(parts);
     const pathParam = parts.length > 1 ? parts[1] : parts[0];
 
+    const externalDomain = env.domain || '';
+    const publicPath = env.absolutePublicPath === 'true' || externalDomain ? '/' : '';
+
     const params = {
         version,
         pathParam,
-        publicPathPrefix: env.absolutePublicPath === 'true' ? '/' : ''
+        publicPathPrefix: externalDomain + publicPath
     };
 
     if (env.theme) {


### PR DESCRIPTION
Adds support for enabling builds with external frontend domain.

Related to https://github.com/oskariorg/oskari-server/pull/897 when configuring an external site for frontend with `oskari.client.domain=https://cdn.domain.org` you also need to specify it for the frontend build with `--env.domain=https://cdn.domain.org`. 

This affects loading assets/images and lazy-loading bundles.