### PR TITLE
Drawtools tooltip click

### DIFF
--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
@@ -742,7 +742,8 @@ Oskari.clazz.define(
          * @param {Object} options
          */
         checkIntersection: function (feature) {
-            if (!this.getOpts('limits').selfIntersection) {
+            // user can draw or modify intersecting polygons only if shape is polygon (not for Circle, Box, Square)
+            if (this.getShape() !== 'Polygon' || !this.getOpts('limits').selfIntersection) {
                 return false;
             }
             const geometry = feature.getGeometry();

--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
@@ -992,6 +992,7 @@ Oskari.clazz.define(
             tooltipElement.className = `drawplugin-tooltip-measure ${shape} ${id}`;
             const tooltip = new olOverlay({
                 element: tooltipElement,
+                stopEvent: false,
                 offset: [0, -5],
                 positioning: 'bottom-center',
                 id: id


### PR DESCRIPTION
Allow to click map trough measurement tooltip/overlay.

Check polygon's self intersection only if shape is polygon. User can draw or modify intersecting polygons only if shape is polygon (not for Circle, Box, Square).

ol.overlay.stopEvent:
`Whether event propagation to the map viewport should be stopped. If true the overlay is placed in the same container as that of the controls (CSS class name ol-overlaycontainer-stopevent); if false it is placed in the container with CSS class name specified by the className property.`