### PR TITLE
Make plugin popups open based on where plugin is located

### DIFF
--- a/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPopup.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPopup.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { showPopup, PLACEMENTS } from 'oskari-ui/components/window';
+import { showPopup } from 'oskari-ui/components/window';
 import { BaseLayerList } from './LayerSelectionPopup/BaseLayerList';
 import { LayerList } from './LayerSelectionPopup/LayerList';
 import { Message } from 'oskari-ui';
 import { LocaleProvider } from 'oskari-ui/util';
+import { getPopupOptions } from '../pluginPopupHelper';
 import styled from 'styled-components';
 
 const BUNDLE_NAME = 'MapModule';
@@ -27,38 +28,11 @@ const LayerSelectionPopup = ({ baseLayers, layers, showMetadata, styleSelectable
     );
 };
 
-export const showLayerSelectionPopup = (baseLayers, layers, onClose, showMetadata, styleSelectable, setLayerVisibility, selectStyle, pluginPosition, theme) => {
-    let position;
-    switch (pluginPosition) {
-    case 'top right':
-        position = PLACEMENTS.TR;
-        break;
-    case 'right top':
-        position = PLACEMENTS.TR;
-        break;
-    case 'top left':
-        position = PLACEMENTS.TL;
-        break;
-    case 'left top':
-        position = PLACEMENTS.TL;
-        break;
-    case 'center top':
-        position = PLACEMENTS.TOP;
-        break;
-    case 'top center':
-        position = PLACEMENTS.TOP;
-        break;
-    default:
-        position = PLACEMENTS.TL;
-        break;
-    }
-
-    const mapModule = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule');
-    const options = {
-        id: POPUP_ID,
-        placement: position,
-        theme: mapModule.getMapTheme()
-    };
+export const showLayerSelectionPopup = (baseLayers, layers, onClose, showMetadata, styleSelectable, setLayerVisibility, selectStyle, pluginLocation) => {
+    const options = getPopupOptions({
+        getName: () => POPUP_ID,
+        getLocation: () => pluginLocation
+    });
 
     const controls = showPopup(
         <Message bundleKey={BUNDLE_NAME} messageKey='plugin.LayerSelectionPlugin.title' />,

--- a/bundles/mapping/mapmodule/plugin/pluginPopupHelper.js
+++ b/bundles/mapping/mapmodule/plugin/pluginPopupHelper.js
@@ -1,0 +1,29 @@
+import { PLACEMENTS } from 'oskari-ui/components/window';
+
+export const getPopupOptions = (plugin) => {
+    const mapModule = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule');
+    return {
+        id: plugin.getName(),
+        placement: getPlacementFromPluginLocation(plugin.getLocation()),
+        theme: mapModule.getMapTheme()
+    };
+};
+
+const getPlacementFromPluginLocation = (pluginLocation) => {
+    switch (pluginLocation) {
+    case 'top right':
+        return PLACEMENTS.TR;
+    case 'right top':
+        return PLACEMENTS.TR;
+    case 'top left':
+        return PLACEMENTS.TL;
+    case 'left top':
+        return PLACEMENTS.TL;
+    case 'center top':
+        return PLACEMENTS.TOP;
+    case 'top center':
+        return PLACEMENTS.TOP;
+    default:
+        return PLACEMENTS.TL;
+    };
+};

--- a/bundles/mapping/mapmodule/plugin/search/SearchPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/search/SearchPlugin.js
@@ -70,7 +70,13 @@ Oskari.clazz.define(
                 this._resultClicked(locations[0]);
                 return;
             }
-            this._popupControls = showResultsPopup(this._loc.title, description, locations, (result) => this._resultClicked(result), () => this._clearPopup());
+            this._popupControls = showResultsPopup(
+                this._loc.title,
+                description,
+                locations,
+                (result) => this._resultClicked(result),
+                () => this._clearPopup(),
+                this.getLocation());
         },
         _setLayerToolsEditModeImpl: function () {
             var me = this,

--- a/bundles/mapping/mapmodule/plugin/search/SearchResultsPopup.jsx
+++ b/bundles/mapping/mapmodule/plugin/search/SearchResultsPopup.jsx
@@ -3,6 +3,7 @@ import { showPopup } from 'oskari-ui/components/window';
 import styled from 'styled-components';
 import { Table, getSorterFor } from 'oskari-ui/components/Table';
 import { Message } from 'oskari-ui';
+import { getPopupOptions } from '../pluginPopupHelper';
 
 const StyledTable = styled(Table)`
     tr {
@@ -62,11 +63,10 @@ const PopupContent = ({ results, description, showResult }) => {
     )
 };
 
-export const showResultsPopup = (title, description, results = [], showResult, onClose) => {
-    const mapModule = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule');
-    const options = {
-        id: 'searchResults',
-        theme: mapModule.getMapTheme()
-    }
+export const showResultsPopup = (title, description, results = [], showResult, onClose, pluginLocation) => {
+    const options = getPopupOptions({
+        getName: () => 'searchResults',
+        getLocation: () => pluginLocation
+    });
     return showPopup(title, <PopupContent description={description} results={results} showResult={showResult} />, onClose, options);
 };

--- a/src/react/components/window/Popup.jsx
+++ b/src/react/components/window/Popup.jsx
@@ -53,9 +53,9 @@ const PopupTitle = styled.span`
     margin-right: auto;
     width: 100%;
 `;
-// Note! max-height isn't recalculated when window size changes :(
+// Note! use vh with max-height so it can handle window size changes
 const PopupBody = styled.div`
-    max-height: ${window.innerHeight - 100}px;
+    max-height: 90vh;
     overflow: auto;
 `;
 const ToolsContainer = styled.div`


### PR DESCRIPTION
If plugin is on the left side the popup will be opened on left side and if plugin is on right side the popup is opened on the right side.
- Move code from LayerSelectionPopup to a new helper `mapmodule/plugin/pluginPopupHelper.js`.
- Make search use the same helper to get popup location based on plugin location.
- Added a small fix to popup max-height so it reacts to window size changes after page has been loaded.