### PR TITLE
3D map vector opacity fix

### DIFF
--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/util/style.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/util/style.js
@@ -76,6 +76,11 @@ export const styleGenerator = (mapmodule, layer) => {
     if (!layer) {
         return getDefaultStyleFunction(mapmodule);
     }
+    // 3D doesn't support cluster and layer opacity is applied to style
+    // Don't use default styles or cluster
+    if (mapmodule.getSupports3D()) {
+        return mapmodule.getStyleForLayer(layer);
+    }
     const style = layer.getCurrentStyle();
     if (!style || !style.hasDefinitions()) {
         return defaultStyleGenerator(mapmodule, layer);


### PR DESCRIPTION
Layer opacity doesn't affect to vector feature styles in 3D mode. Apply layer opacity to styles in 3D mode.

Transparent is used for null color. Added ugly hack to check if color is transparent (changed transparent to 1,1,1,0 to avoid black + 0 opacity handle as transparent).
`Openlayers: Default null; if null, the Canvas/renderer default black will be used.`

Also workaroundForDash uses fixed 0.01 alpha. So layer opacity is added only for first/main style.
