### PR TITLE
Movable containers on map

### DIFF
--- a/bundles/mapping/mapmodule/plugin/pluginPopupHelper.js
+++ b/bundles/mapping/mapmodule/plugin/pluginPopupHelper.js
@@ -23,6 +23,10 @@ const getPlacementFromPluginLocation = (pluginLocation) => {
         return PLACEMENTS.TOP;
     case 'top center':
         return PLACEMENTS.TOP;
+    case 'bottom right':
+        return PLACEMENTS.BR;
+    case 'bottom left':
+        return PLACEMENTS.BL;
     default:
         return PLACEMENTS.TL;
     };

--- a/bundles/statistics/statsgrid2016/instance.js
+++ b/bundles/statistics/statsgrid2016/instance.js
@@ -150,7 +150,7 @@ Oskari.clazz.define(
                     this[plugin].toggleUI();
                 }
             });
-            const visible = this[plugin] && !!this[plugin].getElement();
+            const visible = this[plugin] && this[plugin].isVisible();
             this.togglePlugin.toggleTool(tool, visible);
         },
         isEmbedded: function () {
@@ -479,15 +479,11 @@ Oskari.clazz.define(
                 view: this.visible
             };
         },
-        createClassficationView: function () {
+        createClassificationView: function () {
             const config = jQuery.extend(true, {}, this.getConfiguration());
-            const mapModule = this.getSandbox().findRegisteredModuleInstance('MainMapModule');
-
             this.classificationPlugin = Oskari.clazz.create('Oskari.statistics.statsgrid.ClassificationPlugin', this, config);
             this.classificationPlugin.on('show', () => this.togglePlugin && this.togglePlugin.toggleTool(TOGGLE_TOOL_CLASSIFICATION, true));
             this.classificationPlugin.on('hide', () => this.togglePlugin && this.togglePlugin.toggleTool(TOGGLE_TOOL_CLASSIFICATION, false));
-            mapModule.registerPlugin(this.classificationPlugin);
-            mapModule.startPlugin(this.classificationPlugin);
             this.classificationPlugin.buildUI();
         },
         // TODO do we need to unregister plugin
@@ -501,7 +497,7 @@ Oskari.clazz.define(
         },
         _setClassificationViewVisible: function (visible) {
             if (!this.classificationPlugin && visible) {
-                this.createClassficationView();
+                this.createClassificationView();
                 return;
             }
             if (visible) {

--- a/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { showMovableContainer, PLACEMENTS } from 'oskari-ui/components/window';
 import { LocaleProvider } from 'oskari-ui/util';
 import { Classification } from '../components/classification/Classification';
 import { showHistogramPopup } from '../components/manualClassification/HistogramForm';
+import { getPopupOptions } from '../../../mapping/mapmodule/plugin/pluginPopupHelper';
 import '../resources/scss/classificationplugin.scss';
 /**
  * @class Oskari.statistics.statsgrid.ClassificationPlugin
@@ -21,10 +22,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
         this._defaultLocation = 'right bottom';
         me._fixedLocation = true;
         me._name = 'ClassificationPlugin';
-        me.element = null;
-        me._templates = {
-            main: jQuery('<div class="mapplugin statsgrid-classification-plugin"></div>')
-        };
         // for publisher dragndrop to work needs to have at least:
         // -  mapplugin-class in parent template
         // - _setLayerToolsEditModeImpl()
@@ -33,59 +30,77 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
         me.log = Oskari.log('Oskari.statistics.statsgrid.ClassificationPlugin');
         Oskari.makeObservable(this);
 
-        this.node = null;
         this._overflowedOffset = null;
         this._previousIsEdit = false;
         this.indicatorData = {};
         this._bindToEvents();
         this.service.getStateService().initClassificationPluginState(this._config, this._instance.isEmbedded());
         this.histogramControls = null;
+
+        this.containerController = null;
     }, {
-        _createControlElement: function () {
-            if (this.element !== null) {
-                return this.element;
-            }
-            this.element = this._templates.main.clone();
-            this.element.css('z-index', 15001);
-            return this.element;
+        // buildUI() is the starting point
+        buildUI: function () {
+            this.render();
+            this.trigger('show');
         },
-        rendered: function (isEdit) {
-            // check if edit classification state is changed
-            if (isEdit !== this._previousIsEdit) {
-                if (isEdit) {
-                    this._overflowCheck(true);
-                } else {
-                    this._restoreOverflow();
-                }
-                this._previousIsEdit = isEdit;
+        // this is used to stop this/remove from screen
+        stopPlugin: function () {
+            if (this.containerController) {
+                this.containerController.close();
+                this.containerController = null;
             }
-            this._overflowCheck();
+            this.trigger('hide');
+        },
+        isVisible: function () {
+            return !!this.containerController;
+        },
+        toggleUI: function () {
+            this.containerController ? this.stopPlugin() : this.buildUI();
+            return !!this.containerController;
         },
         render: function () {
-            if (!this.node) {
+            const { error, ...state } = this.service.getStateService().getStateForClassification();
+            if (error) {
                 return;
             }
-            const { error, ...state } = this.service.getStateService().getStateForClassification();
-            if (error) return;
             const { data, status, uniqueCount, minMax } = this.getIndicatorData(state);
-            if (status === 'PENDING') return;
+            if (status === 'PENDING') {
+                return;
+            }
             const editOptions = this.getEditOptions(state, uniqueCount, minMax);
             const classifiedDataset = this.classifyDataset(state, data, uniqueCount);
             // Histogram doesn't need to be updated on every events but props are gathered here
             // and histogram is updated only if it's opened, so update here for now
             this.updateHistogram(state, classifiedDataset, data, editOptions);
-
-            ReactDOM.render((
+            const ui = (
                 <LocaleProvider value={{ bundleKey: this._instance.getName() }}>
                     <Classification
                         { ...state }
                         editOptions = {editOptions}
                         classifiedDataset = {classifiedDataset}
                         startHistogramView = {() => this.startHistogramView(state, classifiedDataset, data, editOptions)}
-                        onRenderChange = {this.rendered.bind(this)}
+                        onRenderChange = {() => { /* no-op */ }}
                     />
-                </LocaleProvider>
-            ), this.node);
+                </LocaleProvider>);
+            if (this.containerController) {
+                this.containerController.update(ui);
+                return;
+            }
+            this.containerController = showMovableContainer(ui, () => this.stopPlugin(), this.__getContainerOpts());
+        },
+        // Use togglePlugin location when available, otherwise default to bottom right
+        __getContainerOpts: function () {
+            let opts = {
+                placement: PLACEMENTS.BR
+            };
+            if (this._instance.togglePlugin) {
+                opts = getPopupOptions(this._instance.togglePlugin);
+            }
+            return {
+                ...opts,
+                id: 'statsgrid_classification'
+            };
         },
         getIndicatorData: function (state) {
             const { activeIndicator, regionset: activeRegionset } = state;
@@ -188,102 +203,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
             }
             this.histogramControls.update(state, classifiedDataset, data, editOptions);
         },
-        redrawUI: function () {
-            // No need to redraw because mobile & desktop is same
-            return false;
-        },
-        toggleUI: function () {
-            this.element ? this.teardownUI() : this.buildUI();
-            return !!this.element;
-        },
-        teardownUI: function () {
-            var element = this.getElement();
-            if (this.node) {
-                ReactDOM.unmountComponentAtNode(this.node);
-                this.node = null;
-            }
-            if (element) {
-                this.removeFromPluginContainer(element);
-                this.element = null;
-            }
-            this.trigger('hide');
-        },
-        buildUI: function () {
-            if (!this.element) {
-                this.addToPluginContainer(this._createControlElement());
-                this._makeDraggable();
-                this.node = this.element.get(0);
-                this.render();
-            }
-            this.trigger('show');
-        },
-        _makeDraggable: function () {
-            this.getElement().draggable({
-                handle: '.classification-header,.classification-legend'
-            });
-        },
-        getElement: function () {
-            return this.element;
-        },
-        stopPlugin: function () {
-            this.teardownUI();
-        },
-        _overflowCheck: function (storeOverflow) {
-            // This is messy.
-            // FIXME: Lets refactor this in a way that it is using the popup/windowing system we have for React
-            // Currently this draggable window is placed inside a plugin container.
-            var pluginEl = this.getElement();
-            if (!pluginEl) {
-                return;
-            }
-            const MARGIN = 10;
-            const position = pluginEl.css('position');
-            if (!['absolute', 'relative'].includes(position)) {
-                // left side plugins use relative
-                // right side plugins use absolute
-                return;
-            }
-
-            const locationList = this.getLocation().split(' ');
-            const pluginContainer = jQuery('.mapplugins.' + locationList.join('.'));
-            const pluginContainerWidth = pluginContainer.outerWidth();
-            const pluginHeight = pluginEl.outerHeight();
-            const pluginWidth = pluginEl.outerWidth();
-            if (locationList.includes('bottom')) {
-                // 0 is the plugin container top and we want to move it up
-                const idealTop = 0 - pluginHeight - MARGIN;
-                pluginEl.css('top', idealTop + 'px');
-            }
-            if (locationList.includes('right')) {
-                const idealLeft = 0 + pluginContainerWidth - pluginWidth - MARGIN;
-                pluginEl.css('left', idealLeft + 'px');
-            }
-
-            if (locationList.includes('top')) {
-                const idealTop = 5 * MARGIN;
-                pluginEl.css('top', idealTop + 'px');
-            }
-            if (locationList.includes('left')) {
-                pluginEl.css('left', MARGIN + 'px');
-                if (locationList.includes('bottom')) {
-                    pluginEl.css('top', -MARGIN + 'px');
-                }
-            }
-        },
-        _restoreOverflow: function () {
-            var pluginEl = this.getElement();
-            if (this._overflowedOffset === null || !pluginEl) {
-                return;
-            }
-            pluginEl.css('top', pluginEl.position().top - this._overflowedOffset + 'px');
-            this._overflowedOffset = null;
-        },
-        hasUI: function () {
-            // Plugin has ui element but returns false, because
-            // otherwise publisher would stop this plugin and start it again when leaving the publisher,
-            // instance updates visibility
-            return false;
-        },
         _bindToEvents: function () {
             // if indicator is removed/added - recalculate the source 1/2 etc links
             this.service.on('StatsGrid.IndicatorEvent', () => this.render());
@@ -306,7 +225,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
             this.service.on('StatsGrid.DatasourceEvent', () => this.render());
         }
     }, {
-        'extend': ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],
         /**
          * @static @property {string[]} protocol array of superclasses
          */

--- a/bundles/statistics/statsgrid2016/plugin/SeriesControlPlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/SeriesControlPlugin.js
@@ -39,6 +39,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SeriesControlPlugin',
             // instance updates visibility
             return false;
         },
+        isVisible: function () {
+            return !!this.element;
+        },
         teardownUI: function () {
             this._isMobileVisible = false;
             if (this.element) {

--- a/src/react/components/window/MovableContainer.jsx
+++ b/src/react/components/window/MovableContainer.jsx
@@ -1,0 +1,95 @@
+import React, { useCallback, useRef, useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { createDraggable, getPositionForCentering, OUTOFSCREEN_CLASSNAME } from './util';
+import { monitorResize, unmonitorResize } from './WindowWatcher';
+import { ThemeConsumer } from '../../util/contexts';
+import { getFontClass } from '../../theme/ThemeHelper';
+
+// Note! use vh with max-height so it can handle window size changes
+// map controls have z-index 15000, make this go over them
+const Container = styled.div`
+    position: absolute;
+    left: 0;
+    top: 0;
+    max-width: 95vw;
+    min-width: 50px;
+    max-height: 90vh;
+    border: 1px solid rgba(100, 100, 100, 0.1);
+    z-index: 15001;
+
+    &.outofviewport {
+        border: 1px solid rgba(100, 0, 0, 0.5);
+    }
+`;
+
+export const MovableContainer = ThemeConsumer(({children, bringToTop, options, theme={}}) => {
+    // hide before we can calculate centering coordinates
+    const [position, setPosition] = useState({ x: -10000, y: 0, centered: false });
+    const containerProps = {
+        style: {
+            transform: `translate(${position.x}px, ${position.y}px)`
+        },
+        className: `t_window t_${options.id} ${getFontClass(theme)}`
+    };
+    const elementRef = useRef();
+    const headerProps = {
+        isDraggable: !!options.isDraggable
+    };
+    const headerFuncs = [];
+    if (typeof bringToTop === 'function') {
+        headerFuncs.push(bringToTop);
+    }
+    if (options.isDraggable === true) {
+        containerProps.ref = elementRef;
+        headerFuncs.push(useCallback(() => createDraggable(position, setPosition, elementRef), [position, setPosition, elementRef]));
+    }
+    if (headerFuncs.length) {
+        headerProps.onMouseDown = () => headerFuncs.forEach(fn => fn());
+        headerProps.onTouchStart = () => headerFuncs.forEach(fn => fn());
+    }
+    const bodyResizeHandler = (newSize, prevSize) => {
+        const windowIsNowBigger = prevSize.width < newSize.width || prevSize.height < newSize.height;
+        const popupNoLongerOnScreen = position.x > newSize.width || position.y > newSize.height;
+        if (elementRef.current && (windowIsNowBigger || popupNoLongerOnScreen)) {
+            // Note! The class is added in createDraggable()
+            // but we might not be able to remove it there after recentering on window size change
+            // remove it if window is now bigger
+            elementRef.current.classList.remove(OUTOFSCREEN_CLASSNAME);
+        }
+        if (popupNoLongerOnScreen) {
+            // console.log('Popup relocating! Window size changed from', prevSize, 'to', newSize);
+            setPosition({
+                ...position,
+                centered: false
+            });
+        }
+    };
+    const handleUnmounting = () => unmonitorResize(bodyResizeHandler);
+    useEffect(() => {
+        monitorResize(document.body, bodyResizeHandler);
+        if (position.centered) {
+            return handleUnmounting;
+        }
+        // center after content has been rendered
+        setPosition({
+            ...getPositionForCentering(elementRef, options.placement),
+            centered: true
+        });
+        return handleUnmounting;
+    });
+    /*
+    Creates:
+    <div class="t_window"></div>
+    */
+
+    return (<Container {...containerProps}  {...headerProps}>
+            {children}
+    </Container>)
+});
+
+MovableContainer.propTypes = {
+    children: PropTypes.any,
+    bringToTop: PropTypes.func,
+    options: PropTypes.object
+};

--- a/src/react/components/window/register.js
+++ b/src/react/components/window/register.js
@@ -1,6 +1,7 @@
 export const TYPE = {
     POPUP: 'popup',
     FLYOUT: 'flyout',
+    CONTAINER: 'container',
     BANNER: 'banner',
     SIDE_PANEL: 'sidePanel'
 };

--- a/src/react/components/window/util.js
+++ b/src/react/components/window/util.js
@@ -20,7 +20,7 @@ export const getAvailableHeight = () => {
 
 const DEFAULT_WIDTH = 700;
 const DEFAULT_HEIGHT = 700;
-const BORDER_MARGIN = 10;
+const BORDER_MARGIN = 50;
 export const OUTOFSCREEN_CLASSNAME = 'outofviewport';
 
 export const createDraggable = (position, setPosition, elementRef) => {


### PR DESCRIPTION
There are a bunch of movable containers that can be shown on the map, but don't use the usual popup/flyout windowing frame and use a "frameless" approach. These have been usually implemented by adding them on the plugin container that is on the map and making them draggable instead. This is problematic for layout purposes on those containers.

This PR adds a new showMovableContainer() function to the windowing helper that creates a container that behaves in the same way as popup and flyouts that use the React-based helper, but without any visual frames on the container. This enables us to share code to make these "floating windows" behave in similar ways through out the UI. The containers that go "out of screen" if the browser window gets smaller get moved back on screen etc.

This migrates the classification window for statistics functionality on Oskari to use the new helper.

TODO:

- [ ]  Try keeping the container on screen when content gets bigger (classification edit opened)
- [x] Try not to block buttons that open classification (maybe open it more to the center instead of directly over the buttons)
- [ ] Maybe save the last position so closing and reopening doesn't reset position of the container


It doesn't look different but the implementation how the draggable container has been rewritten:
![image](https://user-images.githubusercontent.com/2210335/222469172-af785d27-4eb1-445b-b863-75cd76d29214.png)
