### PR TITLE
MyPlaces disallow self-intersecting polygons

### DIFF
--- a/bundles/framework/myplaces3/handler/DrawHandler.js
+++ b/bundles/framework/myplaces3/handler/DrawHandler.js
@@ -68,7 +68,7 @@ export class DrawHandler {
     // DrawTools sends FeatureCollection with one Feature with multi geometry
     // It shouldn't send Feature with invalid geometry (no need to validate coordinates)
     hasValidGeometry () {
-        return this._drawing && this._drawing.features.length > 0;
+        return this._drawing && this._drawing.features.length > 0 && this._drawing.features[0].properties.valid;
     }
 
     setPlaceGeometry (place) {


### PR DESCRIPTION
Check feature's validity from properties. MyPlaces draw request has selfIntersection option so self-intersecting polygons are not allowed.

Not sure if it's better to return feature instead of collection on multiGeom:
`'multiGeom' - gathers drawn shapes into a single feature with multigeometry instead of sending multiple features in DrawingEvent`
DrawingEvent: `Drawn features in GeoJson format`

https://oskari.org/api/requests/#/unreleased/mapping/drawtools/request/startdrawingrequest.md
https://oskari.org/api/events#/unreleased/mapping/drawtools/event/DrawingEvent.md