### PR TITLE
Maplegend cleaning

### DIFF
--- a/bundles/framework/maplegend/Flyout.js
+++ b/bundles/framework/maplegend/Flyout.js
@@ -25,7 +25,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.Flyout',
     function (instance) {
         this.instance = instance;
         this.container = null;
-        this.sandbox = this.instance.getSandbox();
         this.state = null;
         this._legendImagesNotLoaded = {};
     }, {
@@ -71,14 +70,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.Flyout',
          * @return {String} localized text for the title of the flyout
          */
         getTitle: function () {
-            return this.instance.getLocalization('title');
+            return this.instance.loc('title');
         },
         /**
          * @method getDescription
          * @return {String} localized text for the description of the flyout
          */
         getDescription: function () {
-            return this.instance.getLocalization('desc');
+            return this.instance.loc('desc');
         },
         /**
          * @method getOptions
@@ -104,9 +103,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.Flyout',
         },
         showMetadataFlyout: function (event, uuid) {
             event.stopPropagation();
-            this.sandbox.postRequestByName('catalogue.ShowMetadataRequest', [{
-                uuid: uuid
-            }]);
+            this.instance.getSandbox().postRequestByName('catalogue.ShowMetadataRequest', [{ uuid }]);
         },
         /**
          * @method _populateLayerList
@@ -115,7 +112,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.Flyout',
          * Renders legend images as an accordion for the selected layers.
          */
         _populateLayerList: function () {
-            const layers = this.sandbox.findAllSelectedMapLayers();
+            const layers = this.instance.getSandbox().findAllSelectedMapLayers();
 
             // populate selected layer list
             const showMetadata = (event, uuid) => this.showMetadataFlyout(event, uuid);
@@ -147,5 +144,5 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.Flyout',
          * @property {String[]} protocol
          * @static
          */
-        'protocol': ['Oskari.userinterface.Flyout']
+        protocol: ['Oskari.userinterface.Flyout']
     });

--- a/bundles/framework/maplegend/LegendImage.jsx
+++ b/bundles/framework/maplegend/LegendImage.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react';
+import React, { useState } from 'react';
 import { Message } from 'oskari-ui';
 import PropTypes from 'prop-types';
 

--- a/bundles/framework/maplegend/MapLegendList.jsx
+++ b/bundles/framework/maplegend/MapLegendList.jsx
@@ -4,7 +4,6 @@ import { Collapse, CollapsePanel } from 'oskari-ui';
 import { LegendImage } from './LegendImage';
 import { MetadataIcon } from 'oskari-ui/components/icons';
 
-
 export const MapLegendList = ({ legendList }) => {
     const composeHeader = (title, uuid) => {
         return (

--- a/bundles/framework/maplegend/Tile.js
+++ b/bundles/framework/maplegend/Tile.js
@@ -36,8 +36,19 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.Tile',
          * Interface method implementation, calls #refresh()
          */
         startPlugin: function () {
-            if (this.container) {
-                this.container.addClass(this.instance.getName());
+            this._addTileStyleClasses();
+            this.refresh();
+        },
+        _addTileStyleClasses: function () {
+            const isContainer = !!((this.container && this.instance.mediator));
+            const isBundleId = !!((isContainer && this.instance.mediator.bundleId));
+            const isInstanceId = !!((isContainer && this.instance.mediator.instanceId));
+
+            if (isInstanceId && !this.container.hasClass(this.instance.mediator.instanceId)) {
+                this.container.addClass(this.instance.mediator.instanceId);
+            }
+            if (isBundleId && !this.container.hasClass(this.instance.mediator.bundleId)) {
+                this.container.addClass(this.instance.mediator.bundleId);
             }
         },
         /**

--- a/bundles/framework/maplegend/Tile.js
+++ b/bundles/framework/maplegend/Tile.js
@@ -36,19 +36,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.Tile',
          * Interface method implementation, calls #refresh()
          */
         startPlugin: function () {
-            this._addTileStyleClasses();
-            this.refresh();
-        },
-        _addTileStyleClasses: function () {
-            var isContainer = !!((this.container && this.instance.mediator));
-            var isBundleId = !!((isContainer && this.instance.mediator.bundleId));
-            var isInstanceId = !!((isContainer && this.instance.mediator.instanceId));
-
-            if (isInstanceId && !this.container.hasClass(this.instance.mediator.instanceId)) {
-                this.container.addClass(this.instance.mediator.instanceId);
-            }
-            if (isBundleId && !this.container.hasClass(this.instance.mediator.bundleId)) {
-                this.container.addClass(this.instance.mediator.bundleId);
+            if (this.container) {
+                this.container.addClass(this.instance.getName());
             }
         },
         /**
@@ -63,14 +52,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.Tile',
          * @return {String} localized text for the title of the tile
          */
         getTitle: function () {
-            return this.instance.getLocalization('title');
+            return this.instance.loc('title');
         },
         /**
          * @method getDescription
          * @return {String} localized text for the description of the tile
          */
         getDescription: function () {
-            return this.instance.getLocalization('desc');
+            return this.instance.loc('desc');
         },
         /**
          * @method getOptions
@@ -95,5 +84,5 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.Tile',
          * @property {String[]} protocol
          * @static
          */
-        'protocol': ['Oskari.userinterface.Tile']
+        protocol: ['Oskari.userinterface.Tile']
     });

--- a/bundles/framework/maplegend/plugin/MapLegendPlugin.js
+++ b/bundles/framework/maplegend/plugin/MapLegendPlugin.js
@@ -5,46 +5,37 @@ import { QuestionOutlined } from '@ant-design/icons';
 import { showMapLegendPopup } from './MapLegendPopup';
 
 Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin',
-    function (config, plugins) {
-        var me = this;
-        me._config = config || {};
-        me._plugins = plugins;
-        me._clazz = 'Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin';
-        me._defaultLocation = 'top right';
-        me._templates = {
-            maplegend: jQuery('<div class="mapplugin maplegend"></div>'),
-            legendContainer: jQuery('<div class="legendSelector"></div>'),
-            legendInfo: jQuery('<div class="legendInfo"></div>'),
-            legendDivider: jQuery('<div class="maplegend-divider"></div>')
-        };
-        me._index = 90;
-        me._element = null;
-        me._isVisible = false;
-        me._loc = null;
-        me._popup = null;
-        me._popupControls = null;
+    function (config) {
+        this._config = config || {};
+        this._clazz = 'Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin';
+        this._defaultLocation = 'top right';
+        this._index = 90;
+        this._popupControls = null;
     }, {
         _setLayerToolsEditModeImpl: function () {
             if (this.inLayerToolsEditMode() && this.isOpen()) {
-                this._toggleToolState();
+                this.clearPopup();
             }
         },
+        _startPluginImpl: function () {
+            this.addToPluginContainer(this._createControlElement());
+            this.renderButton(this._config.toolStyle);
+            return true;
+        },
+        _stopPluginImpl: function () {
+            this.clearPopup();
+            this.removeFromPluginContainer(this.getElement());
+        },
+        _createControlElement: function () {
+            return jQuery('<div class="mapplugin maplegend"></div>').clone();
+        },
+
         clearPopup: function () {
             if (this._popupControls) {
                 this._popupControls.close();
             }
             this._popupControls = null;
-            this.renderButton(null, null);
-        },
-        _createControlElement: function () {
-            var me = this,
-                loc = Oskari.getLocalization('maplegend', Oskari.getLang());
-            var isMobile = Oskari.util.isMobile();
-
-            this.inMobileMode = isMobile;
-            me._loc = loc;
-
-            return this.createDesktopElement();
+            this.renderButton();
         },
 
         /**
@@ -52,45 +43,29 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
          * Changes the tool style of the plugin
          *
          * @param {Object} style
-         * @param {jQuery} div
          */
-        changeToolStyle: function (style, div) {
-            var me = this,
-                el = div || me.getElement();
-
-            if (!el) {
-                return;
-            }
-
-            const styleClass = style || 'rounded-dark';
-
-            me.renderButton(styleClass, el);
+        changeToolStyle: function (style) {
+            this.renderButton(style);
         },
 
-        renderButton: function (style, element) {
-            let el = element;
-            if (!element) {
-                el = this.getElement();
-            }
+        renderButton: function (style) {
+            const el = this.getElement();
             if (!el) return;
 
-            let styleName = style;
-            if (!style) {
-                styleName = this.getToolStyleFromMapModule();
-            }
-
+            const styleName = style || this.getToolStyleFromMapModule();
+            const title = Oskari.getMsg('maplegend', 'tooltip');
             ReactDOM.render(
                 <MapModuleButton
                     className='t_maplegend'
-                    title={this._loc.tooltip}
+                    title={title}
                     icon={<QuestionOutlined />}
-                    styleName={styleName || 'rounded-dark'}
+                    styleName={styleName}
                     onClick={() => {
                         if (!this.inLayerToolsEditMode()) {
                             this.togglePopup();
                         }
                     }}
-                    iconActive={this._popupControls && this._popupControls !== null}
+                    iconActive={this.isOpen()}
                     position={this.getLocation()}
                 />,
                 el[0]
@@ -104,113 +79,31 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
             return layer.getLegendImage();
         },
         togglePopup: function () {
-            if (this._popupControls) {
+            if (this.isOpen()) {
                 this.clearPopup();
-            } else {
-                const legends = this.getLegends();
-                this._popupControls = showMapLegendPopup(legends, (id) => this.getLegend(id), () => this.clearPopup());
+                return;
             }
-            this.renderButton(null, null);
-        },
-        createDesktopElement: function () {
-            var me = this;
-            var legend = me._templates.maplegend.clone();
-            var popupService = me.getSandbox().getService('Oskari.userinterface.component.PopupService');
-            me._popup = popupService.createPopup();
-            me._popup.addClass('maplegend__popup');
-            popupService.closeAllPopups(true);
-
-            return legend;
-        },
-        getPopupPosition: function () {
-            var popupLocation;
-
-            if (this._config.location && this._config.location.classes === 'top left') {
-                popupLocation = 'right';
-            } else {
-                popupLocation = 'left';
-            }
-            return popupLocation;
+            const legends = this.getLegends();
+            this._popupControls = showMapLegendPopup(legends, (id) => this.getLegend(id), () => this.clearPopup());
+            this.renderButton();
         },
         getLegends: function () {
-            var layers = this.getSandbox().findAllSelectedMapLayers().slice(0);
-            var legendLayers = [];
-
-            layers.forEach(function (layer) {
-                if (!layer.getLegendImage()) {
-                    return;
-                }
-                var layerObject = {
+            return this.getSandbox().findAllSelectedMapLayers()
+                .filter(layer => layer.getLegendImage())
+                .map(layer => ({
                     id: layer.getId(),
                     title: Oskari.util.sanitize(layer.getName())
-                };
-                legendLayers.push(layerObject);
-            });
-            return legendLayers;
-        },
-        _createUI: function () {
-            var me = this,
-                conf = me._config;
-            this._element = this._createControlElement();
-            if (this._element) {
-                this.addToPluginContainer(this._element);
-            }
-            // Change the style if in the conf
-            if (conf && conf.toolStyle) {
-                me.changeToolStyle(conf.toolStyle, me.getElement());
-            } else {
-                var toolStyle = me.getToolStyleFromMapModule();
-                me.changeToolStyle(toolStyle, me.getElement());
-            }
+                }));
         },
         isOpen: function () {
-            return this._isVisible;
-        },
-
-        redrawUI: function (mapInMobileMode, forced) {
-            if (this.getElement()) {
-                this.teardownUI(true);
-            }
-
-            this._createUI();
-        },
-        teardownUI: function () {
-            // detach old element from screen
-            if (this.getElement() !== undefined) {
-                this.getElement().detach();
-                this.removeFromPluginContainer(this.getElement());
-            }
-        },
-        /**
-         * Toggle tool state.
-         * @method @private _toggleToolState
-         */
-        _toggleToolState: function () {
-            if (this.isOpen()) {
-                this._isVisible = false;
-                this._popup.close(true);
-                return this.isOpen();
-            } else {
-                this._isVisible = true;
-                this.createDesktopElement();
-            }
-        },
-        /**
-         * Get jQuery element.
-         * @method @public getElement
-         */
-        getElement: function () {
-            return this._element;
-        },
-        stopPlugin: function () {
-            this.teardownUI();
+            return !!this._popupControls;
         }
     }, {
-        'extend': ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],
+        extend: ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],
         /**
          * @static @property {string[]} protocol array of superclasses
          */
-        'protocol': [
+        protocol: [
             'Oskari.mapframework.module.Module',
             'Oskari.mapframework.ui.module.common.mapmodule.Plugin'
         ]

--- a/bundles/framework/maplegend/plugin/MapLegendPopup.jsx
+++ b/bundles/framework/maplegend/plugin/MapLegendPopup.jsx
@@ -1,72 +1,51 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import { showPopup } from 'oskari-ui/components/window';
 import { LocaleProvider } from 'oskari-ui/util';
-import { Message, Select, Option } from 'oskari-ui';
+import { Message } from 'oskari-ui';
 import styled from 'styled-components';
-
-const Content = styled('div')`
-    margin: 12px 24px 24px;
-    min-width: 300px;
-    display: flex;
-    flex-direction: column;
-`;
-
-const LegendContainer = styled('div')`
-    margin-top: 10px;
-`;
-
-const Legend = styled('div')`
-    display: flex;
-    flex-direction: column;
-`;
-
-const SelectContainer = styled('div')`
-    display: flex;
-    flex-direction: column;
-`;
+import { LegendSelect } from './components/LegendSelect';
+import { Legend } from './components/Legend';
 
 const BUNDLE_KEY = 'maplegend';
 
+const Content = styled('div')`
+    margin: 12px 24px 24px;
+    min-width: 200px;
+    display: flex;
+    flex-direction: column;
+`;
+
+const Margin = styled('div')`
+    margin-top: 10px;
+`;
+
 const MapLegendPopup = ({ legends, getLegendImage }) => {
-    const [selected, setSelected] = useState(legends && legends.length > 0 ? legends[0].id : null);
-    const [legend, setLegend] = useState(legends && legends.length > 0 ? getLegendImage(legends[0].id) : null);
+    const [selected, setSelected] = useState(legends.length > 0 ? legends[0].id : null);
+    const [legend, setLegend] = useState(legends.length > 0 ? getLegendImage(legends[0].id) : null);
+    const [hasError, setError] = useState(false);
     const onChange = (value) => {
         setSelected(value);
+        setError(false);
         setLegend(getLegendImage(value));
     };
-    
     return (
         <LocaleProvider value={{ bundleKey: BUNDLE_KEY }}>
             <Content>
-                {legends && legends.length > 1 && (
-                    <SelectContainer>
-                        <Message bundleKey={BUNDLE_KEY} messageKey='infotext' />
-                        <Select value={selected} onChange={onChange} className="t_legends">
-                            {
-                                legends.map(l =>
-                                    <Option key={l.id} value={l.id}>
-                                        {l.title}
-                                    </Option>
-                                )
-                            }
-                        </Select>
-                    </SelectContainer>
-                )}
-                {!legends || legends.length === 0 && (<Message bundleKey={BUNDLE_KEY} messageKey='noLegendsText' />)}
-                <LegendContainer>
-                    {!legend || legend === null || legend === 'null' ? (
-                        <Message bundleKey={BUNDLE_KEY} messageKey='invalidLegendUrl' />
-                    ) : (
-                        <Legend>
-                            {legends.length === 1 && (<Message bundleKey={BUNDLE_KEY} messageKey='singleLegend' />)}
-                            <a href={legend} target="_blank"><Message bundleKey={BUNDLE_KEY} messageKey='newtab' className="t_newtab" /></a>
-                            <img src={legend} />
-                        </Legend>
-                    )}
-                </LegendContainer>
+                <LegendSelect
+                    legends={legends}
+                    selected={selected}
+                    onChange={onChange} />
+                <Margin />
+                <Legend url={legend} hasError={hasError} setError={setError}/>
             </Content>
         </LocaleProvider>
     );
+};
+
+MapLegendPopup.propTypes = {
+    legends: PropTypes.array.isRequired,
+    getLegendImage: PropTypes.func.isRequired
 };
 
 export const showMapLegendPopup = (legends, getLegendImage, onClose) => {

--- a/bundles/framework/maplegend/plugin/components/Legend.jsx
+++ b/bundles/framework/maplegend/plugin/components/Legend.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Message, Link } from 'oskari-ui';
+
+export const Legend = ({ url, hasError, setError }) => {
+    if (!url || hasError) {
+        return (
+            <Message messageKey='invalidLegendUrl' />
+        );
+    }
+
+    return (
+        <div>
+            <img src={url} onError={ () => setError(true) } />
+            <br/>
+            <Link url={url}>
+                <Message messageKey='newtab'/>
+            </Link>
+        </div>
+    );
+};
+
+Legend.propTypes = {
+    url: PropTypes.string,
+    hasError: PropTypes.bool.isRequired,
+    setError: PropTypes.func.isRequired
+};

--- a/bundles/framework/maplegend/plugin/components/Legend.jsx
+++ b/bundles/framework/maplegend/plugin/components/Legend.jsx
@@ -11,11 +11,11 @@ export const Legend = ({ url, hasError, setError }) => {
 
     return (
         <div>
-            <img src={url} onError={ () => setError(true) } />
-            <br/>
-            <Link url={url}>
+            <Link tooltip={null} url={url}>
                 <Message messageKey='newtab'/>
             </Link>
+            <br/>
+            <img src={url} onError={ () => setError(true) } />
         </div>
     );
 };

--- a/bundles/framework/maplegend/plugin/components/LegendSelect.jsx
+++ b/bundles/framework/maplegend/plugin/components/LegendSelect.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Message, Select, Option } from 'oskari-ui';
+
+const SelectContainer = styled('div')`
+    display: flex;
+    flex-direction: column;
+`;
+
+export const LegendSelect = ({ legends, selected, onChange }) => {
+    const count = legends.length;
+    if (count === 0) {
+        return (
+            <Message messageKey='noLegendsText' />
+        );
+    }
+
+    if (count === 1) {
+        return (
+            <Message messageKey='singleLegend' />
+        );
+    }
+
+    return (
+        <SelectContainer>
+            <Message messageKey='infotext' />
+            <Select value={selected} onChange={onChange} className="t_legends">
+                {
+                    legends.map(l =>
+                        <Option key={l.id} value={l.id}>
+                            {l.title}
+                        </Option>
+                    )
+                }
+            </Select>
+        </SelectContainer>
+    );
+};
+
+LegendSelect.propTypes = {
+    legends: PropTypes.array.isRequired,
+    selected: PropTypes.any,
+    onChange: PropTypes.func.isRequired
+};

--- a/bundles/framework/maplegend/publisher/MapLegend.js
+++ b/bundles/framework/maplegend/publisher/MapLegend.js
@@ -24,42 +24,20 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.MapLegend',
             return this.__sandbox.findRegisteredModuleInstance(this.bundleName);
         },
         getPlugin: function () {
-            var maplegend = this.getInstance() || {};
-            return maplegend.plugin;
+            return this.getInstance().getPlugin();
         },
         /**
          * Initialise tool
          * @method init
          */
         init: function (data) {
-            var me = this;
-
-            if (!data || !data.configuration[me.bundleName]) {
+            if (!data || !data.configuration[this.bundleName]) {
                 return;
             }
-
-            me.setEnabled(true);
+            this.setEnabled(true);
         },
         isDisplayed: function () {
-            var legendLayers = [];
-            var layers = this.__sandbox.findAllSelectedMapLayers().slice(0);
-            layers.forEach(function (layer) {
-                if (!layer.getLegendImage()) {
-                    return;
-                }
-
-                var layerObject = {
-                    id: layer.getId(),
-                    title: Oskari.util.sanitize(layer.getName())
-                };
-
-                legendLayers.push(layerObject);
-            });
-
-            if (legendLayers === undefined || legendLayers.length == 0) {
-                return false;
-            }
-            return true;
+            return this.getSandbox().findAllSelectedMapLayers().some(l => l.getLegendImage());
         },
         /**
          * Set enabled.
@@ -69,22 +47,18 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.MapLegend',
          * @param {Boolean} enabled is tool enabled or not
          */
         setEnabled: function (enabled) {
-            var me = this;
-
             // state actually hasn't changed -> do nothing
-            if (me.state.enabled !== undefined && me.state.enabled !== null && enabled === me.state.enabled) {
+            if (enabled === this.state.enabled) {
                 return;
             }
-            me.state.enabled = enabled;
+            this.state.enabled = enabled;
 
             if (enabled) {
-                me.getInstance().createPlugin();
-                me.__started = true;
+                this.getInstance().createPlugin();
+                this.__started = true;
             } else {
-                if (me.getInstance().plugin) {
-                    me.getInstance().stopPlugin();
-                }
-                me.__started = false;
+                this.getInstance().stopPlugin();
+                this.__started = false;
             }
         },
         /**
@@ -95,23 +69,19 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.MapLegend',
          * @returns {Object} tool value object
          */
         getValues: function () {
-            var me = this;
-            if (me.state.enabled) {
-                var pluginConfig = this.getPlugin().getConfig();
-
-                var json = {
-                    configuration: {}
+            if (this.isEnabled()) {
+                return {
+                    configuration: {
+                        [this.bundleName]: {
+                            conf: this.getPlugin().getConfig(),
+                            state: {}
+                        }
+                    }
                 };
-                json.configuration[me.bundleName] = {
-                    conf: pluginConfig,
-                    state: {}
-                };
-                return json;
-            } else {
-                return null;
             }
+            return null;
         }
     }, {
-        'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],
-        'protocol': ['Oskari.mapframework.publisher.Tool']
+        extend: ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],
+        protocol: ['Oskari.mapframework.publisher.Tool']
     });

--- a/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
@@ -313,11 +313,10 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
         /**
          * @public @method getToolStyleFromMapModule
          *
-         * @return {Object} style object used by mapmodule or null if not available.
+         * @return {String} style class used by mapmodule or default.
          */
         getToolStyleFromMapModule: function () {
-            var value = this.getMapModule().getToolStyle();
-            return value || null;
+            return this.getMapModule().getToolStyle() || 'rounded-dark';
         },
         /**
          * @public @method getToolStyleFromMapModule


### PR DESCRIPTION
Cleaning:
- remove _templates, popup and other jQuery related stuff from plugin
- remove redrawUI from plugin as desktop and mobile have sam UI

Refactoring:
- var => const
- me => this
- localization
- remove '' from object keys
- add Legend.jsx and LegendSelect.jsx

Changes:
- BasicBasicMapModulePlugin getToolStyleFromMapModule defaults to  'rounded-dark'
- added onError to Legend.jsx and changed to use Link component
- popup min width 300 => 200