### PR TITLE
Refactor table size

### DIFF
--- a/bundles/admin/admin-layeranalytics/LayerAnalyticsDetails.jsx
+++ b/bundles/admin/admin-layeranalytics/LayerAnalyticsDetails.jsx
@@ -126,6 +126,7 @@ export const LayerAnalyticsDetails = ({ layerData, isLoading, closeDetailsCallba
             { layerData.details.length > 0 &&
                 <Table
                     columns={ columnSettings }
+                    size={ 'large '}
                     dataSource={ layerData.details.map(item => {
                         return {
                             key: item.time,

--- a/bundles/admin/admin-layeranalytics/LayerAnalyticsList.jsx
+++ b/bundles/admin/admin-layeranalytics/LayerAnalyticsList.jsx
@@ -167,7 +167,7 @@ export const LayerAnalyticsList = ({ analyticsData, isLoading, layerEditorCallba
             dataIndex: 'total',
             sortDirections: ['descend', 'ascend', 'descend'],
             sorter: (a, b) => a.total - b.total,
-            showSorterTooltip: sorterTooltipOptions,
+            showSorterTooltip: sorterTooltipOptions
         },
         {
             align: 'left',

--- a/bundles/admin/admin-layeranalytics/LayerAnalyticsList.jsx
+++ b/bundles/admin/admin-layeranalytics/LayerAnalyticsList.jsx
@@ -13,12 +13,6 @@ const TitleArea = styled.span`
     }
 `;
 
-const StyledTable = styled(Table)`
-    .ant-table-column-sorter {
-        margin: 0 0 0 5px;
-    }
-`;
-
 const FilterContainer = styled('div')`
     padding: 10px;
 `;
@@ -223,8 +217,9 @@ export const LayerAnalyticsList = ({ analyticsData, isLoading, layerEditorCallba
     }
 
     return (
-        <StyledTable
+        <Table
             columns={ columnSettings }
+            size={ 'large' }
             dataSource={ analyticsData.map(item => {
                 return {
                     key: item.id,

--- a/bundles/framework/mydata/view/Account/AccountTab.jsx
+++ b/bundles/framework/mydata/view/Account/AccountTab.jsx
@@ -17,8 +17,7 @@ const StyledTable = styled('table')`
     }
 `;
 
-export const AccountTab = ({ state, controller }) => {
-
+export const AccountTab = ({ state }) => {
     const { user, changeInfoUrl } = state;
 
     const accountData = [{
@@ -53,9 +52,9 @@ export const AccountTab = ({ state, controller }) => {
                 )}
             </div>
         </div>
-    )
+    );
 };
 
 AccountTab.propTypes = {
     state: PropTypes.object.isRequired
-}
+};

--- a/bundles/framework/mydata/view/MyViews/MyViewsList.jsx
+++ b/bundles/framework/mydata/view/MyViews/MyViewsList.jsx
@@ -3,26 +3,13 @@ import PropTypes from 'prop-types';
 import { Table, getSorterFor, ToolsContainer } from 'oskari-ui/components/Table';
 import { Message, Checkbox } from 'oskari-ui';
 import { EditOutlined } from '@ant-design/icons';
-import styled from 'styled-components';
 import { IconButton, DeleteButton } from 'oskari-ui/components/buttons';
 
 const EDIT_ICON_STYLE = {
     fontSize: '16px'
 };
 
-const StyledTable = styled(Table)`
-    tr {
-        th {
-            padding: 8px 8px;
-        }
-        td {
-            padding: 8px;
-        }
-    }
-`;
-
 export const MyViewsList = ({ controller, loading, data = [] }) => {
-
     const columnSettings = [
         {
             align: 'left',
@@ -32,7 +19,7 @@ export const MyViewsList = ({ controller, loading, data = [] }) => {
             render: (title, item) => {
                 return (
                     <Checkbox checked={item.isDefault} onChange={() => controller.setDefaultView(item)} />
-                )
+                );
             }
         },
         {
@@ -44,7 +31,7 @@ export const MyViewsList = ({ controller, loading, data = [] }) => {
             render: (title, item) => {
                 return (
                     <a onClick={() => controller.openView(item)}>{title}</a>
-                )
+                );
             }
         },
         {
@@ -81,13 +68,13 @@ export const MyViewsList = ({ controller, loading, data = [] }) => {
                             onConfirm={() => controller.deleteView(item)}
                         />
                     </ToolsContainer>
-                )
+                );
             }
         }
     ];
 
     return (
-        <StyledTable
+        <Table
             columns={columnSettings}
             dataSource={data.map(item => ({
                 key: item.id,
@@ -96,11 +83,11 @@ export const MyViewsList = ({ controller, loading, data = [] }) => {
             pagination={false}
             loading={loading}
         />
-    )
-}
+    );
+};
 
 MyViewsList.propTypes = {
     controller: PropTypes.object.isRequired,
     data: PropTypes.arrayOf(PropTypes.object),
     loading: PropTypes.bool.isRequired
-}
+};

--- a/bundles/framework/mydata/view/PublishedMaps/PublishedMapsList.jsx
+++ b/bundles/framework/mydata/view/PublishedMaps/PublishedMapsList.jsx
@@ -1,25 +1,13 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { Message, Confirm } from 'oskari-ui'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Message, Confirm } from 'oskari-ui';
 import { IconButton, DeleteButton } from 'oskari-ui/components/buttons';
-import { Table, getSorterFor, ToolsContainer } from 'oskari-ui/components/Table'
-import { EditOutlined, EyeOutlined, EyeInvisibleOutlined, CopyOutlined, PictureOutlined } from '@ant-design/icons'
-import styled from 'styled-components';
+import { Table, getSorterFor, ToolsContainer } from 'oskari-ui/components/Table';
+import { EditOutlined, EyeOutlined, EyeInvisibleOutlined, CopyOutlined, PictureOutlined } from '@ant-design/icons';
 
 const ICON_STYLE = {
     fontSize: '16px'
 };
-
-const StyledTable = styled(Table)`
-    tr {
-        th {
-            padding: 8px 8px;
-        }
-        td {
-            padding: 8px;
-        }
-    }
-`;
 
 const openView = (view) => {
     window.open(
@@ -27,10 +15,9 @@ const openView = (view) => {
         'Published',
         'location=1,status=1,scrollbars=yes,width=850,height=800'
     );
-}
+};
 
 export const PublishedMapsList = ({ controller, data = [], loading }) => {
-
     const columnSettings = [
         {
             align: 'left',
@@ -48,7 +35,7 @@ export const PublishedMapsList = ({ controller, data = [], loading }) => {
             align: 'left',
             title: <Message messageKey='tabs.publishedmaps.grid.domain' />,
             dataIndex: 'pubDomain',
-            sorter: getSorterFor('pubDomain'),
+            sorter: getSorterFor('pubDomain')
         },
         {
             align: 'left',
@@ -124,9 +111,9 @@ export const PublishedMapsList = ({ controller, data = [], loading }) => {
             }
         }
     ];
-    
+
     return (
-        <StyledTable
+        <Table
             columns={columnSettings}
             dataSource={data.map((item) => ({
                 key: item.id,
@@ -135,11 +122,11 @@ export const PublishedMapsList = ({ controller, data = [], loading }) => {
             pagination={false}
             loading={loading}
         />
-    )
-}
+    );
+};
 
 PublishedMapsList.propTypes = {
     data: PropTypes.arrayOf(PropTypes.object),
     controller: PropTypes.object.isRequired,
     loading: PropTypes.bool.isRequired
-}
+};

--- a/bundles/framework/myplaces3/MyPlacesList.jsx
+++ b/bundles/framework/myplaces3/MyPlacesList.jsx
@@ -10,25 +10,13 @@ const EDIT_ICON_STYLE = {
     fontSize: '16px'
 };
 
-const StyledTable = styled(Table)`
-    tr {
-        th {
-            padding: 8px 8px;
-        }
-        td {
-            padding: 8px;
-        }
-    }
-`;
-
 const NameField = styled('div')`
     display: flex;
     flex-direction: row;
     align-items: center;
 `;
 
-export const MyPlacesList = ({data = [], loading, controller }) => {
-
+export const MyPlacesList = ({ data = [], loading, controller }) => {
     const columnSettings = [
         {
             align: 'left',
@@ -101,7 +89,7 @@ export const MyPlacesList = ({data = [], loading, controller }) => {
     ];
 
     return (
-        <StyledTable
+        <Table
             loading={loading}
             columns={columnSettings}
             dataSource={data.map(item => ({
@@ -114,8 +102,8 @@ export const MyPlacesList = ({data = [], loading, controller }) => {
             }))}
             pagination={false}
         />
-    )
-}
+    );
+};
 
 MyPlacesList.propTypes = {
     data: PropTypes.arrayOf(PropTypes.object),

--- a/bundles/framework/myplacesimport/UserLayersList.jsx
+++ b/bundles/framework/myplacesimport/UserLayersList.jsx
@@ -1,21 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Message } from 'oskari-ui';
-import { Table, getSorterFor, ToolsContainer } from 'oskari-ui/components/Table'
-import { EditOutlined } from '@ant-design/icons'
-import styled from 'styled-components';
+import { Table, getSorterFor, ToolsContainer } from 'oskari-ui/components/Table';
+import { EditOutlined } from '@ant-design/icons';
 import { IconButton, DeleteButton } from 'oskari-ui/components/buttons';
-
-const StyledTable = styled(Table)`
-    tr {
-        th {
-            padding: 8px 8px;
-        }
-        td {
-            padding: 8px;
-        }
-    }
-`;
 
 const EDIT_ICON_STYLE = {
     fontSize: '16px'
@@ -81,7 +69,7 @@ export const UserLayersList = ({ data = [], controller, loading }) => {
     ];
 
     return (
-        <StyledTable
+        <Table
             columns={columnSettings}
             dataSource={data.map(item => ({
                 ...item,

--- a/bundles/framework/personaldata/MyViewsList.jsx
+++ b/bundles/framework/personaldata/MyViewsList.jsx
@@ -11,23 +11,11 @@ const BUNDLE_NAME = 'PersonalData';
 const EDIT_ICON_STYLE = {
     fontSize: '14px'
 };
-
-const StyledTable = styled(Table)`
-    tr {
-        th {
-            padding: 8px 8px;
-        }
-        td {
-            padding: 8px;
-        }
-    }
-`
-
 const ButtonContainer = styled.div`
     margin: 10px 0 10px 0;
     display: flex;
     justify-content: flex-end;
-`
+`;
 
 export const MyViewsList = ({ data = [], handleEdit, handleDelete, openView, setDefault, saveCurrent }) => {
     const columnSettings = [
@@ -39,7 +27,7 @@ export const MyViewsList = ({ data = [], handleEdit, handleDelete, openView, set
             render: (title, item) => {
                 return (
                     <Checkbox checked={item.isDefault} onChange={() => setDefault(item)} />
-                )
+                );
             }
         },
         {
@@ -51,7 +39,7 @@ export const MyViewsList = ({ data = [], handleEdit, handleDelete, openView, set
             render: (title, item) => {
                 return (
                     <a onClick={() => openView(item)}>{title}</a>
-                )
+                );
             }
         },
         {
@@ -76,7 +64,7 @@ export const MyViewsList = ({ data = [], handleEdit, handleDelete, openView, set
                             onConfirm={() => handleDelete(item)}
                         />
                     </ToolsContainer>
-                )
+                );
             }
         }
     ];
@@ -88,7 +76,7 @@ export const MyViewsList = ({ data = [], handleEdit, handleDelete, openView, set
                     <Message bundleKey={BUNDLE_NAME} messageKey='tabs.myviews.button.saveCurrent' />
                 </Button>
             </ButtonContainer>
-            <StyledTable
+            <Table
                 columns={columnSettings}
                 dataSource={data.map(item => ({
                     key: item.id,
@@ -97,8 +85,8 @@ export const MyViewsList = ({ data = [], handleEdit, handleDelete, openView, set
                 pagination={false}
             />
         </>
-    )
-}
+    );
+};
 
 MyViewsList.propTypes = {
     data: PropTypes.arrayOf(PropTypes.object),
@@ -107,4 +95,4 @@ MyViewsList.propTypes = {
     openView: PropTypes.func.isRequired,
     setDefault: PropTypes.func.isRequired,
     saveCurrent: PropTypes.func.isRequired
-}
+};

--- a/bundles/framework/personaldata/PublishedMapsList.jsx
+++ b/bundles/framework/personaldata/PublishedMapsList.jsx
@@ -1,26 +1,14 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { Message, Tooltip, Confirm } from 'oskari-ui'
-import { Table, getSorterFor, ToolsContainer } from 'oskari-ui/components/Table'
-import { EditOutlined } from '@ant-design/icons'
-import styled from 'styled-components';
-import { showSnippetPopup } from './view/embedded/SnippetPopup'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Message, Tooltip, Confirm } from 'oskari-ui';
+import { Table, getSorterFor, ToolsContainer } from 'oskari-ui/components/Table';
+import { EditOutlined } from '@ant-design/icons';
+import { showSnippetPopup } from './view/embedded/SnippetPopup';
 import { DeleteButton } from 'oskari-ui/components/buttons';
 
 const EDIT_ICON_STYLE = {
     fontSize: '14px'
 };
-
-const StyledTable = styled(Table)`
-    tr {
-        th {
-            padding: 8px 8px;
-        }
-        td {
-            padding: 8px;
-        }
-    }
-`
 
 const BUNDLE_NAME = 'PersonalData';
 
@@ -30,15 +18,14 @@ const openView = (view) => {
         'Published',
         'location=1,status=1,scrollbars=yes,width=850,height=800'
     );
-}
+};
 
 const showHtml = (view, setPopup, closePopup) => {
     const controls = showSnippetPopup(view, closePopup);
     setPopup(controls);
-}
+};
 
 export const PublishedMapsList = ({ views = [], handleEdit, handleDelete, handlePublish, showOnMap, setPopup, closePopup }) => {
-
     const columnSettings = [
         {
             align: 'left',
@@ -75,11 +62,11 @@ export const PublishedMapsList = ({ views = [], handleEdit, handleDelete, handle
                         >
                             <a><Message messageKey='tabs.publishedmaps.unpublish' bundleKey={BUNDLE_NAME} /></a>
                         </Confirm>
-                    )
+                    );
                 } else {
                     return (
                         <a onClick={() => handlePublish(item)}><Message messageKey='tabs.publishedmaps.publish' bundleKey={BUNDLE_NAME} /></a>
-                    )
+                    );
                 }
             }
         },
@@ -124,10 +111,10 @@ export const PublishedMapsList = ({ views = [], handleEdit, handleDelete, handle
             }
         }
     ];
-    
+
     return (
         <div className="viewsList volatile">
-            <StyledTable
+            <Table
                 columns={columnSettings}
                 dataSource={views.map((item) => ({
                     key: item.id,
@@ -136,8 +123,8 @@ export const PublishedMapsList = ({ views = [], handleEdit, handleDelete, handle
                 pagination={false}
             />
         </div>
-    )
-}
+    );
+};
 
 PublishedMapsList.propTypes = {
     views: PropTypes.arrayOf(PropTypes.object),
@@ -147,4 +134,4 @@ PublishedMapsList.propTypes = {
     showOnMap: PropTypes.func.isRequired,
     setPopup: PropTypes.func.isRequired,
     closePopup: PropTypes.func.isRequired
-}
+};

--- a/bundles/framework/search/view/SearchResultTable.jsx
+++ b/bundles/framework/search/view/SearchResultTable.jsx
@@ -7,13 +7,6 @@ import styled from 'styled-components';
 const PointableTable = styled(Table)`
     tr {
         cursor: pointer;
-
-        th {
-            padding: 8px 8px;
-        }
-        td {
-            padding: 8px;
-        }
     }
 `;
 /*
@@ -57,10 +50,10 @@ export const SearchResultTable = ({ result = {}, onResultClick = noop }) => {
         dataSource={result.locations}
         onRow={(record) => {
             return {
-              onClick: () => onResultClick(record)
+                onClick: () => onResultClick(record)
             };
-          }}
-          pagination={{defaultPageSize: result.totalCount, hideOnSinglePage: true}} />);
+        }}
+        pagination={{ defaultPageSize: result.totalCount, hideOnSinglePage: true }} />);
 };
 
 SearchResultTable.propTypes = {

--- a/bundles/mapping/mapmodule/plugin/search/SearchResultsPopup.jsx
+++ b/bundles/mapping/mapmodule/plugin/search/SearchResultsPopup.jsx
@@ -5,17 +5,6 @@ import { Table, getSorterFor } from 'oskari-ui/components/Table';
 import { Message } from 'oskari-ui';
 import { getPopupOptions } from '../pluginPopupHelper';
 
-const StyledTable = styled(Table)`
-    tr {
-        th {
-            padding: 8px 8px;
-        }
-        td {
-            padding: 8px;
-        }
-    }
-`;
-
 const StyledContent = styled('div')`
     margin: 12px 24px 24px;
     min-width: 300px;
@@ -45,13 +34,13 @@ const PopupContent = ({ results, description, showResult }) => {
             align: 'left',
             title: <Message messageKey='plugin.SearchPlugin.column_type' bundleKey='MapModule' />,
             dataIndex: 'type',
-            sorter: getSorterFor('type'),
+            sorter: getSorterFor('type')
         }
     ];
     return (
         <StyledContent>
             <span>{description}</span>
-            <StyledTable
+            <Table
                 columns={columnSettings}
                 dataSource={results.map((item, index) => ({
                     key: item.id,
@@ -60,7 +49,7 @@ const PopupContent = ({ results, description, showResult }) => {
                 pagination={false}
             />
         </StyledContent>
-    )
+    );
 };
 
 export const showResultsPopup = (title, description, results = [], showResult, onClose, pluginLocation) => {

--- a/bundles/statistics/statsgrid2016/MyIndicatorsList.jsx
+++ b/bundles/statistics/statsgrid2016/MyIndicatorsList.jsx
@@ -2,20 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Message, Button } from 'oskari-ui';
 import { Table, ToolsContainer, getSorterFor } from 'oskari-ui/components/Table';
-import { EditOutlined } from '@ant-design/icons'
+import { EditOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
 import { IconButton, DeleteButton } from 'oskari-ui/components/buttons';
-
-const StyledTable = styled(Table)`
-    tr {
-        th {
-            padding: 8px 8px;
-        }
-        td {
-            padding: 8px;
-        }
-    }
-`;
 
 const ButtonContainer = styled.div`
     margin: 10px 0 10px 0;
@@ -89,7 +78,7 @@ export const MyIndicatorsList = ({ controller, data = [], loading }) => {
                     <Message messageKey='userIndicators.buttonTitle' />
                 </Button>
             </ButtonContainer>
-            <StyledTable
+            <Table
                 columns={columnSettings}
                 dataSource={data.map(item => ({
                     key: item.id,

--- a/src/react/components/Table.jsx
+++ b/src/react/components/Table.jsx
@@ -44,14 +44,14 @@ export const getSorterFor = key => (a, b) => Oskari.util.naturalSort(a[key], b[k
  * - https://github.com/ant-design/ant-design/blob/master/components/locale/fi_FI.tsx
  * - https://github.com/ant-design/ant-design/pull/33372
  */
-export const Table = ({ ...other }) => {
+export const Table = ({ size = 'small', ...other }) => {
     const locale = {
         triggerDesc: getMsg('table.sort.desc'), // 'Click to sort descending',
         triggerAsc: getMsg('table.sort.asc'), //'Click to sort ascending',
         cancelSort: getMsg('table.sort.cancel'), // 'Click to cancel sorting',
         emptyText: getMsg('table.emptyText') // Show when table is empty
     };
-    return (<StyledTable locale={locale} {...other} />);
+    return (<StyledTable locale={locale} size={size} {...other} />);
 };
 
 export const ToolsContainer = ({ children }) => {

--- a/src/react/components/Table.jsx
+++ b/src/react/components/Table.jsx
@@ -20,13 +20,17 @@ const StyledToolsContainer = styled('div')`
 `;
 
 // AntD defines overflow-wrap: break word for tr td
-//  but for some reason we still need word-break so long texts in the table don't break layout
+// but for some reason we still need word-break so long texts in the table don't break layout
+// For narrow columns sorter icon might get stuck to label -> add margin for column sorter
 const StyledTable = styled(AntTable)`
     tr td {
         word-break: break-word;
     }
     a {
         cursor: pointer;
+    }
+    .ant-table-column-sorter {
+        margin: 0 0 0 5px;
     }
 `;
 


### PR DESCRIPTION
- Remove padding styling from components and use antd size.
- Move sorter icon margin to Table
- Changed Table to default small size  (antd defaults to large). 
- Some eslint fixes.

Antd Table paddings for sizes: 
- large: 16px;
- middle: 12px 8px;
- small: 8px 8px;
