### PR TITLE
Enable minimizing SearchPlugin (and refactor to use handler)

### DIFF
--- a/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPopup.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPopup.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { showPopup, PLACEMENTS } from 'oskari-ui/components/window';
+import { showPopup } from 'oskari-ui/components/window';
 import { BaseLayerList } from './LayerSelectionPopup/BaseLayerList';
 import { LayerList } from './LayerSelectionPopup/LayerList';
 import { Message } from 'oskari-ui';
 import { LocaleProvider } from 'oskari-ui/util';
+import { getPopupOptions } from '../pluginPopupHelper';
 import styled from 'styled-components';
 
 const BUNDLE_NAME = 'MapModule';
@@ -27,38 +28,11 @@ const LayerSelectionPopup = ({ baseLayers, layers, showMetadata, styleSelectable
     );
 };
 
-export const showLayerSelectionPopup = (baseLayers, layers, onClose, showMetadata, styleSelectable, setLayerVisibility, selectStyle, pluginPosition, theme) => {
-    let position;
-    switch (pluginPosition) {
-    case 'top right':
-        position = PLACEMENTS.TR;
-        break;
-    case 'right top':
-        position = PLACEMENTS.TR;
-        break;
-    case 'top left':
-        position = PLACEMENTS.TL;
-        break;
-    case 'left top':
-        position = PLACEMENTS.TL;
-        break;
-    case 'center top':
-        position = PLACEMENTS.TOP;
-        break;
-    case 'top center':
-        position = PLACEMENTS.TOP;
-        break;
-    default:
-        position = PLACEMENTS.TL;
-        break;
-    }
-
-    const mapModule = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule');
-    const options = {
-        id: POPUP_ID,
-        placement: position,
-        theme: mapModule.getMapTheme()
-    };
+export const showLayerSelectionPopup = (baseLayers, layers, onClose, showMetadata, styleSelectable, setLayerVisibility, selectStyle, pluginLocation) => {
+    const options = getPopupOptions({
+        getName: () => POPUP_ID,
+        getLocation: () => pluginLocation
+    });
 
     const controls = showPopup(
         <Message bundleKey={BUNDLE_NAME} messageKey='plugin.LayerSelectionPlugin.title' />,

--- a/bundles/mapping/mapmodule/plugin/pluginPopupHelper.js
+++ b/bundles/mapping/mapmodule/plugin/pluginPopupHelper.js
@@ -1,0 +1,29 @@
+import { PLACEMENTS } from 'oskari-ui/components/window';
+
+export const getPopupOptions = (plugin) => {
+    const mapModule = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule');
+    return {
+        id: plugin.getName(),
+        placement: getPlacementFromPluginLocation(plugin.getLocation()),
+        theme: mapModule.getMapTheme()
+    };
+};
+
+const getPlacementFromPluginLocation = (pluginLocation) => {
+    switch (pluginLocation) {
+    case 'top right':
+        return PLACEMENTS.TR;
+    case 'right top':
+        return PLACEMENTS.TR;
+    case 'top left':
+        return PLACEMENTS.TL;
+    case 'left top':
+        return PLACEMENTS.TL;
+    case 'center top':
+        return PLACEMENTS.TOP;
+    case 'top center':
+        return PLACEMENTS.TOP;
+    default:
+        return PLACEMENTS.TL;
+    };
+};

--- a/bundles/mapping/mapmodule/plugin/search/SearchBar.jsx
+++ b/bundles/mapping/mapmodule/plugin/search/SearchBar.jsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { Button, TextInput } from 'oskari-ui';
-import { SearchOutlined } from '@ant-design/icons';
+import { SearchOutlined, SettingOutlined } from '@ant-design/icons';
+import { MapModuleButton } from '../../MapModuleButton';
 import { ThemeConsumer } from 'oskari-ui/util';
 import { getNavigationTheme } from 'oskari-ui/theme';
 
@@ -47,32 +48,51 @@ const SearchContainer = styled('div')`
     box-shadow: 1px 1px 2px rgb(0 0 0 / 60%);
 `;
 
-export const SearchBar = ThemeConsumer(({ theme = {}, search, loading, disabled = false, placeholder }) => {
+export const SearchBar = ThemeConsumer(({ theme = {}, disabled = false, placeholder, state = {}, controller }) => {
     const helper = getNavigationTheme(theme);
     const bgColor = helper.getButtonColor();
     const icon = helper.getTextColor();
     const rounding = helper.getButtonRoundness();
     const opacity = helper.getButtonOpacity();
-    const [value, setValue] = useState('');
-
+    if (state.minimized) {
+        return (
+            <MapModuleButton
+                className='t_search_minimized'
+                icon={<SearchOutlined />}
+                onClick={() => controller.requestSearchUI()}
+            />);
+    }
+    const search = () => controller.doSearch();
     return (
         <SearchContainer backgroundColor={bgColor} rounding={rounding} opacity={opacity}>
             <StyledInput
                 rounding={rounding}
-                value={value}
-                onChange={e => setValue(e.target.value)}
+                value={state.query}
+                onChange={e => controller.setQuery(e.target.value)}
                 allowClear
-                loading={loading}
-                onPressEnter={e => search(value)}
+                onPressEnter={search}
                 disabled={disabled}
                 placeholder={placeholder}
             />
+            { state.hasOptions &&
+                <StyledButton
+                    $rounding={rounding}
+                    $iconColor={icon}
+                    $backgroundColor={bgColor}
+                    onClick={() => controller.showOptions()}
+                    icon={<SettingOutlined />}
+                    className='t_search_options'
+                    disabled={disabled}
+                />
+            }
             <StyledButton
                 $rounding={rounding}
                 $iconColor={icon}
                 $backgroundColor={bgColor}
-                onClick={e => search(value)}
+                onClick={search}
                 icon={<SearchOutlined />}
+                loading={state.loading}
+                className='t_search'
                 disabled={disabled}
             />
         </SearchContainer>

--- a/bundles/mapping/mapmodule/plugin/search/SearchHandler.js
+++ b/bundles/mapping/mapmodule/plugin/search/SearchHandler.js
@@ -56,7 +56,7 @@ class SearchHandler extends StateHandler {
         return 'SearchPluginHandler';
     }
 
-    getSandbox() {
+    getSandbox () {
         return this.plugin.getSandbox();
     }
 

--- a/bundles/mapping/mapmodule/plugin/search/SearchHandler.js
+++ b/bundles/mapping/mapmodule/plugin/search/SearchHandler.js
@@ -1,0 +1,166 @@
+import '../../../../service/search/searchservice';
+import { showResultsPopup } from './SearchResultsPopup';
+import { StateHandler, controllerMixin } from 'oskari-ui/util';
+
+const MARKER_ID = 'SEARCH_RESULT_MARKER';
+class SearchHandler extends StateHandler {
+    constructor (plugin) {
+        super();
+        this.plugin = plugin;
+        this.setState({
+            minimized: false,
+            loading: false,
+            hasOptions: false
+        });
+        this.popupControls = null;
+        this.eventHandlers = this.createEventHandlers();
+        this.service = Oskari.clazz.create('Oskari.service.search.SearchService', this.getSandbox(), plugin.getConfig().url);
+    };
+
+    clearPopup () {
+        this.removeMarker();
+        if (this._popupControls) {
+            this._popupControls.close();
+        }
+        this._popupControls = null;
+    }
+
+    getMsg (key, args) {
+        return Oskari.getMsg('MapModule', 'plugin.SearchPlugin.' + key, args);
+    }
+
+    showResultsPopup (results) {
+        this.clearPopup();
+        const { totalCount, hasMore, locations } = results;
+        const msgKey = hasMore ? 'searchMoreResults' : 'searchResultCount';
+        let title = this.getMsg('title');
+        let description = this.getMsg(msgKey, { count: totalCount });
+
+        if (totalCount === 0) {
+            description = this.getMsg('noresults');
+        } else if (totalCount === 1) {
+            // only one result, show it immediately
+            this.resultClicked(locations[0]);
+            return;
+        }
+        this._popupControls = showResultsPopup(
+            title,
+            description,
+            locations,
+            (result) => this.resultClicked(result),
+            () => this.clearPopup(),
+            this.plugin.getLocation());
+    }
+
+    getName () {
+        return 'SearchPluginHandler';
+    }
+
+    getSandbox() {
+        return this.plugin.getSandbox();
+    }
+
+    setQuery (query) {
+        this.setState({
+            query
+        });
+    }
+
+    /**
+     * Uses SearchService to make the actual search and calls  #_showResults
+     */
+    doSearch () {
+        const { loading, query } = this.getState();
+        if (loading) {
+            return;
+        }
+        this.clearPopup();
+        this.setState({
+            loading: true
+        });
+        this.service.doSearch(query, results => {
+            this.setState({
+                query,
+                loading: false
+            });
+            this.showResultsPopup(results);
+        }, () => {
+            // on error
+            this.setState({
+                loading: false
+            });
+        });
+    }
+
+    resultClicked (result) {
+        var zoom = result.zoomLevel;
+        if (result.zoomScale) {
+            zoom = { scale: result.zoomScale };
+        }
+        this.getSandbox().postRequestByName('MapMoveRequest', [result.lon, result.lat, zoom]);
+        this.setMarker(result);
+    }
+
+    setMarker (result) {
+        const lat = typeof result.lat !== 'number' ? parseFloat(result.lat) : result.lat;
+        const lon = typeof result.lon !== 'number' ? parseFloat(result.lon) : result.lon;
+
+        this.getSandbox().postRequestByName('MapModulePlugin.AddMarkerRequest', [{
+            color: 'ffde00',
+            msg: result.name,
+            shape: 2,
+            size: 3,
+            x: lon,
+            y: lat
+        }, MARKER_ID]);
+    }
+
+    removeMarker () {
+        this.getSandbox().postRequestByName('MapModulePlugin.RemoveMarkersRequest', [MARKER_ID]);
+    }
+
+    /** Restore from minimized state */
+    requestSearchUI () {
+        this.updateState({
+            minimized: false
+        });
+    }
+
+    createEventHandlers () {
+        const handlers = {
+            /** Minimize search bar on map click */
+            'MapClickedEvent': () => {
+                this.updateState({
+                    minimized: true
+                });
+            }
+        };
+        const sandbox = this.getSandbox();
+        Object.getOwnPropertyNames(handlers).forEach(p => sandbox.registerForEventByName(this, p));
+        return handlers;
+    }
+
+    onEvent (e) {
+        var handler = this.eventHandlers[e.getName()];
+        if (!handler) {
+            return;
+        }
+        return handler.apply(this, [e]);
+    }
+
+    showOptions () {
+        // TODO: if the user can select search channels for the query etc
+        // related to state.hasOptions: false
+        // hasOptions is always false for now since this has not been implemented yet
+    }
+}
+
+const wrapped = controllerMixin(SearchHandler, [
+    'resultClicked',
+    'requestSearchUI',
+    'doSearch',
+    'setQuery',
+    'showOptions'
+]);
+
+export { wrapped as SearchHandler };

--- a/bundles/mapping/mapmodule/plugin/search/SearchPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/search/SearchPlugin.js
@@ -70,7 +70,13 @@ Oskari.clazz.define(
                 this._resultClicked(locations[0]);
                 return;
             }
-            this._popupControls = showResultsPopup(this._loc.title, description, locations, (result) => this._resultClicked(result), () => this._clearPopup());
+            this._popupControls = showResultsPopup(
+                this._loc.title,
+                description,
+                locations,
+                (result) => this._resultClicked(result),
+                () => this._clearPopup(),
+                this.getLocation());
         },
         _setLayerToolsEditModeImpl: function () {
             var me = this,

--- a/bundles/mapping/mapmodule/plugin/search/SearchResultsPopup.jsx
+++ b/bundles/mapping/mapmodule/plugin/search/SearchResultsPopup.jsx
@@ -3,6 +3,7 @@ import { showPopup } from 'oskari-ui/components/window';
 import styled from 'styled-components';
 import { Table, getSorterFor } from 'oskari-ui/components/Table';
 import { Message } from 'oskari-ui';
+import { getPopupOptions } from '../pluginPopupHelper';
 
 const StyledTable = styled(Table)`
     tr {
@@ -62,11 +63,10 @@ const PopupContent = ({ results, description, showResult }) => {
     )
 };
 
-export const showResultsPopup = (title, description, results = [], showResult, onClose) => {
-    const mapModule = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule');
-    const options = {
-        id: 'searchResults',
-        theme: mapModule.getMapTheme()
-    }
+export const showResultsPopup = (title, description, results = [], showResult, onClose, pluginLocation) => {
+    const options = getPopupOptions({
+        getName: () => 'searchResults',
+        getLocation: () => pluginLocation
+    });
     return showPopup(title, <PopupContent description={description} results={results} showResult={showResult} />, onClose, options);
 };

--- a/src/react/components/window/Popup.jsx
+++ b/src/react/components/window/Popup.jsx
@@ -53,9 +53,9 @@ const PopupTitle = styled.span`
     margin-right: auto;
     width: 100%;
 `;
-// Note! max-height isn't recalculated when window size changes :(
+// Note! use vh with max-height so it can handle window size changes
 const PopupBody = styled.div`
-    max-height: ${window.innerHeight - 100}px;
+    max-height: 90vh;
     overflow: auto;
 `;
 const ToolsContainer = styled.div`


### PR DESCRIPTION
- Refactor SearchPlugin code to use handler instead of having the logic in the plugin file. 
- Search plugin can now be minimized to a single button if map is clicked (and can be restored to search field when the button is clicked). It still opens as non-minimized to signal user that there is a search available.

Open:
![image](https://user-images.githubusercontent.com/2210335/218341879-3a77ed9d-8cc3-4904-95e2-ead605eb36ed.png)

Minimized:
![image](https://user-images.githubusercontent.com/2210335/218341889-d27bdb2a-30f8-4eb3-b1c8-7d6be78dfcbe.png)


- Also cleaned up dead code for the search plugin
- Added a work-in-progress button thats isn't displayed, but user could use to select which search channels the query will be performed on.

NOTE! Includes commits from #2120 