### PR TITLE
Layerlist backend status

### DIFF
--- a/bundles/framework/layerlist/Flyout.js
+++ b/bundles/framework/layerlist/Flyout.js
@@ -20,6 +20,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerlist.Flyout',
     function (instance) {
         this.instance = instance;
         // the show "add all layers to map" control for groups is disabled by default. Use instance conf to enable it.
+        // view/bundle modifier adds backend status available conf if bundle is present
         const defaultOpts = {
             [LAYER_GROUP_TOGGLE_LIMIT]: LAYER_GROUP_TOGGLE_DEFAULTS.DISABLE_TOGGLE,
             [BACKEND_STATUS_AVAILABLE]: false

--- a/bundles/framework/layerlist/Flyout.js
+++ b/bundles/framework/layerlist/Flyout.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { LocaleProvider, ThemeProvider } from 'oskari-ui/util';
 import { LayerViewTabs, LayerViewTabsHandler, TABS_ALL_LAYERS } from './view/LayerViewTabs/';
-import { LAYER_GROUP_TOGGLE_LIMIT, LAYER_GROUP_TOGGLE_DEFAULTS } from './constants';
+import { LAYER_GROUP_TOGGLE_LIMIT, LAYER_GROUP_TOGGLE_DEFAULTS, BACKEND_STATUS_AVAILABLE } from './constants';
 
 /**
  * @class Oskari.mapframework.bundle.layerlist.Flyout
@@ -21,7 +21,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerlist.Flyout',
         this.instance = instance;
         // the show "add all layers to map" control for groups is disabled by default. Use instance conf to enable it.
         const defaultOpts = {
-            [LAYER_GROUP_TOGGLE_LIMIT]: LAYER_GROUP_TOGGLE_DEFAULTS.DISABLE_TOGGLE
+            [LAYER_GROUP_TOGGLE_LIMIT]: LAYER_GROUP_TOGGLE_DEFAULTS.DISABLE_TOGGLE,
+            [BACKEND_STATUS_AVAILABLE]: false
         };
         const instanceConf = this.instance.conf || {};
         this.optsForUI = {

--- a/bundles/framework/layerlist/constants.js
+++ b/bundles/framework/layerlist/constants.js
@@ -9,3 +9,5 @@ export const LAYER_GROUP_TOGGLE_DEFAULTS = {
     // max reasonable limit of layers to add to the map with a single click
     SANE_LIMIT: 10
 };
+
+export const BACKEND_STATUS_AVAILABLE = 'backendStatusAvailable';

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/Layer/Layer.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/Layer/Layer.jsx
@@ -45,7 +45,7 @@ const onToolClick = tool => {
     }
 };
 
-const Layer = ({ model, selected, controller }) => {
+const Layer = ({ model, selected, opts, controller }) => {
     return (
         <LayerDiv className="t_layer" data-id={model.getId()}>
             <CustomTools className="custom-tools">
@@ -69,7 +69,7 @@ const Layer = ({ model, selected, controller }) => {
                     <div>{model.getName()}</div>
                 </Label>
             </Body>
-            <LayerTools model={model} controller={controller}/>
+            <LayerTools model={model} controller={controller} opts={opts}/>
         </LayerDiv>
     );
 };
@@ -77,6 +77,7 @@ const Layer = ({ model, selected, controller }) => {
 Layer.propTypes = {
     model: PropTypes.any.isRequired,
     selected: PropTypes.bool.isRequired,
+    opts: PropTypes.object.isRequired,
     controller: PropTypes.instanceOf(Controller).isRequired
 };
 

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/Layer/LayerTools.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/Layer/LayerTools.jsx
@@ -5,6 +5,7 @@ import { WarningIcon } from 'oskari-ui';
 import { Controller, LocaleConsumer } from 'oskari-ui/util';
 import { LayerIcon } from '../../../LayerIcon';
 import { MetadataIcon } from 'oskari-ui/components/icons';
+import { BACKEND_STATUS_AVAILABLE } from '../../../../../constants';
 
 const Tools = styled('div')`
     display: flex;
@@ -45,13 +46,14 @@ const getStatusColor = (status) => {
     }
 };
 
-const LayerTools = ({ model, controller }) => {
+const LayerTools = ({ model, controller, opts }) => {
+    const backendAvailable = opts[BACKEND_STATUS_AVAILABLE];
     const map = Oskari.getSandbox().getMap();
     const reasons = !map.isLayerSupported(model) ? map.getUnsupportedLayerReasons(model) : undefined;
     const reason = reasons ? map.getMostSevereUnsupportedLayerReason(reasons) : undefined;
-    const backendStatus = getBackendStatus(model);
+    const backendStatus = backendAvailable ? getBackendStatus(model) : {};
     const statusOnClick =
-        backendStatus.status !== 'UNKNOWN' ? () => controller.showLayerBackendStatus(model.getId()) : undefined;
+        backendAvailable && backendStatus.status !== 'UNKNOWN' ? () => controller.showLayerBackendStatus(model.getId()) : undefined;
 
     return (
         <Tools className="layer-tools">
@@ -67,7 +69,8 @@ const LayerTools = ({ model, controller }) => {
 
 LayerTools.propTypes = {
     model: PropTypes.object.isRequired,
-    controller: PropTypes.instanceOf(Controller).isRequired
+    controller: PropTypes.instanceOf(Controller).isRequired,
+    opts: PropTypes.object.isRequired
 };
 
 const LayerStatus = ({ backendStatus, model, onClick }) => {

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Collapse, CollapsePanel, List, ListItem, Tooltip } from 'oskari-ui';
+import { Collapse, CollapsePanel, List, ListItem } from 'oskari-ui';
 import { Controller, ErrorBoundary } from 'oskari-ui/util';
 import { Layer } from './Layer/';
 import { LayerCountBadge } from './LayerCountBadge';
@@ -79,11 +79,10 @@ const StyledListItem = styled(({ even, ...rest }) => <ListItem {...rest}/>)`
     display: block !important;
 `;
 
-const renderLayer = ({ model, selected, controller }, index) => {
-    const itemProps = { model, selected, controller };
+const renderLayer = (itemProps, index) => {
     return (
-        <StyledListItem key={model.getId()} even={index % 2 === 0}>
-            <Layer  {...itemProps} />
+        <StyledListItem key={itemProps.id} even={index % 2 === 0}>
+            <Layer {...itemProps} />
         </StyledListItem>
     );
 };
@@ -97,6 +96,9 @@ const LayerList = ({ layers }) => {
     return (
         <List bordered={false} dataSource={layers} renderItem={renderLayer} />
     );
+};
+LayerList.propTypes = {
+    layers: PropTypes.array.isRequired
 };
 /* ----- /Layer list ------ */
 
@@ -144,20 +146,21 @@ const StyledCollapsePanel = styled(CollapsePanel)`
     };
 `;
 
-const getLayerRowModels = (layers = [], selectedLayerIds = [], controller) => {
+const getLayerRowModels = (layers = [], selectedLayerIds = [], controller, opts) => {
     return layers.map(oskariLayer => {
         return {
             id: oskariLayer.getId(),
             model: oskariLayer,
             selected: selectedLayerIds.includes(oskariLayer.getId()),
-            controller
+            controller,
+            opts
         };
     });
 };
 
 const LayerCollapsePanel = (props) => {
     const { group, selectedLayerIds, openGroupTitles, opts, controller, ...propsNeededForPanel } = props;
-    const layerRows = getLayerRowModels(group.getLayers(), selectedLayerIds, controller);
+    const layerRows = getLayerRowModels(group.getLayers(), selectedLayerIds, controller, opts);
     // set group switch active if all layers in group are selected
     const allLayersOnMap = layerRows.every(layer => selectedLayerIds.includes(layer.id));
     // Note! Not rendering layerlist/subgroups when the panel is closed is a trade-off for performance


### PR DESCRIPTION
Add backendStatusAvailable from config to opts. Pass opts to LayerTools. Don't use backend status (icon color, tooltip) if it isn't available (no backendstatus bundle in appsetup).  Previously used unknown state.

https://github.com/oskariorg/oskari-server/pull/922