### PR TITLE
Add color overrides to global style enabling theme ~support for jQuery-based components

### DIFF
--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -42,6 +42,13 @@ body {
   */
   overflow: hidden;
 }
+/* Setup body size if Oskari is using it as root element */
+body.oskari-root-el {
+  margin: 0;
+  padding: 0;
+  height: 100vh;
+  width: 100%;
+}
 
 .oskari-root-el {
   display: flex;

--- a/src/react/theme/globalStyles.js
+++ b/src/react/theme/globalStyles.js
@@ -1,4 +1,5 @@
 import { DEFAULT_COLORS } from './constants';
+import { getHeaderTheme } from './ThemeHelper';
 
 const GLOBAL_STYLE = document.createElement('style');
 document.head.appendChild(GLOBAL_STYLE);
@@ -6,9 +7,27 @@ document.head.appendChild(GLOBAL_STYLE);
 export const setGlobalStyle = (theme = {}) => {
     // default to dark gray
     const navColor = theme.navigation?.color?.primary || DEFAULT_COLORS.NAV_BG;
+    const headerTheme = getHeaderTheme(theme);
+    // inject Theme support for jQuery-based UI-elements (navigation, flyout, popup)
     GLOBAL_STYLE.innerHTML = `
         .oskari-root-el > nav {
             background-color: ${navColor};
+        }
+
+        .oskari-flyout .oskari-flyouttoolbar {
+            background-color: ${headerTheme.getBgColor()};
+            color:  ${headerTheme.getTextColor()};
+        }
+
+        .oskari-flyout .oskari-flyoutheading {
+            background-color: ${headerTheme.getAccentColor()};
+            border-top: 1px solid ${headerTheme.getBgBorderColor()};
+            border-bottom: 1px solid ${headerTheme.getBgBorderBottomColor()};
+        }
+
+        div.divmanazerpopup h3.popupHeader {
+            background-color: ${headerTheme.getBgColor()};
+            color:  ${headerTheme.getTextColor()};
         }
     `;
 };


### PR DESCRIPTION
To enable simple theme support for jQuery-based popups/flyouts. Continuing #2099