### PR TITLE
Publisher map layers accordion improvements.

### DIFF
--- a/bundles/framework/maplegend/publisher/MapLegendTool.jsx
+++ b/bundles/framework/maplegend/publisher/MapLegendTool.jsx
@@ -16,7 +16,7 @@ export const MapLegendTool = ({ state, controller }) => {
             onChange={(e) => controller.setShowLegends(e.target.checked)}
             disabled={disabled}
         >
-            <Message bundleKey='maplegend' messageKey='tooltip' />
+            <Message bundleKey='maplegend' messageKey='tool.label' />
         </StyledCheckbox>
     );
 

--- a/bundles/framework/maplegend/resources/locale/en.js
+++ b/bundles/framework/maplegend/resources/locale/en.js
@@ -11,6 +11,9 @@ Oskari.registerLocalization(
         "singleLegend":"Map legend: ",
         "infotext": "Choose the map layer, for which legend is shown:",
         "newtab":"Open in a new tab",
+        "tool": {
+            "label": "Map legends"
+        },
         "guidedTour": {
             "title": "Map Legends",
             "message": "Map legends are visual explanations of the symbols and colours used on the map.",

--- a/bundles/framework/maplegend/resources/locale/fi.js
+++ b/bundles/framework/maplegend/resources/locale/fi.js
@@ -11,6 +11,9 @@ Oskari.registerLocalization(
         "singleLegend":"Karttaselite: ",
         "infotext":"Valitse selitettävä karttataso:",
         "newtab":"Avaa uudessa välilehdessä",
+        "tool": {
+            "label": "Karttaselitteet"
+        },
         "guidedTour": {
             "title": "Karttaselitteet",
             "message": "Karttaselitteet selventävät näkyvissä olevien tasojen symboleja ja merkitystä.",

--- a/bundles/framework/maplegend/resources/locale/sv.js
+++ b/bundles/framework/maplegend/resources/locale/sv.js
@@ -11,6 +11,9 @@ Oskari.registerLocalization(
         "singleLegend":"Förklaring: ",
         "infotext":"Välj kartlager, vars förklaringar visas:",
         "newtab": "Öppna i ny flik",
+        "tool": {
+            "label": "Kartförklaringar"
+        },
         "guidedTour": {
             "title": "Förklaringar",
             "message": "Här kan du se förklaringar av de symboler och färger som används på kartan.",

--- a/bundles/framework/publisher2/resources/locale/en.js
+++ b/bundles/framework/publisher2/resources/locale/en.js
@@ -108,9 +108,10 @@ Oskari.registerLocalization(
                 "layerselection": {
                     "info": "Select the background map layer. You can select the default background map layer in the map preview.",
                     "selectAsBaselayer": "Select as baselayer",
-                    "allowStyleChange": "Allow style change",
+                    "allowStyleChange": "Allow presentation style change",
                     "showMetadata": "Show metadata links",
-                    "noMultipleStyles": "The selected map layers only have a single visualization option/style."
+                    "noMultipleStyles": "The selected map layers only have a single visualization option/style.",
+                    "noMetadata": "No metadata links availabe on the selected map layers"
                 },
                 "mylocation": {
                     "modes": {

--- a/bundles/framework/publisher2/resources/locale/fi.js
+++ b/bundles/framework/publisher2/resources/locale/fi.js
@@ -110,7 +110,8 @@ Oskari.registerLocalization(
                     "selectAsBaselayer": "Taustakarttataso",
                     "allowStyleChange": "Salli esitystyylin valinta",
                     "showMetadata": "Näytä metatietolinkit",
-                    "noMultipleStyles": "Valituilla karttatasoilla on saatavilla vain yksi esitystapa/tyyli."
+                    "noMultipleStyles": "Valituilla karttatasoilla on saatavilla vain yksi esitystapa/tyyli.",
+                    "noMetadata": "Metatietolinkkejä ei saatavilla valituilla karttatasoilla"
                 },
                 "mylocation": {
                     "modes": {

--- a/bundles/framework/publisher2/resources/locale/sv.js
+++ b/bundles/framework/publisher2/resources/locale/sv.js
@@ -108,9 +108,10 @@ Oskari.registerLocalization(
                 "layerselection": {
                     "info": "Välj bakgrundskartlager. Du kan göra förval i förhandsgranskningsvyn.",
                     "selectAsBaselayer": "Välj bakgrundskartlager",
-                    "allowStyleChange": "Tillåta stiländring",
+                    "allowStyleChange": "Tillåt val av visningsstil",
                     "showMetadata": "Visa länkar för metadata",
-                    "noMultipleStyles": "The selected map layers only have a single visualization option/style."
+                    "noMultipleStyles": "The selected map layers only have a single visualization option/style.",
+                    "noMetadata": "Metadatalänkar är inte tillgängliga på valda kartlager"
                 },
                 "mylocation": {
                     "modes": {

--- a/bundles/framework/publisher2/view/MapLayers/MapLayers.jsx
+++ b/bundles/framework/publisher2/view/MapLayers/MapLayers.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Button, Message, Checkbox, Tooltip } from 'oskari-ui';
+import { Button, Message, Checkbox, Tooltip, Card } from 'oskari-ui';
 import { ButtonContainer, IconButton } from 'oskari-ui/components/buttons';
 import { UpCircleOutlined, DownCircleOutlined } from '@ant-design/icons';
 
@@ -46,9 +46,15 @@ const ExtraOptions = styled('div')`
     margin-left: 15px;
 `;
 
+const ToolsContainer = styled('div')`
+    display: flex;
+    flex-direction: column;
+`;
+
 export const MapLayers = ({ state, controller }) => {
     const layers = state.showLayerSelection ? state.layers.filter(l => !state.baseLayers.some(bl => bl.getId() === l.getId())) : state.layers;
     const disableStyleSelect = state.layers.filter(l => l.getStyles().length > 1).length < 1;
+    const disableMetadataSelect = state.layers.filter(l => l.getMetadataIdentifier() !== null).length < 1;
 
     const StyleSelect = (
         <StyledCheckbox
@@ -59,41 +65,55 @@ export const MapLayers = ({ state, controller }) => {
             <Message messageKey='BasicView.maptools.layerselection.allowStyleChange' />
         </StyledCheckbox>
     );
+    const MetadataSelect = (
+        <StyledCheckbox
+            checked={state.showMetadata}
+            onChange={(e) => controller.setShowMetadata(e.target.checked)}
+            disabled={disableMetadataSelect}
+        >
+            <Message messageKey='BasicView.maptools.layerselection.showMetadata' />
+        </StyledCheckbox>
+    );
 
     return (
         <Content>
-            <StyledCheckbox
-                checked={state.showLayerSelection}
-                onChange={(e) => controller.setShowLayerSelection(e.target.checked)}
-            >
-                <Message messageKey='BasicView.layerselection.label' />
-            </StyledCheckbox>
-            {state.showLayerSelection && (
-                <ExtraOptions>
+            <Card title={<Message messageKey='BasicView.maptools.label' />}>
+                <ToolsContainer>
                     <StyledCheckbox
-                        checked={state.showMetadata}
-                        onChange={(e) => controller.setShowMetadata(e.target.checked)}
+                        checked={state.showLayerSelection}
+                        onChange={(e) => controller.setShowLayerSelection(e.target.checked)}
                     >
-                        <Message messageKey='BasicView.maptools.layerselection.showMetadata' />
+                        <Message messageKey='BasicView.layerselection.label' />
                     </StyledCheckbox>
-                    {disableStyleSelect ? (
-                        <Tooltip title={<Message messageKey='BasicView.maptools.layerselection.noMultipleStyles' />}>
-                            {StyleSelect}
-                        </Tooltip>
-                    ) : (
-                        StyleSelect
+                    {state.showLayerSelection && (
+                        <ExtraOptions>
+                            {disableMetadataSelect ? (
+                                <Tooltip title={<Message messageKey='BasicView.maptools.layerselection.noMetadata' />}>
+                                    {MetadataSelect}
+                                </Tooltip>
+                            ) : (
+                                MetadataSelect
+                            )}
+                            {disableStyleSelect ? (
+                                <Tooltip title={<Message messageKey='BasicView.maptools.layerselection.noMultipleStyles' />}>
+                                    {StyleSelect}
+                                </Tooltip>
+                            ) : (
+                                StyleSelect
+                            )}
+                        </ExtraOptions>
                     )}
-                </ExtraOptions>
-            )}
-            {state.externalOptions.map((tool, index) => {
-                return (
-                    <tool.component
-                        key={index}
-                        state={tool.handler.getState()}
-                        controller={tool.handler.getController()}
-                    />
-                )
-            })}
+                    {state.externalOptions.map((tool, index) => {
+                        return (
+                            <tool.component
+                                key={index}
+                                state={tool.handler.getState()}
+                                controller={tool.handler.getController()}
+                            />
+                        )
+                    })}
+                </ToolsContainer>
+            </Card>
             {state.showLayerSelection && (
                 <LayerContainer>
                     <h3><Message messageKey='BasicView.mapLayers.baseLayers' /></h3>

--- a/bundles/framework/publisher2/view/PanelMapLayers.js
+++ b/bundles/framework/publisher2/view/PanelMapLayers.js
@@ -115,7 +115,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapLayers',
                 this.panel = Oskari.clazz.create(
                     'Oskari.userinterface.component.AccordionPanel'
                 );
-                this.panel.setTitle(this.loc.layerselection.label);
+                this.panel.setTitle(this.loc.mapLayers.label);
                 this._populateMapLayerPanel();
             }
         },

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -32,6 +32,7 @@ export { Tooltip } from './components/Tooltip';
 export { LabeledInput } from './components/LabeledInput';
 export { Pagination } from './components/Pagination';
 export { Link } from './components/Link';
+export { Card } from './components/Card';
 // TODO: consider moving these out of index.js so we don't pack them in for embedded maps
 // or in components that are used on embedded maps we could import the components directly and NOT use this index file for imports
 export { UrlInput } from './components/UrlInput';


### PR DESCRIPTION
Translations, Card component for styling and "show metadata" checkbox is now disabled if none of the layers have metadata.