### PR TITLE
VectorTileLayerPlugin map resolutions

### DIFF
--- a/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
@@ -108,7 +108,8 @@ class VectorTileLayerPlugin extends AbstractVectorLayerPlugin {
         if (style.isExternalStyle() && olLayers.length !== 0) {
             const externalStyleDef = style.getExternalDef() || {};
             const sourceLayerIds = externalStyleDef.layers.filter(cur => !!cur.source).map(cur => cur.id);
-            return mapboxStyleFunction(olLayers[0], externalStyleDef, sourceLayerIds);
+            const resolutions = [...this.getMapModule().getResolutionArray()];
+            return mapboxStyleFunction(olLayers[0], externalStyleDef, sourceLayerIds, resolutions);
         }
         return style.hasDefinitions() ? this.mapModule.getStyleForLayer(layer) : this._createDefaultStyle();
     }


### PR DESCRIPTION
Use map resolutions instead of defaults.
https://github.com/openlayers/ol-mapbox-style/blob/main/src/stylefunction.js#L329

If resolutions aren't given, open layers defaults to: 
https://github.com/openlayers/ol-mapbox-style/blob/main/src/util.js#L8-L14