### PR TITLE
Mapmodule cleaning

### DIFF
--- a/bundles/framework/publisher2/instance.js
+++ b/bundles/framework/publisher2/instance.js
@@ -280,11 +280,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
             navigation.css('display', blnEnabled ? 'none' : 'block');
             const mapContainer = Oskari.dom.getMapContainerEl();
             const extraClasses = ['mapPublishMode', Oskari.dom.APP_EMBEDDED_CLASS];
-            data = data || this.getDefaultData();
             if (this.getCustomTileRef()) {
                 blnEnabled ? jQuery(this.getCustomTileRef()).addClass('activePublish') : jQuery(this.getCustomTileRef()).removeClass('activePublish');
             }
             if (blnEnabled) {
+                data = data || this.getDefaultData();
                 // trigger an event letting other bundles know we require the whole UI
                 var eventBuilder = Oskari.eventBuilder('UIChangeEvent');
                 this.sandbox.notifyAll(eventBuilder(this.mediator.bundleId));

--- a/bundles/mapping/heatmap/plugin/AbstractHeatmapPlugin.js
+++ b/bundles/mapping/heatmap/plugin/AbstractHeatmapPlugin.js
@@ -5,9 +5,9 @@
 Oskari.clazz.define(
     'Oskari.mapframework.heatmap.AbstractHeatmapPlugin',
     function () {
-        var me = this;
-        me._clazz = 'Oskari.mapframework.heatmap.HeatmapLayerPlugin';
-        me._name = 'HeatmapLayerPlugin';
+        this._clazz = 'Oskari.mapframework.heatmap.HeatmapLayerPlugin';
+        // layer plugins use two underscores for name while others use one...
+        this.__name = 'HeatmapLayerPlugin';
     }, {
         getLayerTypeSelector: function () {
             return 'HEATMAP';
@@ -175,5 +175,4 @@ Oskari.clazz.define(
         }
     }, {
         'extend': ['Oskari.mapping.mapmodule.AbstractMapLayerPlugin']
-
     });

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1359,13 +1359,7 @@ Oskari.clazz.define(
 
         /* ---------------- THEME ------------------- */
         getTheme: function () {
-            var me = this;
-            var toolStyle = me.getToolStyle();
-            if (toolStyle === null || toolStyle.indexOf('-dark') > 0 || toolStyle === 'default') {
-                return 'dark';
-            } else {
-                return 'light';
-            }
+            return 'dark';
         },
 
         getReverseTheme: function () {

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -2097,47 +2097,6 @@ Oskari.clazz.define(
 
         /* --------------- PLUGIN CONTAINERS ------------------------ */
         /**
-         * Removes all the css classes which respond to given regex from all elements
-         * and adds the given class to them.
-         *
-         * @method changeCssClasses
-         * @param {String} classToAdd the css class to add to all elements.
-         * @param {RegExp} removeClassRegex the regex to test against to determine which classes should be removec
-         * @param {Array[jQuery]} elements The elements where the classes should be changed.
-         */
-        changeCssClasses: function (classToAdd, removeClassRegex, elements) {
-            // TODO: deprecate this, make some error message appear or smthng
-
-            var i,
-                j,
-                el;
-
-            var removeClasses = function (el) {
-                el.removeClass(function (index, classes) {
-                    var removeThese = '';
-                    var classNames = classes.split(' ');
-
-                    // Check if there are any old font classes.
-                    for (j = 0; j < classNames.length; j += 1) {
-                        if (removeClassRegex.test(classNames[j])) {
-                            removeThese += classNames[j] + ' ';
-                        }
-                    }
-
-                    // Return the class names to be removed.
-                    return removeThese;
-                });
-            };
-
-            for (i = 0; i < elements.length; i += 1) {
-                el = elements[i];
-                removeClasses(el);
-
-                // Add the new font as a CSS class.
-                el.addClass(classToAdd);
-            }
-        },
-        /**
          * Sets the style to be used on plugins and asks all the active plugins that support changing style to change their style accordingly.
          *
          * @method changeToolStyle

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -2,7 +2,6 @@ import { UnsupportedLayerSrs } from './domain/UnsupportedLayerSrs';
 
 import React from 'react';
 import { Message } from 'oskari-ui';
-import { DEFAULT_COLORS } from 'oskari-ui/theme';
 
 import './domain/AbstractLayer';
 import './domain/LayerComposingModel';
@@ -101,6 +100,10 @@ import './event/UserLocationEvent';
 import { filterFeaturesByExtent } from './util/vectorfeatures/filter';
 import { FEATURE_QUERY_ERRORS } from './domain/constants';
 import { monitorResize, unmonitorResize } from 'oskari-ui/components/window';
+import { getSortedPlugins, refreshPluginsWithUI } from './util/PluginHelper';
+import { getDefaultMapTheme, setFont } from './util/MapThemeHelper';
+import { addCrosshair, isCrosshairActive, removeCrosshair } from './util/Crosshair'
+
 /**
  * @class Oskari.mapping.mapmodule.AbstractMapModule
  *
@@ -223,14 +226,6 @@ Oskari.clazz.define(
         this._cursorStyle = '';
 
         this.isDrawing = false;
-
-        this.templates = {
-            'crosshair': jQuery(
-                '<div class="oskari-crosshair">' +
-                    '<div class="oskari-crosshair-vertical-bar"></div>' +
-                    '<div class="oskari-crosshair-horizontal-bar"></div>' +
-                '</div>')
-        };
         // adds on/off/trigger functions for internal eventing
         Oskari.makeObservable(this);
     }, {
@@ -305,7 +300,7 @@ Oskari.clazz.define(
 
             me._map = me.createMap();
 
-            if (me._options.crosshair) {
+            if (me._options?.crosshair) {
                 me.toggleCrosshair(true);
             }
 
@@ -348,7 +343,7 @@ Oskari.clazz.define(
             this.log.debug('Starting ' + this.getName());
 
             // listen to application started event and trigger a forced update on any remaining lazy plugins and register RPC functions.
-            Oskari.on('app.start', function (details) {
+            Oskari.on('app.start', function () {
                 // force update on lazy plugins
                 // this means tell plugins to render UI with the means available
                 // if toolbar for example isn't present, most plugins should display "desktop-ui" instead of using the "mobile-ui" toolbar
@@ -471,8 +466,7 @@ Oskari.clazz.define(
             'RPCUIEvent': function (event) {
                 var me = this;
                 if (event.getBundleId() === 'mapmodule.crosshair') {
-                    var show = (me.getMapEl().find('div.oskari-crosshair').length === 0);
-                    me.toggleCrosshair(show);
+                    me.toggleCrosshair(isCrosshairActive(this.getMapDOMEl()));
                 }
             }
         },
@@ -1218,13 +1212,12 @@ Oskari.clazz.define(
             var state = {
                 plugins: {}
             };
-            var pluginName;
-
-            for (pluginName in this._pluginInstances) {
-                if (this._pluginInstances.hasOwnProperty(pluginName) && this._pluginInstances[pluginName].getState) {
-                    state.plugins[pluginName] = this._pluginInstances[pluginName].getState();
+            Object.keys(this._pluginInstances).forEach(pluginName => {
+                const plugin = this._pluginInstances[pluginName];
+                if (typeof plugin?.getState === 'function') {
+                    state.plugins[pluginName] = plugin.getState();
                 }
-            }
+            });
             return state;
         },
         /**
@@ -1233,15 +1226,13 @@ Oskari.clazz.define(
          * @return {String} link parameters for map state
          */
         getStateParameters: function () {
-            var params = '';
-            var pluginName;
-
-            for (pluginName in this._pluginInstances) {
-                if (this._pluginInstances.hasOwnProperty(pluginName) && this._pluginInstances[pluginName].getStateParameters) {
-                    params = params + this._pluginInstances[pluginName].getStateParameters();
+            return Object.values(this._pluginInstances).map(plugin => {
+                if (typeof plugin?.getStateParameters === 'function') {
+                    return plugin.getStateParameters();
                 }
-            }
-            return params;
+                return '';
+            })
+            .join('');
         },
         /**
          * Sets state for mapmodule including plugins that have setState() function
@@ -1250,13 +1241,12 @@ Oskari.clazz.define(
          * @param {Object} properties for each pluginName
          */
         setState: function (state) {
-            var pluginName;
-
-            for (pluginName in this._pluginInstances) {
-                if (this._pluginInstances.hasOwnProperty(pluginName) && state[pluginName] && this._pluginInstances[pluginName].setState) {
-                    this._pluginInstances[pluginName].setState(state[pluginName]);
+            Object.keys(this._pluginInstances).forEach(pluginName => {
+                const plugin = this._pluginInstances[pluginName];
+                if (typeof plugin?.setState === 'function') {
+                    plugin.setState(state[pluginName]);
                 }
-            }
+            });
         },
         /**
          * @method notifyStartMove
@@ -1306,54 +1296,13 @@ Oskari.clazz.define(
         },
 
         _handleMapSizeChanges: function (newSize, pluginName) {
-            var me = this;
-            var modeChanged = false;
-            if (Oskari.util.isMobile()) {
-                modeChanged = me.getMobileMode() !== true;
-                me.setMobileMode(true);
-            } else {
-                modeChanged = me.getMobileMode() !== false;
-                me.setMobileMode(false);
-            }
-
+            const isMobile = Oskari.util.isMobile();
+            const modeChanged = this.getMobileMode() !== isMobile;
+            this.setMobileMode(isMobile);
             if (modeChanged) {
-                me.redrawPluginUIs(modeChanged);
+                // previously called redrawUI() -> now calls changeToolStyle()
+                refreshPluginsWithUI(this._pluginInstances);
             }
-        },
-        /**
-         * @method redrawPluginUIs
-         * Called when map size changes, mode changes or when late comer plugins (coordinatetool, featuredata) enter the mobile toolbar.
-         * Basically just redraws the whole toolbar with the tools in correct order.
-         *
-         * @param {boolean} modeChanged whether there was a transition between mobile <> desktop
-         *
-         */
-        redrawPluginUIs: function (modeChanged) {
-            const sortedList = this._getSortedPlugins() || [];
-            const isInMobileMode = this.getMobileMode();
-            sortedList.forEach((plugin = {}) => {
-                if (typeof plugin.redrawUI === 'function') {
-                    plugin.redrawUI(isInMobileMode, modeChanged);
-                }
-            });
-        },
-        /**
-         * Get a sorted list of plugins. This is used to control order of elements in the UI.
-         * Functionality shouldn't assume order.
-         * @return {Oskari.mapframework.ui.module.common.mapmodule.Plugin[]} index ordered list of registered plugins
-         */
-        _getSortedPlugins: function () {
-            const plugins = Object.values(this._pluginInstances);
-            const getIndex = (plugin) => {
-                if (typeof plugin.getIndex === 'function') {
-                    return plugin.getIndex();
-                }
-                // index not defined, start after ones that have indexes
-                // This is just for the UI order, functionality shouldn't assume order
-                return 99999999999;
-            };
-            plugins.sort((a, b) => getIndex(a) - getIndex(b));
-            return plugins;
         },
 
         /* ---------------- /MAP MOBILE MODE ------------------- */
@@ -1368,7 +1317,7 @@ Oskari.clazz.define(
             // take "global" theme as base and override anything specified for map
             let mapTheme = {
                 ...appTheme,
-                ...this.__injectThemeByToolStyle(),
+                ...getDefaultMapTheme(),
                 ...map
             };
 
@@ -1383,58 +1332,8 @@ Oskari.clazz.define(
             };
             this.__cachedTheme = theme;
             // set font class for map module/map controls. Windows/popups will get it through theme
-            const prefix = 'oskari-theme-font-';
-            const newFontClass = prefix + (theme.font || 'arial');
-            // on unit tests the mapEl might be undefined
-            const classlist = this.getMapEl()[0]?.classList;
-            if (classlist) {
-                classlist.forEach(clazz => {
-                    if (clazz !== newFontClass && clazz.startsWith(prefix)) {
-                        classlist.remove(clazz);
-                    }
-                });
-                classlist.add(newFontClass);
-            }
-            Object.values(this._pluginInstances)
-                .filter((plugin = {}) => {
-                    if (typeof plugin.hasUI === 'function') {
-                        return plugin.hasUI();
-                    }
-                    return false;
-                })
-                .forEach((plugin) => {
-                    if (typeof plugin.changeToolStyle === 'function') {
-                        plugin.changeToolStyle();
-                    }
-                });
-        },
-        // generates base style for map
-        __injectThemeByToolStyle: function () {
-            const mapTheme = {
-                // For buttons on map
-                navigation: {
-                    roundness: 0,
-                    opacity: 0.8,
-                    color: {
-                        primary: DEFAULT_COLORS.DARK_BUTTON_BG,
-                        accent: DEFAULT_COLORS.ACCENT,
-                        text: '#ffffff'
-                    }
-                },
-                // /For buttons on map ^
-                // --------------
-                // For popup headers opened by map:
-                color: {
-                    header: {
-                        // #3c3c3c -> rgb(60,60,60)
-                        bg: '#3c3c3c'
-                    }
-                    // accent should be inherited from global theme accent if not configured
-                    // accent: '#ffd400'
-                }
-                // /For popup headers opened by map ^
-            };
-            return mapTheme;
+            setFont(this.getMapDOMEl(), theme.font);
+            refreshPluginsWithUI(this._pluginInstances);
         },
 
         getCursorStyle: function () {
@@ -1452,13 +1351,10 @@ Oskari.clazz.define(
          * toggles the crosshair marking the center of the map
          */
         toggleCrosshair: function (show) {
-            var crosshair = null;
-            var mapEl = this.getMapEl();
-
-            mapEl.find('div.oskari-crosshair').remove();
             if (show) {
-                crosshair = this.templates.crosshair.clone();
-                mapEl.append(crosshair);
+                addCrosshair(this.getMapDOMEl());
+            } else {
+                removeCrosshair(this.getMapDOMEl());
             }
         },
 
@@ -1669,7 +1565,7 @@ Oskari.clazz.define(
          * calling its startPlugin() method.
          */
         startPlugins: function () {
-            const sortedList = this._getSortedPlugins() || [];
+            const sortedList = getSortedPlugins(this._pluginInstances);;
             sortedList.forEach((plugin = {}) => {
                 if (typeof plugin.startPlugin === 'function') {
                     this.startPlugin(plugin);

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1363,12 +1363,7 @@ Oskari.clazz.define(
         },
 
         getReverseTheme: function () {
-            var me = this;
-            if (me.getTheme() === 'light') {
-                return 'dark';
-            } else {
-                return 'light';
-            }
+            return 'light';
         },
         __cachedTheme: null,
         getMapTheme: function () {

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -35,7 +35,7 @@ import './plugin/scalebar/ScaleBarPlugin.ol';
 import './plugin/markers/MarkersPlugin.ol';
 
 // layer plugins
-import { AbstractVectorLayerPlugin } from './AbstractVectorLayerPlugin';
+import { AbstractVectorLayerPlugin } from './plugin/AbstractVectorLayerPlugin';
 import './plugin/wmslayer/WmsLayerPlugin.ol';
 import './plugin/vectorlayer/VectorLayerPlugin.ol';
 import './plugin/vectortilelayer/VectorTileLayerPlugin';

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -2,6 +2,7 @@ import { UnsupportedLayerSrs } from './domain/UnsupportedLayerSrs';
 
 import React from 'react';
 import { Message } from 'oskari-ui';
+import { DEFAULT_COLORS } from 'oskari-ui/theme';
 
 import './domain/AbstractLayer';
 import './domain/LayerComposingModel';
@@ -1374,7 +1375,7 @@ Oskari.clazz.define(
             // take "global" theme as base and override anything specified for map
             let mapTheme = {
                 ...appTheme,
-                ...this.__injectThemeByToolStyle(this.getToolStyle()),
+                ...this.__injectThemeByToolStyle(),
                 ...map
             };
 
@@ -1415,18 +1416,15 @@ Oskari.clazz.define(
                 });
         },
         // generates base style for map
-        __injectThemeByToolStyle: function (toolStyle) {
-            // Note! these should be configurable on publisher BUT we might want to use some injected theme for "wellkonwn toolstyles"
+        __injectThemeByToolStyle: function () {
             const mapTheme = {
                 // For buttons on map
                 navigation: {
                     roundness: 0,
                     opacity: 0.8,
                     color: {
-                        // #141414 -> rgb(20,20,20)
-                        // #3c3c3c -> rgb(60,60,60)
-                        primary: '#141414',
-                        accent: '#ffd400',
+                        primary: DEFAULT_COLORS.DARK_BUTTON_BG,
+                        accent: DEFAULT_COLORS.ACCENT,
                         text: '#ffffff'
                     }
                 },
@@ -1435,6 +1433,7 @@ Oskari.clazz.define(
                 // For popup headers opened by map:
                 color: {
                     header: {
+                        // #3c3c3c -> rgb(60,60,60)
                         bg: '#3c3c3c'
                     }
                     // accent should be inherited from global theme accent if not configured
@@ -1442,24 +1441,6 @@ Oskari.clazz.define(
                 }
                 // /For popup headers opened by map ^
             };
-            const style = toolStyle || 'rounded-dark';
-            const [shape, theme] = style.split('-');
-            if (shape === 'rounded') {
-                mapTheme.navigation.roundness = 100;
-            } else if (shape === '3d') {
-                mapTheme.navigation.roundness = 20;
-                // themehelper calculates gradients when this is set
-                mapTheme.navigation.effect = '3D';
-            }
-
-            if (theme === 'light') {
-                // buttons
-                mapTheme.navigation.color.primary = '#ffffff';
-                mapTheme.navigation.color.text = '#000000';
-                // popup
-                mapTheme.color.header.bg = '#ffffff';
-            }
-
             return mapTheme;
         },
 

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1359,13 +1359,6 @@ Oskari.clazz.define(
         /* ---------------- /MAP MOBILE MODE ------------------- */
 
         /* ---------------- THEME ------------------- */
-        getTheme: function () {
-            return 'dark';
-        },
-
-        getReverseTheme: function () {
-            return 'light';
-        },
         __cachedTheme: null,
         getMapTheme: function () {
             if (this.__cachedTheme) {

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -102,7 +102,7 @@ import { FEATURE_QUERY_ERRORS } from './domain/constants';
 import { monitorResize, unmonitorResize } from 'oskari-ui/components/window';
 import { getSortedPlugins, refreshPluginsWithUI } from './util/PluginHelper';
 import { getDefaultMapTheme, setFont } from './util/MapThemeHelper';
-import { addCrosshair, isCrosshairActive, removeCrosshair } from './util/Crosshair'
+import { addCrosshair, isCrosshairActive, removeCrosshair } from './util/Crosshair';
 
 /**
  * @class Oskari.mapping.mapmodule.AbstractMapModule
@@ -1232,8 +1232,7 @@ Oskari.clazz.define(
                     return plugin.getStateParameters();
                 }
                 return '';
-            })
-            .join('');
+            }).join('');
         },
         /**
          * Sets state for mapmodule including plugins that have setState() function

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1212,8 +1212,9 @@ Oskari.clazz.define(
             var state = {
                 plugins: {}
             };
-            Object.keys(this._pluginInstances).forEach(pluginName => {
-                const plugin = this._pluginInstances[pluginName];
+            const instances = this.getPluginInstances();
+            Object.keys(instances).forEach(pluginName => {
+                const plugin = instances[pluginName];
                 if (typeof plugin?.getState === 'function') {
                     state.plugins[pluginName] = plugin.getState();
                 }
@@ -1226,7 +1227,7 @@ Oskari.clazz.define(
          * @return {String} link parameters for map state
          */
         getStateParameters: function () {
-            return Object.values(this._pluginInstances).map(plugin => {
+            return Object.values(this.getPluginInstances()).map(plugin => {
                 if (typeof plugin?.getStateParameters === 'function') {
                     return plugin.getStateParameters();
                 }
@@ -1241,8 +1242,9 @@ Oskari.clazz.define(
          * @param {Object} properties for each pluginName
          */
         setState: function (state) {
-            Object.keys(this._pluginInstances).forEach(pluginName => {
-                const plugin = this._pluginInstances[pluginName];
+            const instances = this.getPluginInstances();
+            Object.keys(instances).forEach(pluginName => {
+                const plugin = instances[pluginName];
                 if (typeof plugin?.setState === 'function') {
                     plugin.setState(state[pluginName]);
                 }
@@ -1301,7 +1303,7 @@ Oskari.clazz.define(
             this.setMobileMode(isMobile);
             if (modeChanged) {
                 // previously called redrawUI() -> now calls changeToolStyle()
-                refreshPluginsWithUI(this._pluginInstances);
+                refreshPluginsWithUI(this.getPluginInstances());
             }
         },
 
@@ -1333,7 +1335,7 @@ Oskari.clazz.define(
             this.__cachedTheme = theme;
             // set font class for map module/map controls. Windows/popups will get it through theme
             setFont(this.getMapDOMEl(), theme.font);
-            refreshPluginsWithUI(this._pluginInstances);
+            refreshPluginsWithUI(this.getPluginInstances());
         },
 
         getCursorStyle: function () {
@@ -1481,7 +1483,7 @@ Oskari.clazz.define(
                 '[' + this.getName() + ']' + ' Registering ' + pluginName
             );
             plugin.register();
-            if (this._pluginInstances[pluginName]) {
+            if (this.getPluginInstances(pluginName)) {
                 this.log.warn(
                     '[' + this.getName() + ']' + ' Overwriting plugin with same name ' + pluginName
                 );
@@ -1556,7 +1558,7 @@ Oskari.clazz.define(
          * @param {Oskari.mapframework.ui.module.common.mapmodule.Plugin} plugin
          */
         stopPlugin: function (plugin) {
-            this.log.debug('[' + this.getName() + ']' + ' Starting ' + plugin.getName());
+            this.log.debug('[' + this.getName() + ']' + ' Stopping ' + plugin.getName());
             plugin.stopPlugin(this.getSandbox());
         },
         /**
@@ -1565,7 +1567,7 @@ Oskari.clazz.define(
          * calling its startPlugin() method.
          */
         startPlugins: function () {
-            const sortedList = getSortedPlugins(this._pluginInstances);;
+            const sortedList = getSortedPlugins(this.getPluginInstances());
             sortedList.forEach((plugin = {}) => {
                 if (typeof plugin.startPlugin === 'function') {
                     this.startPlugin(plugin);
@@ -1578,11 +1580,7 @@ Oskari.clazz.define(
          * calling its stopPlugin() method.
          */
         stopPlugins: function () {
-            for (var pluginName in this._pluginInstances) {
-                if (this._pluginInstances.hasOwnProperty(pluginName)) {
-                    this.stopPlugin(this._pluginInstances[pluginName]);
-                }
-            }
+            Object.values(this.getPluginInstances()).forEach((plugin) => this.stopPlugin(plugin));
         },
 
         /* --------------- /PLUGINS ------------------------ */

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1444,36 +1444,6 @@ Oskari.clazz.define(
             return mapTheme;
         },
 
-        getThemeColours: function (theme) {
-            var me = this;
-            // Check at the is konowed theme
-            if (theme && theme !== 'light' && theme !== 'dark') {
-                theme = 'dark';
-            }
-            var wantedTheme = theme || me.getTheme();
-
-            var darkTheme = {
-                textColour: '#ffffff',
-                backgroundColour: '#3c3c3c',
-                activeColour: '#E6E6E6',
-                activeTextColour: '#000000',
-                hoverColour: '#E6E6E6'
-            };
-
-            var lightTheme = {
-                textColour: '#000000',
-                backgroundColour: '#ffffff',
-                activeColour: '#3c3c3c',
-                activeTextColour: '#ffffff',
-                hoverColour: '#3c3c3c'
-            };
-
-            if (wantedTheme === 'dark') {
-                return darkTheme;
-            } else {
-                return lightTheme;
-            }
-        },
         getCursorStyle: function () {
             return this._cursorStyle;
         },

--- a/bundles/mapping/mapmodule/AbstractMapModule.test.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.test.js
@@ -2,6 +2,7 @@ import { afterAll } from '@jest/globals';
 import '../../../src/global';
 import './AbstractMapModule';
 import './service/map.state';
+import { getSortedPlugins } from './util/PluginHelper';
 import jQuery from 'jquery';
 
 const Oskari = window.Oskari;
@@ -51,7 +52,7 @@ describe('MapModule', () => {
         });
     });
     describe('_getSortedPlugins', () => {
-        const sorted = mapModule._getSortedPlugins();
+        const sorted = getSortedPlugins(mapModule.getPluginInstances());
         test('has 3 plugins', () => {
             expect(sorted.length).toEqual(3);
         });

--- a/bundles/mapping/mapmodule/plugin/AbstractMapLayerPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/AbstractMapLayerPlugin.js
@@ -1,4 +1,4 @@
-import './plugin/AbstractMapModulePlugin';
+import './AbstractMapModulePlugin';
 /**
  * @class Oskari.mapping.mapmodule.AbstractMapLayerPlugin
  * Base class for map layer implementations (wms, wmts, vector tile etc.)

--- a/bundles/mapping/mapmodule/plugin/AbstractMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/AbstractMapModulePlugin.js
@@ -41,8 +41,8 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.AbstractMapModulePlugin',
             if (!mapModule) {
                 // clear references
                 // FIXME: this seems to cause troubles in plugins and they are not prepared to handle this...
-                //this._mapModule = null;
-                //this._pluginName = this._name;
+                // this._mapModule = null;
+                // this._pluginName = this._name;
                 return;
             }
             this._mapModule = mapModule;

--- a/bundles/mapping/mapmodule/plugin/AbstractMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/AbstractMapModulePlugin.js
@@ -40,8 +40,9 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.AbstractMapModulePlugin',
         setMapModule: function (mapModule) {
             if (!mapModule) {
                 // clear references
-                this._mapModule = null;
-                this._pluginName = this._name;
+                // FIXME: this seems to cause troubles in plugins and they are not prepared to handle this...
+                //this._mapModule = null;
+                //this._pluginName = this._name;
                 return;
             }
             this._mapModule = mapModule;

--- a/bundles/mapping/mapmodule/plugin/AbstractMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/AbstractMapModulePlugin.js
@@ -405,15 +405,12 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.AbstractMapModulePlugin',
          *
          */
         onEvent: function (event) {
-            var me = this,
-                handler = me._eventHandlers[event.getName()];
-
+            const handler = this._eventHandlers[event.getName()];
             if (handler) {
                 return handler.apply(me, [event]);
             } else {
-                me.getSandbox().printWarn(
-                    'No handler found for registered event', event.getName()
-                );
+                Oskari.log(this.getName())
+                    .warn('No handler found for registered event', event.getName());
             }
         }
     }, {

--- a/bundles/mapping/mapmodule/plugin/AbstractVectorLayerPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/AbstractVectorLayerPlugin.js
@@ -1,4 +1,4 @@
-import { FEATURE_QUERY_ERRORS } from './domain/constants';
+import { FEATURE_QUERY_ERRORS } from '../domain/constants';
 import './AbstractMapLayerPlugin';
 
 const AbstractMapLayerPlugin = Oskari.clazz.get('Oskari.mapping.mapmodule.AbstractMapLayerPlugin');

--- a/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
@@ -9,7 +9,6 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
      */
     function (config) {
         this._config = config;
-        this._ctl = null;
         this._element = null;
         this._enabled = true;
         this._visible = true;
@@ -185,49 +184,18 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
          *
          */
         setLocation: function (location) {
-            var me = this,
-                el = me.getElement();
+            const el = this.getElement();
 
-            if (!me._config) {
-                me._config = {};
+            if (!this._config) {
+                this._config = {};
             }
-            if (!me._config.location) {
-                me._config.location = {};
+            if (!this._config.location) {
+                this._config.location = {};
             }
 
-            me._config.location.classes = location;
+            this._config.location.classes = location;
             this.addToPluginContainer(el);
         },
-
-        /**
-         * @method setColorScheme
-         * Set the plugin's color scheme. Implement if needed.
-         * This will be deprecated if/when we move this to a map-level property.
-         *
-         * @param {Object} colorScheme
-         * Magical object with some colors and classes and whatnot...
-         *
-         */
-        _setColorScheme: function (colorScheme) {},
-
-        /**
-         * @method setFont
-         * Set the plugin's font. Implement if needed.
-         * This will be deprecated if/when we move this to a map-level property.
-         *
-         * @param {string} font Font ID
-         *
-         */
-        _setFont: function (font) {},
-
-        /**
-         * @method setStyle Set the plugin's style. Implement if needed.
-         * This will be deprecated if/when we move this to a map-level property.
-         *
-         * @param {Object} style Magical object with some widths and whatnot...
-         *
-         */
-        _setStyle: function (style) {},
 
         /**
          * @public @method hasUI

--- a/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
@@ -306,22 +306,6 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
         isVisible: function () {
             return this._visible;
         },
-        /**
-         * @public @method getToolStyleFromMapModule
-         *
-         * @return {String} style class used by mapmodule or default.
-         */
-        getToolStyleFromMapModule: function () {
-            return this.getMapModule().getToolStyle() || 'rounded-dark';
-        },
-        /**
-         * @public @method getToolStyleFromMapModule
-         *
-         * @return {String} the font used by mapmodule or null if not available.
-         */
-        getToolFontFromMapModule: function () {
-            return this.getMapModule().getToolFont();
-        },
 
         /**
          * Removes all the css classes which respond to given regex from all elements

--- a/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
@@ -307,43 +307,6 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
             return this._visible;
         },
 
-        /**
-         * Removes all the css classes which respond to given regex from all elements
-         * and adds the given class to them.
-         *
-         * @method changeCssClasses
-         * @param {String} classToAdd the css class to add to all elements.
-         * @param {RegExp} removeClassRegex the regex to test against to determine which classes should be removec
-         * @param {Array[jQuery]} elements The elements where the classes should be changed.
-         */
-        changeCssClasses: function (classToAdd, removeClassRegex, elements) {
-            var i,
-                j,
-                el;
-
-            for (i = 0; i < elements.length; i += 1) {
-                el = elements[i];
-                // FIXME build the function outside the loop
-                el.removeClass(function (index, classes) {
-                    var removeThese = '',
-                        classNames = classes.split(' ');
-
-                    // Check if there are any old font classes.
-                    for (j = 0; j < classNames.length; j += 1) {
-                        if (removeClassRegex.test(classNames[j])) {
-                            removeThese += classNames[j] + ' ';
-                        }
-                    }
-
-                    // Return the class names to be removed.
-                    return removeThese;
-                });
-
-                // Add the new font as a CSS class.
-                el.addClass(classToAdd);
-            }
-        },
-
         /** *****************************************
          * Deprecated functions for backwards compatibility.
          * Removed usage in Oskari 2.10.

--- a/bundles/mapping/mapmodule/plugin/datasource/DataSourcePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/datasource/DataSourcePlugin.js
@@ -207,7 +207,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.DataSourcePlugi
         _createUI: function () {
             var me = this;
             // get div where the map is rendered from openlayers
-            var parentContainer = jQuery(this._map.div);
+            var parentContainer = jQuery(this.getMap().div);
             if (!this.element) {
                 this.element = this.template.clone();
             }

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -1014,7 +1014,7 @@ Oskari.clazz.define(
                 return;
             }
             var vectorLayer = this._olLayers[layer.getId()];
-            this._map.removeLayer(vectorLayer);
+            this.getMap().removeLayer(vectorLayer);
             delete this._olLayers[layer.getId()];
         },
         /**

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -69,6 +69,7 @@ Oskari.clazz.define(
         this._log = Oskari.log('VectorLayerPlugin');
         this._styleCache = {};
         this._animatingFeatures = {};
+        this._name = 'VectorLayerPlugin';
     }, {
         __name: 'Oskari.mapframework.mapmodule.VectorLayerPlugin',
         /**

--- a/bundles/mapping/mapmodule/util/Crosshair.js
+++ b/bundles/mapping/mapmodule/util/Crosshair.js
@@ -1,0 +1,34 @@
+const template = jQuery(
+    `<div class="oskari-crosshair">
+        <div class="oskari-crosshair-vertical-bar"></div>
+        <div class="oskari-crosshair-horizontal-bar"></div>
+    </div>`);
+
+let crosshairOnMap = false;
+
+export const isCrosshairActive = () => crosshairOnMap;
+/**
+ * @method toggleCrosshair
+ * toggles the crosshair marking the center of the map
+ */
+export const toggleCrosshair = (mapEl) => {
+    if (isCrosshairActive()) {
+        removeCrosshair(mapEl);
+    } else {
+        addCrosshair(mapEl);
+    }
+};
+
+export const removeCrosshair = (mapEl) => {
+    if (crosshairOnMap) {
+        jQuery(mapEl).find('div.oskari-crosshair').remove();
+        crosshairOnMap = false;
+    }
+};
+
+export const addCrosshair = (mapEl) => {
+    if (!crosshairOnMap) {
+        jQuery(mapEl).append(template.clone());
+        crosshairOnMap = true;
+    }
+};

--- a/bundles/mapping/mapmodule/util/MapThemeHelper.js
+++ b/bundles/mapping/mapmodule/util/MapThemeHelper.js
@@ -1,0 +1,47 @@
+
+import { DEFAULT_COLORS } from 'oskari-ui/theme';
+
+const CSS_CLASS_PREFIX_FONT = 'oskari-theme-font-';
+
+export const getDefaultMapTheme = () => {
+    return {
+        // For buttons on map
+        navigation: {
+            roundness: 0,
+            opacity: 0.8,
+            color: {
+                primary: DEFAULT_COLORS.DARK_BUTTON_BG,
+                accent: DEFAULT_COLORS.ACCENT,
+                text: '#ffffff'
+            }
+        },
+        // /For buttons on map ^
+        // --------------
+        // For popup headers opened by map:
+        color: {
+            header: {
+                // #3c3c3c -> rgb(60,60,60)
+                bg: '#3c3c3c'
+            }
+            // accent should be inherited from global theme accent if not configured
+            // accent: '#ffd400'
+        }
+        // /For popup headers opened by map ^
+    };
+};
+
+// set font class for map module/map controls. Windows/popups will get it through theme
+export const setFont = (mapEl, requestedFont = 'arial') => {
+    // on unit tests the mapEl might be undefined
+    const classlist = mapEl?.classList;
+    if (!classlist) {
+        return;
+    }
+    const newFontClass = CSS_CLASS_PREFIX_FONT + (requestedFont || 'arial');
+    classlist.forEach(clazz => {
+        if (clazz !== newFontClass && clazz.startsWith(CSS_CLASS_PREFIX_FONT)) {
+            classlist.remove(clazz);
+        }
+    });
+    classlist.add(newFontClass);
+};

--- a/bundles/mapping/mapmodule/util/PluginHelper.js
+++ b/bundles/mapping/mapmodule/util/PluginHelper.js
@@ -1,5 +1,3 @@
-
-
 /**
  * Get a sorted list of plugins. This is used to control order of elements in the UI.
  * Functionality shouldn't assume order.
@@ -22,7 +20,7 @@ const getPluginIndex = (plugin) => {
 };
 
 export const getPluginsWithUI = (pluginInstances = {}) => {
-    const plugins = Object.values(pluginInstances);
+    const plugins = getSortedPlugins(pluginInstances);
     return plugins.filter((plugin = {}) => !!plugin?.hasUI());
 };
 

--- a/bundles/mapping/mapmodule/util/PluginHelper.js
+++ b/bundles/mapping/mapmodule/util/PluginHelper.js
@@ -21,7 +21,12 @@ const getPluginIndex = (plugin) => {
 
 export const getPluginsWithUI = (pluginInstances = {}) => {
     const plugins = getSortedPlugins(pluginInstances);
-    return plugins.filter((plugin = {}) => !!plugin?.hasUI());
+    return plugins.filter((plugin = {}) => {
+        if (typeof plugin.hasUI === 'function') {
+            return plugin.hasUI();
+        }
+        return false;
+    });
 };
 
 export const refreshPluginsWithUI = (pluginInstances = {}) => {

--- a/bundles/mapping/mapmodule/util/PluginHelper.js
+++ b/bundles/mapping/mapmodule/util/PluginHelper.js
@@ -1,0 +1,36 @@
+
+
+/**
+ * Get a sorted list of plugins. This is used to control order of elements in the UI.
+ * Functionality shouldn't assume order.
+ * @param {Object} where object values are the plugins to sort
+ * @return {Oskari.mapframework.ui.module.common.mapmodule.Plugin[]} index ordered list of registered plugins
+ */
+export const getSortedPlugins = (pluginInstances = {}) => {
+    const plugins = Object.values(pluginInstances);
+    plugins.sort((a, b) => getPluginIndex(a) - getPluginIndex(b));
+    return plugins;
+};
+
+const getPluginIndex = (plugin) => {
+    if (typeof plugin?.getIndex !== 'function') {
+        // index not defined, start after ones that have indexes
+        // This is just for the UI order, functionality shouldn't assume order
+        return 99999999999;
+    }
+    return plugin.getIndex();
+};
+
+export const getPluginsWithUI = (pluginInstances = {}) => {
+    const plugins = Object.values(pluginInstances);
+    return plugins.filter((plugin = {}) => !!plugin?.hasUI());
+};
+
+export const refreshPluginsWithUI = (pluginInstances = {}) => {
+    return getPluginsWithUI(pluginInstances).forEach((plugin) => {
+        if (typeof plugin.changeToolStyle === 'function') {
+            // TODO: is this the function that we should use?
+            plugin.changeToolStyle();
+        }
+    });
+};

--- a/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
+++ b/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
@@ -109,11 +109,11 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
             // if deg is number use it for degrees otherwise use 0
             var degrees = (typeof deg === 'number') ? deg : 0;
             this.rotateIcon(degrees);
-            this._map.getView().setRotation(rot);
+            this.getMap().getView().setRotation(rot);
             this.setDegrees(degrees);
         },
         getRotation: function () {
-            var rot = this._map.getView().getRotation();
+            var rot = this.getMap().getView().getRotation();
             // radians to degrees with one decimal
             var deg = Math.round(rot * 573) / 10;
             return deg;

--- a/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
+++ b/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
@@ -35,6 +35,7 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
         me.inMobileMode = false;
         this._dragRotate = null;
         this._removeListenerKey = null;
+        this._name = 'MapRotatorPlugin';
     }, {
         handleEvents: function () {
             if (this._dragRotate) {
@@ -69,7 +70,7 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
          */
         _createControlElement: function () {
             this._locale = Oskari.getLocalization('maprotator', Oskari.getLang() || Oskari.getDefaultLanguage()).display;
-            if (!this.hasUi()) {
+            if (!this.hasUI()) {
                 return null;
             }
             return this._templates.maprotatortool.clone();
@@ -145,6 +146,9 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
                 }
             };
         },
+        _startPluginImpl: function () {
+            this._createUI();
+        },
         /**
          * Handle plugin UI and change it when desktop / mobile mode
          * @method  @public redrawUI
@@ -152,13 +156,8 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
          * @param {Boolean} forced application has started and ui should be rendered with assets that are available
          */
         redrawUI: function (mapInMobileMode) {
-            var isMobile = mapInMobileMode || Oskari.util.isMobile();
-            if (this.getElement()) {
-                this.teardownUI(true);
-            }
-
-            this.inMobileMode = isMobile;
-            this._createUI();
+            // we don't need to do anything here any more
+            // FIXME: remove calls to this OR changeToolStyle() and use one function to update UI
         },
         teardownUI: function () {
             // detach old element from screen
@@ -168,7 +167,7 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
             this.getElement().detach();
             this.removeFromPluginContainer(this.getElement());
         },
-        hasUi: function () {
+        hasUI: function () {
             return !this._config.noUI;
         },
         /**
@@ -178,7 +177,7 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
         getElement: function () {
             return this._element;
         },
-        stopPlugin: function () {
+        _stopPluginImpl: function () {
             this.teardownUI();
             if (this._dragRotate) {
                 this.getMap().removeInteraction(this._dragRotate);

--- a/bundles/mapping/maprotator/publisher/MapRotator.js
+++ b/bundles/mapping/maprotator/publisher/MapRotator.js
@@ -39,7 +39,6 @@ Oskari.clazz.define('Oskari.mapping.publisher.tool.MapRotator',
          */
         init: function (data) {
             var me = this;
-
             var bundleData = data && data.configuration[me.bundleName];
             if (!bundleData) {
                 return;

--- a/bundles/statistics/statsgrid2016/plugin/TogglePlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/TogglePlugin.js
@@ -16,6 +16,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.TogglePlugin', function (flyout
             classes: location || this._defaultLocation
         }
     };
+    this._name = 'statsgrid.TogglePlugin';
 
     this.flyoutManager.on('show', function (tool) {
         me.toggleTool(tool, true);

--- a/src/react/theme/constants.js
+++ b/src/react/theme/constants.js
@@ -13,6 +13,7 @@ export const DEFAULT_COLORS = {
     NAV_BG: '#333438',
     HEADER_BG: '#fdf8d9',
     ACCENT: '#ffd400',
+    // 141414 -> rgb(20,20,20)
     DARK_BUTTON_BG: '#141414'
 };
 

--- a/src/react/theme/index.js
+++ b/src/react/theme/index.js
@@ -1,3 +1,3 @@
-export { EFFECT } from './constants';
+export { DEFAULT_COLORS, EFFECT } from './constants';
 export { setGlobalStyle } from './globalStyles';
 export { getColorEffect, getTextColor, getHeaderTheme, getNavigationTheme } from './ThemeHelper';


### PR DESCRIPTION
- Remove references to toolstyle
- Moved abstract plugin files from mapmodule root to plugin folder where some of the other abstract plugin files already were located
- Move functionality to helper-files to make the module more readable (crosshair, plugins handling, theme)