### PR TITLE
Move main navigation theming from CSS to JS-theme

### DIFF
--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -61,7 +61,10 @@ body {
   overflow: auto;
 
   /* for application to set */
+  /*
+  See src/react/theme/globalStyles.js
   background-color: #333438;
+  */
 }
 
 .oskari-map-container-el {

--- a/src/react/theme/ThemeHelper.js
+++ b/src/react/theme/ThemeHelper.js
@@ -1,23 +1,24 @@
 
-import { EFFECT } from './constants';
+import { EFFECT, DEFAULT_COLORS } from './constants';
+
 
 export const getHeaderTheme = (theme) => {
-    const bgColor = theme.color.header?.bg || theme.color.primary;
+    const bgColor = theme.color?.header?.bg || theme.color?.primary || DEFAULT_COLORS.HEADER_BG;
     const headerTextColor = getTextColor(bgColor);
     const funcs = {
         getBgColor: () => bgColor,
         getAccentColor: () => theme.color.accent,
         getBgBorderColor: () => getColorEffect(theme.color.accent, -10),
         getBgBorderBottomColor: () => getColorEffect(theme.color.accent, 20),
-        getTextColor: () => theme.color.header?.text || headerTextColor,
-        getToolColor: () => theme.color.header?.icon || funcs.getTextColor(),
-        getToolHoverColor: () => theme.color.accent
+        getTextColor: () => theme.color?.header?.text || headerTextColor,
+        getToolColor: () => theme.color?.header?.icon || funcs.getTextColor(),
+        getToolHoverColor: () => theme.color?.accent
     };
     return funcs;
 };
 
 export const getNavigationTheme = (theme) => {
-    const primary = theme.navigation?.color?.primary || '#141414';
+    const primary = theme.navigation?.color?.primary || DEFAULT_COLORS.DARK_BUTTON_BG;
     const textColor = getTextColor(primary);
     let borderRadius = undefined;
     if (theme?.navigation?.roundness) {
@@ -32,7 +33,7 @@ export const getNavigationTheme = (theme) => {
         getPrimary: () => primary,
         getTextColor: () => theme.navigation?.color?.text || textColor,
         getButtonColor: () => buttonColor,
-        getButtonHoverColor: () => theme.navigation?.color?.accent || theme.color.accent || '#ffd400',
+        getButtonHoverColor: () => theme.navigation?.color?.accent || theme.color.accent || DEFAULT_COLORS.ACCENT,
         getButtonRoundness: () => borderRadius,
         getEffect: () => theme.navigation?.effect,
         getButtonOpacity: () => theme.navigation?.opacity || 1

--- a/src/react/theme/constants.js
+++ b/src/react/theme/constants.js
@@ -9,6 +9,13 @@ const MINOR = 'minor';
 const NORMAL = 'normal';
 const MAJOR = 'major';
 
+export const DEFAULT_COLORS = {
+    NAV_BG: '#333438',
+    HEADER_BG: '#fdf8d9',
+    ACCENT: '#ffd400',
+    DARK_BUTTON_BG: '#141414'
+};
+
 export const EFFECT = {
     NONE: 'none',
     AUTO,

--- a/src/react/theme/globalStyles.js
+++ b/src/react/theme/globalStyles.js
@@ -1,0 +1,14 @@
+import { DEFAULT_COLORS } from './constants';
+
+const GLOBAL_STYLE = document.createElement('style');
+document.head.appendChild(GLOBAL_STYLE);
+
+export const setGlobalStyle = (theme = {}) => {
+    // default to dark gray
+    const navColor = theme.navigation?.color?.primary || DEFAULT_COLORS.NAV_BG;
+    GLOBAL_STYLE.innerHTML = `
+        .oskari-root-el > nav {
+            background-color: ${navColor};
+        }
+    `;
+};

--- a/src/react/theme/index.js
+++ b/src/react/theme/index.js
@@ -1,2 +1,3 @@
 export { EFFECT } from './constants';
+export { setGlobalStyle } from './globalStyles';
 export { getColorEffect, getTextColor, getHeaderTheme, getNavigationTheme } from './ThemeHelper';

--- a/src/theming.js
+++ b/src/theming.js
@@ -1,3 +1,5 @@
+import { setGlobalStyle } from './react/theme'
+
 const DEFAULT_THEME = {
     color: {
         icon: '#3c3c3c',
@@ -18,6 +20,7 @@ export const THEMING = {
     setTheme(newTheme = {}) {
         // start with new object so we bust any memoized value for listeners and get a good value for reset as well
         currentTheme = merge({}, DEFAULT_THEME, newTheme);
+        setGlobalStyle(currentTheme);
         listeners.forEach(l => l(currentTheme));
     },
     /**


### PR DESCRIPTION
Remove default nav background-color from `portal.css` and set global theming based on theme JSON.

With this change and application code NOT overriding colors, setting the navigation background can be done with (or it should be in the database table `oskari_appsetup` in column `metadata` (under `theme` key)):
```

Oskari.app.getTheming().setTheme({
    "navigation": {
        "color": {
            "primary": "#ffffff"
        }
    });