### PR TITLE
Remove property named 'geometry' to solve OL feature handling issue

### DIFF
--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
@@ -169,6 +169,16 @@ export class VectorLayerHandler extends AbstractLayerHandler {
                 },
                 url: Oskari.urls.getRoute('GetWFSFeatures'),
                 success: (resp) => {
+                    resp?.features?.forEach(feature => {
+                        if (feature?.properties?.geometry) {
+                            // Openlayers will override feature.geometry with properties.geometry if both are present
+                            // https://github.com/openlayers/openlayers/blob/v7.1.0/src/ol/format/GeoJSON.js#L125-L133
+                            // https://github.com/openlayers/openlayers/blob/v7.1.0/src/ol/Feature.js#L260
+                            // https://github.com/openlayers/openlayers/blob/v7.1.0/src/ol/Object.js#L229
+                            // so we must remove it before passing the GeoJSON to OL
+                            delete feature.properties.geometry;
+                        }
+                    });
                     const features = source.getFormat().readFeatures(resp);
                     features.forEach(ftr => ftr.set(WFS_ID_KEY, ftr.getId()));
                     source.addFeatures(features);


### PR DESCRIPTION
Workaround for OpenLayers handling feature properties with problematic names:

https://github.com/openlayers/openlayers/blob/v7.1.0/src/ol/format/GeoJSON.js#L125-L133

Both setGeometry() and setProperties() set props on the feature. So if we have a property named "geometry" it will override the actual geometry. Not sure if this is a bug or a feature in OpenLayers:

https://github.com/openlayers/openlayers/blob/v7.1.0/src/ol/Feature.js#L260
https://github.com/openlayers/openlayers/blob/v7.1.0/src/ol/Object.js#L229

An example feature:
```
{
    "type": "FeatureCollection",
    "crs": {
        "type": "name",
        "properties": {
            "name": "EPSG:3575"
        }
    },
    "features": [
        {
            "type": "Feature",
            "geometry": {
                "type": "Polygon",
                "coordinates": [
                    [
                        [
                            874759.64,
                            -2809573.03
                        ],
                        [
                            874811.74,
                            -2809404.03
                        ],
                        [
                            874796.24,
                            -2809399.93
                        ],
                        [
                            874743.45,
                            -2809568.74
                        ],
                        [
                            874759.64,
                            -2809573.03
                        ]
                    ]
                ]
            },
            "properties": {
                "@featureType": "Lock",
                "beginLifespanVersion": "2016-11-09T00:00:00Z",
                "condition": "{@href=https:\/\/inspire.ec.europa.eu\/codelist\/ConditionOfFacilityValue\/functional, @title=functional}",
                "hydroId": "{@dataType=hydroId, HydroIdentifier={@dataType=HydroIdentifier, localId=1422, namespace=FI}}",
                "geometry": "{@dataType=GeometricPrimitiveProperty, Polygon={type=Polygon, coordinates=[[[27.29395985, 63.39837458], [27.29590671, 63.39971924], [27.29564227, 63.39979782], [27.29368361, 63.39845666], [27.29395985, 63.39837458]]]}}",
                "levelOfDetail": "{@dataType=levelOfDetail, MD_Resolution={@dataType=MD_Resolution, equivalentScale={@dataType=MD_RepresentativeFraction, denominator=10000}}}",
                "geographicalName": "{@dataType=geographicalName, GeographicalName={@dataType=GeographicalName, language=fin, nameStatus={@href=https:\/\/inspire.ec.europa.eu\/codelist\/NameStatusValue\/other, @title=other}, nativeness={@href=https:\/\/inspire.ec.europa.eu\/codelist\/NativenessValue\/endonym, @title=endonym}, pronunciation={@dataType=pronunciation, @nilReason=missing, @nil=true}, sourceOfName={@nilReason=https:\/\/inspire.ec.europa.eu\/codelist\/VoidReasonValue\/Unknowm, @nil=true}, spelling={@dataType=SpellingOfName, script=Latn, text=Nerkoo}}}",
                "inspireId": "{@dataType=Identifier, localId=1422, namespace=http:\/\/paikkatiedot.fi\/so\/1000321\/hy-p\/Lock}"
            },
            "id": "hy-p.1422"
        }
    ]
}