### PR TITLE
Backwards compatibility handling for map plugins

### DIFF
--- a/bundles/framework/publisher2/resources/locale/en.js
+++ b/bundles/framework/publisher2/resources/locale/en.js
@@ -243,7 +243,9 @@ Oskari.registerLocalization(
                 "nohelp": "The user guide is not available.",
                 "saveFailed": "The embedded map could not be saved.",
                 "nameIllegalCharacters": "The map name contains illegal characters (e.g. html-tags). Please correct the name and try again.",
-                "domainIllegalCharacters": "The website address contains illegal characters. Type a website URL-address without prefixes or a subpage address. For example: homepage.com. Allowed characters are letters (a-z, A-Z, å, ä, ö, Å, Ä, Ö), numbers (0-9) and special characters (-, _, ., !, ~, *, ' and ()). Please correct the address and try again."
+                "domainIllegalCharacters": "The website address contains illegal characters. Type a website URL-address without prefixes or a subpage address. For example: homepage.com. Allowed characters are letters (a-z, A-Z, å, ä, ö, Å, Ä, Ö), numbers (0-9) and special characters (-, _, ., !, ~, *, ' and ()). Please correct the address and try again.",
+                "enablePreview": "An error occured while opening preview. The preview might have additional tools that will not be part of the embedded map.",
+                "disablePreview": "An error occured while returning from preview mode. Page reload is recommended.",
             },
             "noUI": "Hide user interface (Use RPC interface)"
         },

--- a/bundles/framework/publisher2/resources/locale/fi.js
+++ b/bundles/framework/publisher2/resources/locale/fi.js
@@ -243,7 +243,9 @@ Oskari.registerLocalization(
                 "nohelp": "Ohjetta ei löytynyt.",
                 "saveFailed": "Kartan tallennus epäonnistui.",
                 "nameIllegalCharacters": "Kartan nimessä on kiellettyjä merkkejä (esim. html-tagit). Poista kielletyt merkit ja yritä uudelleen.",
-                "domainIllegalCharacters": "Verkkosivuston osoitteessa on kiellettyjä merkkejä. Anna verkkosivuston osoite eli domain-nimi ilman http- tai www-etuliitettä tai alasivun osoitetta. Esimerkiksi: omakotisivu.com. Sallittuja merkkejä ovat aakkoset (a-z, A-Z), numerot (0-9) sekä yhdysviiva (-), alaviiva (_), piste (.), huutomerkki (!), aaltoviiva (~), asteriski (*), puolilainausmerkki (') ja sulut ()."
+                "domainIllegalCharacters": "Verkkosivuston osoitteessa on kiellettyjä merkkejä. Anna verkkosivuston osoite eli domain-nimi ilman http- tai www-etuliitettä tai alasivun osoitetta. Esimerkiksi: omakotisivu.com. Sallittuja merkkejä ovat aakkoset (a-z, A-Z), numerot (0-9) sekä yhdysviiva (-), alaviiva (_), piste (.), huutomerkki (!), aaltoviiva (~), asteriski (*), puolilainausmerkki (') ja sulut ().",
+                "enablePreview": "Virheitä esikatselun avaamisessa. Esikatselu ei täysin vastaa julkaistua karttaa.",
+                "disablePreview": "Virheitä esikatselusta palautumisessa. Sivu kannattaa ladata uudestaan.",
             },
             "noUI": "Piilota käyttöliittymä (käytä RPC-rajapinnan kautta)"
         },

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -1,3 +1,5 @@
+import { Messaging } from 'oskari-ui/util';
+
 const hasSizeUpdateFn = panel => typeof panel.updateMapSize === 'function';
 /**
  * @class Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
@@ -521,9 +523,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
             Object.values(mapModule.getPluginInstances())
                 .filter(plugin => plugin.hasUI && plugin.hasUI())
                 .forEach(plugin => {
-                    plugin.stopPlugin(sandbox);
-                    mapModule.unregisterPlugin(plugin);
-                    this.normalMapPlugins.push(plugin);
+                    try {
+                        plugin.stopPlugin(sandbox);
+                        mapModule.unregisterPlugin(plugin);
+                        this.normalMapPlugins.push(plugin);
+                    } catch(err) {
+                        Oskari.log('Publisher').error('Enable preview', err);
+                        Messaging.error(this.loc.error.enablePreview);
+                    }
                 });
         },
 
@@ -540,8 +547,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
             Object.values(mapModule.getPluginInstances())
                 .filter(plugin => plugin.hasUI && plugin.hasUI())
                 .forEach(plugin => {
-                    plugin.stopPlugin(sandbox);
-                    mapModule.unregisterPlugin(plugin);
+                    try {
+                        plugin.stopPlugin(sandbox);
+                        mapModule.unregisterPlugin(plugin);
+                    } catch(err) {
+                        Oskari.log('Publisher').error('Disable preview', err);
+                        Messaging.error(this.loc.error.disablePreview);
+                    }
                 });
 
             // resume normal plugins

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -527,7 +527,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                         plugin.stopPlugin(sandbox);
                         mapModule.unregisterPlugin(plugin);
                         this.normalMapPlugins.push(plugin);
-                    } catch(err) {
+                    } catch (err) {
                         Oskari.log('Publisher').error('Enable preview', err);
                         Messaging.error(this.loc.error.enablePreview);
                     }
@@ -550,7 +550,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                     try {
                         plugin.stopPlugin(sandbox);
                         mapModule.unregisterPlugin(plugin);
-                    } catch(err) {
+                    } catch (err) {
                         Oskari.log('Publisher').error('Disable preview', err);
                         Messaging.error(this.loc.error.disablePreview);
                     }

--- a/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
@@ -362,6 +362,22 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
                 // Add the new font as a CSS class.
                 el.addClass(classToAdd);
             }
+        },
+
+        /** *****************************************
+         * Deprecated functions for backwards compatibility.
+         * Removed usage in Oskari 2.10.
+         * These can be removed after/in Oskari ~2.12
+         */
+        getMobileDefs: function() {
+            Oskari.log('BasicMapModulePlugin').deprecated('getMobileDefs');
+            return {};
+        },
+        removeToolbarButtons: function() {
+            Oskari.log('BasicMapModulePlugin').deprecated('removeToolbarButtons');
+        },
+        addToolbarButtons: function() {
+            Oskari.log('BasicMapModulePlugin').deprecated('addToolbarButtons');
         }
     }, {
         /**

--- a/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
@@ -369,14 +369,14 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
          * Removed usage in Oskari 2.10.
          * These can be removed after/in Oskari ~2.12
          */
-        getMobileDefs: function() {
+        getMobileDefs: function () {
             Oskari.log('BasicMapModulePlugin').deprecated('getMobileDefs');
             return {};
         },
-        removeToolbarButtons: function() {
+        removeToolbarButtons: function () {
             Oskari.log('BasicMapModulePlugin').deprecated('removeToolbarButtons');
         },
-        addToolbarButtons: function() {
+        addToolbarButtons: function () {
             Oskari.log('BasicMapModulePlugin').deprecated('addToolbarButtons');
         }
     }, {


### PR DESCRIPTION
- Add dummy-methods for BasicMapModule so plugins can still call them.
- Handle error on publisher when setting up/tearing down plugins for preview. Give user a warning about something not working as expected but don't crash entirely.