### PR TITLE
Fix PanButtons publisher tool / Bump ESLint ecmaVersion for optional chaining

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,7 +34,7 @@ module.exports = {
     // ----
     },
     parserOptions: {
-        ecmaVersion: 9,
+        ecmaVersion: 2020,
         sourceType: 'module'
     },
     // https://github.com/feross/standard/blob/master/RULES.md#javascript-standard-style

--- a/bundles/framework/publisher2/tools/PanButtonsTool.js
+++ b/bundles/framework/publisher2/tools/PanButtonsTool.js
@@ -27,7 +27,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.PanButtonsTool',
             return {
                 id: 'Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
                 title: 'PanButtons',
-                config: plugin.config || {}
+                config: plugin?.config || {}
             };
         },
         /**


### PR DESCRIPTION
Plugin is not always present or have config.

Using optional chaining: https://caniuse.com/mdn-javascript_operators_optional_chaining

Looking at built min.js code Babel doesn't transform optional chaining at the moment but we also have these from some of our dependencies so if they become a problem we need to solve it at build level anyway.