### PR TITLE
ThemedBadge component

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/SelectedTab.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/SelectedTab.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Message } from 'oskari-ui';
 import { ThemeConsumer } from 'oskari-ui/util';
 import styled, { css, keyframes } from 'styled-components';
-import { getTextColor } from 'oskari-ui/theme/ThemeHelper';
+import { getTextColor, getHeaderTheme } from 'oskari-ui/theme/ThemeHelper';
 
 const animation = keyframes`
     0% {opacity: 1;}
@@ -33,7 +33,8 @@ const StyledBadge = styled.div`
         animation-iteration-count: ${BLINK_COUNT};`}
 `;
 const NumberBadge = ThemeConsumer(({theme, isBlinking, count}) => {
-    return (<StyledBadge color={theme?.color?.accent || '#ffd400'} blink={isBlinking}>
+    const helper = getHeaderTheme(theme);
+    return (<StyledBadge color={helper.getAccentColor()} blink={isBlinking}>
                 {count}
             </StyledBadge>);
 });

--- a/src/react/components/ThemedBadge.jsx
+++ b/src/react/components/ThemedBadge.jsx
@@ -1,0 +1,24 @@
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Badge as AntBadge } from 'antd';
+import { ThemeConsumer } from '../util';
+import 'antd/es/badge/style/index.js';
+import { getTextColor, getHeaderTheme } from 'oskari-ui/theme/ThemeHelper';
+
+export const ThemedBadge = ThemeConsumer(({ count, theme }) => {
+    const helper = getHeaderTheme(theme);
+    const style = {
+        backgroundColor: helper.getAccentColor(),
+        color: getTextColor(helper.getAccentColor()),
+        whiteSpace: 'nowrap',
+    };
+    return <AntBadge count={count} style={style} overflowCount={999} showZero={true}/>;
+});
+ThemedBadge.propTypes = {
+    count: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+    ]),
+    inversed: PropTypes.bool
+};

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -1,5 +1,6 @@
 export { Alert } from './components/Alert';
 export { Badge } from './components/Badge';
+export { ThemedBadge } from './components/ThemedBadge';
 export { Button } from './components/Button';
 export { Checkbox } from './components/Checkbox';
 export { Collapse, Panel as CollapsePanel } from './components/Collapse';

--- a/src/react/theme/ThemeHelper.js
+++ b/src/react/theme/ThemeHelper.js
@@ -5,14 +5,15 @@ import { EFFECT, DEFAULT_COLORS } from './constants';
 export const getHeaderTheme = (theme) => {
     const bgColor = theme.color?.header?.bg || theme.color?.primary || DEFAULT_COLORS.HEADER_BG;
     const headerTextColor = getTextColor(bgColor);
+    const accentColor = theme.color?.accent || DEFAULT_COLORS.ACCENT;
     const funcs = {
         getBgColor: () => bgColor,
-        getAccentColor: () => theme.color.accent,
-        getBgBorderColor: () => getColorEffect(theme.color.accent, -10),
-        getBgBorderBottomColor: () => getColorEffect(theme.color.accent, 20),
+        getAccentColor: () => accentColor,
+        getBgBorderColor: () => getColorEffect(accentColor, -10),
+        getBgBorderBottomColor: () => getColorEffect(accentColor, 20),
         getTextColor: () => theme.color?.header?.text || headerTextColor,
         getToolColor: () => theme.color?.header?.icon || funcs.getTextColor(),
-        getToolHoverColor: () => theme.color?.accent
+        getToolHoverColor: () => accentColor
     };
     return funcs;
 };


### PR DESCRIPTION
- Moved accent color default from layerlist "Selected Layers tab" to ThemeHelper so it functions the same way in each component.
- Added a ThemedBadge component (removed text-shadow/weight from styling compared to the other Badge component)

![image](https://user-images.githubusercontent.com/2210335/223224561-113e20e7-397e-4a52-b6b1-f2ce6aaa9f08.png)

Accent color defaults to `#ffd400` if not set.