### PR TITLE
Bump ESLint version to support Node 16

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,7 +27,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version:  ${{ matrix.node }}
-          cache: 'npm'
+# We need package-lock.json to use cache this way
+#          cache: 'npm'
       - name: Install dependencies
+# With package-lock.json we should use "npm ci"
         run: npm install
       - run: npm test

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,25 +17,17 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ 16 ]
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          node-version:  ${{ matrix.node }}
+          cache: 'npm'
       - name: Install dependencies
         run: npm install
       - run: npm test

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '16.x'
       - name: Cache node modules
         uses: actions/cache@v2
         env:

--- a/bundles/framework/divmanazer/component/UIHelper.js
+++ b/bundles/framework/divmanazer/component/UIHelper.js
@@ -75,7 +75,7 @@ Oskari.clazz.define('Oskari.userinterface.component.UIHelper',
                     }
                 },
                 success: function (resp) {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     if (resp && resp.articles[0] && resp.articles[0].content) {
                         callback(true, resp.articles[0].content);
                     } else {

--- a/bundles/framework/guidedtour/handler/GuidedTourHandler.js
+++ b/bundles/framework/guidedtour/handler/GuidedTourHandler.js
@@ -134,7 +134,7 @@ class TourHandler extends StateHandler {
                 }
             },
             success: function (resp) {
-                /* eslint-disable node/no-callback-literal */
+                /* eslint-disable n/no-callback-literal */
                 if (resp && resp.articles[0] && resp.articles[0].content) {
                     callback(true, resp.articles[0].content);
                 } else {

--- a/bundles/framework/mydata/service/ViewService.js
+++ b/bundles/framework/mydata/service/ViewService.js
@@ -59,11 +59,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mydata.service.ViewService',
                     }
                 },
                 success: function (response) {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     callback(true, response);
                 },
                 error: function () {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     callback(false);
                 }
             });
@@ -91,11 +91,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mydata.service.ViewService',
                     }
                 },
                 success: function (response) {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     callback(true);
                 },
                 error: function () {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     callback(false);
                 }
             });
@@ -128,11 +128,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mydata.service.ViewService',
                     }
                 },
                 success: function (response) {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     callback(true);
                 },
                 error: function () {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     callback(false);
                 }
             });
@@ -168,11 +168,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mydata.service.ViewService',
                     }
                 },
                 success: function (response) {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     callback(true);
                 },
                 error: function () {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     callback(false);
                 }
             });

--- a/bundles/framework/personaldata/service/ViewService.js
+++ b/bundles/framework/personaldata/service/ViewService.js
@@ -64,11 +64,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.service.ViewService
                     }
                 },
                 success: function (response) {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     callback(true, response);
                 },
                 error: function () {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     callback(false);
                 }
             });
@@ -98,11 +98,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.service.ViewService
                     }
                 },
                 success: function (response) {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     callback(true);
                 },
                 error: function () {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     callback(false);
                 }
             });
@@ -137,11 +137,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.service.ViewService
                     }
                 },
                 success: function (response) {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     callback(true);
                 },
                 error: function () {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     callback(false);
                 }
             });
@@ -178,11 +178,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.personaldata.service.ViewService
                     }
                 },
                 success: function (response) {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     callback(true);
                 },
                 error: function () {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     callback(false);
                 }
             });

--- a/bundles/framework/timeseries/WMSAnimator.js
+++ b/bundles/framework/timeseries/WMSAnimator.js
@@ -151,7 +151,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.WMSAnimator',
          * @param {Function} callback is called when loading is ready or 5000 ms timeout reached
          */
         _bufferImages: function (urls, nextTime, callback) {
-            /* eslint-disable node/no-callback-literal */
+            /* eslint-disable n/no-callback-literal */
             var imgCount = urls.length;
             if (imgCount === 0) {
                 callback(true);

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -404,7 +404,7 @@ export class MapModule extends AbstractMapModule {
 
         if (this.isLoading()) {
             if (numOfTries < 0) {
-                /* eslint-disable node/no-callback-literal */
+                /* eslint-disable n/no-callback-literal */
                 callback('');
                 return;
             }
@@ -439,7 +439,7 @@ export class MapModule extends AbstractMapModule {
             me.getMap().renderSync();
         } catch (err) {
             me.log.warn('Error in screenshot map render sync: ' + err);
-            /* eslint-disable node/no-callback-literal */
+            /* eslint-disable n/no-callback-literal */
             callback('');
         }
     }
@@ -769,7 +769,7 @@ export class MapModule extends AbstractMapModule {
             if (!isNaN(zoom)) {
                 view.setZoom(zoom);
             }
-            /* eslint-disable node/no-callback-literal */
+            /* eslint-disable n/no-callback-literal */
             callback(true);
             break;
         }

--- a/bundles/statistics/statsgrid2016/service/CacheHelper.js
+++ b/bundles/statistics/statsgrid2016/service/CacheHelper.js
@@ -57,7 +57,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.CacheHelper', function (cache, 
                     return '' + ind.id === '' + data.id;
                 });
                 if (!existingIndicator) {
-                    /* eslint-disable node/no-callback-literal */
+                    /* eslint-disable n/no-callback-literal */
                     callback('Tried saving an indicator with id, but id didn\'t match existing indicator');
                     return;
                 }
@@ -95,7 +95,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.CacheHelper', function (cache, 
                 return '' + ind.id === '' + indicatorId;
             });
             if (!existingIndicator) {
-                /* eslint-disable node/no-callback-literal */
+                /* eslint-disable n/no-callback-literal */
                 callback('Tried saving dataset for an indicator, but id didn\'t match existing indicator');
                 return;
             }

--- a/bundles/statistics/statsgrid2016/service/StatisticsService.js
+++ b/bundles/statistics/statsgrid2016/service/StatisticsService.js
@@ -2,7 +2,7 @@
  * @class Oskari.statistics.statsgrid.StatisticsService
  */
 (function (Oskari) {
-    /* eslint-disable node/no-callback-literal */
+    /* eslint-disable n/no-callback-literal */
     const _log = Oskari.log('StatsGrid.StatisticsService');
     let _cacheHelper = null;
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "(MIT OR EUPL-1.1)",
   "main": "grunt.js",
   "engines": {
-    "node": ">=10.12.0",
+    "node": "^12.22.0 || ^14.17.0 || >=16.0.0",
     "npm": ">=6.0.0"
   },
   "scripts": {
@@ -51,13 +51,13 @@
     "draft-js-export-html": "1.4.1",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",
-    "eslint": "8.9.0",
-    "eslint-config-standard": "16.0.3",
+    "eslint": "8.35.0",
+    "eslint-config-standard": "17.0.0",
     "eslint-import-resolver-webpack": "0.13.2",
-    "eslint-plugin-import": "2.25.4",
+    "eslint-plugin-import": "2.27.5",
     "eslint-plugin-node": "11.1.0",
-    "eslint-plugin-promise": "6.0.0",
-    "eslint-plugin-react": "7.29.1",
+    "eslint-plugin-promise": "6.1.1",
+    "eslint-plugin-react": "7.32.2",
     "expose-loader": "0.7.5",
     "file-loader": "4.2.0",
     "fs-extra": "8.1.0",


### PR DESCRIPTION
- eslint 8.9.0 -> 8.35.0
- eslint-config-standard 16.0.3 -> 17.0.0
- eslint-plugin-import 2.25.4 -> 2.27.5
- eslint-plugin-promise 6.0.0 -> 6.1.1
- eslint-plugin-react 7.29.1 -> 7.32.2

Node.js engine versions copied from eslint:
-  node `>=10.12.0` -> `^12.22.0 || ^14.17.0 || >=16.0.0`

Tested with Node 16.13.2 (as more recent versions seem to not work with nvm 1.1. 7 on windows: https://github.com/coreybutler/nvm-windows/issues/814)

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/