### PR TITLE
Publisher: add text color selection for popup

### DIFF
--- a/bundles/framework/publisher2/resources/locale/en.js
+++ b/bundles/framework/publisher2/resources/locale/en.js
@@ -149,6 +149,10 @@ Oskari.registerLocalization(
             },
             "layout": {
                 "label": "Graphic Layout",
+                "title": {
+                    "popup": "Popup window",
+                    "buttons": "Buttons"
+                },
                 "fields": {
                     "colours": {
                         "label": "Color scheme",
@@ -181,7 +185,8 @@ Oskari.registerLocalization(
                         "3d-dark": "Three-dimensional (dark)",
                         "3d-light": "Three-dimensional (light)"
                     },
-                    "popupHeaderColor": "Pop-up header background color",
+                    "popupHeaderColor": "Title background color",
+                    "popupHeaderTextColor": "Title color",
                     "buttonBackgroundColor": "Button background color",
                     "buttonTextColor": "Icon color",
                     "buttonAccentColor": "Icon effect color",

--- a/bundles/framework/publisher2/resources/locale/en.js
+++ b/bundles/framework/publisher2/resources/locale/en.js
@@ -187,7 +187,7 @@ Oskari.registerLocalization(
                     },
                     "popupHeaderColor": "Title background color",
                     "popupHeaderTextColor": "Title color",
-                    "buttonBackgroundColor": "Button background color",
+                    "buttonBackgroundColor": "Background color",
                     "buttonTextColor": "Icon color",
                     "buttonAccentColor": "Icon effect color",
                     "buttonRounding": "Button rounding",

--- a/bundles/framework/publisher2/resources/locale/fi.js
+++ b/bundles/framework/publisher2/resources/locale/fi.js
@@ -149,6 +149,10 @@ Oskari.registerLocalization(
             },
             "layout": {
                 "label": "Ulkoasu",
+                "title": {
+                    "popup": "Ponnahdusikkuna",
+                    "buttons": "Painikkeet"
+                },
                 "fields": {
                     "colours": {
                         "label": "Värimaailma",
@@ -181,8 +185,9 @@ Oskari.registerLocalization(
                         "3d-dark": "Kolmiulotteinen (tumma)",
                         "3d-light": "Kolmiulotteinen (vaalea)"
                     },
-                    "popupHeaderColor": "Pop-upin otsikon taustaväri",
-                    "buttonBackgroundColor": "Painikkeiden taustaväri",
+                    "popupHeaderColor": "Otsikon taustaväri",
+                    "popupHeaderTextColor": "Otsikon väri",
+                    "buttonBackgroundColor": "Taustaväri",
                     "buttonTextColor": "Ikonien väri",
                     "buttonAccentColor": "Ikonien tehosteväri",
                     "buttonRounding": "Painikkeiden pyöristys",

--- a/bundles/framework/publisher2/resources/locale/sv.js
+++ b/bundles/framework/publisher2/resources/locale/sv.js
@@ -149,6 +149,10 @@ Oskari.registerLocalization(
             },
             "layout": {
                 "label": "Grafisk layout",
+                "title": {
+                    "popup": "Popup window",
+                    "buttons": "Buttons"
+                },
                 "fields": {
                     "colours": {
                         "label": "Färgschema",
@@ -181,7 +185,8 @@ Oskari.registerLocalization(
                         "3d-dark": "3D (mörk)",
                         "3d-light": "3D (ljus)"
                     },
-                    "popupHeaderColor": "Pop-upin otsikon taustaväri",
+                    "popupHeaderColor": "Otsikon taustaväri",
+                    "popupHeaderTextColor": "Otsikon väri",
                     "buttonBackgroundColor": "Painikkeiden taustaväri",
                     "buttonTextColor": "Ikonien väri",
                     "buttonAccentColor": "Ikonien tehosteväri",

--- a/bundles/framework/publisher2/resources/locale/sv.js
+++ b/bundles/framework/publisher2/resources/locale/sv.js
@@ -150,8 +150,8 @@ Oskari.registerLocalization(
             "layout": {
                 "label": "Grafisk layout",
                 "title": {
-                    "popup": "Popup window",
-                    "buttons": "Buttons"
+                    "popup": "Popupfönster",
+                    "buttons": "Knappar"
                 },
                 "fields": {
                     "colours": {
@@ -175,7 +175,7 @@ Oskari.registerLocalization(
                         }
                     },
                     "fonts": {
-                        "label": "Typsnitt"
+                        "label": "Välj font"
                     },
                     "toolStyles": {
                         "rounded-dark": "Avrundad (mörk)",
@@ -185,15 +185,15 @@ Oskari.registerLocalization(
                         "3d-dark": "3D (mörk)",
                         "3d-light": "3D (ljus)"
                     },
-                    "popupHeaderColor": "Otsikon taustaväri",
-                    "popupHeaderTextColor": "Otsikon väri",
-                    "buttonBackgroundColor": "Painikkeiden taustaväri",
-                    "buttonTextColor": "Ikonien väri",
-                    "buttonAccentColor": "Ikonien tehosteväri",
-                    "buttonRounding": "Painikkeiden pyöristys",
-                    "effect": "Efekti",
+                    "popupHeaderColor": "Rubrikens bakgrundsfärg",
+                    "popupHeaderTextColor": "Rubrikens färg",
+                    "buttonBackgroundColor": "Bakgrundsfärg",
+                    "buttonTextColor": "Ikonernas färg",
+                    "buttonAccentColor": "Ikonernas effektfärg",
+                    "buttonRounding": "Knapparnas avrundning",
+                    "effect": "Effekt",
                     "3d": "3D",
-                    "presets": "Valmiit tyylimääritykset"
+                    "presets": "Färdiga stilkonfigurationer"
                 },
                 "popup": {
                     "title": "Välj färgschema",

--- a/bundles/framework/publisher2/view/PanelToolStyles.jsx
+++ b/bundles/framework/publisher2/view/PanelToolStyles.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { Message, Slider, Checkbox, Dropdown, Button, Select, Option, NumberInput } from 'oskari-ui';
+import { Divider, Message, Slider, Checkbox, Dropdown, Button, Select, Option, NumberInput } from 'oskari-ui';
 import { ColorPicker } from 'oskari-ui/components/ColorPicker';
 
 const BUNDLE_KEY = 'Publisher2';
@@ -67,6 +67,8 @@ const StyledSelect = styled(Select)`
 export const PanelToolStyles = ({ mapTheme, changeTheme, fonts }) => {
     const [font, setFont] = useState(mapTheme?.font || fonts[0].val);
     const [popupHeader, setPopupHeader] = useState(mapTheme?.color?.header?.bg);
+    const [popupHeaderText, setPopupHeaderText] = useState(mapTheme?.color?.header?.text);
+
     const [buttonBackground, setButtonBackground] = useState(mapTheme?.navigation?.color?.primary);
     const [buttonText, setButtonText] = useState(mapTheme?.navigation?.color?.text);
     const [buttonAccent, setButtonAccent] = useState(mapTheme?.navigation?.color?.accent);
@@ -81,8 +83,11 @@ export const PanelToolStyles = ({ mapTheme, changeTheme, fonts }) => {
                 ...mapTheme.color,
                 header: {
                     ...mapTheme.color.header,
-                    bg: popupHeader
-                }
+                    bg: popupHeader,
+                    text: popupHeaderText,
+                    icon: popupHeaderText
+                },
+                accent: buttonAccent
             },
             navigation: {
                 ...mapTheme.navigation,
@@ -97,7 +102,7 @@ export const PanelToolStyles = ({ mapTheme, changeTheme, fonts }) => {
             }
         };
         changeTheme(theme);
-    }, [font, popupHeader, buttonBackground, buttonText, buttonAccent, buttonRounding, buttonEffect]);
+    }, [font, popupHeader, popupHeaderText, buttonBackground, buttonText, buttonAccent, buttonRounding, buttonEffect]);
 
     const setPreset = (style) => {
         let rounding = 100;
@@ -126,6 +131,7 @@ export const PanelToolStyles = ({ mapTheme, changeTheme, fonts }) => {
         setButtonText(icon);
         setButtonAccent(hover);
         setButtonEffect(effect);
+        setPopupHeaderText(icon);
     };
 
     const toolStyles = Oskari.getMsg(BUNDLE_KEY, 'BasicView.layout.fields.toolStyles') || {};
@@ -157,15 +163,7 @@ export const PanelToolStyles = ({ mapTheme, changeTheme, fonts }) => {
                     ))}
                 </StyledSelect>
             </Field>
-            <Field>
-                <Message bundleKey={BUNDLE_KEY} messageKey='BasicView.layout.fields.popupHeaderColor' />
-                <StyledColorPicker>
-                    <ColorPicker
-                        value={popupHeader}
-                        onChange={(e) => setPopupHeader(e.target.value)}
-                    />
-                </StyledColorPicker>
-            </Field>
+            <Divider><Message bundleKey={BUNDLE_KEY} messageKey='BasicView.layout.title.buttons' /></Divider>
             <Field>
                 <Message bundleKey={BUNDLE_KEY} messageKey='BasicView.layout.fields.buttonBackgroundColor' />
                 <StyledColorPicker>
@@ -213,14 +211,33 @@ export const PanelToolStyles = ({ mapTheme, changeTheme, fonts }) => {
                     </NumberInputContainer>
                 </SliderContainer>
             </Field>
-            <Message bundleKey={BUNDLE_KEY} messageKey='BasicView.layout.fields.effect' />
             <Field>
+                <Message bundleKey={BUNDLE_KEY} messageKey='BasicView.layout.fields.effect' />
                 <Checkbox
                     checked={buttonEffect === '3D'}
                     onChange={e => setButtonEffect(e.target.checked ? '3D' : undefined)}
                 >
                     <Message bundleKey={BUNDLE_KEY} messageKey='BasicView.layout.fields.3d' />
                 </Checkbox>
+            </Field>
+            <Divider><Message bundleKey={BUNDLE_KEY} messageKey='BasicView.layout.title.popup' /></Divider>
+            <Field>
+                <Message bundleKey={BUNDLE_KEY} messageKey='BasicView.layout.fields.popupHeaderColor' />
+                <StyledColorPicker>
+                    <ColorPicker
+                        value={popupHeader}
+                        onChange={(e) => setPopupHeader(e.target.value)}
+                    />
+                </StyledColorPicker>
+            </Field>
+            <Field>
+                <Message bundleKey={BUNDLE_KEY} messageKey='BasicView.layout.fields.popupHeaderTextColor' />
+                <StyledColorPicker>
+                    <ColorPicker
+                        value={popupHeaderText}
+                        onChange={(e) => setPopupHeaderText(e.target.value)}
+                    />
+                </StyledColorPicker>
             </Field>
         </Content>
     );


### PR DESCRIPTION
And group related color/visual selections under "buttons" and "popups":

![image](https://user-images.githubusercontent.com/2210335/218526479-9579a8ce-8519-4f0a-b614-d4bbbe3c54b3.png)

TODO: missing swedish translations