### PR TITLE
Compatibility fixes

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -327,31 +327,14 @@ Oskari.clazz.define(
             Oskari.app.getTheming().addListener(newTheme => {
                 this.setMapTheme(newTheme.map);
             });
-
-            /*
-            const style = me.getToolStyle();
-
-            let bgColor = theme.color.primary;
-            let textColor = '#000000';
-            if (style?.includes('dark') || style?.includes('default')) {
-                bgColor = '#3c3c3c';
-                textColor = '#ffffff';
-            } else if (style?.includes('light')) {
-                bgColor = '#ffffff';
-            }
-
-            theme = {
+            // setup map theme for well known tool styles
+            Oskari.app.getTheming().setTheme({
                 ...theme,
-                color: {
-                    header: {
-                        bg: bgColor,
-                        text: textColor
-                    }
+                map: {
+                    ...this.getMapTheme()
                 }
-            };
+            });
 
-            Oskari.app.getTheming().setTheme(theme);
-            */
             this.log.debug('Starting ' + this.getName());
 
             // listen to application started event and trigger a forced update on any remaining lazy plugins and register RPC functions.

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -2190,7 +2190,7 @@ Oskari.clazz.define(
          * @method changeToolStyle
          * @param {Object} style The style object to be applied on all plugins that support changing style.
          */
-        changeToolStyle: function (style) {
+        changeToolStyle: function (style = this._options.style) {
             const clonedStyle = {
                 ...style
             };

--- a/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol.js
@@ -7,6 +7,7 @@ import olLayerVectorTile from 'ol/layer/VectorTile';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { MapModuleButton } from '../../MapModuleButton';
+import { getNavigationTheme } from 'oskari-ui/theme';
 
 /**
  * @class Oskari.mapframework.bundle.mapmodule.plugin.IndexMapPlugin
@@ -33,7 +34,6 @@ Oskari.clazz.define(
         me._name = 'IndexMapPlugin';
         me._indexMap = null;
         me._baseLayerId = null;
-        me._indElement = null;
     },
     {
         _stopPluginImpl: function () {
@@ -59,11 +59,7 @@ Oskari.clazz.define(
                 el = jQuery('<div class="mapplugin indexmap"></div>');
             }
 
-            var toggleButton = jQuery('<div class="indexmapToggle"></div>');
-            // button has to be added separately so the element order is correct...
-            el.append(toggleButton);
-            var toolStyle = this.getToolStyleFromMapModule();
-            this.changeToolStyle(toolStyle, el);
+            this.changeToolStyle(undefined, el);
 
             return el;
         },
@@ -142,19 +138,17 @@ Oskari.clazz.define(
             this.renderButton(style, element);
         },
         renderButton: function (style, element) {
-            let el = element;
-            if (!element) {
-                el = this.getElement();
+            let el = element || this.getElement();
+            if (!el) {
+                return;
             }
-            if (!el) return;
-            el = el.find('.indexmapToggle');
+            const theme = this.getMapModule().getMapTheme();
+            const helper = getNavigationTheme(theme);
+            const isDark = Oskari.util.isDarkColor(helper.getPrimary());
             // the icon is switched based on styleName -> passed to classes -> see scss
-            let styleName = style;
-            if (!style) {
-                styleName = this.getToolStyleFromMapModule();
-            }
-            if (!styleName) {
-                styleName = 'rounded-dark';
+            let styleName = 'bg-dark';
+            if (!isDark) {
+                styleName = 'bg-light';
             }
 
             ReactDOM.render(

--- a/bundles/mapping/mapmodule/plugin/publishertoolbar/PublisherToolbarPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/publishertoolbar/PublisherToolbarPlugin.js
@@ -30,10 +30,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolba
     }, {
         // templates for tools-mapplugin
         templates: {
-            main: jQuery(
-                '<div class="mapplugin tools"></div>'
-            ),
-            container: jQuery('<div></div>')
+            main: '<div class="mapplugin tools"></div>'
         },
 
         /**
@@ -105,11 +102,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolba
          * @private @method _createControlElement
          */
         _createControlElement: function () {
-            var me = this,
-                el;
-
-            el = me.template.clone();
-            return el;
+            return jQuery(this.templates.main);
         },
 
         teardownUI: function () {


### PR DESCRIPTION
- Mapmodule now initializes mapstyle based on well known toolstyles at startup. This fixes an issue where publisher "default theme" was not working properly. 
- Indexmap now detects the button color based on theme color instead of the well known toolstyle name.
- Fixed erronous reference to template in Toolbar button so it works on embedded map.