### PR TITLE
Handle growing (in pixel size) MovableContainers

### DIFF
--- a/src/react/components/window/Popup.jsx
+++ b/src/react/components/window/Popup.jsx
@@ -2,7 +2,7 @@ import React, { useCallback, useRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { CloseIcon } from './CloseIcon';
-import { createDraggable, getPositionForCentering, OUTOFSCREEN_CLASSNAME } from './util';
+import { createDraggable, getPositionForCentering, createDocumentSizeHandler } from './util';
 import { monitorResize, unmonitorResize } from './WindowWatcher';
 import { ICON_SIZE } from './constants';
 import { ThemeConsumer } from '../../util/contexts';
@@ -99,23 +99,7 @@ export const Popup = ThemeConsumer(( {title = '', children, onClose, bringToTop,
         headerProps.onMouseDown = () => headerFuncs.forEach(fn => fn());
         headerProps.onTouchStart = () => headerFuncs.forEach(fn => fn());
     }
-    const bodyResizeHandler = (newSize, prevSize) => {
-        const windowIsNowBigger = prevSize.width < newSize.width || prevSize.height < newSize.height;
-        const popupNoLongerOnScreen = position.x > newSize.width || position.y > newSize.height;
-        if (elementRef.current && (windowIsNowBigger || popupNoLongerOnScreen)) {
-            // Note! The class is added in createDraggable()
-            // but we might not be able to remove it there after recentering on window size change
-            // remove it if window is now bigger
-            elementRef.current.classList.remove(OUTOFSCREEN_CLASSNAME);
-        }
-        if (popupNoLongerOnScreen) {
-            // console.log('Popup relocating! Window size changed from', prevSize, 'to', newSize);
-            setPosition({
-                ...position,
-                centered: false
-            });
-        }
-    };
+    const bodyResizeHandler = createDocumentSizeHandler(elementRef, position, setPosition);
     const handleUnmounting = () => unmonitorResize(bodyResizeHandler);
     useEffect(() => {
         monitorResize(document.body, bodyResizeHandler);

--- a/src/react/components/window/util.js
+++ b/src/react/components/window/util.js
@@ -188,3 +188,58 @@ export const getPositionForCentering = (elementRef, placement) => {
     }
     return getPlacementXY(width, height, placement);
 };
+
+/**
+ * Create ResizeObserver handler for an element to detect if browser window size changes to
+ *  try and keep elements in viewport if they would be out of screen after size change.
+ * @param {React.useRef()} elementRef for element that we want to keep on screen
+ * @param {Object} position with x and y keys
+ * @param {Function} setPosition to set new position
+ * @returns function to register for monitoring
+ */
+export const createDocumentSizeHandler = (elementRef, position, setPosition) => {
+    return (newSize, prevSize) => {
+        const windowIsNowBigger = prevSize.width < newSize.width || prevSize.height < newSize.height;
+        const elementNoLongerOnScreen = position.x > newSize.width || position.y > newSize.height;
+        if (elementRef.current && (windowIsNowBigger || elementNoLongerOnScreen)) {
+            // Note! The class is added in createDraggable()
+            // but we might not be able to remove it there after recentering on window size change
+            // remove it if window is now bigger
+            elementRef.current.classList.remove(OUTOFSCREEN_CLASSNAME);
+        }
+        if (elementNoLongerOnScreen) {
+            // console.log('Element relocating! Window size changed from', prevSize, 'to', newSize);
+            setPosition({
+                ...position,
+                centered: false
+            });
+        }
+    };
+};
+
+/**
+ * Create ResizeObserver handler for an element to detect if it's size changes in a way that would make the element bleed out of screen from the left or bottom.
+ * Tries to keep element in viewport by moving it up/left if it would grow large enough to go out of screen.
+ * @param {React.useRef()} elementRef for element that we want to keep on screen
+ * @param {Object} position with x and y keys
+ * @param {Function} setPosition to set new position
+ * @returns function to register for monitoring
+ */
+export const createDraggableSizeHandler = (elementRef, position, setPosition) => {
+    return (newSize, prevSize) => {
+        const popupGotBigger = prevSize.width < newSize.width || prevSize.height < newSize.height;
+        if (!elementRef.current || !popupGotBigger) {
+            // got smaller, we don't need to relocate
+            return;
+        }
+        let x = Math.min(getAvailableWidth() - newSize.width, position.x);
+        let y = Math.min(getAvailableHeight() - newSize.height, position.y);
+        if (x !== position.x || y !== position.y) {
+            setPosition({
+                x,
+                y,
+                centered: false
+            });
+        }
+    };
+};


### PR DESCRIPTION
Fixes an issue with Resize observer for popups etc where the HTML Element was used as an object key. Now generates a unique key to make it work as expected (HTMLElement.div was getting overwritten on object map when another listener for another div was added).

Adds a handler that tries to keep a MovableContainer on screen even if the size of the element changes (for example in classification container, when the edit mode is opened). Moves the element left and up if it would grow out of screen from bottom or right.