### PR TITLE
Fix opacity CSS for publisher drag-tool

### DIFF
--- a/bundles/mapping/mapmodule/resources/scss/mapmodule.ol.scss
+++ b/bundles/mapping/mapmodule/resources/scss/mapmodule.ol.scss
@@ -8,7 +8,7 @@ $pluginMargin: 10px;
     display: inline-block;
     position: absolute;
     right: -24px;
-    opacity: 50%;
+    opacity: 0.5;
     top: 20%;
     cursor: pointer;
 }


### PR DESCRIPTION
Otherwise on build it's set to 1% and user can't see it.