### PR TITLE
Create tile & flyout for metadata when search is not present

### DIFF
--- a/bundles/catalogue/metadatacatalogue/instance.js
+++ b/bundles/catalogue/metadatacatalogue/instance.js
@@ -590,7 +590,7 @@ Oskari.clazz.define(
         },
 
         /* ----------- Tile and Flyout ------------- */
-        __addTileAndFlyout: function() {
+        __addTileAndFlyout: function () {
             const request = Oskari.requestBuilder('userinterface.AddExtensionRequest')(this);
             this.getSandbox().request(this, request);
             // attach content to flyout when divmanazer has set up root element


### PR DESCRIPTION
The metadata search relies on `search` bundle being present and offering the `Search.AddTabRequest`. This makes metadata search create its own tile and flyout if the request is not available on the appsetup.