### PR TITLE
Admin time formatter

### DIFF
--- a/bundles/admin/admin-layeranalytics/LayerAnalyticsDetails.jsx
+++ b/bundles/admin/admin-layeranalytics/LayerAnalyticsDetails.jsx
@@ -1,47 +1,22 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Table } from 'oskari-ui/components/Table';
-import { Button, Message, Space, Spin, Tooltip } from 'oskari-ui';
+import { Button, Message, Space, Spin, Link } from 'oskari-ui';
 import { DeleteButton } from 'oskari-ui/components/buttons';
 import { ArrowLeftOutlined } from '@ant-design/icons';
 
 const dateLocale = 'fi-FI';
 const localeDateOptions = {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit'
+    second: '2-digit'
 };
 
 const sorterTooltipOptions = {
     title: <Message messageKey='flyout.sorterTooltip' />
 };
 
-// timestamp formatting copied from admin-layereditor in oskari-frontend
-// TO-DO: Move both to helper class
-const formatTimestamp = (timestamp) => {
-    let date;
-    if (typeof timestamp !== 'undefined') {
-        date = new Date(timestamp);
-    }
-    return  formatDate(date) + ' ' + formatTime(date);
-};
-const formatDate = (date) => {
-    if (typeof date === 'undefined') {
-        return '--.--.----';
-    }
-    return date.toLocaleDateString(dateLocale, localeDateOptions);
-};
-
-const formatTime = (date) => {
-    if (typeof date === 'undefined') {
-        return '--:--:--';
-    }
-    return date.toLocaleTimeString(dateLocale).replace(/\./g, ':');
-};
-
 const generateLink = (item) => {
     let toScaleURL = '/?coord=' + item.x + '_' + item.y;
-    
+
     toScaleURL += '&mapLayers=';
     for (const [index, value] of item.layers.entries()) {
         toScaleURL += value; // add layer id
@@ -58,7 +33,6 @@ const generateLink = (item) => {
 };
 
 export const LayerAnalyticsDetails = ({ layerData, isLoading, closeDetailsCallback, removeAnalyticsCallback }) => {
-
     const columnSettings = [
         {
             title: <b><Message messageKey='flyout.successTitle' /></b>,
@@ -81,7 +55,7 @@ export const LayerAnalyticsDetails = ({ layerData, isLoading, closeDetailsCallba
             sortDirections: ['descend', 'ascend', 'descend'],
             sorter: (a, b) => a.time - b.time,
             showSorterTooltip: sorterTooltipOptions,
-            render: (text) => <Space>{ formatTimestamp(text) }</Space>
+            render: (text) => <Space>{ Oskari.util.formatDate(text, localeDateOptions, dateLocale) }</Space>
         },
         {
             title: '',
@@ -90,9 +64,9 @@ export const LayerAnalyticsDetails = ({ layerData, isLoading, closeDetailsCallba
                 const link = generateLink(item);
                 return (
                     <Fragment key={ link }>
-                        <Tooltip title={ <Message messageKey='flyout.moveToScaleTooltip' /> }>
-                            <a href={ link } target='_blank'><Message messageKey='flyout.moveToScale' /> { index + 1 }</a><br/>
-                        </Tooltip>
+                        <Link url={link} tooltip={<Message messageKey='flyout.moveToScaleTooltip'/> }>
+                            <Message messageKey='flyout.moveToScale' /> { index + 1 }
+                        </Link>
                     </Fragment>
                 )})
         },
@@ -109,7 +83,7 @@ export const LayerAnalyticsDetails = ({ layerData, isLoading, closeDetailsCallba
     ];
 
     if (isLoading) {
-        return ( <Spin/> );
+        return (<Spin/>);
     }
 
     return (
@@ -118,7 +92,7 @@ export const LayerAnalyticsDetails = ({ layerData, isLoading, closeDetailsCallba
                 <ArrowLeftOutlined /> <Message messageKey='flyout.backToList' />
             </Button>
             <b>{ layerData.title }</b>
-            { layerData.layerOrganization && 
+            { layerData.layerOrganization &&
                 <div><Message messageKey='flyout.layerDataProvider' />: { layerData.layerOrganization }</div>
             }
             <div><Message messageKey='flyout.successTitle' />: { layerData.success } ({ layerData.successPercentage }%)</div>

--- a/bundles/admin/admin-layeranalytics/LayerAnalyticsDetails.jsx
+++ b/bundles/admin/admin-layeranalytics/LayerAnalyticsDetails.jsx
@@ -5,7 +5,6 @@ import { Button, Message, Space, Spin, Link } from 'oskari-ui';
 import { DeleteButton } from 'oskari-ui/components/buttons';
 import { ArrowLeftOutlined } from '@ant-design/icons';
 
-const dateLocale = 'fi-FI';
 const dateOptions = {
     time: {
         second: '2-digit'
@@ -57,7 +56,7 @@ export const LayerAnalyticsDetails = ({ layerData, isLoading, closeDetailsCallba
             sortDirections: ['descend', 'ascend', 'descend'],
             sorter: (a, b) => a.time - b.time,
             showSorterTooltip: sorterTooltipOptions,
-            render: (text) => <Space>{ Oskari.util.formatDate(text, dateOptions, dateLocale) }</Space>
+            render: (text) => <Space>{ Oskari.util.formatDate(text, dateOptions) }</Space>
         },
         {
             title: '',

--- a/bundles/admin/admin-layeranalytics/LayerAnalyticsDetails.jsx
+++ b/bundles/admin/admin-layeranalytics/LayerAnalyticsDetails.jsx
@@ -6,8 +6,10 @@ import { DeleteButton } from 'oskari-ui/components/buttons';
 import { ArrowLeftOutlined } from '@ant-design/icons';
 
 const dateLocale = 'fi-FI';
-const localeDateOptions = {
-    second: '2-digit'
+const dateOptions = {
+    time: {
+        second: '2-digit'
+    }
 };
 
 const sorterTooltipOptions = {
@@ -55,7 +57,7 @@ export const LayerAnalyticsDetails = ({ layerData, isLoading, closeDetailsCallba
             sortDirections: ['descend', 'ascend', 'descend'],
             sorter: (a, b) => a.time - b.time,
             showSorterTooltip: sorterTooltipOptions,
-            render: (text) => <Space>{ Oskari.util.formatDate(text, localeDateOptions, dateLocale) }</Space>
+            render: (text) => <Space>{ Oskari.util.formatDate(text, dateOptions, dateLocale) }</Space>
         },
         {
             title: '',

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/LayerGeneralInfo.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/LayerGeneralInfo.jsx
@@ -4,46 +4,20 @@ import { Message } from 'oskari-ui';
 import { Row, Col } from 'antd';
 import styled from 'styled-components';
 
-
 const StyledRoot = styled('div')`
     padding-bottom: 20px;
 `;
 
 const dateLocale = 'fi-FI'; // we are not using here other locales than Finnish so we can hard core it into constant variable
-const localeDateOptions = {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit'
-};
-
-const formatTimestamp = (timestamp) => {
-    let date;
-    if (typeof timestamp !== 'undefined') {
-        date = new Date(timestamp);
+const dateOptions = {
+    time: {
+        second: '2-digit'
     }
-    return {
-        date: formatDate(date),
-        time: formatTime(date)
-    };
-};
-
-const formatDate = (date) => {
-    if (typeof date === 'undefined') {
-        return '--.--.----';
-    }
-    return date.toLocaleDateString(dateLocale, localeDateOptions);
-};
-
-const formatTime = (date) => {
-    if (typeof date === 'undefined') {
-        return '--:--:--';
-    }
-    return date.toLocaleTimeString(dateLocale).replace(/\./g, ':');
 };
 
 export const LayerGeneralInfo = ({ layer }) => {
-    const created = formatTimestamp(layer.created);
-    const updated = formatTimestamp(layer.updated);
+    const created = Oskari.util.formatDate(layer.created, dateOptions, dateLocale);
+    const updated = Oskari.util.formatDate(layer.updated, dateOptions, dateLocale);
 
     return (
         <StyledRoot>
@@ -53,11 +27,11 @@ export const LayerGeneralInfo = ({ layer }) => {
             </Row>
             <Row>
                 <Col span={ 12 }><Message messageKey='fields.created' /></Col>
-                <Col span={ 12 }>{ created.date } { created.time }</Col>
+                <Col span={ 12 }>{ created }</Col>
             </Row>
             <Row>
                 <Col span={ 12 }><Message messageKey='fields.updated' /></Col>
-                <Col span={ 12 }>{ updated.date } { updated.time }</Col>
+                <Col span={ 12 }>{ updated }</Col>
             </Row>
         </StyledRoot>
     );

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/LayerGeneralInfo.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/LayerGeneralInfo.jsx
@@ -8,7 +8,6 @@ const StyledRoot = styled('div')`
     padding-bottom: 20px;
 `;
 
-const dateLocale = 'fi-FI'; // we are not using here other locales than Finnish so we can hard core it into constant variable
 const dateOptions = {
     time: {
         second: '2-digit'
@@ -16,8 +15,8 @@ const dateOptions = {
 };
 
 export const LayerGeneralInfo = ({ layer }) => {
-    const created = Oskari.util.formatDate(layer.created, dateOptions, dateLocale);
-    const updated = Oskari.util.formatDate(layer.updated, dateOptions, dateLocale);
+    const created = Oskari.util.formatDate(layer.created, dateOptions);
+    const updated = Oskari.util.formatDate(layer.updated, dateOptions);
 
     return (
         <StyledRoot>

--- a/src/util.js
+++ b/src/util.js
@@ -775,11 +775,11 @@ Oskari.util = (function () {
     /**
      * Format timestamp to more readable date
      * @param {String} text
-     * @param {Object} options optional
+     * @param {Object} options optional { time, date }
      * @param {Array || String} locales optional
      * @returns {String}
      */
-    util.formatDate = (text, options = {}, locales = []) => {
+    util.formatDate = (text, options, locales = []) => {
         if (!text) {
             return '';
         }
@@ -787,13 +787,14 @@ Oskari.util = (function () {
         if (isNaN(dateTime.getMilliseconds())) {
             return '';
         }
+        const { date = {}, time = {}} = options || {};
         const defaults = {
             hour: '2-digit',
             minute: '2-digit'
         };
-        const date = dateTime.toLocaleDateString(locales, options);
-        const time = dateTime.toLocaleTimeString(locales, {...defaults, ...options});
-        return `${date} ${time}`;
+        const localeDate = dateTime.toLocaleDateString(locales, date);
+        const localeTime = dateTime.toLocaleTimeString(locales, {...defaults, ...time});
+        return `${localeDate} ${localeTime}`;
     }
 
     return util;

--- a/src/util.js
+++ b/src/util.js
@@ -779,7 +779,7 @@ Oskari.util = (function () {
      * @param {Array || String} locales optional
      * @returns {String}
      */
-    util.formatDate = (text, options, locales = []) => {
+    util.formatDate = (text, options, locales) => {
         if (!text) {
             return '';
         }
@@ -788,6 +788,13 @@ Oskari.util = (function () {
             return '';
         }
         const { date = {}, time = {}} = options || {};
+        if (!locales) {
+            // default to locale by selected language
+            // en -> en_US -> en-US
+            locales = Oskari.getSupportedLocales()
+                .filter(loc => loc.includes(Oskari.getLang()))
+                .map(loc => loc.replace('_', '-'));
+        }
         const defaults = {
             hour: '2-digit',
             minute: '2-digit'


### PR DESCRIPTION
Change admin layer editor and analytics to use util date formatter. Had to split options to date and time.

Changes:
- time: 12:00:00 -> 12.00.00
- without timestamp: '--.--.-- '-> ''

If admin needs different formatting, maybe util options could be expanded.

Other functionalities (MyData, Announcements,..) uses util formatter with default options (without seconds).

EDIT:
- default locale to selected language

Note: Date uses hyphen ('en-US') locale and oskari supported locale uses  underscore ('en_US').
