### PR TITLE
Make map and it's controls theme-aware

### DIFF
--- a/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
+++ b/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
@@ -1,9 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { MapModuleButton } from '../../../mapping/mapmodule/MapModuleButton';
+import styled from 'styled-components';
 
 const cloneJSON = (original) => JSON.parse(JSON.stringify(original));
 
+const StyledDiv = styled('div')`
+    font-weight: bold;
+`;
+const CoordinateIcon = () => (<StyledDiv>XY</StyledDiv>);
 /**
  * @class Oskari.mapframework.bundle.coordinatetool.plugin.CoordinateToolPlugin
  * Provides a coordinate display for map
@@ -1127,21 +1132,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
             }
             if (!el) return;
 
-            let styleName = style;
-            if (!style) {
-                styleName = this.getToolStyleFromMapModule();
-            }
-
-            const CoordinateIcon = () => (
-                <div>XY</div>
-            );
-
             ReactDOM.render(
                 <MapModuleButton
                     className='t_coordinatetool'
                     title={this._locale('display.tooltip.tool')}
                     icon={<CoordinateIcon />}
-                    styleName={styleName || 'rounded-dark'}
                     onClick={() => {
                         if (!this.inLayerToolsEditMode()) {
                             this._toggleToolState();

--- a/bundles/framework/maplegend/plugin/MapLegendPlugin.js
+++ b/bundles/framework/maplegend/plugin/MapLegendPlugin.js
@@ -50,16 +50,16 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
 
         renderButton: function (style) {
             const el = this.getElement();
-            if (!el) return;
+            if (!el) {
+                return;
+            }
 
-            const styleName = style || this.getToolStyleFromMapModule();
             const title = Oskari.getMsg('maplegend', 'tooltip');
             ReactDOM.render(
                 <MapModuleButton
                     className='t_maplegend'
                     title={title}
                     icon={<QuestionOutlined />}
-                    styleName={styleName}
                     onClick={() => {
                         if (!this.inLayerToolsEditMode()) {
                             this.togglePopup();

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1391,6 +1391,50 @@ Oskari.clazz.define(
                 return 'light';
             }
         },
+        __cachedTheme: null,
+        getMapTheme: function() {
+            if (this.__cachedTheme) {
+                return this.__cachedTheme;
+            }
+            const { map = {}, ...appTheme } = Oskari.app.getTheming().getTheme();
+            // take "global" theme as base and override anything specified for map
+            let mapTheme = {
+                ...appTheme,
+                ...map
+            };
+            if (!mapTheme.navigation) {
+                mapTheme.navigation = {};
+            }
+            const style = this.getToolStyle() || 'rounded-dark';
+            const [shape, theme] = style.split('-');
+            if (!mapTheme.navigation.roundness) {
+                mapTheme.navigation.roundness = 0;
+                if (shape === 'rounded') {
+                    mapTheme.navigation.roundness = 100;
+                } else if (shape === '3d') {
+                    mapTheme.navigation.roundness = 20;
+                }
+            }
+            if (!mapTheme.navigation.color) {
+                mapTheme.navigation.color = {};
+            }
+            // #141414 -> rgb(20,20,20)
+            // #3c3c3c -> rgb(60,60,60)
+            mapTheme.navigation.color.primary = '#141414';
+            mapTheme.navigation.color.accent = '#ffd400';
+            mapTheme.navigation.color.text = '#ffffff';
+
+            if (shape === '3d') {
+                // themehelper calculates gradients when this is set
+                mapTheme.navigation.effect = '3D';
+            }
+            if (theme === 'light') {
+                mapTheme.navigation.color.primary = '#ffffff';
+                mapTheme.navigation.color.text = '#000000';
+            }
+            this.__cachedTheme = mapTheme;
+            return mapTheme;
+        },
 
         getThemeColours: function (theme) {
             var me = this;
@@ -2130,6 +2174,7 @@ Oskari.clazz.define(
          * @param {Object} style The style object to be applied on all plugins that support changing style.
          */
         changeToolStyle: function (style) {
+            this.__cachedTheme = null;
             const clonedStyle = {
                 ...style
             };

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1407,6 +1407,7 @@ Oskari.clazz.define(
             this.__cachedTheme = mapTheme;
             return mapTheme;
         },
+        // generates base style for map
         __injectThemeByToolStyle: function (toolStyle) {
             // Note! these should be configurable on publisher BUT we might want to use some injected theme for "wellkonwn toolstyles"
             const mapTheme = {
@@ -1427,12 +1428,12 @@ Oskari.clazz.define(
                 color: {
                     header: {
                         bg: '#3c3c3c'
-                    },
+                    }
                     // accent should be inherited from global theme accent if not configured
                     // accent: '#ffd400'
                 }
                 // /For popup headers opened by map ^
-            }
+            };
             const style = toolStyle || 'rounded-dark';
             const [shape, theme] = style.split('-');
             if (shape === 'rounded') {
@@ -1447,10 +1448,10 @@ Oskari.clazz.define(
                 // buttons
                 mapTheme.navigation.color.primary = '#ffffff';
                 mapTheme.navigation.color.text = '#000000';
-                //  popup
+                // popup
                 mapTheme.color.header.bg = '#ffffff';
             }
-            
+
             return mapTheme;
         },
 

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1400,39 +1400,57 @@ Oskari.clazz.define(
             // take "global" theme as base and override anything specified for map
             let mapTheme = {
                 ...appTheme,
+                ...this.__injectThemeByToolStyle(this.getToolStyle()),
                 ...map
             };
-            if (!mapTheme.navigation) {
-                mapTheme.navigation = {};
-            }
-            const style = this.getToolStyle() || 'rounded-dark';
-            const [shape, theme] = style.split('-');
-            if (!mapTheme.navigation.roundness) {
-                mapTheme.navigation.roundness = 0;
-                if (shape === 'rounded') {
-                    mapTheme.navigation.roundness = 100;
-                } else if (shape === '3d') {
-                    mapTheme.navigation.roundness = 20;
-                }
-            }
-            if (!mapTheme.navigation.color) {
-                mapTheme.navigation.color = {};
-            }
-            // #141414 -> rgb(20,20,20)
-            // #3c3c3c -> rgb(60,60,60)
-            mapTheme.navigation.color.primary = '#141414';
-            mapTheme.navigation.color.accent = '#ffd400';
-            mapTheme.navigation.color.text = '#ffffff';
 
-            if (shape === '3d') {
+            this.__cachedTheme = mapTheme;
+            return mapTheme;
+        },
+        __injectThemeByToolStyle: function (toolStyle) {
+            // Note! these should be configurable on publisher BUT we might want to use some injected theme for "wellkonwn toolstyles"
+            const mapTheme = {
+                // For buttons on map
+                navigation: {
+                    roundness: 0,
+                    color: {
+                        // #141414 -> rgb(20,20,20)
+                        // #3c3c3c -> rgb(60,60,60)
+                        primary: '#141414',
+                        accent: '#ffd400',
+                        text: '#ffffff'
+                    }
+                },
+                // /For buttons on map ^
+                // --------------
+                // For popup headers opened by map:
+                color: {
+                    header: {
+                        bg: '#3c3c3c'
+                    },
+                    // accent should be inherited from global theme accent if not configured
+                    // accent: '#ffd400'
+                }
+                // /For popup headers opened by map ^
+            }
+            const style = toolStyle || 'rounded-dark';
+            const [shape, theme] = style.split('-');
+            if (shape === 'rounded') {
+                mapTheme.navigation.roundness = 100;
+            } else if (shape === '3d') {
+                mapTheme.navigation.roundness = 20;
                 // themehelper calculates gradients when this is set
                 mapTheme.navigation.effect = '3D';
             }
+
             if (theme === 'light') {
+                // buttons
                 mapTheme.navigation.color.primary = '#ffffff';
                 mapTheme.navigation.color.text = '#000000';
+                //  popup
+                mapTheme.color.header.bg = '#ffffff';
             }
-            this.__cachedTheme = mapTheme;
+            
             return mapTheme;
         },
 

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1392,7 +1392,7 @@ Oskari.clazz.define(
             }
         },
         __cachedTheme: null,
-        getMapTheme: function() {
+        getMapTheme: function () {
             if (this.__cachedTheme) {
                 return this.__cachedTheme;
             }

--- a/bundles/mapping/mapmodule/MapModuleButton.jsx
+++ b/bundles/mapping/mapmodule/MapModuleButton.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { MapButton, Toolbar } from 'oskari-ui/components/buttons';
+import { ThemeProvider } from 'oskari-ui/util/contexts';
 import styled from 'styled-components';
 
 const Container = styled('div')`
@@ -14,67 +15,11 @@ const Container = styled('div')`
 `;
 
 const StyledButton = styled(MapButton)`
+    opacity: 0.8;
     z-index: 1;
 `;
-
-const THEME_LIGHT = {
-    color: {
-        primary: '#ffffff',
-        accent: '#000000'
-    }
-};
-const THEME_LIGHT_GRADIENT = {
-    color: {
-        primary: 'linear-gradient(180deg, rgba(255,255,255,1) 0%, rgba(240,240,240,1) 35%, rgba(221,221,221,1) 100%)',
-        accent: '#000000'
-    }
-};
-const THEME_DARK = {
-    color: {
-        primary: '#3c3c3c',
-        accent: '#ffffff'
-    }
-};
-const THEME_DARK_GRADIENT = {
-    color: {
-        primary: 'linear-gradient(180deg, rgba(101,101,101,1) 0%, rgba(60,60,60,1) 35%, rgba(9,9,9,1) 100%)',
-        accent: '#ffffff'
-    }
-};
-
-export const MapModuleButton = ({ styleName, title, icon, onClick, size = '32px', noMargin = false, iconActive = false, withToolbar = false, iconSize = '18px', className, children, disabled = false, position, toolbarDirection }) => {
+export const MapModuleButton = ({ title, icon, onClick, size = '32px', noMargin = false, iconActive = false, withToolbar = false, iconSize = '18px', className, children, disabled = false, position, toolbarDirection }) => {
     const [toolbarOpen, setToolbarOpen] = useState(false);
-
-    let roundingPercent = 0;
-    let color;
-
-    let style = 'rounded-dark';
-    if (styleName) {
-        style = styleName;
-    }
-
-    const [shape, theme] = style.split('-');
-
-    if (shape === 'rounded') {
-        roundingPercent = 50;
-    } else if (shape === 'sharp') {
-        roundingPercent = 0;
-    } else if (shape === '3d') {
-        roundingPercent = 10;
-    }
-    if (theme === 'light') {
-        if (shape === '3d') {
-            color = THEME_LIGHT_GRADIENT;
-        } else {
-            color = THEME_LIGHT;
-        }
-    } else if (theme === 'dark') {
-        if (shape === '3d') {
-            color = THEME_DARK_GRADIENT
-        } else {
-            color = THEME_DARK;
-        }
-    }
 
     let toolbarOpenDirection = 'right';
     if (toolbarDirection) {
@@ -91,26 +36,29 @@ export const MapModuleButton = ({ styleName, title, icon, onClick, size = '32px'
         toolbarMaxWidth = children.length * 34 + 10;
         toolbarMargin = `margin-${marginDirection}: ${toolbarMaxWidth}px`;
     }
-
+    // FIXME: we shouldn't reference mapmodule here, BUT the themeprovider should be in map module and not here.
+    // after we have fully migrated the tools on map to React we can pass theme from map module with ThemeProvider and remove it from here.
+    const mapModule = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule');
     return (
-        <Container size={size} noMargin={noMargin} withToolbar={withToolbar} toolbarOpen={toolbarOpen} toolbarMargin={toolbarMargin}>
-            <StyledButton
-                onClick={withToolbar ? () => setToolbarOpen(!toolbarOpen) : onClick}
-                icon={icon}
-                theme={{ ...color, roundingPercent }}
-                title={title}
-                size={size}
-                iconActive={iconActive || (withToolbar && toolbarOpen)}
-                iconSize={iconSize}
-                className={className}
-                disabled={disabled}
-                position={position}
-            />
-            {withToolbar && (
-                <Toolbar height='32px' open={toolbarOpen} shape={shape} direction={toolbarOpenDirection} maxWidth={toolbarMaxWidth + 100}>
-                    {children}
-                </Toolbar>
-            )}
-        </Container>
+        <ThemeProvider value={mapModule.getMapTheme()}>
+            <Container size={size} noMargin={noMargin} withToolbar={withToolbar} toolbarOpen={toolbarOpen} toolbarMargin={toolbarMargin}>
+                <StyledButton
+                    onClick={withToolbar ? () => setToolbarOpen(!toolbarOpen) : onClick}
+                    icon={icon}
+                    title={title}
+                    size={size}
+                    iconActive={iconActive || (withToolbar && toolbarOpen)}
+                    iconSize={iconSize}
+                    className={className}
+                    disabled={disabled}
+                    position={position}
+                />
+                {withToolbar && (
+                    <Toolbar height='32px' open={toolbarOpen} shape={shape} direction={toolbarOpenDirection} maxWidth={toolbarMaxWidth + 100}>
+                        {children}
+                    </Toolbar>
+                )}
+            </Container>
+        </ThemeProvider>
     );
 };

--- a/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol.js
@@ -148,6 +148,14 @@ Oskari.clazz.define(
             }
             if (!el) return;
             el = el.find('.indexmapToggle');
+            // the icon is switched based on styleName -> passed to classes -> see scss
+            let styleName = style;
+            if (!style) {
+                styleName = this.getToolStyleFromMapModule();
+            }
+            if (!styleName) {
+                styleName = 'rounded-dark';
+            }
 
             ReactDOM.render(
                 <div className={`indexmapToggle ${styleName}`}>

--- a/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol.js
@@ -149,14 +149,6 @@ Oskari.clazz.define(
             if (!el) return;
             el = el.find('.indexmapToggle');
 
-            let styleName = style;
-            if (!style) {
-                styleName = this.getToolStyleFromMapModule();
-            }
-            if (!styleName) {
-                styleName = 'rounded-dark';
-            }
-
             ReactDOM.render(
                 <div className={`indexmapToggle ${styleName}`}>
                     <MapModuleButton
@@ -167,7 +159,6 @@ Oskari.clazz.define(
                             }
                         }}
                         size='48px'
-                        styleName={styleName}
                         icon={<div className='icon' />}
                     />
                 </div>,

--- a/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPlugin.js
@@ -425,15 +425,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionP
             };
             if (!el) return;
 
-            let styleName = style;
-            if (!style) {
-                styleName = this.getToolStyleFromMapModule();
-            }
-
             ReactDOM.render(
                 <MapModuleButton
                     className='t_layerselect'
-                    styleName={styleName || 'rounded-dark'}
                     icon={<LayersIcon />}
                     title={this._loc.title}
                     onClick={(e) => {

--- a/bundles/mapping/mapmodule/plugin/mylocation/MyLocationPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/mylocation/MyLocationPlugin.js
@@ -102,11 +102,9 @@ Oskari.clazz.define(
             if (!el) {
                 return;
             }
-            const styleClass = style || 'rounded-dark';
             ReactDOM.render(
                 <MapModuleButton
                     className='t_mylocation'
-                    styleName={styleClass}
                     icon={<AimOutlined />}
                     title={this.loc('plugin.MyLocationPlugin.tooltip')}
                     onClick={(e) => {

--- a/bundles/mapping/mapmodule/plugin/panbuttons/PanButton.jsx
+++ b/bundles/mapping/mapmodule/plugin/panbuttons/PanButton.jsx
@@ -4,17 +4,20 @@ import styled from 'styled-components';
 import { PanButton3D } from './PanButton3D';
 import { ReturnIcon } from 'oskari-ui/components/icons';
 import { MapModuleButton } from '../../MapModuleButton';
+import { ThemeConsumer } from 'oskari-ui/util';
+import { getNavigationTheme } from 'oskari-ui/theme';
 
 const StyledButtonContainer = styled('div')`
     position: relative;
     margin-bottom: 20px;
-    ${(props) => props.rounded && 'border-radius: 50%;'}
+    ${(props) => props.roundness && `border-radius: ${props.roundness};`}
     box-shadow: 1px 1px 2px 1px rgb(0 0 0 / 60%);
+    opacity: 0.8;
 `;
 
 const StyledReturnButton = styled('div')`
     cursor: pointer;
-    ${(props) => props.rounded && 'border-radius: 50%;'}
+    ${(props) => props.roundness && `border-radius: ${props.roundness};`}
     width: 40px;
     height: 40px;
     background-color: ${(props) => props.backgroundColor};
@@ -24,7 +27,7 @@ const StyledReturnButton = styled('div')`
     box-shadow: 1px 1px 2px rgb(0 0 0 / 60%);
     fill: ${(props) => props.iconColor};
     &:hover {
-        fill: #ffd400;
+        fill: ${(props) => props.hovercolor};
     }
     svg {
         width: 18px;
@@ -33,7 +36,7 @@ const StyledReturnButton = styled('div')`
 `;
 
 const StyledArrowsButton = styled('div')`
-    ${(props) => props.rounded && 'border-radius: 50%;'}
+    ${(props) => props.roundness && `border-radius: ${props.roundness};`}
     width: 84px;
     height: 84px;
     display: flex;
@@ -58,31 +61,34 @@ const ArrowIcon = styled('div')`
     left: ${props => props.left};
     color: ${(props) => props.color};
     &:hover {
-        color: #ffd400;
+        color: ${(props) => props.hovercolor};
     }
 `;
 
-const ArrowButton = ({ children, onClick, color, top = 'initial', right = 'initial', bottom = 'initial', left = 'initial' }) => {
+const ArrowButton = ({ children, onClick, colors, top = 'initial', right = 'initial', bottom = 'initial', left = 'initial' }) => {
     return (
-        <ArrowIcon onClick={onClick} color={color} top={top} right={right} bottom={bottom} left={left}>
+        <ArrowIcon onClick={onClick} color={colors.icon} hovercolor={colors.hover} top={top} right={right} bottom={bottom} left={left}>
             {children}
         </ArrowIcon>
     );
 }
 
-export const PanButton = ({ resetClicked, panClicked, styleName = 'rounded-dark', isMobile = false, showArrows = false }) => {
+export const PanButton = ThemeConsumer(({ theme, resetClicked, panClicked, isMobile = false, showArrows = false }) => {
 
-    const [shape, color] = styleName.split('-');
-    let iconColor = '#ffffff';
-    let backgroundColor = "#3c3c3c";
-
-    if (color === 'light') {
-        iconColor = "#3c3c3c";
-        backgroundColor = "#ffffff";
+    const helper = getNavigationTheme(theme);
+    const bgColor = helper.getButtonColor();
+    const icon = helper.getTextColor();
+    const hover = helper.getButtonHoverColor();
+    const rounding = helper.getButtonRoundness();
+    const colors = {
+        primary: helper.getPrimary(),
+        bgColor,
+        icon,
+        hover
     }
 
-    if (shape === '3d') {
-        return <PanButton3D resetClicked={resetClicked} panClicked={panClicked} color={color} isMobile={isMobile} showArrows={showArrows} />
+    if (helper.getEffect() === '3D') {
+        return (<PanButton3D resetClicked={resetClicked} panClicked={panClicked} colors={colors} isMobile={isMobile} showArrows={showArrows} />);
     }
 
     if (isMobile || !showArrows) {
@@ -90,7 +96,6 @@ export const PanButton = ({ resetClicked, panClicked, styleName = 'rounded-dark'
             <MapModuleButton
                 onClick={resetClicked}
                 title={Oskari.getMsg('MapModule', 'plugin.PanButtonsPlugin.center.tooltip')}
-                styleName={styleName}
                 icon={<ReturnIcon />}
                 iconSize='18px'
                 className='t_reset'
@@ -100,25 +105,30 @@ export const PanButton = ({ resetClicked, panClicked, styleName = 'rounded-dark'
 
     return (
         <div>
-            <StyledButtonContainer rounded={shape === 'rounded'}>
-                <ArrowButton color={iconColor} onClick={() => panClicked(0, -1)} right='32px' top='0' className='t_pan_up'>
+            <StyledButtonContainer roundness={rounding}>
+                <ArrowButton colors={colors} onClick={() => panClicked(0, -1)} right='32px' top='0' className='t_pan_up'>
                     <CaretUpOutlined />
                 </ArrowButton>
-                <ArrowButton color={iconColor} onClick={() => panClicked(-1, 0)} left='0' top='32px' className='t_pan_right'>
+                <ArrowButton colors={colors} onClick={() => panClicked(-1, 0)} left='0' top='32px' className='t_pan_right'>
                     <CaretLeftOutlined />
                 </ArrowButton>
-                <StyledArrowsButton backgroundColor={backgroundColor} rounded={shape === 'rounded'}>
-                    <StyledReturnButton onClick={resetClicked} title={Oskari.getMsg('MapModule', 'plugin.PanButtonsPlugin.center.tooltip')} backgroundColor={backgroundColor} iconColor={iconColor} rounded={shape === 'rounded'} className='t_reset'>
+                <StyledArrowsButton backgroundColor={bgColor} roundness={rounding}>
+                    <StyledReturnButton onClick={resetClicked} title={Oskari.getMsg('MapModule', 'plugin.PanButtonsPlugin.center.tooltip')}
+                        backgroundColor={bgColor}
+                        iconColor={icon}
+                        hovercolor={hover}
+                        roundness={rounding}
+                        className='t_reset'>
                         <ReturnIcon />
                     </StyledReturnButton>
                 </StyledArrowsButton>
-                <ArrowButton color={iconColor} onClick={() => panClicked(0, 1)} right='32px' bottom='0' className='t_pan_down'>
+                <ArrowButton colors={colors} onClick={() => panClicked(0, 1)} right='32px' bottom='0' className='t_pan_down'>
                     <CaretDownOutlined />
                 </ArrowButton>
-                <ArrowButton color={iconColor} onClick={() => panClicked(1, 0)} right='0' top='32px' className='t_pan_left'>
+                <ArrowButton colors={colors} onClick={() => panClicked(1, 0)} right='0' top='32px' className='t_pan_left'>
                     <CaretRightOutlined />
                 </ArrowButton>
             </StyledButtonContainer>
         </div>
     );
-}
+});

--- a/bundles/mapping/mapmodule/plugin/panbuttons/PanButton3D.jsx
+++ b/bundles/mapping/mapmodule/plugin/panbuttons/PanButton3D.jsx
@@ -3,10 +3,12 @@ import { CaretDownOutlined, CaretUpOutlined, CaretLeftOutlined, CaretRightOutlin
 import styled from 'styled-components';
 import { ReturnIcon } from 'oskari-ui/components/icons';
 import { MapModuleButton } from '../../MapModuleButton';
+import { getColorEffect, EFFECT } from 'oskari-ui/theme';
 
 const StyledButtonContainer = styled('div')`
     position: relative;
     margin: 0 25px 20px 25px;
+    opacity: 0.8;
 `;
 
 const StyledButton = styled('div')`
@@ -56,7 +58,7 @@ const StyledReturnButton = styled('div')`
     fill: ${(props) => props.color};
     z-index: 1;
     &:hover {
-        fill: #ffd400;
+        fill: ${(props) => props.hovercolor};
     }
     svg {
         width: 18px;
@@ -80,36 +82,27 @@ const ArrowIcon = styled('div')`
     left: ${props => props.left};
     color: ${(props) => props.color};
     &:hover {
-        color: #ffd400;
+        color: ${(props) => props.hovercolor};
     }
 `;
 
-const ArrowButton = ({ children, onClick, color, top = 'initial', right = 'initial', bottom = 'initial', left = 'initial' }) => {
+const ArrowButton = ({ children, onClick, colors, top = 'initial', right = 'initial', bottom = 'initial', left = 'initial' }) => {
     return (
-        <ArrowIcon onClick={onClick} color={color} top={top} right={right} bottom={bottom} left={left}>
+        <ArrowIcon onClick={onClick} color={colors.icon} hovercolor={colors.hover} top={top} right={right} bottom={bottom} left={left}>
             {children}
         </ArrowIcon>
     );
 }
 
-export const PanButton3D = ({ resetClicked, panClicked, color = 'dark', isMobile = false, showArrows = false }) => {
-
-    let backgroundV = 'linear-gradient(180deg,rgba(101,101,101,1) 0%,rgba(60,60,60,1) 35%,rgba(9,9,9,1) 100%)';
-    let backgroundH = 'linear-gradient(180deg,#3c3c3c 0%,rgba(60,60,60,1) 35%,#232323 100%)';
-    let iconColor = '#ffffff';
-
-    if (color === 'light') {
-        backgroundV = 'linear-gradient(180deg,rgba(255,255,255,1) 0%,rgba(240,240,240,1) 35%,rgba(221,221,221,1) 100%)';
-        backgroundH = 'linear-gradient(180deg,#efefef 0%,rgba(240,240,240,1) 35%,#e6e6e6 100%)';
-        iconColor = '#3c3c3c';
-    }
-
+export const PanButton3D = ({ colors, resetClicked, panClicked, isMobile = false, showArrows = false }) => {
+    const { bgColor, icon, hover, primary } = colors;
+    let backgroundV = bgColor;
+    let backgroundH = `linear-gradient(180deg, ${primary} 0%, ${primary} 35%, ${getColorEffect(primary, EFFECT.LIGHTEN_MINOR)} 100%)`;
     if (isMobile || !showArrows) {
         return (
             <MapModuleButton
                 icon={<MobileIcon />}
                 title={Oskari.getMsg('MapModule', 'plugin.PanButtonsPlugin.center.tooltip')}
-                styleName={`3d-${color}`}
                 onClick={resetClicked}
                 iconSize='18px'
                 className='t_reset'
@@ -120,22 +113,22 @@ export const PanButton3D = ({ resetClicked, panClicked, color = 'dark', isMobile
     return (
         <StyledButtonContainer>
             <StyledButton backgroundV={backgroundV} backgroundH={backgroundH} >
-                <ArrowButton color={iconColor} onClick={() => panClicked(0, -1)} right='2.5px' top='0' className='t_pan_up'>
+                <ArrowButton colors={colors} onClick={() => panClicked(0, -1)} right='2.5px' top='0' className='t_pan_up'>
                     <CaretUpOutlined />
                 </ArrowButton>
-                <ArrowButton color={iconColor} onClick={() => panClicked(-1, 0)} left='-29.5px' top='32px' className='t_pan_right'>
+                <ArrowButton colors={colors} onClick={() => panClicked(-1, 0)} left='-29.5px' top='32px' className='t_pan_right'>
                     <CaretLeftOutlined />
                 </ArrowButton>
-                <StyledReturnButton title={Oskari.getMsg('MapModule', 'plugin.PanButtonsPlugin.center.tooltip')} color={iconColor} onClick={resetClicked} className='t_reset'>
+                <StyledReturnButton title={Oskari.getMsg('MapModule', 'plugin.PanButtonsPlugin.center.tooltip')} color={icon} hovercolor={hover}  onClick={resetClicked} className='t_reset'>
                     <ReturnIcon />
                 </StyledReturnButton>
-                <ArrowButton color={iconColor} onClick={() => panClicked(0, 1)} right='2.5px' bottom='0' className='t_pan_right'>
+                <ArrowButton colors={colors} onClick={() => panClicked(0, 1)} right='2.5px' bottom='0' className='t_pan_right'>
                     <CaretDownOutlined />
                 </ArrowButton>
-                <ArrowButton color={iconColor} onClick={() => panClicked(1, 0)} right='-29.5px' top='32px' className='t_pan_left'>
+                <ArrowButton colors={colors} onClick={() => panClicked(1, 0)} right='-29.5px' top='32px' className='t_pan_left'>
                     <CaretRightOutlined />
                 </ArrowButton>
             </StyledButton>
         </StyledButtonContainer>
     );
-}
+};

--- a/bundles/mapping/mapmodule/plugin/panbuttons/PanButtons.js
+++ b/bundles/mapping/mapmodule/plugin/panbuttons/PanButtons.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { PanButton } from './PanButton';
 import { showResetPopup } from '../../MapResetPopup';
+import { ThemeProvider } from 'oskari-ui/util/contexts';
 
 /**
  * @class Oskari.mapframework.bundle.mapmodule.plugin.PanButtons
@@ -114,19 +115,15 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
             }
             if (!el) return;
 
-            let styleName = style;
-            if (!style) {
-                styleName = this.getToolStyleFromMapModule();
-            }
-
             ReactDOM.render(
-                <PanButton
-                    resetClicked={() => this._resetClicked()}
-                    panClicked={(x, y) => this._panClicked(x, y)}
-                    styleName={styleName || 'rounded-dark'}
-                    isMobile={this.inMobileMode}
-                    showArrows={this.showArrows}
-                />,
+                <ThemeProvider value={this.getMapModule().getMapTheme()}>
+                    <PanButton
+                        resetClicked={() => this._resetClicked()}
+                        panClicked={(x, y) => this._panClicked(x, y)}
+                        isMobile={this.inMobileMode}
+                        showArrows={this.showArrows}
+                    />
+                </ThemeProvider>,
                 el[0]
             );
         },

--- a/bundles/mapping/mapmodule/plugin/publishertoolbar/PublisherToolbarPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/publishertoolbar/PublisherToolbarPlugin.js
@@ -162,15 +162,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolba
             }
             if (!el) return;
 
-            let styleName = style;
-            if (!style) {
-                styleName = this.getToolStyleFromMapModule();
-            }
-
             ReactDOM.render(
                 <MapModuleButton
                     className='t_publishertoolbar'
-                    styleName={styleName || 'rounded-dark'}
                     icon={<MenuOutlined />}
                     title={this._loc.title}
                     withToolbar

--- a/bundles/mapping/mapmodule/plugin/zoombar/ZoomSlider.jsx
+++ b/bundles/mapping/mapmodule/plugin/zoombar/ZoomSlider.jsx
@@ -178,7 +178,6 @@ export const ZoomSlider = ({ changeZoom, zoom = 0, maxZoom, styleName = 'rounded
                     }}
                     size='32px'
                     className='t_plus'
-                    styleName={styleName}
                 />
                 <MapModuleButton
                     icon={<MinusIcon />}
@@ -187,7 +186,6 @@ export const ZoomSlider = ({ changeZoom, zoom = 0, maxZoom, styleName = 'rounded
                     }}
                     size='32px'
                     className='t_minus'
-                    styleName={styleName}
                 />
             </MobileContainer>
         );
@@ -203,7 +201,6 @@ export const ZoomSlider = ({ changeZoom, zoom = 0, maxZoom, styleName = 'rounded
                 }}
                 size='18px'
                 noMargin
-                styleName={styleName}
             />
             {!isMobile && (
                 <StyledSlider
@@ -228,7 +225,6 @@ export const ZoomSlider = ({ changeZoom, zoom = 0, maxZoom, styleName = 'rounded
                 }}
                 size='18px'
                 noMargin
-                styleName={styleName}
             />
         </Container>
     );

--- a/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
+++ b/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
@@ -86,17 +86,11 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
             }
             if (!el) return;
 
-            let styleName = style;
-            if (!style) {
-                styleName = this.getToolStyleFromMapModule();
-            }
-
             ReactDOM.render(
                 <MapModuleButton
                     className='t_maprotator'
                     title={this._locale.tooltip.tool}
                     icon={<StyledIcon degrees={degrees || 0}><NorthIcon /></StyledIcon>}
-                    styleName={styleName || 'rounded-dark'}
                     onClick={() => {
                         if (!this.inLayerToolsEditMode()) {
                             this.setRotation(0);

--- a/bundles/mapping/time-control-3d/plugin/TimeControl3dPlugin.js
+++ b/bundles/mapping/time-control-3d/plugin/TimeControl3dPlugin.js
@@ -42,7 +42,7 @@ class TimeControl3dPlugin extends BasicMapModulePlugin {
     }
     setOpen (bln) {
         this._toolOpen = bln;
-        this._renderControlElement();
+        this.renderButton();
     }
     _setLayerToolsEditModeImpl () {
         const el = this.getElement();
@@ -115,36 +115,12 @@ class TimeControl3dPlugin extends BasicMapModulePlugin {
         let el;
         el = this._createControlElement();
         this.addToPluginContainer(el);
-        this._renderControlElement();
+        this.renderButton();
     }
     _createControlElement () {
         const el = this._mountPoint.clone();
         this._element = el;
         return el;
-    }
-    _renderControlElement () {
-        const el = this.getElement();
-        if (!el) return;
-
-        const conf = this._conf;
-        const styleClass = conf && conf.toolStyle ? conf.toolStyle : this.getToolStyleFromMapModule();
-
-        ReactDOM.render(
-            <MapModuleButton
-                className='t_timecontrol'
-                title={this.loc('tooltip')}
-                styleName={styleClass || 'rounded-dark'}
-                icon={<ControlIcon />}
-                onClick={() => {
-                    if (!this.inLayerToolsEditMode()) {
-                        this._toggleToolState();
-                    }
-                }}
-                position={this.getLocation()}
-                iconActive={this.isOpen()}
-            />,
-            el.get(0)
-        );
     }
 
     _toggleToolState () {
@@ -192,16 +168,10 @@ class TimeControl3dPlugin extends BasicMapModulePlugin {
         }
         if (!el) return;
 
-        let styleName = style;
-        if (!style) {
-            styleName = this.getToolStyleFromMapModule();
-        }
-
         ReactDOM.render(
             <MapModuleButton
                 className='t_timecontrol'
                 title={this.loc('tooltip')}
-                styleName={styleName || 'rounded-dark'}
                 icon={<ControlIcon isMobile={this._isMobile} controlIsActive={this.isOpen()} />}
                 onClick={() => {
                     if (!this.inLayerToolsEditMode()) {

--- a/src/react/components/buttons/MapButton.jsx
+++ b/src/react/components/buttons/MapButton.jsx
@@ -3,32 +3,26 @@ import PropTypes from 'prop-types';
 import { Button } from '../Button';
 import { Tooltip } from '../Tooltip';
 import { ThemeConsumer } from '../../util';
+import { getNavigationTheme } from '../../theme';
 import styled from 'styled-components';
-import { ThemeProvider } from '../../util/contexts';
 
+// focus and active are only so we don't get the default blue from antd on some occurances.
+// Also when the button is "not active" it remains in "focus" so it stays at hover color when the tool is closed
+// if we don't actively style it this way
+// One option would be to trigger a blur() on the component when active changes to non-active.
+// That way tab-focusing would work really nice if we don't force the button to "inactive colors"
 const StyledButton = styled(Button)`
     width: ${props => props.size};
     height: ${props => props.size};
     border: none;
+    ${(props) => props.rounding && `border-radius: ${props.rounding};`}
     border-radius: ${props => props.rounding};
-    color: ${props => props.$active ? '#ffd400' : props.accent};
+    color: ${props => props.$active ? props.hover : props.iconcolor};
     path {
-        fill: ${props => props.$active ? '#ffd400' : props.accent};
+        fill: ${props => props.$active ? props.hover : props.iconcolor};
     }
-    background: ${props => props.primary};
+    background: ${props => props.bg};
     box-shadow: 1px 1px 2px rgb(0 0 0 / 60%);
-    &:hover {
-        color: ${props => props.$active ? '#ffd400' : props.accent};
-        background: ${props => props.primary};
-    }
-    &:active {
-        color: ${props => props.$active ? '#ffd400' : props.accent};
-        background: ${props => props.primary};
-    }
-    &:focus {
-        color: ${props => props.$active ? '#ffd400' : props.accent};
-        background: ${props => props.primary};
-    }
     display: flex;
     align-items: center;
     justify-content: center;
@@ -36,13 +30,30 @@ const StyledButton = styled(Button)`
         max-width: ${props => props.$iconSize};
         max-height: ${props => props.$iconSize};
     }
+    &:hover
+    {
+        color: ${props => props.hover};
+        background: ${props => props.bg};
+
+        path {
+            fill: ${props => props.hover};
+        }
+    }
+    &:focus,
+    &:active
+    {
+        color: ${props => props.$active ? props.hover : props.iconcolor};
+        background: ${props => props.bg};
+    }
 `;
 
 const ThemeButton = ThemeConsumer(({ theme = {}, active, ...rest }) => {
-    const primary = theme?.color?.primary || '#3c3c3c';
-    const accent = theme?.color?.accent || '#ffffff';
-    const rounding = `${theme.roundingPercent || 0}%`;
-    return <StyledButton primary={primary} accent={accent} rounding={rounding} { ...rest }/>
+    const helper = getNavigationTheme(theme);
+    const bgColor = helper.getButtonColor();
+    const icon = helper.getTextColor();
+    const hover = helper.getButtonHoverColor();
+    const rounding = helper.getButtonRoundness();
+    return <StyledButton bg={bgColor} iconcolor={icon} hover={hover} rounding={rounding} { ...rest }/>
 });
 
 export const MapButton = ({ title, icon, onClick, theme, disabled, size = '32px', iconActive, iconSize = '18px', children, position, ...rest }) => {
@@ -56,7 +67,6 @@ export const MapButton = ({ title, icon, onClick, theme, disabled, size = '32px'
     if (title) {
         return (
             <Tooltip title={title} placement={tooltipPosition}>
-                <ThemeProvider value={theme}>
                     <ThemeButton
                         icon={icon}
                         onClick={onClick}
@@ -66,12 +76,10 @@ export const MapButton = ({ title, icon, onClick, theme, disabled, size = '32px'
                         disabled={disabled}
                         { ...rest }
                     />
-                </ThemeProvider>
             </Tooltip>
         );
     } else {
         return (
-            <ThemeProvider value={theme}>
                 <ThemeButton
                     icon={icon}
                     onClick={onClick}
@@ -81,7 +89,6 @@ export const MapButton = ({ title, icon, onClick, theme, disabled, size = '32px'
                     disabled={disabled}
                     { ...rest }
                 />
-            </ThemeProvider>
         );
     }
 };

--- a/src/react/theme/ThemeHelper.js
+++ b/src/react/theme/ThemeHelper.js
@@ -2,9 +2,10 @@
 import { EFFECT } from './constants';
 
 export const getHeaderTheme = (theme) => {
-    const headerTextColor = getTextColor(theme.color.primary);
+    const bgColor = theme.color.header?.bg || theme.color.primary;
+    const headerTextColor = getTextColor(bgColor);
     const funcs = {
-        getBgColor: () => theme.color.header?.bg || theme.color.primary,
+        getBgColor: () => bgColor,
         getAccentColor: () => theme.color.accent,
         getBgBorderColor: () => getColorEffect(theme.color.accent, -10),
         getBgBorderBottomColor: () => getColorEffect(theme.color.accent, 20),
@@ -31,7 +32,7 @@ export const getNavigationTheme = (theme) => {
         getPrimary: () => primary,
         getTextColor: () => theme.navigation?.color?.text || textColor,
         getButtonColor: () => buttonColor,
-        getButtonHoverColor: () => theme.navigation?.color?.accent || '#ffd400',
+        getButtonHoverColor: () => theme.navigation?.color?.accent || theme.color.accent || '#ffd400',
         getButtonRoundness: () => borderRadius,
         getEffect: () => theme.navigation?.effect
     };

--- a/src/react/theme/ThemeHelper.js
+++ b/src/react/theme/ThemeHelper.js
@@ -15,6 +15,29 @@ export const getHeaderTheme = (theme) => {
     return funcs;
 };
 
+export const getNavigationTheme = (theme) => {
+    const primary = theme.navigation?.color?.primary || '#141414';
+    const textColor = getTextColor(primary);
+    let borderRadius = undefined;
+    if (theme?.navigation?.roundness) {
+        borderRadius = `${(theme?.navigation?.roundness || 0) / 2}%`;
+    }
+
+    let buttonColor = primary;
+    if (theme.navigation?.effect === '3D') {
+        buttonColor = `linear-gradient(180deg, ${getColorEffect(primary, EFFECT.DARKEN)} 0%, ${primary} 35%, ${getColorEffect(primary, EFFECT.LIGHTEN)} 100%)`;
+    }
+    const funcs = {
+        getPrimary: () => primary,
+        getTextColor: () => theme.navigation?.color?.text || textColor,
+        getButtonColor: () => buttonColor,
+        getButtonHoverColor: () => theme.navigation?.color?.accent || '#ffd400',
+        getButtonRoundness: () => borderRadius,
+        getEffect: () => theme.navigation?.effect
+    };
+    return funcs;
+};
+
 export const getTextColor = (bgColor) => {
     if (Oskari.util.isDarkColor(bgColor)) {
         return '#FFFFFF';

--- a/src/react/theme/index.js
+++ b/src/react/theme/index.js
@@ -1,2 +1,2 @@
 export { EFFECT } from './constants';
-export { getColorEffect, getTextColor, getHeaderTheme } from './ThemeHelper';
+export { getColorEffect, getTextColor, getHeaderTheme, getNavigationTheme } from './ThemeHelper';


### PR DESCRIPTION
Removed the "toolstyle=rounded-dark" type of handling from map tools and let map module generate a theme for controls. This will allow an editor to be created in publisher.

Added a new "block" for theme called "navigation" that we can use to refer to that dark gray in default color palette on the navigation block and the "dark" buttons on map.

Also added support for a new "block" for theme called "map". It can have the same definitions as regular/the global theme, but it is a way to override some theme settings that are used for things _on_ the map like the buttons. This way we can create an editor that only edits the "map theme" without affecting the "geoportal/global theme". The controls on map will not receive the global theme, but a theme that's constructed by the mapmodule by combining the global theme with the "map" theme. The modified theme is available with `mapmodule.getMapTheme()`.

TODO:
- cleanup handling of toolstyles/older theme handling from map module
- There's probably some tools that have not been migrated yet (those that are selectable in publisher/3D but not readily available on the geoportal page).

Theme for well- known tool styles is implemented in `AbstractMapModule.__injectThemeByToolStyle(toolStyle)`.
```
- theme.map.navigation.color.primary = base color of buttons (as hex color)
- theme.map.navigation.roundness = button rounding (as integer between 0 and 100)
- theme.map.navigation.color.text = icon color on button (as hex color)
- theme.map.navigation.color.accent= icon color on button when the buttons is active or hovered (as hex color)
- theme.map.color.header.bg = header for popups opened by map controls (as hex color)
- theme.map.navigation.effect = undefined OR '3D' to get the "well known toolstyle" for 3d effect
```