### PR TITLE
Layerlist add missing layer type tooltips

### DIFF
--- a/bundles/framework/layerlist/resources/locale/en.js
+++ b/bundles/framework/layerlist/resources/locale/en.js
@@ -71,10 +71,10 @@ Oskari.registerLocalization(
                 'vectortile': 'Raster layer',
                 'wfs': 'Vector layer',
                 'vector': 'Vector layer',
-                'userlayer': '',
-                'myplaces': '',
-                'analysislayer': '',
-                'tiles3d': ''
+                'userlayer': 'Own dataset',
+                'myplaces': 'My map layer',
+                'analysislayer': 'Own analysis',
+                'tiles3d': '3D layer'
             },
             'guidedTour': {
                 'title': 'Map layers',

--- a/bundles/framework/layerlist/resources/locale/en.js
+++ b/bundles/framework/layerlist/resources/locale/en.js
@@ -69,6 +69,7 @@ Oskari.registerLocalization(
                 'arcgis93': 'Raster layer',
                 'arcgis': 'Raster layer',
                 'vectortile': 'Raster layer',
+                'bingmaps': 'Raster layer',
                 'wfs': 'Vector layer',
                 'vector': 'Vector layer',
                 'userlayer': 'Own dataset',

--- a/bundles/framework/layerlist/resources/locale/fi.js
+++ b/bundles/framework/layerlist/resources/locale/fi.js
@@ -69,6 +69,7 @@ Oskari.registerLocalization(
                 'arcgis93': 'Rasteritaso',
                 'arcgis': 'Rasteritaso',
                 'vectortile': 'Rasteritaso',
+                'bingmaps': 'Rasteritaso',
                 'wfs': 'Vektoritaso',
                 'vector': 'Vektoritaso',
                 'userlayer': 'Oma aineisto',

--- a/bundles/framework/layerlist/resources/locale/fi.js
+++ b/bundles/framework/layerlist/resources/locale/fi.js
@@ -71,10 +71,10 @@ Oskari.registerLocalization(
                 'vectortile': 'Rasteritaso',
                 'wfs': 'Vektoritaso',
                 'vector': 'Vektoritaso',
-                'userlayer': '',
-                'myplaces': '',
-                'analysislayer': '',
-                'tiles3d': ''
+                'userlayer': 'Oma aineisto',
+                'myplaces': 'Oma karttataso',
+                'analysislayer': 'Oma analyysi',
+                'tiles3d': '3D-taso'
             },
             'guidedTour': {
                 'title': 'Karttatasot',

--- a/bundles/framework/layerlist/resources/locale/sv.js
+++ b/bundles/framework/layerlist/resources/locale/sv.js
@@ -68,6 +68,7 @@ Oskari.registerLocalization(
                 'arcgis93': 'Kartlager i rasterformat',
                 'arcgis': 'Kartlager i rasterformat',
                 'vectortile': 'Kartlager i rasterformat',
+                'bingmaps': 'Kartlager i rasterformat',
                 'wfs': 'Kartlager i vektorformat',
                 'vector': 'Kartlager i vektorformat',
                 'userlayer': 'Eget dataset',

--- a/bundles/framework/layerlist/resources/locale/sv.js
+++ b/bundles/framework/layerlist/resources/locale/sv.js
@@ -70,10 +70,10 @@ Oskari.registerLocalization(
                 'vectortile': 'Kartlager i rasterformat',
                 'wfs': 'Kartlager i vektorformat',
                 'vector': 'Kartlager i vektorformat',
-                'userlayer': '',
-                'myplaces': '',
-                'analysislayer': '',
-                'tiles3d': ''
+                'userlayer': 'Eget dataset',
+                'myplaces': 'Mitt kartlager',
+                'analysislayer': 'Min analys',
+                'tiles3d': '3D kartlager'
             },
             'guidedTour': {
                 'title': 'Kartlager',

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerIcon.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerIcon.jsx
@@ -9,7 +9,7 @@ export const LayerIcon = ({ type, hasTimeseries = false, additionalTooltipKey, .
         if (hasTimeseries) {
             return <TimeSerieIcon {...rest} />;
         }
-        if (['wmts', 'wms', 'arcgis93', 'arcgis', 'vectortile'].includes(type)) {
+        if (['wmts', 'wms', 'arcgis93', 'arcgis', 'vectortile', 'bingmaps'].includes(type)) {
             return <ImageLayerIcon {...rest} />;
         }
         if (['wfs'].includes(type)) {


### PR DESCRIPTION
Maybe we should handle raster, vector,.. layer types (export constant or function) in one place and use also that for tooltip:
https://github.com/oskariorg/oskari-frontend/blob/develop/bundles/mapping/mapmodule/service/map.layer.js#L63

https://github.com/oskariorg/oskari-frontend/blob/develop/bundles/framework/layerlist/view/LayerViewTabs/LayerIcon.jsx#L12