### PR TITLE
Layer visibility info

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/Layer/LayerTools.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/Layer/LayerTools.jsx
@@ -48,16 +48,14 @@ const getStatusColor = (status) => {
 
 const LayerTools = ({ model, controller, opts }) => {
     const backendAvailable = opts[BACKEND_STATUS_AVAILABLE];
-    const map = Oskari.getSandbox().getMap();
-    const reasons = !map.isLayerSupported(model) ? map.getUnsupportedLayerReasons(model) : undefined;
-    const reason = reasons ? map.getMostSevereUnsupportedLayerReason(reasons) : undefined;
+    const { unsupported } = model.getVisibilityInfo();
     const backendStatus = backendAvailable ? getBackendStatus(model) : {};
     const statusOnClick =
         backendAvailable && backendStatus.status !== 'UNKNOWN' ? () => controller.showLayerBackendStatus(model.getId()) : undefined;
 
     return (
         <Tools className="layer-tools">
-            {reason && <WarningIcon tooltip={reason.getDescription()} />}
+            {unsupported && <WarningIcon tooltip={unsupported.getDescription()} />}
             <LayerStatus backendStatus={backendStatus} model={model} onClick={statusOnClick} />
             <MetadataIcon
                 metadataId={model.getMetadataIdentifier()}

--- a/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/Footer/Footer.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/Footer/Footer.jsx
@@ -26,8 +26,8 @@ const GrayRow = styled(Row)`
     }
 `;
 
-const getVisibilityInfoProps = ({ layer, visibilityInfo, controller }) => {
-    const { unsupported, visible, inScale, geometryMatch } = visibilityInfo;
+const getVisibilityInfoProps = ({ layer, controller }) => {
+    const { unsupported, visible, inScale, geometryMatch } = layer.getVisibilityInfo();
     if (!visible) {
         return {
             messageKey: 'layer.hidden'
@@ -48,11 +48,11 @@ const getVisibilityInfoProps = ({ layer, visibilityInfo, controller }) => {
     }
 };
 
-export const Footer = ({ layer, controller, visibilityInfo }) => {
+export const Footer = ({ layer, controller }) => {
     const tools = layer.getTools();
     const opacity = layer.getOpacity();
     const layerType = layer.getLayerType();
-    const visibilityInfoProps = getVisibilityInfoProps({ layer, controller, visibilityInfo });
+    const visibilityInfoProps = getVisibilityInfoProps({ layer, controller });
     return (
         <GrayRow>
             <ColAuto>
@@ -88,6 +88,5 @@ export const Footer = ({ layer, controller, visibilityInfo }) => {
 
 Footer.propTypes = {
     layer: PropTypes.object.isRequired,
-    visibilityInfo: PropTypes.object.isRequired,
     controller: PropTypes.instanceOf(Controller).isRequired
 };

--- a/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/LayerBox.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/LayerBox.jsx
@@ -31,17 +31,12 @@ const PublishableCol = styled(ColAutoRight)`
     align-self: flex-end;
 `;
 
-const LayerBox = ({ layer, index, visibilityInfo, controller }) => {
+const LayerBox = ({ layer, index, controller }) => {
     const organizationName = layer.getOrganizationName();
     const publishable = layer.hasPermission('publish');
-
-    const [visible, setVisible] = useState(visibilityInfo.visible);
-    useEffect(() => {
-        setVisible(visibilityInfo.visible);
-    }, [visibilityInfo]);
+    const visible = layer.isVisible();
 
     const handleToggleVisibility = () => {
-        setVisible(!visible);
         controller.toggleLayerVisibility(layer);
     };
     const handleRemoveLayer = () => {
@@ -102,7 +97,7 @@ const LayerBox = ({ layer, index, visibilityInfo, controller }) => {
                                         />
                                     </ColAutoRight>
                                 </Row>
-                                <Footer layer={layer} controller={controller} visibilityInfo={visibilityInfo}/>
+                                <Footer layer={layer} controller={controller}/>
                             </StyledBox>
                         </Col>
                     </Row>
@@ -115,7 +110,6 @@ const LayerBox = ({ layer, index, visibilityInfo, controller }) => {
 LayerBox.propTypes = {
     layer: PropTypes.object.isRequired,
     index: PropTypes.number.isRequired,
-    visibilityInfo: PropTypes.object.isRequired,
     controller: PropTypes.instanceOf(Controller).isRequired
 };
 

--- a/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/SelectedLayers.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/SelectedLayers.jsx
@@ -5,18 +5,16 @@ import { Controller } from 'oskari-ui/util';
 import { LayerBox } from './LayerBox/';
 
 // Ensuring the whole list does not re-render when the droppable re-renders
-const Layers = React.memo(({ layers, visibilityInfo, ...rest }) => (
+const Layers = React.memo(({ layers, ...rest }) => (
     layers.map((layer, index) => {
-        const visibilityCheck = visibilityInfo.find(v => v.id === layer.getId());
-        return <LayerBox key={layer.getId()} layer={layer} index={index} visibilityInfo={visibilityCheck} {...rest} />;
+        return <LayerBox key={layer.getId()} layer={layer} index={index} {...rest} />;
     })
 ));
 Layers.displayName = 'Layers';
 
 Layers.propTypes = {
     layers: PropTypes.arrayOf(PropTypes.object).isRequired,
-    controller: PropTypes.instanceOf(Controller).isRequired,
-    visibilityInfo: PropTypes.arrayOf(PropTypes.object)
+    controller: PropTypes.instanceOf(Controller).isRequired
 };
 
 const reorder = (result, controller) => {
@@ -26,12 +24,12 @@ const reorder = (result, controller) => {
     controller.reorderLayers(result.source.index, result.destination.index);
 };
 
-export const SelectedLayers = ({ layers, controller, visibilityInfo }) => (
+export const SelectedLayers = ({ layers, controller }) => (
     <DragDropContext onDragEnd={result => reorder(result, controller)}>
         <Droppable droppableId="layers">
             {provided => (
                 <div ref={provided.innerRef} {...provided.droppableProps}>
-                    <Layers layers={layers} controller={controller} visibilityInfo={visibilityInfo} />
+                    <Layers layers={layers} controller={controller} />
                     {provided.placeholder}
                 </div>
             )}
@@ -41,6 +39,5 @@ export const SelectedLayers = ({ layers, controller, visibilityInfo }) => (
 
 SelectedLayers.propTypes = {
     layers: Layers.propTypes.layers,
-    controller: PropTypes.instanceOf(Controller).isRequired,
-    visibilityInfo: PropTypes.arrayOf(PropTypes.object)
+    controller: PropTypes.instanceOf(Controller).isRequired
 };

--- a/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/SelectedLayersHandler.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/SelectedLayersHandler.js
@@ -5,10 +5,8 @@ class ViewHandler extends StateHandler {
         super();
         this.instance = instance;
         this.sandbox = instance.getSandbox();
-        const layers = this._getLayers();
         this.state = {
-            layers,
-            visibilityInfo: layers.map(lyr => this._getInitialVisibilityInfoForLayer(lyr))
+            layers: this._getLayers()
         };
     }
 
@@ -16,51 +14,13 @@ class ViewHandler extends StateHandler {
         return [...this.sandbox.findAllSelectedMapLayers()].reverse();
     }
 
-    _getInitialVisibilityInfoForLayer (layer) {
-        if (!layer) {
-            return;
-        }
-        const info = {
-            id: layer.getId(),
-            visible: layer.isVisible(),
-            inScale: layer.isInScale(),
-            geometryMatch: true
-        };
-        const map = this.sandbox.getMap();
-        if (!map.isLayerSupported(layer)) {
-            info.unsupported = map.getMostSevereUnsupportedLayerReason(layer);
-        }
-        return info;
-    }
-
-    _refreshVisibilityInfoForLayer (layer) {
-        const oldInfo = this.state.visibilityInfo.find(info => info.id === layer.getId());
-        const geometryMatch = oldInfo ? oldInfo.geometryMatch : true;
-        return {
-            ...this._getInitialVisibilityInfoForLayer(layer),
-            geometryMatch
-        };
-    }
-
     updateLayers () {
-        const layers = this._getLayers();
-        const visibilityInfo = layers.map(layer => this._refreshVisibilityInfoForLayer(layer));
-        this.updateState({ layers, visibilityInfo });
+        this.updateState({ layers: this._getLayers() });
     }
 
     updateVisibilityInfo (event) {
-        // refresh all
-        const visibilityInfo = this.state.layers.map(layer => this._refreshVisibilityInfoForLayer(layer));
-        if (event) {
-            const layer = event.getMapLayer();
-            const layerData = visibilityInfo.find(info => info.id === layer.getId());
-            if (!layerData) {
-                // layer not included in selected layers.
-                return;
-            }
-            layerData.geometryMatch = event.isGeometryMatch();
-        }
-        this.updateState({ visibilityInfo });
+        // trigger change
+        this.updateState({});
     }
 
     reorderLayers (fromPosition, toPosition) {

--- a/bundles/framework/publisher2/resources/locale/en.js
+++ b/bundles/framework/publisher2/resources/locale/en.js
@@ -268,7 +268,6 @@ Oskari.registerLocalization(
             "denied_tooltip": "These map layers are not publishable in embedded maps. Data producers have not granted permissions for publishing or the current map projection is unsupported. Please check publishable map layers in the Selected Layers menu.",
             "myPlacesDisclaimer": "NOTE! If you are using this map layer in an embedded map, the map layer will be published.",
             "noRights": "no permission",
-            "unsupportedProjection": "unsupported projection",
             "buttons": {
                 "continue": "Continue",
                 "continueAndAccept": "Accept and continue",

--- a/bundles/framework/publisher2/resources/locale/fi.js
+++ b/bundles/framework/publisher2/resources/locale/fi.js
@@ -268,7 +268,6 @@ Oskari.registerLocalization(
             "denied_tooltip": "Karttatasot eivät ole julkaistavissa upotetussa kartassa. Tiedontuottaja ei ole antanut lupaa julkaista karttatasoa muissa verkkopalveluissa tai tasoa ei voida näyttää tässä karttaprojektiossa. Tarkista karttatason julkaisuoikeudet Valitut tasot -valikosta.",
             "myPlacesDisclaimer": "HUOM! Jos käytät karttatasoa karttajulkaisussa, karttatasosta tulee julkinen.",
             "noRights": "ei julkaisuoikeutta",
-            "unsupportedProjection": "väärä karttaprojektio",
             "buttons": {
                 "continue": "Jatka",
                 "continueAndAccept": "Hyväksy ehdot ja jatka",

--- a/bundles/framework/publisher2/resources/locale/sv.js
+++ b/bundles/framework/publisher2/resources/locale/sv.js
@@ -266,7 +266,6 @@ Oskari.registerLocalization(
             "denied_tooltip": "Kartdataproducenterna har inte gett publiceringstillstånd till dessa material i andra webbtjänster eller denna kartlager kan inte visas med den valda kartprojektionen. Kontrollera rätten att publicera i menyn \"Valda Kartlager\" innan du börjar skapa kartan.",
             "myPlacesDisclaimer": "Obs! Du publicerar ditt eget kartlager.",
             "noRights": "inget tillstånd",
-            "unsupportedProjection": "ostödd kartprojektion",
             "buttons": {
                 "continue": "Fortsätt",
                 "continueAndAccept": "Godkänn användningsvillkor och fortsätt",

--- a/bundles/framework/publisher2/view/FlyoutStartView.js
+++ b/bundles/framework/publisher2/view/FlyoutStartView.js
@@ -118,7 +118,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.FlyoutStartView'
             var layers = [];
             var deniedLayers = [];
             me.instance.sandbox.findAllSelectedMapLayers().forEach(function (layer) {
-                if (!me.service.hasPublishRight(layer) || !me.instance.sandbox.getMap().isLayerSupported(layer)) {
+                const { unsupported } = layer.getVisibilityInfo();
+                if (!me.service.hasPublishRight(layer) || unsupported) {
                     deniedLayers.push(layer);
                 } else {
                     layers.push(layer);
@@ -189,15 +190,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.FlyoutStartView'
                 if (!this.service.hasPublishRight(layer)) {
                     reasons.push(this.loc.noRights);
                 }
-                if (!map.isLayerSupported(layer)) {
-                    reasons = reasons.concat(map.getUnsupportedLayerReasons(layer)
-                        .map(cur => {
-                            if (cur instanceof UnsupportedLayerSrs) {
-                                return this.loc.unsupportedProjection;
-                            }
-                            return cur.getDescription().replace(/\./g, '');
-                        })
-                    );
+                const { unsupported } = layer.getVisibilityInfo();
+                if (unsupported) {
+                    reasons.push(unsupported.getDescription());
                 }
                 if (reasons.length) {
                     txt += ' (' + reasons.join(', ') + ')';

--- a/bundles/framework/publisher2/view/FlyoutStartView.js
+++ b/bundles/framework/publisher2/view/FlyoutStartView.js
@@ -1,5 +1,3 @@
-import { UnsupportedLayerSrs } from '../../../mapping/mapmodule/domain/UnsupportedLayerSrs';
-
 /**
  * @class Oskari.mapframework.bundle.publisher2.view.StartView
  *
@@ -177,7 +175,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.FlyoutStartView'
             var layerList = this.templateLayerList.clone();
             var listElement = layerList.find('ul');
             var listItemTemplate = this.templateListItem;
-            var map = this.instance.sandbox.getMap();
 
             list.forEach((layer) => {
                 var item = listItemTemplate.clone();

--- a/bundles/mapping/dimension-change/domain/UnsupportedLayerType.js
+++ b/bundles/mapping/dimension-change/domain/UnsupportedLayerType.js
@@ -5,14 +5,16 @@ const unsupportedIn2D = ['tiles3d'];
 export class UnsupportedLayerType extends UnsupportedLayerReason {
     constructor (severity) {
         super('dimension', severity);
-        const map = Oskari.getSandbox().getMap();
+        const mapSupports3D = Oskari.getSandbox().getMap().getSupports3D();
         this.setLayerCheckFunction(layer => {
-            if (isLayerSupported(layer, map.getSupports3D())) {
+            if (isLayerSupported(layer, mapSupports3D)) {
                 return true;
             }
             // not supported -> Return an instance of UnsupportedLayerReason
             return this;
         });
+        const dimension = mapSupports3D ? '3D' : '2D';
+        this.setDescription(Oskari.getMsg('MapModule', 'layerUnsupported.dimension', { dimension }));
     }
 }
 

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -2486,32 +2486,17 @@ Oskari.clazz.define(
          * @return {undefined}
          */
         afterMapLayerAddEvent: function (event) {
-            var layer = event.getMapLayer();
-            var keepLayersOrder = true;
-            var isBaseMap = false;
-            var layerPlugins = this.getLayerPlugins();
-            var layerFunctions = [];
-            var sandbox = this.getSandbox();
-            var publisherService = sandbox.getService('Oskari.mapframework.bundle.publisher2.PublisherService');
-            var isPublisherActive = publisherService && publisherService.getIsActive();
+            const layer = event.getMapLayer();
+            const keepLayersOrder = true;
+            const isBaseMap = false;
+            const layerPlugins = this.getLayerPlugins();
 
-            if (!sandbox.getMap().isLayerSupported(layer) && !isPublisherActive) {
-                this._mapLayerService.showUnsupportedPopup();
+            const supportedByPlugins = Object.values(layerPlugins)
+                .filter(plugin => plugin.isLayerSupported && plugin.isLayerSupported(layer));
+            if (supportedByPlugins.length !== 1) {
+                // TODO: should we handle somehow if 0 or > 1 plugins
             }
-            const isSupported = (plugin, layer) => typeof plugin.isLayerSupported === 'function' && plugin.isLayerSupported(layer);
-
-            Object.values(layerPlugins).forEach((plugin) => {
-                // true if either plugin doesn't have the function or says the layer is supported.
-                if (isSupported(plugin, layer) && typeof plugin.addMapLayerToMap === 'function') {
-                    var layerFunction = plugin.addMapLayerToMap(layer, keepLayersOrder, isBaseMap);
-                    if (typeof layerFunction === 'function') {
-                        layerFunctions.push(layerFunction);
-                    }
-                }
-            });
-
-            // Execute each layer function
-            layerFunctions.forEach((func) => func.apply());
+            supportedByPlugins.forEach(plugin => plugin.addMapLayerToMap(layer, keepLayersOrder, isBaseMap));
         },
 
         /**

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -1231,21 +1231,24 @@ export class MapModule extends AbstractMapModule {
     }
 
     isLayerVisible (layer) {
-        if (typeof layer === 'undefined') {
-            return false;
-        }
+        this.log.deprecated('isLayerVisible', 'Use layer.isVisibleOnMap() instead');
+
         if (Array.isArray(layer)) {
-            // getOLMapLayers() returns an array -> check that atleast one of them is visible
-            // group layers can have multiple layers with only some visible
-            return layer.some(l => this.isLayerVisible(l));
+            // passed [layerImpl] directly -> check that atleast one of them is visible
+            return layer.some(l => typeof l.getVisible === 'function' && l.getVisible());
         }
         if (typeof layer === 'object') {
-            // probably passed the layer impl directly
-            return layer.getVisible();
+            if (typeof layer.getVisible === 'function') {
+                // probably passed the layer impl directly
+                return layer.getVisible();
+            } else if (typeof layer.isVisibleOnMap === 'function') {
+                // probably passed the oskari layer directly
+                return layer.isVisibleOnMap();
+            }
         }
         // layer is probably id
-        const layerImpl = this.getOLMapLayers(layer);
-        return this.isLayerVisible(layerImpl);
+        const oskariLayer = this._sandbox.findMapLayerFromSelectedMapLayers(layer);
+        return oskariLayer ? oskariLayer.isVisibleOnMap() : false;
     }
 
     /**

--- a/bundles/mapping/mapmodule/domain/AbstractLayer.js
+++ b/bundles/mapping/mapmodule/domain/AbstractLayer.js
@@ -1273,7 +1273,8 @@ Oskari.clazz.define(
         },
         isVisibleOnMap () {
             const { unsupported, ...booleans } = this.getVisibilityInfo();
-            return Object.values(booleans).every(b => b === true) && !unsupported;
+            return this.getOpacity() !== 0 && !unsupported &&
+                Object.values(booleans).every(b => b === true);
         }
     }
 );

--- a/bundles/mapping/mapmodule/domain/AbstractLayer.js
+++ b/bundles/mapping/mapmodule/domain/AbstractLayer.js
@@ -54,9 +54,6 @@ Oskari.clazz.define(
         /* Min scale for layer */
         me._minScale = null;
 
-        /* is layer visible */
-        me._visible = null;
-
         /* opacity from 0 to 100 */
         me._opacity = 100;
 
@@ -136,7 +133,12 @@ Oskari.clazz.define(
 
         me._orderNumber = 1000000;
 
-        me._unsupportedReason = null;
+        me._visibilityInfo = {
+            visible: true, // {Boolean} visible/hidden by the user
+            inScale: true, // {Boolean} map viewport scale (zoom) is in the layer's scale range
+            geometryMatch: true, // {Boolean} map viewport overlaps defined coverage/geometry
+            unsupported: null // {UnsupportedLayerReason} most severe reason if unsupported
+        };
     }, {
         /**
          * @method setId
@@ -503,14 +505,14 @@ Oskari.clazz.define(
          * @return {Boolean} true if this is should be shown
          */
         isVisible: function () {
-            return this._visible === true;
+            return this._visibilityInfo.visible === true;
         },
         /**
          * @method setVisible
          * @param {Boolean} visible true if this is should be shown
          */
         setVisible: function (visible) {
-            this._visible = visible;
+            this.updateVisibilityInfo({ visible });
         },
         /**
          * @method setOpacity
@@ -1259,6 +1261,19 @@ Oskari.clazz.define(
         },
         getGeometryType: function () {
             return null;
+        },
+        getVisibilityInfo () {
+            return this._visibilityInfo;
+        },
+        setVisibilityInfo (info) {
+            this._visibilityInfo = info;
+        },
+        updateVisibilityInfo (updated) {
+            this._visibilityInfo = { ...this._visibilityInfo, ...updated };
+        },
+        isVisibleOnMap () {
+            const { unsupported, ...booleans } = this.getVisibilityInfo();
+            return Object.values(booleans).every(b => b === true) && !unsupported;
         }
     }
 );

--- a/bundles/mapping/mapmodule/domain/UnsupportedLayerReason.js
+++ b/bundles/mapping/mapmodule/domain/UnsupportedLayerReason.js
@@ -3,52 +3,58 @@ export class UnsupportedLayerReason {
         this._id = id || 'default';
         this._severity = severity || UnsupportedLayerReason.WARNING;
     }
+
     setId (id) {
         this._id = id;
     }
+
     getId () {
         return this._id;
     }
+
     setSeverity (level) {
         this._severity = level;
     }
+
     getSeverity () {
         return this._severity;
     }
+
     setDescription (desc) {
         this._description = desc;
     }
+
     getDescription () {
-        if (!this._description) {
-            this._description = Oskari.getMsg('MapModule', 'unsupported-layer');
-        }
-        return this._description;
+        return this._description || Oskari.getMsg('MapModule', 'layerUnsupported.common');
     }
+
     setAction (action) {
         this._action = action;
     }
+
     getAction () {
         return this._action;
     }
+
     setActionText (text) {
         this._actionText = text;
     }
+
     getActionText () {
         return this._actionText;
     }
+
     setLayerCheckFunction (check) {
         this._layerCheck = check;
     }
+
     /**
      * @method isLayerSupported     *
      * For checking wether layer is supported in current map view or not.
      * @return function that receives layer as param and should return boolean or `UnsupportedLayerReason` if layer is not supported.
      */
     getLayerCheckFunction () {
-        if (!this._layerCheck) {
-            this._layerCheck = () => true;
-        }
-        return this._layerCheck;
+        return typeof this._layerCheck === 'function' ? this._layerCheck : () => true;
     }
 }
 

--- a/bundles/mapping/mapmodule/domain/UnsupportedLayerSrs.js
+++ b/bundles/mapping/mapmodule/domain/UnsupportedLayerSrs.js
@@ -5,7 +5,7 @@ export class UnsupportedLayerSrs extends UnsupportedLayerReason {
         super('srs', severity);
         const map = Oskari.getSandbox().getMap();
         this.setLayerCheckFunction(layer => layer.isSupportedSrs(map.getSrsName()) ? true : this);
-        this.setDescription(Oskari.getMsg('MapModule', 'unsupported-layer-projection'));
+        this.setDescription(Oskari.getMsg('MapModule', 'layerUnsupported.srs'));
     }
 }
 

--- a/bundles/mapping/mapmodule/mapmodule.olcs.js
+++ b/bundles/mapping/mapmodule/mapmodule.olcs.js
@@ -449,25 +449,14 @@ class MapModuleOlCesium extends MapModuleOl {
      * @param {String|Number|Cesium.Cesium3DTileset|ol.layer} layer id in Oskari or the layer implementation
      */
     isLayerVisible (layer) {
-        if (typeof layer === 'undefined') {
-            return false;
-        }
-        if (layer instanceof Cesium.Cesium3DTileset) {
-            // probably passed the layer impl directly
-            return layer.show || false;
-        }
         if (Array.isArray(layer)) {
-            // getOLMapLayers() returns an array -> check that atleast one of them is visible
-            // group layers can have multiple layers with only some visible
             return layer.some(l => this.isLayerVisible(l));
         }
-        if (typeof layer === 'object') {
-            // probably passed the ol layer impl directly
-            return super.isLayerVisible(layer);
+        if (layer instanceof Cesium.Cesium3DTileset) {
+            this.log.deprecated('isLayerVisible', 'Use layer.isVisibleOnMap() instead');
+            return layer.show || false;
         }
-        // layer is probably id
-        const layerImpl = this.getOLMapLayers(layer);
-        return this.isLayerVisible(layerImpl);
+        super.isLayerVisible(layer);
     }
     /**
      * @param {Object} layerImpl ol/layer/Layer or Cesium.Cesium3DTileset, olcs specific!

--- a/bundles/mapping/mapmodule/plugin/layers/LayersPlugin.olcs.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayersPlugin.olcs.js
@@ -14,6 +14,7 @@ class LayersPluginOlcs extends LayersPlugin {
             return layer.getVisible();
         }
     }
+
     /**
      * @method _setLayerImplVisible Sets layer visibility on map.
      * @param {Cesium.Cesium3DTileset | olLayer} layer
@@ -26,46 +27,12 @@ class LayersPluginOlcs extends LayersPlugin {
             return layer.setVisible(visible);
         }
     }
-    /**
-     * @method handleMapLayerVisibility
-     * Checks layer's visibility (visible, inScale, inGeometry) and sets ol layers' visibilities.
-     * notifies bundles about visibility changes by sending MapLayerVisibilityChangedEvent.
-     * @param {Oskari.mapframework.domain.AbstractMapLayer} layer layer to check against
-     * @param {Boolean} isRequest if MapLayerVisibilityRequest, then trigger always change because layer's visibility has changed
-     */
-    handleMapLayerVisibility (layer, isRequest) {
-        let scaleOk = layer.isVisible();
-        let geometryMatch = layer.isVisible();
-        let triggerChange = (isRequest === true);
-        // if layer is visible check actual values
-        if (layer.isVisible()) {
-            scaleOk = this._isInScale(layer);
-            geometryMatch = this.isInGeometry(layer);
-        }
-        const mapLayers = this.getMapModule().getOLMapLayers(layer.getId());
-        if (!mapLayers || !mapLayers.length) {
-            if (triggerChange) {
-                this.notifyLayerVisibilityChanged(layer, scaleOk, geometryMatch);
-            }
-            return;
-        }
-        const visibility = scaleOk && geometryMatch && layer.isVisible();
-        mapLayers.forEach(mapLayer => {
-            if (visibility !== this._isLayerImplVisible(mapLayer)) {
-                this._setLayerImplVisible(mapLayer, visibility);
-                triggerChange = true;
-            }
-        });
-        if (triggerChange) {
-            this.notifyLayerVisibilityChanged(layer, scaleOk, geometryMatch);
-        }
-    }
 }
 
 Oskari.clazz.defineES('Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin',
     LayersPluginOlcs,
     {
-        'protocol': [
+        protocol: [
             'Oskari.mapframework.module.Module',
             'Oskari.mapframework.ui.module.common.mapmodule.Plugin'
         ]

--- a/bundles/mapping/mapmodule/plugin/layers/LayersPlugin.olcs.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayersPlugin.olcs.js
@@ -6,7 +6,6 @@ class LayersPluginOlcs extends LayersPlugin {
      * @param {Cesium.Cesium3DTileset | olLayer} layer
      */
     _isLayerImplVisible (layer) {
-        // NOTE! mapmodule has isLayerVisible() that is the same thing but uses layer id as param
         // OL version doesn't have this method at all
         if (layer instanceof Cesium.Cesium3DTileset) {
             return layer.show;

--- a/bundles/mapping/mapmodule/plugin/layers/LayersPluginClass.ol.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayersPluginClass.ol.js
@@ -194,8 +194,9 @@ export class LayersPlugin extends AbstractMapModulePlugin {
         if (geometries.length === 0) {
             return true;
         }
-        const extent = this.getMapModule().getExtentArray();
-        return geometries[0].intersectsExtent(extent);
+        const viewBounds = this.getMapModule().getCurrentExtent();
+        const olExtent = [viewBounds.left, viewBounds.bottom, viewBounds.right, viewBounds.top];
+        return geometries[0].intersectsExtent(olExtent);
     }
 
     /**

--- a/bundles/mapping/mapmodule/resources/locale/en.js
+++ b/bundles/mapping/mapmodule/resources/locale/en.js
@@ -19,14 +19,9 @@ Oskari.registerLocalization(
             "zoomLvl-11": "",
             "zoomLvl-12": ""
         },
-        "unsupportedProjHeader": "Notice",
-        "unsupportedProj": "Some layers added to this map view cannot be shown with the current map projection.",
-        "unsupported-layer": "Map Layer cannot be shown.",
-        "unsupported-layer-projection": "Map layer cannot be shown in selected map projection.",
         "styles": {
             "defaultTitle": "Default style"
         },
-        "mapLayerUnavailable": `Map layer \"{name}"\ can not be shown.`,
         "plugin": {
             "LogoPlugin": {
                 "terms": "Terms of Use",
@@ -124,6 +119,12 @@ Oskari.registerLocalization(
         "layerVisibility": {
             "notInScale": "The map layer \"{name}\" has no visible features in this zoom level. Move to a suitable map level.",
             "notInGeometry": "The map layer \"{name}\" has no features in this area. Move to a better location on map."
+        },
+        "layerUnsupported": {
+            "common": "Map Layer cannot be shown.",
+            "srs": "Map layer cannot be shown with the current map projection.",
+            "dimension": "Map layer cannot be shown with {dimension} map view.",
+            "unavailable": 'Map layer "{name}" cannot be shown.'
         },
         "guidedTour": {
             "help1": {

--- a/bundles/mapping/mapmodule/resources/locale/fi.js
+++ b/bundles/mapping/mapmodule/resources/locale/fi.js
@@ -19,14 +19,9 @@ Oskari.registerLocalization(
             "zoomLvl-11": "",
             "zoomLvl-12": ""
         },
-        "unsupportedProjHeader": "Huom.",
-        "unsupportedProj": "Joitain karttatasoja ei voida näyttää tässä karttaprojektiossa.",
-        "unsupported-layer": "Karttatasoa ei voida näyttää.",
-        "unsupported-layer-projection": "Karttatasoa ei voida näyttää tässä karttaprojektiossa.",
         "styles": {
             "defaultTitle" : "Oletustyyli"
         },
-        "mapLayerUnavailable": `Karttatasoa \"{name}"\ ei voida näyttää.`,
         "plugin": {
             "LogoPlugin": {
                 "terms": "Käyttöehdot",
@@ -122,6 +117,12 @@ Oskari.registerLocalization(
         "layerVisibility": {
             "notInScale": "Karttatason \"{name}\" kohteet eivät näy tässä mittakaavassa. Siirry soveltuvalle mittakaavatasolle.",
             "notInGeometry": "Karttatasolla \"{name}\" ei ole kohteita tällä alueella. Siirry kohteeseen kartalla."
+        },
+        "layerUnsupported": {
+            "common": "Karttatasoa ei voida näyttää.",
+            "srs": "Karttatasoa ei voida näyttää tässä karttaprojektiossa.",
+            "dimension": "Karttatasoa ei voida näyttää {dimension}-karttanäkymässä.",
+            "unavailable": 'Karttatasoa "{name}" ei voida näyttää.'
         },
         "guidedTour": {
             "help1": {

--- a/bundles/mapping/mapmodule/resources/locale/fr.js
+++ b/bundles/mapping/mapmodule/resources/locale/fr.js
@@ -19,10 +19,6 @@ Oskari.registerLocalization(
             "zoomLvl-11": "",
             "zoomLvl-12": ""
         },
-        "unsupportedProjHeader": "Avis",
-        "unsupportedProj": "Impossible d'afficher certaines couches ajoutées à cette vue cartographique avec la projection cartographique actuelle.",
-        "unsupported-layer": "La couche de carte ne peut pas être affichée.",
-        "unsupported-layer-projection": "La couche cartographique ne peut pas être affichée dans la projection cartographique sélectionnée.",
         "styles": {
             "defaultTitle": "Style par défaut"
         },
@@ -122,6 +118,12 @@ Oskari.registerLocalization(
                     "confirmReset": "Souhaitez-vous revenir à l’étendue précédente?"
                 }
             },
+        },
+        "layerUnsupported": {
+            "common": "La couche de carte ne peut pas être affichée.",
+            "srs": "La couche cartographique ne peut pas être affichée dans la projection cartographique sélectionnée.",
+            "dimension": "La couche cartographique ne peut pas être affichée dans la projection cartographique sélectionnée.",
+            "unavailable": "La couche de carte ne peut pas être affichée."
         },
         "guidedTour": {
             "help1": {

--- a/bundles/mapping/mapmodule/resources/locale/ru.js
+++ b/bundles/mapping/mapmodule/resources/locale/ru.js
@@ -19,10 +19,6 @@ Oskari.registerLocalization(
             "zoomLvl-11": "",
             "zoomLvl-12": ""
         },
-        "unsupportedProjHeader": "Уведомление",
-        "unsupportedProj": "Некоторые слои, добавленные в этот вид карты, не могут быть показаны в текущей проекции карты.",
-        "unsupported-layer": "Слой карты не может быть показан.",
-        "unsupported-layer-projection": "Слой карты не может быть показан в выбранной проекции карты.",
         "styles": {
             "defaultTitle": "Стиль по умолчанию"
         },
@@ -117,6 +113,12 @@ Oskari.registerLocalization(
             "MyLocationPlugin": {
                 "tooltip": "Центровать карту относительно вашего местоположения"
             }
+        },
+        "layerUnsupported": {
+            "common": "Слой карты не может быть показан.",
+            "srs": "Слой карты не может быть показан в выбранной проекции карты.",
+            "dimension": "Слой карты не может быть показан в выбранной проекции карты.",
+            "unavailable": "Слой карты не может быть показан."
         },
         "guidedTour": {
             "help1": {

--- a/bundles/mapping/mapmodule/resources/locale/sv.js
+++ b/bundles/mapping/mapmodule/resources/locale/sv.js
@@ -19,7 +19,6 @@ Oskari.registerLocalization(
             "zoomLvl-11": "",
             "zoomLvl-12": ""
         },
-        "unsupportedProj": "Vissa kartlager i denna kartvy kan inte visas med den  kartprojektionen.",
         "styles": {
             "defaultTitle": "Standard stil"
         },

--- a/bundles/mapping/mapmodule/resources/locale/sv.js
+++ b/bundles/mapping/mapmodule/resources/locale/sv.js
@@ -19,14 +19,10 @@ Oskari.registerLocalization(
             "zoomLvl-11": "",
             "zoomLvl-12": ""
         },
-        "unsupportedProjHeader": "Obs.",
-        "unsupportedProj": "Vissa kartlager i denna kartvy kan inte visas med den aktuella kartprojektionen.",
-        "unsupported-layer": "Denna kartlager kan inte visas.",
-        "unsupported-layer-projection": "Denna kartlager kan inte visas med den valda kartprojektionen.",
+        "unsupportedProj": "Vissa kartlager i denna kartvy kan inte visas med den  kartprojektionen.",
         "styles": {
             "defaultTitle": "Standard stil"
         },
-        "mapLayerUnavailable": `Kartlagret \"{name}"\ kan inte visas.`,
         "plugin": {
             "LogoPlugin": {
                 "terms": "Användarvillkor",
@@ -124,6 +120,12 @@ Oskari.registerLocalization(
         "layerVisibility": {
             "notInScale": "\"{name}\" kartlagrets objekter kan inte visas i denna skala. Välj en lämplig skalnivå.",
             "notInGeometry": "Kartlagret \"{name}\" har inga objekter i detta område. Gå till en annan vy på kartan."
+        },
+        "layerUnsupported": {
+            "common": "Denna kartlager kan inte visas.",
+            "srs": "Denna kartlager kan inte visas med den aktuella kartprojektionen.",
+            "dimension": "Vissa kartlager i denna kartvy kan inte visas med {dimension}.",
+            "mapLayerUnavailable": 'Kartlagret "{name}" kan inte visas.'
         },
         "guidedTour": {
             "help1": {

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -519,21 +519,6 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
             }
             // TODO: notify if layer not found?
         },
-        showUnsupportedPopup: function () {
-            if (this.popupCoolOff) {
-                return;
-            }
-            var popup = this._popupService.createPopup();
-
-            var buttons = [popup.createCloseButton('OK')];
-            const dimension = this.getSandbox().getMap().getSupports3D() ? '3D' : '2D';
-            popup.show(this.loc('unsupportedProjHeader'), this.loc('unsupportedProj', { dimension }).replace(/[\n]/g, '<br>'), buttons);
-
-            this.popupCoolOff = true;
-            setTimeout(function () {
-                this.popupCoolOff = false;
-            }.bind(this), 500);
-        },
 
         /**
          * @method loadAllLayerGroupsAjax


### PR DESCRIPTION
Gather visibilityInfo to layer on visibility change and check unsupported reason on start. Selected layer can use whole visibleInfo and layerlist can use unsupported on render (no need to check or get values). 

layer has methods:
- isVisible() => user 
- isVisibleOnMap() => maplayer is visible on map (visible, geom, scale, supported, opacity != 0)
- const {unsupported} = layer.getVisibleInfo() => most severe UnsupportedReason

Changes:
- update visibility info and unsupported reason on layers plugin. remove override from 3D/cesium plugin
- selected layers uses visibilityInfo
- layerlist uses unsupported to show most severe unsupported reason
- mapfull gather params uses isVisibleOnMap if optimized
- publisher shows most severe unsupported reason (earlier listed all unsupported reasons)
- deprecate mapmodule isLayerVisible