### PR TITLE
React icon type

### DIFF
--- a/bundles/framework/oskariui/resources/locale/en.js
+++ b/bundles/framework/oskariui/resources/locale/en.js
@@ -20,6 +20,7 @@ Oskari.registerLocalization({
             reset: 'Reset'
         },
         messages: {
+            confirm: 'Are you sure you want to continue?',
             confirmDelete: 'Are you sure you wish to delete?'
         },
         error: {

--- a/bundles/framework/oskariui/resources/locale/fi.js
+++ b/bundles/framework/oskariui/resources/locale/fi.js
@@ -20,6 +20,7 @@ Oskari.registerLocalization({
             reset: 'Tyhjennä'
         },
         messages: {
+            confirm: 'Haluatko varmasti jatkaa?',
             confirmDelete: 'Haluatko varmasti poistaa?'
         },
         error: {

--- a/bundles/framework/oskariui/resources/locale/sv.js
+++ b/bundles/framework/oskariui/resources/locale/sv.js
@@ -20,6 +20,7 @@ Oskari.registerLocalization({
             reset: 'Återställa'
         },
         messages: {
+            confirm: 'Är du säker på att du vill fortsätta?',
             confirmDelete: 'Vill du säkert ta bort?'
         },
         error: {

--- a/src/react/components/buttons/IconButton.jsx
+++ b/src/react/components/buttons/IconButton.jsx
@@ -59,8 +59,8 @@ const getConfirmProps = (type) => {
         };
     }
     return {
-        okText: <Message messageKey='buttons.Kyllä' bundleKey='oskariui'/>,
-        cancelText: <Message messageKey='buttons.Ei' bundleKey='oskariui'/>,
+        okText: <Message messageKey='buttons.yes' bundleKey='oskariui'/>,
+        cancelText: <Message messageKey='buttons.no' bundleKey='oskariui'/>,
         title: <Message messageKey='messages.confirm' bundleKey='oskariui'/>
     };
 };
@@ -96,7 +96,7 @@ export const IconButton = ({
             <Confirm
                 overlayClassName='t_confirm'
                 onConfirm={onConfirm}
-                okButtonProps={{className: `t_button t_${type || 'yes'}`}}
+                okButtonProps={{className: `t_button t_${type || 'ok'}`}}
                 cancelButtonProps={{className: 't_button t_cancel'}}
                 disabled={disabled}
                 placement={title ? 'bottom' : 'top'}

--- a/src/react/components/buttons/IconButton.jsx
+++ b/src/react/components/buttons/IconButton.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from '../Button';
-import { Tooltip } from '../Tooltip';
+import { Message, Confirm, Button, Tooltip } from 'oskari-ui';
 import { ThemeConsumer } from '../../util';
 import { getColorEffect, EFFECT } from '../../theme';
 import styled from 'styled-components';
+import { PlusOutlined, EditOutlined, QuestionCircleOutlined, DeleteOutlined } from '@ant-design/icons';
+import { red } from '@ant-design/colors'
+import { Forward } from '../icons/Forward'
+import { Backward } from '../icons/Backward'
 
 // Note! AntD buttons default at 32x32px
 //  If the font-size of the icon is > 32px it will be clipped by at least Safari
 //  Let the user of this component define the size of the button instead of doing it here.
-const StyledButton = styled(Button)`
+const BorderlessButton = styled(Button)`
     border: none;
     background: none;
     &:hover {
@@ -17,8 +20,52 @@ const StyledButton = styled(Button)`
         background: none;
     }
 `;
+const BorderedButton = styled(Button)`
+    &:hover {
+        color: ${props => props.color};
+        border-color: ${props => props.color};
+    }
+`;
 
-const ThemeButton = ThemeConsumer(({ theme, ...rest }) => {
+const getPredefinedIcon = (type) => {
+    if (type === 'add') {
+        return <PlusOutlined/>;
+    }
+    if (type === 'edit') {
+        return <EditOutlined/>;
+    }
+    if (type === 'info') {
+        return <QuestionCircleOutlined style={{ color: '#0290ff', borderRadius: '50%' }}/>;
+    }
+    if (type === 'next') {
+        return <Forward/>;
+    }
+    if (type === 'previous') {
+        return <Backward/>;
+    }
+    if (type === 'delete') {
+        return <DeleteOutlined style={{color: red.primary}} />
+    }
+    return null;
+}
+
+const getConfirmProps = (type) => {
+    if (type === 'delete') {
+        return {
+            okText: <Message messageKey='buttons.delete' bundleKey='oskariui'/>,
+            cancelText: <Message messageKey='buttons.cancel' bundleKey='oskariui'/>,
+            title: <Message messageKey='messages.confirmDelete' bundleKey='oskariui'/>,
+            okType: 'danger'
+        };
+    }
+    return {
+        okText: <Message messageKey='buttons.Kyllä' bundleKey='oskariui'/>,
+        cancelText: <Message messageKey='buttons.Ei' bundleKey='oskariui'/>,
+        title: <Message messageKey='messages.confirm' bundleKey='oskariui'/>
+    };
+};
+
+const ThemeButton = ThemeConsumer(({ theme, bordered, ...rest }) => {
     let color = theme?.color?.accent;
     if (color && Oskari.util.isDarkColor(color)) {
         color = theme?.color?.primary;
@@ -28,29 +75,61 @@ const ThemeButton = ThemeConsumer(({ theme, ...rest }) => {
     } else if (Oskari.util.isDarkColor(color)) {
         color = getColorEffect(color, EFFECT.LIGHTEN);
     }
-    return <StyledButton color={color} { ...rest }/>
+    if (bordered) {
+        return <BorderedButton color={color} { ...rest }/>
+    }
+    // default
+    return <BorderlessButton color={color} { ...rest }/>
 });
 
-export const IconButton = ({ title, icon, onClick, ...rest }) => {
+export const IconButton = ({
+    type,
+    title = type ? <Message messageKey={`buttons.${type}`} bundleKey='oskariui'/> : '',
+    icon = type ? getPredefinedIcon(type) : null,
+    onClick,
+    onConfirm,
+    disabled = false,
+    ...rest
+}) => {
+    if (onConfirm) {
+        return (
+            <Confirm
+                overlayClassName='t_confirm'
+                onConfirm={onConfirm}
+                okButtonProps={{className: `t_button t_${type || 'yes'}`}}
+                cancelButtonProps={{className: 't_button t_cancel'}}
+                disabled={disabled}
+                placement={title ? 'bottom' : 'top'}
+                { ...getConfirmProps(type) }>
+                <Tooltip title={title}>
+                    <ThemeButton disabled={disabled} onClick={onClick} { ...rest }>
+                        {icon}
+                    </ThemeButton>
+                </Tooltip>
+            </Confirm>
+        );
+    }
     if (title) {
         return (
             <Tooltip title={title}>
-                <ThemeButton icon={icon} onClick={onClick} { ...rest }/>
+                <ThemeButton disabled={disabled} onClick={onClick} { ...rest }>
+                    {icon}
+                </ThemeButton>
             </Tooltip>
         );
-    } else {
-        return (
-            <ThemeButton
-                icon={icon}
-                onClick={onClick}
-                { ...rest }
-            />
-        );
     }
+    return (
+        <ThemeButton onClick={onClick} { ...rest }>
+            {icon}
+        </ThemeButton>
+    );
+
 };
 
 IconButton.propTypes = {
+    type: PropTypes.oneOf(['add', 'edit', 'info', 'next', 'previous', 'delete']),
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-    icon: PropTypes.node.isRequired,
-    onClick: PropTypes.func
+    icon: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+    onClick: PropTypes.func,
+    onConfirm: PropTypes.func
 };


### PR DESCRIPTION
Add predefined icons for IconButton (like Primary/Secondary buttons) 
- No need to add test classes or tooltip localization
- same icons are used and theme

Not sure if wrapping confirm confuses more than helps. Mostly it's used with delete. At least it would help conditional handlers:
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/framework/mydata/view/PublishedMaps/PublishedMapsList.jsx#L89-L110
`isPublic ? props.onConfirm : props.onClick`