### PR TITLE
Fix for statsgrid publisher tools

### DIFF
--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -537,7 +537,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
             this._editToolLayoutOff();
             this.tools.forEach(tool => {
                 // just call stop for the tools that haven't already been shut down by the tool panel
-                if (tool.isStarted() && tool.getPlugin() && tool.getPlugin().getSandbox()) {
+                if (tool.isStarted()) {
                     tool.stop();
                     tool.setEnabled(false);
                 }

--- a/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
@@ -156,7 +156,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
             }
 
             // if dataset has negative and positive values it can be divided, base !== 0 has to be given in metadata
-            const dividable = minMax.min < 0 && minMax.max > 0;
+            const dividable = minMax && minMax.min < 0 && minMax.max > 0;
             if (typeof base !== 'number' && !dividable) {
                 // disable option if base isn't given in metadata or dataset isn't dividable
                 disabled.push('div');

--- a/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
@@ -6,7 +6,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractStatsPluginTool'
         // There will be "too many calls" to this but it's not too bad and
         // we want the location always set or reset no matter which tool sets it
         this.getStatsgridBundle()?.togglePlugin?.setLocation(conf.location?.classes);
-        this.getStatsgridBundle()?.classificationPlugin?.setLocation(conf.location?.classes);
         return conf;
     },
 

--- a/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
@@ -69,8 +69,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationTool', fun
         if (service) {
             service.getStateService().resetClassificationPluginState('editEnabled');
         }
-        // HACK: remove when publisher doesn't delete all draggables
-        setTimeout(() => this.getPlugin()._makeDraggable(), 500);
     }
 }, {
     'extend': ['Oskari.mapframework.publisher.tool.AbstractStatsPluginTool'],


### PR DESCRIPTION
The tools were broken on #2145 with AbstractStatsPluginTool.js calling classificationPlugin?.setLocation that it no longer has as it was removed from plugin containers and in to a movable container on the map.