### PR TITLE
Simplify map size-methods

### DIFF
--- a/bundles/framework/mapfull/instance.js
+++ b/bundles/framework/mapfull/instance.js
@@ -28,7 +28,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
          */
         this.mapDivId = 'mapdiv';
         this.contentMapDivId = 'contentMap';
-        this.resizeTimer = null;
         this._initialStateInit = true;
     }, {
         getName: function () {
@@ -92,20 +91,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
 
             me.mapmodule = module;
             me.getSandbox().register(module);
-
-            // react to window resize with timer so app stays responsive
-            jQuery(window).on('resize', function () {
-                clearTimeout(me.resizeTimer);
-                me.resizeTimer = setTimeout(
-                    function () {
-                        me.updateSize();
-                    },
-                    100
-                );
-            });
-
-            me.updateSize();
-
             // startup plugins
             if (me.conf.plugins) {
                 const plugins = this.conf.plugins;
@@ -515,7 +500,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
          *
          */
         updateSize: function () {
-            this.getMapModule().updateSize();
+            // FIXME: remove this function. Map module now listens to its own size
+            // this.getMapModule().updateSize();
         },
 
         /**

--- a/bundles/framework/mapfull/instance.js
+++ b/bundles/framework/mapfull/instance.js
@@ -1,3 +1,7 @@
+import './request/MapWindowFullScreenRequest';
+import './request/MapWindowFullScreenRequestHandler';
+import './request/MapSizeUpdateRequest';
+import './request/MapSizeUpdateRequestHandler';
 import { automagicPlugins } from './automagicPlugins';
 
 const LOG = Oskari.log('MapFullBundleInstance');
@@ -54,14 +58,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
         },
 
         /**
-         * @method  @public adjustMapSize adjust map size
-         */
-        adjustMapSize: function () {
-            // notify map module that size has changed
-            this.updateSize();
-        },
-
-        /**
          * @private @method _createUi
          * Creates the map module and rendes it to DOM element that has the id
          * specified by #mapDivId. Sets the size of the element if specified in
@@ -102,13 +98,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
                 clearTimeout(me.resizeTimer);
                 me.resizeTimer = setTimeout(
                     function () {
-                        me.adjustMapSize();
+                        me.updateSize();
                     },
                     100
                 );
             });
 
-            me.adjustMapSize();
+            me.updateSize();
 
             // startup plugins
             if (me.conf.plugins) {
@@ -510,16 +506,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
         },
 
         /**
-         * @method toggleFullScreen
-         * Toggles normal/full screen view of the map window.
-         *
-         *
-         */
-        toggleFullScreen: function () {
-            this.adjustMapSize();
-        },
-
-        /**
          * @public @method updateSize
          * Tells the map module that it should update/refresh its size.
          *
@@ -528,12 +514,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
          * we update the container size as well.
          *
          */
-        updateSize: function (fullUpdate) {
-            if (fullUpdate) {
-                this.adjustMapSize();
-            } else {
-                this.getMapModule().updateSize();
-            }
+        updateSize: function () {
+            this.getMapModule().updateSize();
         },
 
         /**

--- a/bundles/framework/mapfull/request/MapSizeUpdateRequestHandler.js
+++ b/bundles/framework/mapfull/request/MapSizeUpdateRequestHandler.js
@@ -20,7 +20,8 @@ Oskari.clazz.define(
          *
          */
         handleRequest: function (core, request) {
-            this.mapfull.updateSize(request.fullUpdate);
+            // FIXME: this is wrong. The Publisher makes the map element go to set size, this just updates the size info for map...
+            this.mapfull.updateSize();
         }
     }, {
         /**

--- a/bundles/framework/mapfull/request/MapWindowFullScreenRequestHandler.js
+++ b/bundles/framework/mapfull/request/MapWindowFullScreenRequestHandler.js
@@ -21,7 +21,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.request.MapWindowFullScr
      *      request to handle
      */
         handleRequest: function (core, request) {
-            this.mapfull.toggleFullScreen();
+            // FIXME: this is wrong. The FullScreen plugin makes the map element go "full screen", this just updates the size...
+            this.mapfull.updateSize();
         }
     }, {
     /**

--- a/bundles/framework/mapfull/resources/scss/style.scss
+++ b/bundles/framework/mapfull/resources/scss/style.scss
@@ -1,8 +1,0 @@
-#contentMap.oskari-map-window-fullscreen {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    z-index: 3;
-    margin: 0 !important;
-}

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1070,20 +1070,14 @@ Oskari.clazz.define(
          * Signal map-engine that DOMElement size has changed and trigger a MapSizeChangedEvent
          */
         updateSize: function () {
-            var sandbox = this.getSandbox();
-            var mapVO = sandbox.getMap();
-            var width = mapVO.getWidth();
-            var height = mapVO.getHeight();
-
             this._updateSizeImpl();
             this.updateDomain();
 
-            var widthNew = mapVO.getWidth();
-            var heightNew = mapVO.getHeight();
+            const sandbox = this.getSandbox();
+            const mapVO = sandbox.getMap();
+
             // send as an event forward
-            console.log('w: ' + width + ' -> ' + widthNew + '\n' +
-            'h: ' + height + ' -> ' + heightNew + '\n');
-            var evt = Oskari.eventBuilder('MapSizeChangedEvent')(widthNew, heightNew);
+            const evt = Oskari.eventBuilder('MapSizeChangedEvent')(mapVO.getWidth(), mapVO.getHeight());
             sandbox.notifyAll(evt);
         },
         /**

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -384,7 +384,6 @@ Oskari.clazz.define(
             this.started = this._startImpl();
             this.setMobileMode(Oskari.util.isMobile());
             me.startPlugins();
-            me._adjustMobileMapSize();
             this.updateCurrentState();
             this._registerForGuidedTour();
         },
@@ -1082,10 +1081,10 @@ Oskari.clazz.define(
             var widthNew = mapVO.getWidth();
             var heightNew = mapVO.getHeight();
             // send as an event forward
-            if (width !== widthNew || height !== heightNew) {
-                var evt = Oskari.eventBuilder('MapSizeChangedEvent')(widthNew, heightNew);
-                sandbox.notifyAll(evt);
-            }
+            console.log('w: ' + width + ' -> ' + widthNew + '\n' +
+            'h: ' + height + ' -> ' + heightNew + '\n');
+            var evt = Oskari.eventBuilder('MapSizeChangedEvent')(widthNew, heightNew);
+            sandbox.notifyAll(evt);
         },
         /**
          * @method updateCurrentState
@@ -1298,7 +1297,6 @@ Oskari.clazz.define(
             if (modeChanged) {
                 me.redrawPluginUIs(modeChanged);
             }
-            me._adjustMobileMapSize();
         },
         /**
          * @method redrawPluginUIs
@@ -1334,10 +1332,6 @@ Oskari.clazz.define(
             };
             plugins.sort((a, b) => getIndex(a) - getIndex(b));
             return plugins;
-        },
-        // NOTE! This is called from BasicMapModulePlugin so we can hide or show toolbar when buttons are added/removed
-        _adjustMobileMapSize: function () {
-            this.updateSize();
         },
 
         /* ---------------- /MAP MOBILE MODE ------------------- */
@@ -1608,7 +1602,6 @@ Oskari.clazz.define(
                     me.lazyStartPlugins.push(plugin);
                 }
             });
-            me._adjustMobileMapSize();
         },
         /**
          * @method stopPlugin

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -99,7 +99,7 @@ import './event/UserLocationEvent';
 
 import { filterFeaturesByExtent } from './util/vectorfeatures/filter';
 import { FEATURE_QUERY_ERRORS } from './domain/constants';
-
+import { monitorResize, unmonitorResize } from 'oskari-ui/components/window';
 /**
  * @class Oskari.mapping.mapmodule.AbstractMapModule
  *
@@ -386,6 +386,8 @@ Oskari.clazz.define(
             me.startPlugins();
             this.updateCurrentState();
             this._registerForGuidedTour();
+            // monitor size of element map is rendered in
+            monitorResize(this.getMapEl()[0], this.updateSize.bind(this));
         },
         /**
          * @method stop
@@ -397,6 +399,7 @@ Oskari.clazz.define(
             if (!this.started) {
                 return;
             }
+            unmonitorResize(this.updateSize.bind(this));
 
             sandbox = sandbox || this.getSandbox();
             sandbox.requestHandler('MapModulePlugin.MapLayerUpdateRequest', null);

--- a/bundles/mapping/mapmodule/resources/scss/mapmodule.ol.scss
+++ b/bundles/mapping/mapmodule/resources/scss/mapmodule.ol.scss
@@ -4,6 +4,16 @@ $pluginMargin: 10px;
     height: 100%;
 }
 
+/* Fullscreen mode assigns this class for #contentMap div */
+#contentMap.oskari-map-window-fullscreen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 3;
+    margin: 0 !important;
+}
+
 .mapplugin.toollayoutedit.ui-draggable-handle > div::after {
     content: url("../images/holder-icon.svg");
     width: 24px;

--- a/packages/framework/bundle/mapfull/bundle.js
+++ b/packages/framework/bundle/mapfull/bundle.js
@@ -59,21 +59,6 @@ function() {
         "scripts" : [{
             "type" : "text/javascript",
             "src" : "../../../../bundles/framework/mapfull/instance.js"
-        }, {
-            "type" : "text/javascript",
-            "src" : "../../../../bundles/framework/mapfull/request/MapWindowFullScreenRequest.js"
-        }, {
-            "type" : "text/javascript",
-            "src" : "../../../../bundles/framework/mapfull/request/MapWindowFullScreenRequestHandler.js"
-        }, {
-            "type" : "text/javascript",
-            "src" : "../../../../bundles/framework/mapfull/request/MapSizeUpdateRequest.js"
-        }, {
-            "type" : "text/javascript",
-            "src" : "../../../../bundles/framework/mapfull/request/MapSizeUpdateRequestHandler.js"
-        }, {
-            "type" : "text/css",
-            "src" : "../../../../bundles/framework/mapfull/resources/scss/style.scss"
         }],
         "locales": [{
             "lang": "en",

--- a/src/react/components/window/index.js
+++ b/src/react/components/window/index.js
@@ -7,6 +7,8 @@ import { REGISTER, TYPE } from './register';
 import { ThemeProvider } from '../../util/contexts';
 // expose util function for centering elements
 export { getPositionForCentering } from './util';
+// expose monitor function for detecting size changes
+export { monitorResize, unmonitorResize } from './WindowWatcher';
 
 /* ************************************************
  * Note! The API is not finalized and can change unexpectedly!!


### PR DESCRIPTION
`mapmodule` bundle now monitors its element size for changes. `mapfull` bundle no longer needs to monitor it nor notify mapmodule of changes.