### PR TITLE
Disable style checkbox if layers don't have multiple styles.

### DIFF
--- a/bundles/framework/publisher2/resources/locale/en.js
+++ b/bundles/framework/publisher2/resources/locale/en.js
@@ -109,7 +109,8 @@ Oskari.registerLocalization(
                     "info": "Select the background map layer. You can select the default background map layer in the map preview.",
                     "selectAsBaselayer": "Select as baselayer",
                     "allowStyleChange": "Allow style change",
-                    "showMetadata": "Show metadata links"
+                    "showMetadata": "Show metadata links",
+                    "noMultipleStyles": "The selected map layers only have a single visualization option/style."
                 },
                 "mylocation": {
                     "modes": {

--- a/bundles/framework/publisher2/resources/locale/fi.js
+++ b/bundles/framework/publisher2/resources/locale/fi.js
@@ -109,7 +109,8 @@ Oskari.registerLocalization(
                     "info": "Valitse taustakarttoina näytettävät karttatasot. Oletusvalinnan voit tehdä esikatselukartassa.",
                     "selectAsBaselayer": "Taustakarttataso",
                     "allowStyleChange": "Salli esitystyylin valinta",
-                    "showMetadata": "Näytä metatietolinkit"
+                    "showMetadata": "Näytä metatietolinkit",
+                    "noMultipleStyles": "Valituilla karttatasoilla on saatavilla vain yksi esitystapa/tyyli."
                 },
                 "mylocation": {
                     "modes": {

--- a/bundles/framework/publisher2/resources/locale/sv.js
+++ b/bundles/framework/publisher2/resources/locale/sv.js
@@ -109,7 +109,8 @@ Oskari.registerLocalization(
                     "info": "Välj bakgrundskartlager. Du kan göra förval i förhandsgranskningsvyn.",
                     "selectAsBaselayer": "Välj bakgrundskartlager",
                     "allowStyleChange": "Tillåta stiländring",
-                    "showMetadata": "Visa länkar för metadata"
+                    "showMetadata": "Visa länkar för metadata",
+                    "noMultipleStyles": "The selected map layers only have a single visualization option/style."
                 },
                 "mylocation": {
                     "modes": {

--- a/bundles/framework/publisher2/view/MapLayers/MapLayers.jsx
+++ b/bundles/framework/publisher2/view/MapLayers/MapLayers.jsx
@@ -48,6 +48,18 @@ const ExtraOptions = styled('div')`
 
 export const MapLayers = ({ state, controller }) => {
     const layers = state.showLayerSelection ? state.layers.filter(l => !state.baseLayers.some(bl => bl.getId() === l.getId())) : state.layers;
+    const disableStyleSelect = state.layers.filter(l => l.getStyles().length > 1).length < 1;
+
+    const StyleSelect = (
+        <StyledCheckbox
+            checked={state.allowStyleChange}
+            onChange={(e) => controller.setAllowStyleChange(e.target.checked)}
+            disabled={disableStyleSelect}
+        >
+            <Message messageKey='BasicView.maptools.layerselection.allowStyleChange' />
+        </StyledCheckbox>
+    );
+
     return (
         <Content>
             <StyledCheckbox
@@ -64,12 +76,13 @@ export const MapLayers = ({ state, controller }) => {
                     >
                         <Message messageKey='BasicView.maptools.layerselection.showMetadata' />
                     </StyledCheckbox>
-                    <StyledCheckbox
-                        checked={state.allowStyleChange}
-                        onChange={(e) => controller.setAllowStyleChange(e.target.checked)}
-                    >
-                        <Message messageKey='BasicView.maptools.layerselection.allowStyleChange' />
-                    </StyledCheckbox>
+                    {disableStyleSelect ? (
+                        <Tooltip title={<Message messageKey='BasicView.maptools.layerselection.noMultipleStyles' />}>
+                            {StyleSelect}
+                        </Tooltip>
+                    ) : (
+                        StyleSelect
+                    )}
                 </ExtraOptions>
             )}
             {state.externalOptions.map((tool, index) => {


### PR DESCRIPTION
If selected layers don't have multiple styles, disable checkbox that allows style selection on layer selection popup.