### PR TITLE
Drawtools multigeom fix

### DIFF
--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
@@ -261,13 +261,13 @@ Oskari.clazz.define(
             let geometry;
             switch (first.getGeometry().getType()) {
             case 'Point':
-                geometry = new olGeom.MultiPoint([coords]);
+                geometry = new olGeom.MultiPoint(coords);
                 break;
             case 'LineString':
-                geometry = new olGeom.MultiLineString([coords]);
+                geometry = new olGeom.MultiLineString(coords);
                 break;
             case 'Polygon':
-                geometry = new olGeom.MultiPolygon([coords]);
+                geometry = new olGeom.MultiPolygon(coords);
                 break;
             default:
                 throw new Error('Unsupported geometry type!');

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol.test.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol.test.js
@@ -132,11 +132,11 @@ describe('DrawPlugin', () => {
             expect(features).toEqual([]);
         });
         test('multiGeom', () => {
-            const geojson = {
+            const geom = {
                 type: 'MultiPoint',
                 coordinates: [[350208, 7011328], [385024, 6982144], [330240, 6947328]]
             };
-            draw('Point', { allowMultipleDrawing: 'multiGeom', geojson });
+            draw('Point', { allowMultipleDrawing: 'multiGeom', geojson: geom });
             // drawtools doesn't handle multi geoms
             // check from source that multigeom is parsed to simple features
             const olFeatures = plugin.getDrawSource().getFeatures();
@@ -148,7 +148,7 @@ describe('DrawPlugin', () => {
             // for event splitted features are gathered to one MultiPoint
             const { features } = getGeoJSON();
             expect(features.length).toBe(1);
-            expect(features[0].geometry.type).toEqual('MultiPoint');
+            expect(features[0].geometry).toEqual(geom);
             expect(features[0].properties.valid).toBe(true);
         });
         test('selfIntersect', () => {


### PR DESCRIPTION
Remove extra array. Compare geojson's geometry to geom to check coordinates and type.