### PR TITLE
Cleaning up publisher/plugin/mapmodule interaction

### DIFF
--- a/bundles/framework/maplegend/publisher/MapLegend.js
+++ b/bundles/framework/maplegend/publisher/MapLegend.js
@@ -60,11 +60,8 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.MapLegend',
                 }
             }
         },
-        isDisplayed: function () {
-            return this.sandbox.findAllSelectedMapLayers().some(l => l.getLegendImage());
-        },
-        isShownInToolsPanel: function () {
-            return false;
+        isDisabled: function () {
+            return !this.sandbox.findAllSelectedMapLayers().some(l => l.getLegendImage());
         },
         isStarted: function () {
             return !!this.getPlugin();
@@ -91,5 +88,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.MapLegend',
             return null;
         }
     }, {
+        'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],
         'protocol': ['Oskari.mapframework.publisher.LayerTool']
     });

--- a/bundles/framework/maplegend/publisher/MapLegend.js
+++ b/bundles/framework/maplegend/publisher/MapLegend.js
@@ -6,12 +6,24 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.MapLegend',
         this.handler = null;
         this.tool = null;
         this.sandbox = sandbox;
+        this.allowedLocations = ['*'];
+        this.allowedSiblings = ['*'];
     }, {
+        group: 'layers',
         bundleName: 'maplegend',
         getComponent: function () {
             return {
                 component: MapLegendTool,
                 handler: this.handler
+            };
+        },
+        getTool: function () {
+            return {
+                id: 'Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin',
+                title: 'MapLegend',
+                config: {
+                    instance: this.getInstance()
+                }
             };
         },
         getInstance: function () {
@@ -47,6 +59,18 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.MapLegend',
                     this.getInstance().stopPlugin();
                 }
             }
+        },
+        isDisplayed: function () {
+            return this.sandbox.findAllSelectedMapLayers().some(l => l.getLegendImage());
+        },
+        isShownInToolsPanel: function () {
+            return false;
+        },
+        isStarted: function () {
+            return !!this.getPlugin();
+        },
+        isEnabled: function () {
+            return this.getPlugin().isEnabled();
         },
         /**
          * Get values.

--- a/bundles/framework/publisher2/instance.js
+++ b/bundles/framework/publisher2/instance.js
@@ -143,7 +143,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
                 // Create edit request handler callback
                 openingOnAppStart = true;
                 // Send request on app start
-                Oskari.on('app.start', function (details) {
+                Oskari.on('app.start', function () {
                     if (Oskari.user().isLoggedIn()) {
                         me._sendEditRequest(uuid);
                     } else {
@@ -170,61 +170,57 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherBundleInstan
          * @return {function} callback function for PublishMapEditorRequestHandler
          */
         _openPublisherForEditingCbFactory: function (infoDialog, openingOnAppStart) {
-            var me = this;
-            var layerCheckDone = false;
+            const me = this;
+            let layerCheckDone = false;
             return function (data) {
-                if (openingOnAppStart && !layerCheckDone) {
-                    // Check that the data contains selected layers configuration
-                    var dataHasLayersConfig =
-                        data &&
-                        data.configuration &&
-                        data.configuration.mapfull &&
-                        data.configuration.mapfull.state &&
-                        data.configuration.mapfull.state.selectedLayers;
+                if (!openingOnAppStart || layerCheckDone) {
+                    // open publisher
+                    me.setPublishMode(true, data);
+                    return;
+                }
+                // Opening on startup
+                // Check that the data contains selected layers configuration
+                const selectedLayers = data?.configuration?.mapfull?.state?.selectedLayers || [];
+                // Perform layer check only once when opening the publisher on startup.
+                layerCheckDone = true;
 
-                    if (dataHasLayersConfig) {
-                        var selectedLayers = data.configuration.mapfull.state.selectedLayers;
-                        var mapLayerService = me.sandbox.getService('Oskari.mapframework.service.MapLayerService');
-                        var timeoutInMillis = 1000; // one second;
-                        var maxTries = 30;
-                        var numTries = 0;
+                if (!selectedLayers.length) {
+                    if (infoDialog) {
+                        infoDialog.fadeout();
+                    }
+                    me._showOpeningPublisherErrorMsg();
+                    return;
+                }
+                const mapLayerService = me.sandbox.getService('Oskari.mapframework.service.MapLayerService');
+                const timeoutInMillis = 1000; // one second;
+                const maxTries = 30;
+                let numTries = 0;
 
-                        // Interval checks if layers have been loaded.
-                        var intervalId = setInterval(function () {
-                            var layerIds = selectedLayers.map(function (l) { return l.id; });
-                            var layersFound = mapLayerService.hasLayers(layerIds);
+                // Interval checks if layers have been loaded.
+                const intervalId = setInterval(function () {
+                    const layerIds = selectedLayers.map(function (l) { return l.id; });
+                    const layersFound = mapLayerService.hasLayers(layerIds);
 
-                            // try until we get the layers...
-                            if (layersFound) {
-                                if (infoDialog) {
-                                    infoDialog.close();
-                                }
-                                clearInterval(intervalId);
-                                me.setPublishMode(true, data);
-                                return;
-                            }
-                            numTries++;
+                    // try until we get the layers...
+                    if (layersFound) {
+                        if (infoDialog) {
+                            infoDialog.close();
+                        }
+                        clearInterval(intervalId);
+                        me.setPublishMode(true, data);
+                        return;
+                    }
+                    numTries++;
 
-                            // ...or the max try count is reached
-                            if (numTries === maxTries) {
-                                clearInterval(intervalId);
-                                if (infoDialog) {
-                                    infoDialog.fadeout();
-                                }
-                                me._showOpeningPublisherErrorMsg();
-                            }
-                        }, timeoutInMillis);
-                    } else {
+                    // ...or the max try count is reached
+                    if (numTries === maxTries) {
+                        clearInterval(intervalId);
                         if (infoDialog) {
                             infoDialog.fadeout();
                         }
                         me._showOpeningPublisherErrorMsg();
                     }
-                    // Perform layer check only once when opening the publisher on startup.
-                    layerCheckDone = true;
-                } else {
-                    me.setPublishMode(true, data);
-                }
+                }, timeoutInMillis);
             };
         },
         /**

--- a/bundles/framework/publisher2/resources/locale/fi.js
+++ b/bundles/framework/publisher2/resources/locale/fi.js
@@ -107,7 +107,7 @@ Oskari.registerLocalization(
                 },
                 "layerselection": {
                     "info": "Valitse taustakarttoina näytettävät karttatasot. Oletusvalinnan voit tehdä esikatselukartassa.",
-                    "selectAsBaselayer": "Taustakarttataso",
+                    "selectAsBaselayer": "Valitse taustakartaksi",
                     "allowStyleChange": "Salli esitystyylin valinta",
                     "showMetadata": "Näytä metatietolinkit",
                     "noMultipleStyles": "Valituilla karttatasoilla on saatavilla vain yksi esitystapa/tyyli."

--- a/bundles/framework/publisher2/tools/AbstractPluginTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPluginTool.js
@@ -53,6 +53,9 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
     getSandbox: function () {
         return this.__sandbox;
     },
+    getMapmodule: function () {
+        return this.__mapmodule;
+    },
     /**
      * If the tool requires space for the UI next to the map return the required height/width
      * @return {Object} object with keys height and width used for map size calculation
@@ -88,13 +91,15 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
             return;
         }
         this.state.enabled = enabled;
-        if (!this.__plugin && enabled) {
-            this.__plugin = Oskari.clazz.create(tool.id, tool.config);
-            this.__mapmodule.registerPlugin(this.__plugin);
+        let plugin = this.getPlugin();
+        if (!plugin && enabled) {
+            plugin = Oskari.clazz.create(tool.id, tool.config);
+            this.__plugin = plugin;
         }
 
         if (enabled) {
-            this.__plugin.startPlugin(this.__sandbox);
+            this.getMapmodule().registerPlugin(plugin);
+            plugin.startPlugin(this.getSandbox());
             this.__started = true;
         } else {
             this.stop();
@@ -250,7 +255,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
         if (this.getSandbox()) {
             plugin.stopPlugin(this.getSandbox());
         }
-        this.__mapmodule.unregisterPlugin(plugin);
+        this.getMapmodule().unregisterPlugin(plugin);
         this.__plugin = null;
     }
 });

--- a/bundles/framework/publisher2/tools/AbstractPluginTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPluginTool.js
@@ -85,30 +85,27 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
     * @param {Boolean} enabled is tool enabled or not
     */
     setEnabled: function (enabled) {
-        var me = this;
-        var tool = me.getTool();
+        var tool = this.getTool();
 
         // state actually hasn't changed -> do nothing
-        if (me.state.enabled !== undefined && me.state.enabled !== null && enabled === me.state.enabled) {
+        if (this.isEnabled() === enabled) {
             return;
         }
-        me.state.enabled = enabled;
-        if (!me.__plugin && enabled) {
-            me.__plugin = Oskari.clazz.create(tool.id, tool.config);
-            me.__mapmodule.registerPlugin(me.__plugin);
+        this.state.enabled = enabled;
+        if (!this.__plugin && enabled) {
+            this.__plugin = Oskari.clazz.create(tool.id, tool.config);
+            this.__mapmodule.registerPlugin(this.__plugin);
         }
 
-        if (enabled === true) {
-            me.__plugin.startPlugin(me.__sandbox);
-            me.__started = true;
+        if (enabled) {
+            this.__plugin.startPlugin(this.__sandbox);
+            this.__started = true;
         } else {
-            if (me.__started === true) {
-                me.stop();
-            }
+            this.stop();
         }
         this._setEnabledImpl(enabled);
         var event = Oskari.eventBuilder('Publisher2.ToolEnabledChangedEvent')(this);
-        me.getSandbox().notifyAll(event);
+        this.getSandbox().notifyAll(event);
     },
     /**
      * @method _setEnabledImpl
@@ -117,7 +114,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
     _setEnabledImpl: function () {},
 
     isEnabled: function () {
-        return this.state.enabled;
+        return !!this.state.enabled;
     },
 
     /**
@@ -239,13 +236,19 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
     * @public
     */
     stop: function () {
+        // TODO: do we really need started as an additional flag?
+        if (!this.__started) {
+            return;
+        }
         this.__started = false;
-        if (!this.__plugin) {
+        const plugin = this.getPlugin();
+        if (!plugin) {
             return;
         }
         if (this.getSandbox()) {
-            this.__plugin.stopPlugin(this.getSandbox());
+            plugin.stopPlugin(this.getSandbox());
         }
-        this.__mapmodule.unregisterPlugin(this.__plugin);
+        this.__mapmodule.unregisterPlugin(plugin);
+        this.__plugin = null;
     }
 });

--- a/bundles/framework/publisher2/tools/AbstractPluginTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPluginTool.js
@@ -6,7 +6,7 @@
  * @param  {Oskari.mapframework.bundle.publisher2.PublisherBundleInstance} instance
  * @param  {Object} handlers     with Oskari event names as keys and handler functions as values
  */
-Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', function (sandbox, mapmodule, localization, instance, handlers) {
+Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', function (sandbox, mapmodule, localization, instance) {
     this.__index = 0;
     this.__sandbox = sandbox;
     this.__mapmodule = mapmodule;
@@ -14,7 +14,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
     this.__instance = instance;
     this.__plugin = null;
     this.__tool = null;
-    this.__handlers = handlers;
     // This is used to watch tool plugin start/stop changes. If plugin is started then change this value to true, if stopped then change to false.
     // If tool plugin is started then we can call stop plugin if unchecking this tools (otherwise we get error when sopping plugin).
     this.__started = false;

--- a/bundles/framework/publisher2/tools/AbstractPluginTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPluginTool.js
@@ -238,7 +238,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
     */
     stop: function () {
         // TODO: do we really need started as an additional flag?
-        if (!this.__started) {
+        if (!this.isStarted()) {
             return;
         }
         this._stopImpl();

--- a/bundles/framework/publisher2/tools/AbstractPluginTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPluginTool.js
@@ -4,7 +4,7 @@
  * @param  {Oskari.mapframework.ui.module.common.MapModule} mapmodule
  * @param  {Object} localization Localization under publisher.BasicView
  */
-Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', function (sandbox, mapmodule, localization) {
+Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', function (sandbox, mapmodule, localization = {}) {
     this.__index = 0;
     this.__sandbox = sandbox;
     this.__mapmodule = mapmodule;

--- a/bundles/framework/publisher2/tools/AbstractPluginTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPluginTool.js
@@ -227,6 +227,11 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
         return true;
     },
     /**
+     * @method _stopImpl
+     * override if needed.
+     */
+    _stopImpl: function () {},
+    /**
     * Stop tool.
     * @method stop
     * @public
@@ -236,6 +241,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
         if (!this.__started) {
             return;
         }
+        this._stopImpl();
         this.__started = false;
         const plugin = this.getPlugin();
         if (!plugin) {

--- a/bundles/framework/publisher2/tools/AbstractPluginTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPluginTool.js
@@ -3,15 +3,12 @@
  * @param  {Oskari.Sandbox} sandbox
  * @param  {Oskari.mapframework.ui.module.common.MapModule} mapmodule
  * @param  {Object} localization Localization under publisher.BasicView
- * @param  {Oskari.mapframework.bundle.publisher2.PublisherBundleInstance} instance
- * @param  {Object} handlers     with Oskari event names as keys and handler functions as values
  */
-Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', function (sandbox, mapmodule, localization, instance) {
+Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', function (sandbox, mapmodule, localization) {
     this.__index = 0;
     this.__sandbox = sandbox;
     this.__mapmodule = mapmodule;
     this.__loc = localization[this.group];
-    this.__instance = instance;
     this.__plugin = null;
     this.__tool = null;
     // This is used to watch tool plugin start/stop changes. If plugin is started then change this value to true, if stopped then change to false.

--- a/bundles/framework/publisher2/tools/AbstractPluginTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPluginTool.js
@@ -141,18 +141,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
         return this.__loc[this.getTool().title];
     },
     /**
-    * Is displayed in mode.
-    * @method isDisplayedInMode
-    * @public
-    *
-    * @param {String} mode the checked mode
-    *
-    * @returns {Boolean} is displayed in wanted mode
-    */
-    isDisplayedInMode: function (mode) {
-        return true;
-    },
-    /**
     * Is displayed. We can use this to tell when tool is displayed.
     * For example if stats layers are added to map when opening publisher we can tell at then this tool need to be shown (ShowStatsTableTool).
     * Is there is no stats layer then not show the tool.
@@ -184,16 +172,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
     */
     isStarted: function () {
         return this.__started;
-    },
-    /**
-    * Whether or not to create a panel and checkbox for the tool in the tools' panel.
-    * @method isShownInToolsPanel
-    * @public
-    *
-    * @returns {Boolean} is the tool displayed in the tools' panel
-    */
-    isShownInToolsPanel: function () {
-        return true;
     },
 
     /**

--- a/bundles/framework/publisher2/tools/FeaturedataTool.js
+++ b/bundles/framework/publisher2/tools/FeaturedataTool.js
@@ -61,17 +61,10 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.FeaturedataTool',
             }
         },
         isDisplayed: function () {
-        // Check if selected layers include wfs layers
-            var wfs = false,
-                layers = this.__sandbox.findAllSelectedMapLayers(),
-                j;
-            for (j = 0; j < layers.length; ++j) {
-                if (layers[j].hasFeatureData()) {
-                    wfs = true;
-                    break;
-                }
-            }
-            return wfs;
+            // Check if selected layers include wfs layers
+            return this.getSandbox()
+                .findAllSelectedMapLayers()
+                .some(l => l.hasFeatureData());
         }
     }, {
         'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],

--- a/bundles/framework/publisher2/tools/GetInfoTool.js
+++ b/bundles/framework/publisher2/tools/GetInfoTool.js
@@ -158,20 +158,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
         isColourDialogOpen: false,
 
         /**
-    * Set enabled.
-    * @method setEnabled
-    * @public
-    *
-    * @param {Boolean} enabled is tool enabled or not
-    */
-        _setEnabledImpl: function (enabled) {
-            var me = this;
-            if (enabled === true && me.state.mode !== null && me.__plugin && typeof me.__plugin.setMode === 'function') {
-                me.__plugin.setMode(me.state.mode);
-            }
-        },
-
-        /**
     * Get extra options.
     * @method getExtraOptions
     * @public

--- a/bundles/framework/publisher2/tools/GetInfoTool.js
+++ b/bundles/framework/publisher2/tools/GetInfoTool.js
@@ -410,7 +410,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
             popup.show(this.getMsg('BasicView.layout.fields.colours.custom'), content, [closeButton]);
             this._customColoursPopup = popup;
         },
-        _stopImpl: function() {
+        _stopImpl: function () {
             if (this._colourSchemePopup) {
                 this._colourSchemePopup.close(true);
                 this._colourSchemePopup = null;

--- a/bundles/framework/publisher2/tools/GetInfoTool.js
+++ b/bundles/framework/publisher2/tools/GetInfoTool.js
@@ -314,7 +314,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
             var dialogContent = jQuery('<div></div>'),
                 header = jQuery('<div class="popupTitle"></div>'),
                 headerWrapper = jQuery('<div class="popupHeader"></div>'),
-                headerCloseButton = jQuery('<div class="olPopupCloseBox icon-close-white" style="position: absolute; top: 12px;"></div>'),
+                headerCloseButton = jQuery('<div class="olPopupCloseBox icon-close-white"></div>'),
                 contentDiv = jQuery('<div class="popupContent"></div>'),
                 contentWrapper = jQuery('<div class="contentWrapper"></div>'),
                 popupDataContent = jQuery('<div class="myplaces_wrapper"><div class="myplaces_place">' +
@@ -409,6 +409,17 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
 
             popup.show(this.getMsg('BasicView.layout.fields.colours.custom'), content, [closeButton]);
             this._customColoursPopup = popup;
+        },
+        _stopImpl: function() {
+            if (this._colourSchemePopup) {
+                this._colourSchemePopup.close(true);
+                this._colourSchemePopup = null;
+                this.isColourDialogOpen = false;
+            }
+            if (this._customColoursPopup) {
+                this._customColoursPopup.close(true);
+                this._customColoursPopup = null;
+            }
         },
 
         /**

--- a/bundles/framework/publisher2/tools/GetInfoTool.js
+++ b/bundles/framework/publisher2/tools/GetInfoTool.js
@@ -183,7 +183,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
             const template = me.templates.colours.clone();
             let selectedColour = me.values.colourScheme;
             if (!selectedColour?.val) {
-                selectedColour = initialValues.find(color => color.val === 'dark_grey');
+                selectedColour = this.initialValues.find(color => color.val === 'dark_grey');
             }
             
             const colourName = this.getMsg(`BasicView.layout.fields.colours.${selectedColour.val}`);

--- a/bundles/framework/publisher2/tools/GetInfoTool.js
+++ b/bundles/framework/publisher2/tools/GetInfoTool.js
@@ -185,7 +185,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
             if (!selectedColour?.val) {
                 selectedColour = this.initialValues.find(color => color.val === 'dark_grey');
             }
-            
+
             const colourName = this.getMsg(`BasicView.layout.fields.colours.${selectedColour.val}`);
             const colourLabel = this.getMsg('BasicView.layout.fields.colours.label');
             const colourPlaceholder = this.getMsg('BasicView.layout.fields.colours.placeholder');
@@ -207,7 +207,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
             var input = Oskari.clazz.create(
                 'Oskari.userinterface.component.CheckboxInput'
             );
-            
+
             input.setTitle(this.getMsg('BasicView.noUI'));
             input.setHandler(function (checked) {
                 if (checked === 'on') {
@@ -349,8 +349,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
      * @return {jQuery} returns the sample gfi
      */
         _createGfiPreview: function () {
-        // Example data
-            
+            // Example data
             const linkUrl = window.location;
             // Templates
             var dialogContent = jQuery('<div></div>'),
@@ -469,8 +468,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
             iconClsInputs.find('label[for=icon-close-white]')
                 .html(this.getMsg('BasicView.layout.fields.colours.customLabels.iconCloseWhiteLabel'));
 
-                this._createColorPickers();
-
+            this._createColorPickers();
             var colorPickerBackground = this.templates.colorPickers.background.clone(),
                 colorPickerTitle = this.templates.colorPickers.title.clone(),
                 colorPickerHeader = this.templates.colorPickers.header.clone();

--- a/bundles/framework/publisher2/tools/GetInfoTool.js
+++ b/bundles/framework/publisher2/tools/GetInfoTool.js
@@ -90,22 +90,8 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
 
         maxColourValue: 255,
         minColourValue: 0,
-        eventHandlers: {
-            'Publisher2.ToolEnabledChangedEvent': function (event) {
-                const tool = event.getTool();
-                if (tool.getTool().id !== this.getTool().id) {
-                    return;
-                }
-                if (tool.isStarted() && this.values.colourScheme) {
-                    this._sendColourSchemeChangedEvent(this.values.colourScheme);
-                }
-            }
-        },
         noUI: false,
         init: function (data) {
-            Object.keys(this.eventHandlers).forEach(eventName => {
-                this.__sandbox.registerForEventByName(this, eventName);
-            });
             if (!Oskari.util.keyExists(data, 'configuration.mapfull.conf.plugins')) {
                 return;
             }
@@ -117,34 +103,24 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
                 // Gets plugin color scheme
                 if (colourScheme) {
                     this.values.colourScheme = colourScheme;
-                    this._sendColourSchemeChangedEvent(colourScheme);
                 }
 
                 this.noUI = !!noUI;
                 this.setEnabled(true);
             }
         },
+        _setEnabledImpl: function () {
+            this._sendColourSchemeChangedEvent(this.values.colourScheme);
+        },
         getName: function () {
             return 'Oskari.mapframework.publisher.tool.GetInfoTool';
         },
         /**
-     * @method onEvent
-     * @param {Oskari.mapframework.event.Event} event a Oskari event object
-     * Event is handled forwarded to correct #eventHandlers if found or discarded if not.
-     */
-        onEvent: function (event) {
-            var handler = this.eventHandlers[event.getName()];
-            if (!handler) {
-                return;
-            }
-            return handler.apply(this, [event]);
-        },
-        /**
-    * Get tool object.
-    * @method getTool
-    *
-    * @returns {Object} tool description
-    */
+        * Get tool object.
+        * @method getTool
+        *
+        * @returns {Object} tool description
+        */
         getTool: function () {
             return {
                 id: 'Oskari.mapframework.mapmodule.GetInfoPlugin',
@@ -158,12 +134,12 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
         isColourDialogOpen: false,
 
         /**
-    * Get extra options.
-    * @method getExtraOptions
-    * @public
-    *
-    * @returns {Object} jQuery element
-    */
+        * Get extra options.
+        * @method getExtraOptions
+        * @public
+        *
+        * @returns {Object} jQuery element
+        */
         getExtraOptions: function () {
             const me = this;
             const template = me.templates.colours.clone();
@@ -218,42 +194,39 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
         },
 
         /**
-    * Get values.
-    * @method getValues
-    * @public
-    *
-    * @returns {Object} tool value object
-    */
+        * Get values.
+        * @method getValues
+        * @public
+        *
+        * @returns {Object} tool value object
+        */
         getValues: function () {
-            var me = this;
-
-            if (me.state.enabled) {
-                return {
-                    configuration: {
-                        mapfull: {
-                            conf: {
-                                plugins: [{
-                                    id: this.getTool().id,
-                                    config: {
-                                        colourScheme: me.values.colourScheme || {},
-                                        noUI: me.noUI
-                                    }
-                                }]
-                            }
-                        }
-                    }
-                };
-            } else {
+            if (!this.isEnabled()) {
                 return null;
             }
+            return {
+                configuration: {
+                    mapfull: {
+                        conf: {
+                            plugins: [{
+                                id: this.getTool().id,
+                                config: {
+                                    colourScheme: this.values.colourScheme || {},
+                                    noUI: this.noUI
+                                }
+                            }]
+                        }
+                    }
+                }
+            };
         },
 
         /**
-     * Creates and opens the dialog from which to choose the colour scheme.
-     * Also handles the creation of the sample gfi popup.
-     *
-     * @method _openColourDialog
-     */
+         * Creates and opens the dialog from which to choose the colour scheme.
+         * Also handles the creation of the sample gfi popup.
+         *
+         * @method _openColourDialog
+         */
         _openColourDialog: function () {
             const me = this;
             const popup = Oskari.clazz.create('Oskari.userinterface.component.Popup');
@@ -329,11 +302,11 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
         },
 
         /**
-     * Creates the sample gfi where the user can see the effects of the chosen colour scheme.
-     *
-     * @method _createGfiPreview
-     * @return {jQuery} returns the sample gfi
-     */
+         * Creates the sample gfi where the user can see the effects of the chosen colour scheme.
+         *
+         * @method _createGfiPreview
+         * @return {jQuery} returns the sample gfi
+         */
         _createGfiPreview: function () {
             // Example data
             const linkUrl = window.location;
@@ -377,12 +350,12 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
         },
 
         /**
-     * Sets the styles of the sample gfi with the selected colour scheme.
-     *
-     * @method _changeGfiColours
-     * @param {Object} selectedColour
-     * @param {jQuery} container (optional, defaults to the colour preview element on page)
-     */
+         * Sets the styles of the sample gfi with the selected colour scheme.
+         *
+         * @method _changeGfiColours
+         * @param {Object} selectedColour
+         * @param {jQuery} container (optional, defaults to the colour preview element on page)
+         */
         _changeGfiColours: function (selectedColour, container) {
             container = container || jQuery('div#publisher-colour-popup');
 
@@ -409,11 +382,11 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
         },
 
         /**
-     * Creates a popup from which custom colour scheme can be defined.
-     *
-     * @method _createCustomColoursPopup
-     * @return {undefined}
-     */
+         * Creates a popup from which custom colour scheme can be defined.
+         *
+         * @method _createCustomColoursPopup
+         * @return {undefined}
+         */
         _createCustomColoursPopup: function () {
             const popup = Oskari.clazz.create('Oskari.userinterface.component.Popup');
             const closeButton = Oskari.clazz.create('Oskari.userinterface.component.buttons.CloseButton');
@@ -439,11 +412,11 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
         },
 
         /**
-     * Creates the inputs for putting in your favourite colours.
-     *
-     * @method _createCustomColoursInputs
-     * @return {jQuery} return the template to select custom colours
-     */
+         * Creates the inputs for putting in your favourite colours.
+         *
+         * @method _createCustomColoursInputs
+         * @return {jQuery} return the template to select custom colours
+         */
         _createCustomColoursInputs: function () {
             const me = this;
             const template = me.templates.customClrs.clone();
@@ -492,12 +465,12 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
         },
 
         /**
-     * Prepopulates the custom colours template with saved colour values.
-     *
-     * @method  _prepopulateCustomColoursTemplate
-     * @param  {jQuery} template
-     * @return {undefined}
-     */
+         * Prepopulates the custom colours template with saved colour values.
+         *
+         * @method  _prepopulateCustomColoursTemplate
+         * @param  {jQuery} template
+         * @return {undefined}
+         */
         _prepopulateCustomColoursTemplate: function (template) {
             var me = this,
                 iconClsInputs = template.find('div#publisher-custom-colours-iconcls'),
@@ -513,18 +486,18 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
         },
 
         /**
-     * Prepopulates an rgb div with given values
-     *
-     * @method _prepopulateRgbDiv
-     * @param  {jQuery} rgbDiv
-     * @param  {Object} colours
-     *          {
-     *              red: <0-255>,
-     *              green: <0-255>,
-     *              blue: <0-255>
-     *          }
-     * @return {undefined}
-     */
+         * Prepopulates an rgb div with given values
+         *
+         * @method _prepopulateRgbDiv
+         * @param  {jQuery} rgbDiv
+         * @param  {Object} colours
+         *          {
+         *              red: <0-255>,
+         *              green: <0-255>,
+         *              blue: <0-255>
+         *          }
+         * @return {undefined}
+         */
         _prepopulateRgbDiv: function (rgbDiv, colours) {
             if (!colours) {
                 return;
@@ -536,12 +509,12 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
         },
 
         /**
-     * Collects the custom colours values from the content div.
-     *
-     * @method _collectCustomColourValues
-     * @param  {jQuery} content
-     * @return {undefined}
-     */
+         * Collects the custom colours values from the content div.
+         *
+         * @method _collectCustomColourValues
+         * @param  {jQuery} content
+         * @return {undefined}
+         */
         _collectCustomColourValues: function (content) {
             var me = this,
                 iconCls = content.find('div#publisher-custom-colours-iconcls input[name=custom-icon-class]:checked').val(),
@@ -559,17 +532,17 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
         },
 
         /**
-     * Returns an rgb colour object parsed from the div.
-     *
-     * @method _getColourFromRgbDiv
-     * @param {jQuery} rgbDiv
-     * @return {Object} returns an rgb colour object
-     *          {
-     *              red: <0-255>,
-     *              green: <0-255>,
-     *              blue: <0-255>
-     *          }
-     */
+         * Returns an rgb colour object parsed from the div.
+         *
+         * @method _getColourFromRgbDiv
+         * @param {jQuery} rgbDiv
+         * @return {Object} returns an rgb colour object
+         *          {
+         *              red: <0-255>,
+         *              green: <0-255>,
+         *              blue: <0-255>
+         *          }
+         */
         _getColourFromRgbDiv: function (rgbDiv) {
             var red = rgbDiv.find('input[name=red]').val(),
                 green = rgbDiv.find('input[name=green]').val(),
@@ -587,23 +560,23 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
         },
 
         /**
-     * Retrieves the item from the list which value matches the code given
-     * or null if not found on the list.
-     *
-     * @method _getItemByCode
-     * @param {String} code
-     * @param {Array[Object]} list
-     * @return {Object/null}
-     */
+         * Retrieves the item from the list which value matches the code given
+         * or null if not found on the list.
+         *
+         * @method _getItemByCode
+         * @param {String} code
+         * @param {Array[Object]} list
+         * @return {Object/null}
+         */
         _getItemByCode: function (code, list) {
             return list.find(l => l.val === code) || null;
         },
 
         /**
-     * @method createColorPickers
-     * Creates an array of color picker components
-     * @private
-     */
+         * @method createColorPickers
+         * Creates an array of color picker components
+         * @private
+         */
         _createColorPickers: function () {
             var options = { className: 'oskari-colorpickerinput', cancelText: this.getMsg('BasicView.buttons.cancel') };
             this._colorPickers = [
@@ -614,11 +587,10 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
         },
 
         /**
-     * @method updatePreviewFromCustomValues
-     * Updates preview colors from color pickers and icon choice
-     * @param {Object} content
-     */
-
+         * @method updatePreviewFromCustomValues
+         * Updates preview colors from color pickers and icon choice
+         * @param {Object} content
+         */
         _updatePreviewFromCustomValues: function (content) {
             var selectedColour = {};
             selectedColour.bgColour = this._colorPickers[0].getValue();
@@ -633,64 +605,45 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
         },
 
         /**
-     * Returns an rgb colour object in css formatted string.
-     *
-     * @method _getCssRgb
-     * @param  {Object} rgb
-     *          {
-     *              red: <0-255>,
-     *              green: <0-255>,
-     *              blue: <0-255>
-     *          }
-     * @return {String}
-     */
+         * Returns an rgb colour object in css formatted string.
+         *
+         * @method _getCssRgb
+         * @param  {Object} rgb
+         *          {
+         *              red: <0-255>,
+         *              green: <0-255>,
+         *              blue: <0-255>
+         *          }
+         * @return {String}
+         */
         _getCssRgb: function (rgb) {
             return 'rgb(' + rgb.red + ', ' + rgb.green + ', ' + rgb.blue + ')';
         },
 
         /**
-     * Sends an event to notify interested parties that the colour scheme has changed.
-     *
-     * @method _sendColourSchemeChangedEvent
-     * @param {Object} colourScheme the changed colour scheme
-     */
+         * Sends an event to notify interested parties that the colour scheme has changed.
+         *
+         * @method _sendColourSchemeChangedEvent
+         * @param {Object} colourScheme the changed colour scheme
+         */
         _sendColourSchemeChangedEvent: function (colourScheme) {
             this._sendEvent('Publisher2.ColourSchemeChangedEvent', colourScheme);
         },
 
         /**
-     * "Sends" an event, that is, notifies other components of something.
-     *
-     * @method _sendEvent
-     * @param {String} eventName the name of the event
-     * @param {Whatever} eventData the data we want to send with the event
-     */
+         * "Sends" an event, that is, notifies other components of something.
+         *
+         * @method _sendEvent
+         * @param {String} eventName the name of the event
+         * @param {Whatever} eventData the data we want to send with the event
+         */
         _sendEvent: function (eventName, eventData) {
-            var eventBuilder = Oskari.eventBuilder(eventName),
-                evt;
+            const eventBuilder = Oskari.eventBuilder(eventName);
 
             if (eventBuilder) {
-                evt = eventBuilder(eventData);
-                this.__sandbox.notifyAll(evt);
+                const evt = eventBuilder(eventData);
+                this.getSandbox().notifyAll(evt);
             }
-        },
-        /**
-    * Stop tool.
-    * @method stop
-    * @public
-    */
-        stop: function () {
-            var me = this;
-            if (me.__plugin) {
-                if (me.__sandbox && me.__plugin.getSandbox()) {
-                    me.__plugin.stopPlugin(me.__sandbox);
-                }
-                me.__mapmodule.unregisterPlugin(me.__plugin);
-            }
-
-            Object.keys(me.eventHandlers).forEach(eventName => {
-                me.__sandbox.unregisterFromEventByName(me, eventName);
-            });
         }
     }, {
         'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],

--- a/bundles/framework/publisher2/tools/GetInfoTool.js
+++ b/bundles/framework/publisher2/tools/GetInfoTool.js
@@ -170,9 +170,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
             }
         },
 
-        isEnabled: function () {
-            return this.state.enabled;
-        },
         /**
     * Get extra options.
     * @method getExtraOptions

--- a/bundles/framework/publisher2/tools/GetInfoTool.js
+++ b/bundles/framework/publisher2/tools/GetInfoTool.js
@@ -183,7 +183,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
             const template = me.templates.colours.clone();
             let selectedColour = me.values.colourScheme;
             if (!selectedColour?.val) {
-                selectedColour = this.initialValues.find(color => color.val === 'dark_grey');
+                selectedColour = this.initialValues.colours.find(color => color.val === 'dark_grey');
             }
 
             const colourName = this.getMsg(`BasicView.layout.fields.colours.${selectedColour.val}`);

--- a/bundles/framework/publisher2/tools/LayerTool.js
+++ b/bundles/framework/publisher2/tools/LayerTool.js
@@ -6,9 +6,18 @@
 */
 
 Oskari.clazz.define('Oskari.mapframework.publisher.tool.LayerTool',
-    function () {
+    function (sandbox, mapmodule, localization) {
         this._log = Oskari.log('publisher.LayerTool');
+        // sandbox
+        this.__sandbox = sandbox;
+        // mapmodule
+        this.__mapmodule = mapmodule;
+        // localization
+        this.__loc = localization;
+        // plugin
+        this.__plugin = null;
     }, {
+        group: 'layers',
         /**
         * Initialize tool
         * Override

--- a/bundles/framework/publisher2/tools/LogoTool.js
+++ b/bundles/framework/publisher2/tools/LogoTool.js
@@ -45,7 +45,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.LogoTool',
                 return null;
             }
         },
-        isShownInToolsPanel: function () {
+        isDisplayed: function () {
             return false;
         }
     }, {

--- a/bundles/framework/publisher2/tools/Tool.js
+++ b/bundles/framework/publisher2/tools/Tool.js
@@ -91,25 +91,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.Tool',
 
         },
         /**
-        * Is displayed in mode.
-        * @method isDisplayedInMode
-        * @public
-        *
-        * @param {String} mode the checked mode
-        *
-        * @returns {Boolean} is displayed in wanted mode
-        */
-        isDisplayedInMode: function (mode) {
-            var me = this;
-            var supportedModes = [];
-
-            supportedModes = jQuery.grep(me.__supportedModes, function (modename) {
-                return modename === mode;
-            });
-
-            return supportedModes > 0;
-        },
-        /**
         * Is displayed.
         * @method isDisplayed
         * @public

--- a/bundles/framework/publisher2/view/PanelMapPreview.js
+++ b/bundles/framework/publisher2/view/PanelMapPreview.js
@@ -55,7 +55,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapPreview'
         this.tools = tools;
 
         me.panel = null;
-        me.modeChangedCB = null;
         this.templates = {
             help: jQuery('<div class="help icon-info"></div>')
         };
@@ -137,29 +136,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapPreview'
          * @return {Object} size
          */
         _getActiveMapSize: function () {
-            var mapDiv = this.mapmodule.getMapEl(),
-                width = mapDiv.width(),
-                height = mapDiv.height();
-
+            const mapDiv = this.mapmodule.getMapEl();
             return {
-                width: width,
-                height: height
+                width: mapDiv.width(),
+                height: mapDiv.height()
             };
         },
-
-        /**
-         * @private @method _calculateLeftComponentsWidth
-         * Calculates a sensible width for components on the left panel (but doesn't set it...)
-         */
-        _calculateLeftComponentsWidth: function () {
-            var toolsWidth = 0;
-            this.tools.forEach(function (tool) {
-                toolsWidth = toolsWidth + (tool.getAdditionalSize().width || 0);
-            });
-            // Width, but 400 at most.
-            return Math.min(toolsWidth, 400);
-        },
-
         /**
          * @private @method _adjustDataContainer
          * This horrific thing is what sets the left panel components, container and map size.
@@ -170,37 +152,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapPreview'
             const mapDiv = this.mapmodule.getMapEl();
             mapDiv.width(size.width || '100%');
             mapDiv.height(size.height || '100%');
-
-            // notify map module that size has changed
-            this._updateMapModuleSize();
         },
 
-        /**
-        * @private @method _updateMapModuleSize
-        * Update map size
-        */
-        _updateMapModuleSize: function (isStopping) {
-            // turn off event handlers in order to avoid consecutive calls to mapsizechanged
-            this._unregisterEventHandlers();
-            this._updateMapMode();
-
-            // turn event handlers back on.
-            if (!isStopping) {
-                this._registerEventHandlers();
-            }
-        },
-
-        /**
-        * @private @method _updateMapMode
-        * Update map mode
-        */
-        _updateMapMode: function () {
-            const size = this._getSelectedMapSize();
-
-            if (typeof this.modeChangedCB === 'function') {
-                this.modeChangedCB(size.option.id);
-            }
-        },
         /**
          * @private @method _getSelectedMapSize
          * Returns an object containing the user seleted/set map size and the corresponding size option
@@ -243,9 +196,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapPreview'
          *
          * @method init
          * @param {Object} pData initial data
-         * @param {Object} modeChangedCB mode changed callback
          */
-        init: function (pData, modeChangedCB) {
+        init: function (pData) {
             var me = this,
                 fkey,
                 data,
@@ -254,7 +206,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapPreview'
                 contentPanel = panel.getContainer(),
                 tooltipCont = me.templates.help.clone();
 
-            me.modeChangedCB = modeChangedCB;
             // initial mode selection if modify.
             if (pData && pData.metadata && pData.metadata.preview) {
                 var selectedOptions = me.sizeOptions.filter(function (option) {

--- a/bundles/framework/publisher2/view/PanelMapTools.js
+++ b/bundles/framework/publisher2/view/PanelMapTools.js
@@ -107,10 +107,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
          * @private
          * @method _setToolLocation
          * Sets the tool's location according to users selection. (lefhanded/righthanded/userlayout)
+         * 
+         * FIXME: this is only called because left/right handed layout option. If we replace them with "toggle" we can remove this.
          */
         _setToolLocation: function (tool) {
-            const layoutPanel = this.instance.publisher.panels.find(
-                panel => panel.getName && panel.getName() === 'Oskari.mapframework.bundle.publisher2.view.PanelToolLayout');
+            const layoutPanel = this.instance.publisher.panels
+                .filter(panel => typeof panel.getName === 'function')
+                .find(panel => panel.getName() === 'Oskari.mapframework.bundle.publisher2.view.PanelToolLayout');
             if (!layoutPanel || !tool[layoutPanel.activeToolLayout]) {
                 return;
             }

--- a/bundles/framework/publisher2/view/PanelMapTools.js
+++ b/bundles/framework/publisher2/view/PanelMapTools.js
@@ -107,7 +107,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
          * @private
          * @method _setToolLocation
          * Sets the tool's location according to users selection. (lefhanded/righthanded/userlayout)
-         * 
+         *
          * FIXME: this is only called because left/right handed layout option. If we replace them with "toggle" we can remove this.
          */
         _setToolLocation: function (tool) {

--- a/bundles/framework/publisher2/view/PanelMapTools.js
+++ b/bundles/framework/publisher2/view/PanelMapTools.js
@@ -43,7 +43,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
          */
         init: function (pData) {
             const instance = this.instance;
-            const sandbox = this.sandbox;
             this.data = pData;
 
             if (pData) {
@@ -55,42 +54,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
                             .error('Error initializing publisher tool:', tool.getTool().id);
                     }
                 });
-            }
-
-            Object.keys(this.eventHandlers)
-                .forEach(eventName => sandbox.registerForEventByName(this, eventName));
-        },
-        /**
-         * @method onEvent
-         * @param {Oskari.mapframework.event.Event} event a Oskari event object
-         * Event is handled forwarded to correct #eventHandlers if found or discarded if not.
-         */
-        onEvent: function (event) {
-            var handler = this.eventHandlers[event.getName()];
-            if (!handler) {
-                return;
-            }
-            return handler.apply(this, [event]);
-        },
-        /**
-         * @property {Object} eventHandlers
-         * @static
-         */
-        eventHandlers: {
-            /**
-             * @method MapLayerEvent
-             * @param {Oskari.mapframework.event.common.MapLayerEvent} event
-             *
-             * Calls  handleDrawLayerSelectionChanged() functions
-             */
-            MapLayerEvent: function (event) {
-                const toolbarTool = this._getToolbarTool('PublisherToolbarPlugin');
-                if (toolbarTool && (event.getOperation() === 'add')) {
-                    // handleDrawLayerSelectionChanged
-                    toolbarTool.handleDrawLayerSelectionChanged(
-                        event.getLayerId()
-                    );
-                }
             }
         },
         getName: function () {
@@ -269,8 +232,5 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
                         .error('Error stopping publisher tool:', tool.getTool().id);
                 }
             });
-
-            Object.keys(this.eventHandlers)
-                .forEach(eventName => this.sandbox.unregisterFromEventByName(this, eventName));
         }
     });

--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -32,6 +32,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
         );
 
         me.toolLayouts = ['lefthanded', 'righthanded', 'userlayout'];
+        // This is publisher.sidebar.data
         me.data = me.instance.publisher.data;
         me.activeToolLayout = 'userlayout';
         if (me.instance.publisher.data &&
@@ -55,22 +56,22 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
          * Creates the Oskari.userinterface.component.AccordionPanel where the UI is rendered
          */
         init: function (data) {
-            var me = this;
-            me.toolLayoutEditMode = false;
-            for (var p in me.eventHandlers) {
-                if (me.eventHandlers.hasOwnProperty(p)) {
-                    me.sandbox.registerForEventByName(me, p);
-                }
-            }
-            if (!me.panel) {
-                me.panel = me._populateToolLayoutPanel(data);
+            this.toolLayoutEditMode = false;
+            // Listens to tools being enabled while dragging is active
+            Object.keys(this.eventHandlers)
+                .forEach(eventName => this.sandbox.registerForEventByName(this, eventName));
+            if (!this.panel) {
+                this.panel = this._populateToolLayoutPanel(data);
             }
 
             // init the tools' plugins location infos
-            if (me.data && me.activeToolLayout === 'userlayout') {
-                me._initUserLayout();
+            if (this.data && this.activeToolLayout === 'userlayout') {
+                // this is always true, however we should not call setLocation for plugins here.
+                // Instead they should start at the location they were when saved.
+                // Problem: getTool() returns empty config usually so plugin is created with empty config instead of actual config that was used to save the map.
+                this._initUserLayout();
             } else {
-                me._changeToolLayout(me.activeToolLayout, null);
+                this._changeToolLayout(this.activeToolLayout, null);
             }
         },
         getName: function () {

--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -159,7 +159,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
             var me = this;
             this.tools.forEach(tool => {
                 // don't call for tools that already have been set enabled (=plugin has already been created.)
-                if (tool.isDisplayed(me.data) && !tool.isShownInToolsPanel() && !tool.state.enabled) {
+                if (tool.isDisplayed(me.data) && !tool.state.enabled) {
                     tool.setEnabled(true);
                 }
             });

--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -66,7 +66,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
                 me.panel = me._populateToolLayoutPanel(data);
             }
 
-            me._toggleAdditionalTools();
             // init the tools' plugins location infos
             if (me.data && me.activeToolLayout === 'userlayout') {
                 me._initUserLayout();
@@ -150,20 +149,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
                 return;
             }
             return handler.apply(this, [event]);
-        },
-        /**
-         * @method _toggleAdditionalTools
-         *   sets on the tools that are displayed but aren't showing in the tools panel (LogoPlugin etc.)
-         */
-        _toggleAdditionalTools: function () {
-            var me = this;
-            this.tools.forEach(tool => {
-                // don't call for tools that already have been set enabled (=plugin has already been created.)
-                if (tool.isDisplayed(me.data) && !tool.state.enabled) {
-                    tool.setEnabled(true);
-                }
-            });
-            return null;
         },
         /**
          * Returns the UI panel and populates it with the data that we want to show the user.

--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -394,8 +394,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
             if (!elem || this._addedDraggables.includes(elem)) {
                 return;
             }
-            const enabled = tool.state.enabled === true;
-            if (enabled) {
+            if (tool.isEnabled()) {
                 this._makeDraggable(elem);
                 this._addedDraggables.push(elem);
             } else if (elem.hasClass('ui-draggable')) {

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -80,7 +80,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
             // bind close from header (X)
             container
                 .find('div.header div.icon-close')
-                .on('click',() => this.cancel());
+                .on('click', () => this.cancel());
 
             // -- create panels --
             const genericInfoPanel = this._createGeneralInfoPanel();
@@ -532,7 +532,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
         _disablePreview: function () {
             const sandbox = this.instance.sandbox;
             var mapModule = sandbox.findRegisteredModuleInstance('MainMapModule');
-/*
+            /*
             // FIXME: let tools stop the plugins they started on stop() instead!
             // Remove plugins added during publishing session
             Object.values(mapModule.getPluginInstances())
@@ -546,7 +546,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                         Messaging.error(this.loc.error.disablePreview);
                     }
                 });
-*/
+            */
             // resume normal plugins
             this.normalMapPlugins.forEach(plugin => {
                 mapModule.registerPlugin(plugin);

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -156,7 +156,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
 
             // initialize form (restore data when editing)
             form.init(me.data);
-
             // open generic info by default
             form.getPanel().open();
             return form;
@@ -176,7 +175,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
 
             // initialize form (restore data when editing)
             form.init(me.data);
-
             return form;
         },
         _createMapLayersPanel: function () {
@@ -201,7 +199,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
 
             // initialize form (restore data when editing)
             form.init(me.data);
-
             return form;
         },
         /**
@@ -490,15 +487,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                 this._stopEditorPanels();
                 this._disablePreview();
             }
-            /*
-            // FIXME: notify all visible tools the enabled status changes? WHY?
-            var sb = this.instance.sandbox;
-            var publisherTools = this._createToolGroupings();
-            publisherTools.tools.forEach(function (tool) {
-                var event = Oskari.eventBuilder('Publisher2.ToolEnabledChangedEvent')(tool);
-                sb.notifyAll(event);
-            });
-            */
         },
 
         /**
@@ -532,21 +520,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
         _disablePreview: function () {
             const sandbox = this.instance.sandbox;
             var mapModule = sandbox.findRegisteredModuleInstance('MainMapModule');
-            /*
-            // FIXME: let tools stop the plugins they started on stop() instead!
-            // Remove plugins added during publishing session
-            Object.values(mapModule.getPluginInstances())
-                .filter(plugin => plugin.hasUI && plugin.hasUI())
-                .forEach(plugin => {
-                    try {
-                        plugin.stopPlugin(sandbox);
-                        mapModule.unregisterPlugin(plugin);
-                    } catch (err) {
-                        Oskari.log('Publisher').error('Disable preview', err);
-                        Messaging.error(this.loc.error.disablePreview);
-                    }
-                });
-            */
             // resume normal plugins
             this.normalMapPlugins.forEach(plugin => {
                 mapModule.registerPlugin(plugin);

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -287,27 +287,24 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
          * and {Oskari.mapframework.publisher.tool.Tool[]} tools not displayed in panel
          */
         _createToolGroupings: function () {
-            var me = this;
-            var sandbox = this.instance.getSandbox();
-            var mapmodule = sandbox.findRegisteredModuleInstance('MainMapModule');
-            var definedTools = Oskari.clazz.protocol('Oskari.mapframework.publisher.Tool');
-            var grouping = {};
-            var allTools = [];
+            const sandbox = this.instance.getSandbox();
+            const mapmodule = sandbox.findRegisteredModuleInstance('MainMapModule');
+            const definedTools = Oskari.clazz.protocol('Oskari.mapframework.publisher.Tool');
+            const grouping = {};
+            const allTools = [];
             // group tools per tool-group
             definedTools.forEach(toolname => {
-                var tool = Oskari.clazz.create(toolname, sandbox, mapmodule, me.loc, me.instance, me.getHandlers());
-                if (tool.isDisplayed(me.data) === true && tool.isShownInToolsPanel()) {
-                    var group = tool.getGroup();
-                    if (!grouping[group]) {
-                        grouping[group] = [];
-                    }
-                    me._addToolConfig(tool);
-                    grouping[group].push(tool);
+                const tool = Oskari.clazz.create(toolname, sandbox, mapmodule, this.loc, this.instance, this.getHandlers());
+                if (tool.isDisplayed(this.data) !== true) {
+                    return;
                 }
-
-                if (tool.isDisplayed(me.data) === true) {
-                    allTools.push(tool);
+                var group = tool.getGroup();
+                if (!grouping[group]) {
+                    grouping[group] = [];
                 }
+                this._addToolConfig(tool);
+                grouping[group].push(tool);
+                allTools.push(tool);
             });
             return {
                 groups: grouping,

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -175,7 +175,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                 );
 
             // initialize form (restore data when editing)
-            form.init(me.data, function (value) {});
+            form.init(me.data);
 
             return form;
         },
@@ -183,7 +183,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
             const sandbox = this.instance.getSandbox();
             const mapModule = sandbox.findRegisteredModuleInstance('MainMapModule');
             const form = Oskari.clazz.create('Oskari.mapframework.bundle.publisher2.view.PanelMapLayers', sandbox, mapModule, this.loc, this.instance);
-            form.init(this.data, (value) => {});
+            form.init(this.data);
             return form;
         },
         /**
@@ -200,7 +200,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                 );
 
             // initialize form (restore data when editing)
-            form.init(me.data, function (value) {});
+            form.init(me.data);
 
             return form;
         },
@@ -217,7 +217,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                 );
 
             // initialize form (restore data when editing)
-            form.init(me.data, function (value) {});
+            form.init(me.data);
 
             return form;
         },
@@ -226,7 +226,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
             const form = Oskari.clazz.create('Oskari.mapframework.bundle.publisher2.view.PanelRpc',
                 tools, sandbox, this.loc, this.instance
             );
-            form.init(this.data, (value) => {});
+            form.init(this.data);
             return form;
         },
 
@@ -566,20 +566,15 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
          * @param {Object[]} errors validation error objects to show
          *
          */
-        _showValidationErrorMessage: function (errors) {
-            var dialog = Oskari.clazz.create(
-                    'Oskari.userinterface.component.Popup'
-                ),
-                okBtn = dialog.createCloseButton(this.loc.buttons.ok),
-                content = jQuery('<ul></ul>'),
-                i,
-                row;
-
-            for (i = 0; i < errors.length; i += 1) {
-                row = jQuery('<li></li>');
-                row.append(errors[i].error);
-                content.append(row);
-            }
+        _showValidationErrorMessage: function (errors = []) {
+            const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+            const okBtn = dialog.createCloseButton(this.loc.buttons.ok);
+            const content = jQuery('<ul></ul>');
+            errors.map(err => {
+                const row = jQuery('<li></li>');
+                row.append(err.error);
+                return row;
+            }).forEach(row => content.append(row));
             dialog.makeModal();
             dialog.show(this.loc.error.title, content, [okBtn]);
         },
@@ -591,19 +586,15 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
          *
          */
         _showReplaceConfirm: function (continueCallback) {
-            var dialog = Oskari.clazz.create(
-                    'Oskari.userinterface.component.Popup'
-                ),
-                okBtn = Oskari.clazz.create(
-                    'Oskari.userinterface.component.Button'
-                );
+            const dialog = Oskari.clazz.create('Oskari.userinterface.component.Popup');
+            const okBtn = Oskari.clazz.create('Oskari.userinterface.component.Button');
             okBtn.setTitle(this.loc.buttons.replace);
             okBtn.addClass('primary');
             okBtn.setHandler(function () {
                 dialog.close();
                 continueCallback();
             });
-            var cancelBtn = dialog.createCloseButton(this.loc.buttons.cancel);
+            const cancelBtn = dialog.createCloseButton(this.loc.buttons.cancel);
             dialog.show(
                 this.loc.confirm.replace.title,
                 this.loc.confirm.replace.msg,

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -107,7 +107,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                 if (group === 'rpc') {
                     rpcPanel = this._createRpcPanel(tools);
                     rpcPanel.getPanel().addClass('t_rpc');
-                } else if (group !== 'layers'){
+                } else if (group !== 'layers') {
+                    // ignore tools under "layers" as these are the new React-based tools shown on the layers panel
                     const toolPanel = Oskari.clazz.create('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
                         group, tools, this.instance, this.loc
                     );

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -40,8 +40,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
 
         me.templateButtonsDiv = jQuery('<div class="buttons"></div>');
         me.normalMapPlugins = [];
-        // additional bundles (=not map plugins) that were stopped when entering publisher
-        me.stoppedBundles = [];
 
         me.loc = localization;
         me.accordion = null;
@@ -60,54 +58,47 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
          * rendered to
          */
         render: function (container) {
-            var me = this,
-                content = me.template.clone();
-            me.mainPanel = content;
+            const content = this.template.clone();
+            this.mainPanel = content;
 
-            me.progressSpinner.insertTo(content);
+            this.progressSpinner.insertTo(content);
             // prepend makes the sidebar go on the left side of the map
             // we could use getNavigationDimensions() and check placement from it to append OR prepend,
             // but it does work with the navigation even on the right hand side being hidden,
             //  a new panel appearing on the left hand side and the map moves accordingly
             container.prepend(content);
-            var contentDiv = content.find('div.content'),
-                accordion = Oskari.clazz.create(
-                    'Oskari.userinterface.component.Accordion'
-                );
-            me.accordion = accordion;
+            const accordion = Oskari.clazz.create('Oskari.userinterface.component.Accordion');
+            this.accordion = accordion;
 
             // setup title based on new/edit
-            var sidebarTitle = content.find('div.header h3');
+            const sidebarTitle = content.find('div.header h3');
 
-            if (me.data.uuid) {
-                sidebarTitle.append(me.loc.titleEdit);
+            if (this.data.uuid) {
+                sidebarTitle.text(this.loc.titleEdit);
             } else {
-                sidebarTitle.append(me.loc.title);
+                sidebarTitle.text(this.loc.title);
             }
             // bind close from header (X)
-            container.find('div.header div.icon-close').on(
-                'click',
-                function () {
-                    me.cancel();
-                }
-            );
+            container
+                .find('div.header div.icon-close')
+                .on('click',() => this.cancel());
 
             // -- create panels --
-            var genericInfoPanel = me._createGeneralInfoPanel();
+            const genericInfoPanel = this._createGeneralInfoPanel();
             genericInfoPanel.getPanel().addClass('t_generalInfo');
-            me.panels.push(genericInfoPanel);
+            this.panels.push(genericInfoPanel);
             accordion.addPanel(genericInfoPanel.getPanel());
 
-            var publisherTools = me._createToolGroupings(accordion);
+            var publisherTools = this._createToolGroupings(accordion);
 
-            var mapPreviewPanel = me._createMapPreviewPanel(publisherTools.tools);
+            var mapPreviewPanel = this._createMapPreviewPanel(publisherTools.tools);
             mapPreviewPanel.getPanel().addClass('t_size');
-            me.panels.push(mapPreviewPanel);
+            this.panels.push(mapPreviewPanel);
             accordion.addPanel(mapPreviewPanel.getPanel());
 
-            const mapLayersPanel = me._createMapLayersPanel();
+            const mapLayersPanel = this._createMapLayersPanel();
             mapLayersPanel.getPanel().addClass('t_layers');
-            me.panels.push(mapLayersPanel);
+            this.panels.push(mapLayersPanel);
             accordion.addPanel(mapLayersPanel.getPanel());
 
             // create panel for each tool group
@@ -120,42 +111,36 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                     accordion.addPanel(rpcPanel.getPanel());
                 } else {
                     const toolPanel = Oskari.clazz.create('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
-                        group, tools, me.instance, me.loc
+                        group, tools, this.instance, this.loc
                     );
-                    toolPanel.init(me.data);
-                    me.panels.push(toolPanel);
+                    toolPanel.init(this.data);
+                    this.panels.push(toolPanel);
                     const panel = toolPanel.getPanel();
                     panel.addClass('t_tools');
                     panel.addClass('t_' + group);
                     accordion.addPanel(panel);
                 }
             });
-            var toolLayoutPanel = me._createToolLayoutPanel(publisherTools.tools);
+            const toolLayoutPanel = this._createToolLayoutPanel(publisherTools.tools);
             toolLayoutPanel.getPanel().addClass('t_toollayout');
-            me.panels.push(toolLayoutPanel);
+            this.panels.push(toolLayoutPanel);
             accordion.addPanel(toolLayoutPanel.getPanel());
 
-            var layoutPanel = me._createLayoutPanel();
+            const layoutPanel = this._createLayoutPanel();
             layoutPanel.getPanel().addClass('t_style');
-            me.panels.push(layoutPanel);
+            this.panels.push(layoutPanel);
             accordion.addPanel(layoutPanel.getPanel());
 
             // -- render to UI and setup buttons --
+            const contentDiv = content.find('div.content');
             accordion.insertTo(contentDiv);
-            contentDiv.append(me._getButtons());
+            contentDiv.append(this._getButtons());
 
             // disable keyboard map moving whenever a text-input is focused element
-            var inputs = me.mainPanel.find('input[type=text]');
-            inputs.on('focus', function () {
-                me.instance.sandbox.postRequestByName(
-                    'DisableMapKeyboardMovementRequest'
-                );
-            });
-            inputs.on('blur', function () {
-                me.instance.sandbox.postRequestByName(
-                    'EnableMapKeyboardMovementRequest'
-                );
-            });
+            const inputs = this.mainPanel.find('input[type=text]');
+            const sandbox = this.instance.getSandbox();
+            inputs.on('focus', () => sandbox.postRequestByName('DisableMapKeyboardMovementRequest'));
+            inputs.on('blur', () => sandbox.postRequestByName('EnableMapKeyboardMovementRequest'));
         },
 
         /**

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -242,7 +242,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
         _createToolGroupings: function () {
             const sandbox = this.instance.getSandbox();
             const mapmodule = sandbox.findRegisteredModuleInstance('MainMapModule');
-            const definedTools = Oskari.clazz.protocol('Oskari.mapframework.publisher.Tool');
+            const definedTools = [...Oskari.clazz.protocol('Oskari.mapframework.publisher.Tool'), ...Oskari.clazz.protocol('Oskari.mapframework.publisher.LayerTool')];
             const grouping = {};
             const allTools = [];
             // group tools per tool-group

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -101,14 +101,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
             accordion.addPanel(mapLayersPanel.getPanel());
 
             // create panel for each tool group
+            let rpcPanel = null;
             Object.keys(publisherTools.groups).forEach(group => {
                 const tools = publisherTools.groups[group];
                 if (group === 'rpc') {
-                    const rpcPanel = this._createRpcPanel(tools);
+                    rpcPanel = this._createRpcPanel(tools);
                     rpcPanel.getPanel().addClass('t_rpc');
-                    this.panels.push(rpcPanel);
-                    accordion.addPanel(rpcPanel.getPanel());
-                } else {
+                } else if (group !== 'layers'){
                     const toolPanel = Oskari.clazz.create('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
                         group, tools, this.instance, this.loc
                     );
@@ -120,6 +119,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                     accordion.addPanel(panel);
                 }
             });
+            if (rpcPanel) {
+                // add rpc panel after the other tools
+                this.panels.push(rpcPanel);
+                accordion.addPanel(rpcPanel.getPanel());
+            }
             const toolLayoutPanel = this._createToolLayoutPanel(publisherTools.tools);
             toolLayoutPanel.getPanel().addClass('t_toollayout');
             this.panels.push(toolLayoutPanel);

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -1,6 +1,5 @@
 import { Messaging } from 'oskari-ui/util';
 
-const hasSizeUpdateFn = panel => typeof panel.updateMapSize === 'function';
 /**
  * @class Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
  * Renders the publishers "publish mode" sidebar view where the user can make
@@ -144,15 +143,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
         },
 
         /**
-        * Handles panels update map size changes
-        * @method @private _handleMapSizeChange
-        */
-        _handleMapSizeChange: function () {
-            this.panels
-                .filter(hasSizeUpdateFn)
-                .forEach(panel => panel.updateMapSize());
-        },
-        /**
          * @private @method _createGeneralInfoPanel
          * Creates the Location panel of publisher
          */
@@ -239,19 +229,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
             form.init(this.data, (value) => {});
             return form;
         },
-        /**
-        * Get panel/tool handlers
-        * @method getHandlers
-        * @public
-        */
-        getHandlers: function () {
-            var me = this;
-            return {
-                'MapSizeChanged': function () {
-                    me._handleMapSizeChange();
-                }
-            };
-        },
 
         /**
          * @private @method _createToolGroupings
@@ -270,7 +247,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
             const allTools = [];
             // group tools per tool-group
             definedTools.forEach(toolname => {
-                const tool = Oskari.clazz.create(toolname, sandbox, mapmodule, this.loc, this.instance, this.getHandlers());
+                const tool = Oskari.clazz.create(toolname, sandbox, mapmodule, this.loc, this.instance);
                 if (tool.isDisplayed(this.data) !== true) {
                     return;
                 }

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -247,7 +247,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
             const allTools = [];
             // group tools per tool-group
             definedTools.forEach(toolname => {
-                const tool = Oskari.clazz.create(toolname, sandbox, mapmodule, this.loc, this.instance);
+                const tool = Oskari.clazz.create(toolname, sandbox, mapmodule, this.loc);
                 if (tool.isDisplayed(this.data) !== true) {
                     return;
                 }

--- a/bundles/mapping/mapmodule/plugin/AbstractMapLayerPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/AbstractMapLayerPlugin.js
@@ -20,6 +20,8 @@ Oskari.clazz.define(
         this._log = Oskari.log(this.getName());
     }, {
         /** @static @property __name plugin name */
+        // FIXME: in AbstractMapModulePlugin it's _name or _pluginName (not really sure which will be used ultimately)
+        // This means that layerplugins use __name and other plugins _name (or _pluginName)
         __name: 'OVERRIDETHIS',
         /**
          * @method getName

--- a/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
+++ b/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
@@ -197,7 +197,7 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
             try {
                 return this._map.forEachFeatureAtPixel(pixel, featureHitCb, {
                     layerFilter: layer => this._onlyRegisteredTypesFilter(layer)
-                });
+                }) || {};
             } catch (ex) {
                 if (ex.message === `Cannot read property 'forEachFeatureAtCoordinate' of undefined`) {
                     this._log.debug('Could not find features at hover location. Omitted ol renderer error:\n', ex);

--- a/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
+++ b/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
@@ -196,7 +196,7 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
             const featureHitCb = (feature, layer) => ({ feature, layer });
             let ftrAndLyr;
             try {
-                ftrAndLyr = this._map.forEachFeatureAtPixel(pixel, featureHitCb, {
+                ftrAndLyr = this.getMap().forEachFeatureAtPixel(pixel, featureHitCb, {
                     layerFilter: layer => this._onlyRegisteredTypesFilter(layer)
                 });
             } catch (ex) {

--- a/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
+++ b/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
@@ -194,9 +194,8 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
         _getTopmostFeatureAndLayer (event) {
             const pixel = [event.getPageX(), event.getPageY()];
             const featureHitCb = (feature, layer) => ({ feature, layer });
-            let ftrAndLyr;
             try {
-                ftrAndLyr = this.getMap().forEachFeatureAtPixel(pixel, featureHitCb, {
+                return this._map.forEachFeatureAtPixel(pixel, featureHitCb, {
                     layerFilter: layer => this._onlyRegisteredTypesFilter(layer)
                 });
             } catch (ex) {
@@ -206,7 +205,7 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
                     throw ex;
                 }
             }
-            return ftrAndLyr || {};
+            return {};
         }
 
         /**

--- a/bundles/mapping/mapmodule/util/MapThemeHelper.js
+++ b/bundles/mapping/mapmodule/util/MapThemeHelper.js
@@ -7,7 +7,7 @@ export const getDefaultMapTheme = () => {
     return {
         // For buttons on map
         navigation: {
-            roundness: 0,
+            roundness: 100,
             opacity: 0.8,
             color: {
                 primary: DEFAULT_COLORS.DARK_BUTTON_BG,

--- a/bundles/mapping/maprotator/instance.js
+++ b/bundles/mapping/maprotator/instance.js
@@ -56,6 +56,9 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorBundleInstance',
             this._mapmodule.startPlugin(plugin);
             this.plugin = plugin;
         },
+        getPlugin: function () {
+            return this.plugin;
+        },
         stopPlugin: function () {
             this._mapmodule.unregisterPlugin(this.plugin);
             this._mapmodule.stopPlugin(this.plugin);

--- a/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
+++ b/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
@@ -100,6 +100,7 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
         },
         _createUI: function () {
             this._element = this._createControlElement();
+            this.setDegrees(this.getRotation());
             this._renderButton();
             this.handleEvents();
             this.addToPluginContainer(this._element);
@@ -132,9 +133,6 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
          */
         _createEventHandlers: function () {
             return {
-                MapSizeChangedEvent: function () {
-                    this.setRotation(this.getDegrees());
-                },
                 /**
                  * @method RPCUIEvent
                  * will open/close coordinatetool's popup
@@ -178,6 +176,7 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
             return this._element;
         },
         _stopPluginImpl: function () {
+            this.setRotation(0);
             this.teardownUI();
             if (this._dragRotate) {
                 this.getMap().removeInteraction(this._dragRotate);

--- a/bundles/mapping/maprotator/publisher/MapRotator.js
+++ b/bundles/mapping/maprotator/publisher/MapRotator.js
@@ -82,25 +82,25 @@ Oskari.clazz.define('Oskari.mapping.publisher.tool.MapRotator',
          * @returns {Object} tool value object
          */
         getValues: function () {
-            var me = this;
             if (!this.isEnabled()) {
                 return null;
             }
             var pluginConfig = this.getPlugin().getConfig();
             for (var configName in pluginConfig) {
-                if (configName === 'noUI' && !me.noUI) {
+                if (configName === 'noUI' && !this.noUI) {
                     pluginConfig[configName] = null;
                     delete pluginConfig[configName];
                 }
             }
-            if (me.noUI) {
-                pluginConfig.noUI = me.noUI;
+            if (this.noUI) {
+                pluginConfig.noUI = this.noUI;
             }
-            pluginConfig.enabled = me.state.enabled;
+            // TODO: is this enabled needed? it's always true if tool.isEnabled()
+            pluginConfig.enabled = true;
             var json = {
                 configuration: {}
             };
-            json.configuration[me.bundleName] = {
+            json.configuration[this.bundleName] = {
                 conf: pluginConfig,
                 state: this.getMapRotatorInstance().getState()
             };


### PR DESCRIPTION
Includes commits from #2156

Notes for future self:

Entering publisher:
1) Sends UIChangeEvent with param `publisher2` to notify other functionalities that they should clean up the UI
2) When editing: sets the app state with `StateHandler.SetStateRequest`
3) Stops and unregisters all mapmodule plugins where hasUI() returns true (keeps track of these for resuming after publisher as `sidebar.normalMapPlugins`)
4) Fetches all `Tool` classes, calls `Oskari.clazz.create()` and filters out any where `tool.isDisplayed(data) != true`

Exiting publisher:
1) calls stop() for each "panel" (==accordion component). The panels are responsible for tearing down anything they changed during use of the publisher functionality. For example the "PanelMapTools" will in turn call stop() for each of the publisher tools that are then responsible for tearing down anything they have set up during the use of publisher functionality. The tools can in turn call plugin.stop() which should tear down a plugin that the tool has initialized.
2) Restores any plugins that were "stashed" in `sidebar.normalMapPlugins` during startup

Note! `Publisher2.ToolEnabledChangedEvent` is used by `AbstractPluginTool.setEnabled()` to notify the app that a tool has been enabled/disabled. This is only used to notify the `PanelToolLayout` that any tools that are activated during the "drag and drop" of plugins between plugin containers should start in the dragging mode or stop the dragging mode on disable.

Removed:
- `tool.isShownInToolsPanel()` as this was not used in a meaningful way where `isDisplayed()` could not be used.
- `tool.isDisplayedInMode()` as this was not used at all
- `tools panel setMode()` as this was not used
- myplaces/drawing related code for embedded maps tools as this hasn't been re-implemented after OL2 departure
- duplicated `Publisher2.ToolEnabledChangedEvent` sent on setEnabled() as render() is called right after that sends these again (see 4 above)
- Tools no longer receive references to publisher instance or `handlers` in panel tools. These were not used and instance was only used to reference localization that was already available to tools in another constructor param.
- `sidebar._disablePreview()` no longer stops plugins as any plugins started by publisher tools should be cleaned up by the tools stop() function that is called when publisher is exited

The tool API:
- isDisplayed() is used to detect if tool should be shown as a selection to user. This might be false if we don't want the user to be able to disable something like the "terms of use" plugin. It can still be shown on the map and dragged to different plugin containers.
- isDisabled() if true the selection is shown to the user but it is disabled. There should be a tooltip shown to the user instructing why the tool is disabled
- isEnabled() if the tool is activated (checkbox checked for the tool)
- setEnabled() the tool should initialize the plugin on the map corresponding to the tool. This is implemented in AbstractPluginTool and works for many of the tool choices. Should send on `Publisher2.ToolEnabledChangedEvent` 
- stop() should stop and clean out the plugin the tool is controlling (closing any additional popups etc)
- getExtraOptions() should return a jQuery reference that presents any extra options that the tool offers to the user.