### PR TITLE
Cleanup publisher tools

### DIFF
--- a/bundles/framework/maplegend/publisher/MapLegend.js
+++ b/bundles/framework/maplegend/publisher/MapLegend.js
@@ -63,9 +63,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.MapLegend',
         isDisabled: function () {
             return !this.sandbox.findAllSelectedMapLayers().some(l => l.getLegendImage());
         },
-        isStarted: function () {
-            return !!this.getPlugin();
-        },
         isEnabled: function () {
             return !!this.getPlugin();
         },

--- a/bundles/framework/maplegend/publisher/MapLegend.js
+++ b/bundles/framework/maplegend/publisher/MapLegend.js
@@ -67,7 +67,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.MapLegend',
             return !!this.getPlugin();
         },
         isEnabled: function () {
-            return this.getPlugin().isEnabled();
+            return !!this.getPlugin();
         },
         /**
          * Get values.

--- a/bundles/framework/publisher2/tools/AbstractPluginTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPluginTool.js
@@ -11,9 +11,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
     this.__loc = localization[this.group];
     this.__plugin = null;
     this.__tool = null;
-    // This is used to watch tool plugin start/stop changes. If plugin is started then change this value to true, if stopped then change to false.
-    // If tool plugin is started then we can call stop plugin if unchecking this tools (otherwise we get error when sopping plugin).
-    this.__started = false;
     this.state = {
         // This variable is used to save tool state (is checked) and if it's true then we get tool json when saving published map.
         enabled: false,
@@ -29,8 +26,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
     righthanded: '',
     // List of plugin classes that can reside in same container(?) like 'Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin'
     allowedSiblings: ['*'],
-    // ??
-    groupedSiblings: false,
 
     /**
     * Initialize tool
@@ -100,7 +95,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
         if (enabled) {
             this.getMapmodule().registerPlugin(plugin);
             plugin.startPlugin(this.getSandbox());
-            this.__started = true;
         } else {
             this.stop();
         }
@@ -160,16 +154,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
     */
     isDisabled: function (data) {
         return false;
-    },
-    /**
-    * Is started.
-    * @method isStarted
-    * @public
-    *
-    * @returns {Boolean} is the tool started.
-    */
-    isStarted: function () {
-        return this.__started;
     },
 
     /**
@@ -242,12 +226,10 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
     * @public
     */
     stop: function () {
-        // TODO: do we really need started as an additional flag?
-        if (!this.isStarted()) {
+        if (!this.isEnabled()) {
             return;
         }
         this._stopImpl();
-        this.__started = false;
         const plugin = this.getPlugin();
         if (!plugin) {
             return;

--- a/bundles/framework/publisher2/tools/FeaturedataTool.js
+++ b/bundles/framework/publisher2/tools/FeaturedataTool.js
@@ -5,7 +5,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.FeaturedataTool',
         // Disabled for now, need to fix config reading first allowedLocations: ['top left', 'top right', 'bottom left', 'bottom right'],
         lefthanded: 'top right',
         righthanded: 'top right',
-        groupedSiblings: false,
         /**
     * Get tool object.
     * @method getTool

--- a/bundles/framework/publisher2/tools/GetInfoTool.js
+++ b/bundles/framework/publisher2/tools/GetInfoTool.js
@@ -6,8 +6,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.GetInfoTool',
         allowedLocations: [],
         allowedSiblings: [],
 
-        groupedSiblings: true,
-
         templates: {
             colours: jQuery('<div id="publisher-layout-colours" class="tool-options">' + '<label for="publisher-colours"></label>' + '<div id="publisher-layout-coloursSelector">' + '<input type="text" name="publisher-colour" disabled />' + '<button id="publisher-colours"></button>' + '</div>' + '</div>'),
             coloursPopup: jQuery('<div id="publisher-colour-popup">' + '<div id="publisher-colour-inputs"></div>' + '<div id="publisher-colour-preview"></div>' + '</div>'),

--- a/bundles/framework/publisher2/tools/IndexMapTool.js
+++ b/bundles/framework/publisher2/tools/IndexMapTool.js
@@ -40,21 +40,18 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.IndexMapTool',
         * @returns {Object} tool value object
         */
         getValues: function () {
-            var me = this;
-
-            if (me.state.enabled) {
-                return {
-                    configuration: {
-                        mapfull: {
-                            conf: {
-                                plugins: [{ id: this.getTool().id, config: this.getPlugin().getConfig() }]
-                            }
-                        }
-                    }
-                };
-            } else {
+            if (!this.isEnabled()) {
                 return null;
             }
+            return {
+                configuration: {
+                    mapfull: {
+                        conf: {
+                            plugins: [{ id: this.getTool().id, config: this.getPlugin().getConfig() }]
+                        }
+                    }
+                }
+            };
         }
     }, {
         'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],

--- a/bundles/framework/publisher2/tools/IndexMapTool.js
+++ b/bundles/framework/publisher2/tools/IndexMapTool.js
@@ -5,8 +5,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.IndexMapTool',
         lefthanded: 'bottom right',
         righthanded: 'bottom left',
 
-        groupedSiblings: false,
-
         /**
         * Get tool object.
         * @method getTool

--- a/bundles/framework/publisher2/tools/LogoTool.js
+++ b/bundles/framework/publisher2/tools/LogoTool.js
@@ -7,13 +7,12 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.LogoTool',
 
         groupedSiblings: false,
 
-        // _showInToolsPanel: false,
         /**
-    * Get tool object.
-    * @method getTool
-    *
-    * @returns {Object} tool description
-    */
+        * Get tool object.
+        * @method getTool
+        *
+        * @returns {Object} tool description
+        */
         getTool: function () {
             return {
                 id: 'Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin',
@@ -21,32 +20,40 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.LogoTool',
                 config: {}
             };
         },
-        /**
-    * Get values.
-    * @method getValues
-    * @public
-    *
-    * @returns {Object} tool value object
-    */
-        getValues: function () {
-            var me = this;
-
-            if (me.state.enabled) {
-                return {
-                    configuration: {
-                        mapfull: {
-                            conf: {
-                                plugins: [{ id: this.getTool().id, config: this.getPlugin().getConfig() }]
-                            }
-                        }
-                    }
-                };
-            } else {
-                return null;
-            }
-        },
+        // not displayed on tool panels so user can't disable it
         isDisplayed: function () {
             return false;
+        },
+        getPlugin: function () {
+            // always use the instance on map, not a new copy
+            return this.getMapmodule().getPluginInstances('LogoPlugin');
+        },
+        // always enabled, use the instance that is on map
+        isEnabled: function () {
+            return true;
+        },
+        stop: function () {
+            // when we exit publisher:
+            // move plugin back to bottom left if it was dragged during publisher
+            this.getPlugin().setLocation('bottom left');
+        },
+        /**
+        * Get values.
+        * @method getValues
+        * @public
+        *
+        * @returns {Object} tool value object
+        */
+        getValues: function () {
+            return {
+                configuration: {
+                    mapfull: {
+                        conf: {
+                            plugins: [{ id: this.getTool().id, config: this.getPlugin().getConfig() }]
+                        }
+                    }
+                }
+            };
         }
     }, {
         'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],

--- a/bundles/framework/publisher2/tools/LogoTool.js
+++ b/bundles/framework/publisher2/tools/LogoTool.js
@@ -5,8 +5,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.LogoTool',
         lefthanded: 'bottom left',
         righthanded: 'bottom right',
 
-        groupedSiblings: false,
-
         /**
         * Get tool object.
         * @method getTool

--- a/bundles/framework/publisher2/tools/MyLocationTool.js
+++ b/bundles/framework/publisher2/tools/MyLocationTool.js
@@ -5,7 +5,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.MyLocationTool',
         lefthanded: 'top left',
         righthanded: 'top right',
 
-        groupedSiblings: true,
         defaultExtraOptions: {
             mode: 'single',
             centerMapAutomatically: false,
@@ -53,30 +52,27 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.MyLocationTool',
     * @returns {Object} tool value object
     */
         getValues: function () {
-            var me = this;
-
-            if (me.state.enabled) {
-                var pluginConfig = this.getPlugin().getConfig();
-
-                // add selected extraoptions to conf
-                for (var key in me.selected) {
-                    if (me.selected.hasOwnProperty(key)) {
-                        pluginConfig[key] = me.selected[key];
-                    }
-                }
-
-                return {
-                    configuration: {
-                        mapfull: {
-                            conf: {
-                                plugins: [{ id: this.getTool().id, config: pluginConfig }]
-                            }
-                        }
-                    }
-                };
-            } else {
+            if (!this.isEnabled()) {
                 return null;
             }
+            const pluginConfig = this.getPlugin().getConfig();
+
+            // add selected extraoptions to conf
+            for (var key in this.selected) {
+                if (this.selected.hasOwnProperty(key)) {
+                    pluginConfig[key] = this.selected[key];
+                }
+            }
+
+            return {
+                configuration: {
+                    mapfull: {
+                        conf: {
+                            plugins: [{ id: this.getTool().id, config: pluginConfig }]
+                        }
+                    }
+                }
+            };
         },
         /**
      * Get extra options.

--- a/bundles/framework/publisher2/tools/PanButtonsTool.js
+++ b/bundles/framework/publisher2/tools/PanButtonsTool.js
@@ -4,7 +4,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.PanButtonsTool',
         index: 2,
         lefthanded: 'top left',
         righthanded: 'top right',
-        groupedSiblings: true,
         _templates: {
             extraOptions: jQuery(`
                 <div class="publisher2 panbutton-options tool-options">

--- a/bundles/framework/publisher2/tools/ScalebarTool.js
+++ b/bundles/framework/publisher2/tools/ScalebarTool.js
@@ -2,10 +2,8 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ScalebarTool',
     function () {
     }, {
         index: 0,
-        allowedLocations: ['*'],
         lefthanded: 'bottom left',
         righthanded: 'bottom right',
-        allowedSiblings: ['*'],
 
         /**
         * Get tool object.

--- a/bundles/framework/publisher2/tools/ScalebarTool.js
+++ b/bundles/framework/publisher2/tools/ScalebarTool.js
@@ -2,20 +2,10 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ScalebarTool',
     function () {
     }, {
         index: 0,
-        allowedLocations: ['bottom left', 'bottom right'],
+        allowedLocations: ['*'],
         lefthanded: 'bottom left',
         righthanded: 'bottom right',
-        allowedSiblings: [
-            'Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataPlugin',
-            'Oskari.mapframework.bundle.mapmodule.plugin.MyLocationPlugin',
-            'Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
-            'Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar',
-            'Oskari.mapframework.bundle.coordinatetool.plugin.CoordinateToolPlugin',
-            'Oskari.mapping.cameracontrols3d.CameraControls3dPlugin',
-            'Oskari.mapping.time-control-3d.TimeControl3dPlugin',
-            'Oskari.mapping.maprotator.MapRotatorPlugin'
-        ],
-        groupedSiblings: false,
+        allowedSiblings: ['*'],
 
         /**
         * Get tool object.
@@ -51,21 +41,18 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ScalebarTool',
         * @returns {Object} tool value object
         */
         getValues: function () {
-            var me = this;
-
-            if (me.state.enabled) {
-                return {
-                    configuration: {
-                        mapfull: {
-                            conf: {
-                                plugins: [{ id: this.getTool().id, config: this.getPlugin().getConfig() }]
-                            }
-                        }
-                    }
-                };
-            } else {
+            if (!this.isEnabled()) {
                 return null;
             }
+            return {
+                configuration: {
+                    mapfull: {
+                        conf: {
+                            plugins: [{ id: this.getTool().id, config: this.getPlugin().getConfig() }]
+                        }
+                    }
+                }
+            };
         }
     }, {
         'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],

--- a/bundles/framework/publisher2/tools/SearchTool.js
+++ b/bundles/framework/publisher2/tools/SearchTool.js
@@ -5,14 +5,12 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.SearchTool',
         lefthanded: 'top right',
         righthanded: 'top left',
 
-        groupedSiblings: false,
-
         /**
-    * Get tool object.
-    * @method getTool
-    *
-    * @returns {Object} tool description
-    */
+        * Get tool object.
+        * @method getTool
+        *
+        * @returns {Object} tool description
+        */
         getTool: function () {
             return {
                 id: 'Oskari.mapframework.bundle.mapmodule.plugin.SearchPlugin',
@@ -21,28 +19,25 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.SearchTool',
             };
         },
         /**
-    * Get values.
-    * @method getValues
-    * @public
-    *
-    * @returns {Object} tool value object
-    */
+        * Get values.
+        * @method getValues
+        * @public
+        *
+        * @returns {Object} tool value object
+        */
         getValues: function () {
-            var me = this;
-
-            if (me.state.enabled) {
-                return {
-                    configuration: {
-                        mapfull: {
-                            conf: {
-                                plugins: [{ id: this.getTool().id, config: this.getPlugin().getConfig() }]
-                            }
-                        }
-                    }
-                };
-            } else {
+            if (!this.isEnabled()) {
                 return null;
             }
+            return {
+                configuration: {
+                    mapfull: {
+                        conf: {
+                            plugins: [{ id: this.getTool().id, config: this.getPlugin().getConfig() }]
+                        }
+                    }
+                }
+            };
         }
     }, {
         'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],

--- a/bundles/framework/publisher2/tools/Tool.js
+++ b/bundles/framework/publisher2/tools/Tool.js
@@ -35,7 +35,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.Tool',
             'Oskari.mapframework.bundle.mapmodule.plugin.PanButtons'
         ],
 
-        groupedSiblings: true,
         /**
         * Initialize tool
         * Override

--- a/bundles/framework/publisher2/tools/ToolbarTool.js
+++ b/bundles/framework/publisher2/tools/ToolbarTool.js
@@ -5,8 +5,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ToolbarTool',
         lefthanded: 'top right',
         righthanded: 'top left',
 
-        groupedSiblings: false,
-
         // toolbarConfig stores the current state
         toolbarConfig: {},
 
@@ -319,23 +317,18 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ToolbarTool',
             return false;
         },
 
-        stop: function () {
-            var me = this;
-
-            if (me.__plugin) {
-                // send remove request per active button
-                for (var toolName in me.selectedTools) {
-                    if (me.selectedTools.hasOwnProperty(toolName) && toolName) {
-                        me.__plugin.removeToolButton(toolName);
-                    }
+        /**
+        * Stop _stopImpl.
+        * @method _stopImpl
+        */
+        _stopImpl: function () {
+            // send remove request per active button
+            for (var toolName in this.selectedTools) {
+                if (this.selectedTools.hasOwnProperty(toolName) && toolName) {
+                    this.__plugin.removeToolButton(toolName);
                 }
-                if (me.__sandbox) {
-                    me.__plugin.stopPlugin(me.__sandbox);
-                }
-                me.__mapmodule.unregisterPlugin(me.__plugin);
             }
         }
-
     }, {
         'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],
         'protocol': ['Oskari.mapframework.publisher.Tool']

--- a/bundles/framework/publisher2/tools/ZoombarTool.js
+++ b/bundles/framework/publisher2/tools/ZoombarTool.js
@@ -5,8 +5,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ZoombarTool',
         lefthanded: 'top left',
         righthanded: 'top right',
 
-        groupedSiblings: true,
-
         /**
     * Get tool object.
     * @method getTool
@@ -28,21 +26,18 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ZoombarTool',
     * @returns {Object} tool value object
     */
         getValues: function () {
-            var me = this;
-
-            if (me.state.enabled) {
-                return {
-                    configuration: {
-                        mapfull: {
-                            conf: {
-                                plugins: [{ id: this.getTool().id, config: this.getPlugin().getConfig() }]
-                            }
-                        }
-                    }
-                };
-            } else {
+            if (!this.isEnabled()) {
                 return null;
             }
+            return {
+                configuration: {
+                    mapfull: {
+                        conf: {
+                            plugins: [{ id: this.getTool().id, config: this.getPlugin().getConfig() }]
+                        }
+                    }
+                }
+            };
         }
     }, {
         'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],

--- a/bundles/framework/publisher2/view/PanelMapTools.js
+++ b/bundles/framework/publisher2/view/PanelMapTools.js
@@ -72,38 +72,38 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
             this.tools
                 .filter(tool => tool.isDisplayed())
                 .forEach(tool => {
-                const ui = jQuery(me.templates.tool({ title: tool.getTitle() }));
-                // setup values when editing an existing map
-                ui.find('input').prop('checked', !!tool.isEnabled());
-                ui.find('input').prop('disabled', !!tool.isDisabled());
+                    const ui = jQuery(me.templates.tool({ title: tool.getTitle() }));
+                    // setup values when editing an existing map
+                    ui.find('input').prop('checked', !!tool.isEnabled());
+                    ui.find('input').prop('disabled', !!tool.isDisabled());
 
-                contentPanel.append(ui);
+                    contentPanel.append(ui);
 
-                ui.find('input').first().on('change', function () {
-                    var enabled = jQuery(this).is(':checked');
-                    // TODO: maybe wrap in try catch and on error show the user a message about faulty functionality
-                    tool.setEnabled(enabled);
-                    if (enabled) {
+                    ui.find('input').first().on('change', function () {
+                        var enabled = jQuery(this).is(':checked');
+                        // TODO: maybe wrap in try catch and on error show the user a message about faulty functionality
+                        tool.setEnabled(enabled);
+                        if (enabled) {
+                            ui.find('.extraOptions').show();
+                            me._setToolLocation(tool);
+                        } else {
+                            ui.find('.extraOptions').hide();
+                        }
+                    });
+
+                    const extraOptions = tool.getExtraOptions(ui);
+                    if (extraOptions) {
+                        ui.find('.extraOptions').append(extraOptions);
+                    }
+
+                    const initStateEnabled = ui.find('input').first().is(':checked');
+                    tool.setEnabled(initStateEnabled);
+                    if (initStateEnabled) {
                         ui.find('.extraOptions').show();
-                        me._setToolLocation(tool);
                     } else {
                         ui.find('.extraOptions').hide();
                     }
                 });
-
-                const extraOptions = tool.getExtraOptions(ui);
-                if (extraOptions) {
-                    ui.find('.extraOptions').append(extraOptions);
-                }
-
-                const initStateEnabled = ui.find('input').first().is(':checked');
-                tool.setEnabled(initStateEnabled);
-                if (initStateEnabled) {
-                    ui.find('.extraOptions').show();
-                } else {
-                    ui.find('.extraOptions').hide();
-                }
-            });
             me.panel = panel;
             return panel;
         },

--- a/bundles/framework/publisher2/view/PanelMapTools.js
+++ b/bundles/framework/publisher2/view/PanelMapTools.js
@@ -30,6 +30,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
          *
          * @method init
          * @param {Object} pData initial data
+         * @returns {Boolean} if this panel has any tools/should be shown
          */
         init: function (pData) {
             const instance = this.instance;
@@ -46,6 +47,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
                         .error('Error initializing publisher tool:', tool.getTool().id);
                 }
             });
+            return this.tools.some(tool => tool.isDisplayed());
         },
         getName: function () {
             return 'Oskari.mapframework.bundle.publisher2.view.PanelMapTools';
@@ -67,7 +69,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
             panel.getHeader().append(tooltipCont);
 
             // Add tools to panel
-            this.tools.forEach(tool => {
+            this.tools
+                .filter(tool => tool.isDisplayed())
+                .forEach(tool => {
                 const ui = jQuery(me.templates.tool({ title: tool.getTitle() }));
                 // setup values when editing an existing map
                 ui.find('input').prop('checked', !!tool.isEnabled());

--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -399,7 +399,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
             return plugin.getElement();
         },
         _initDraggables: function () {
-            const tools = this.tools.filter(tool => tool.isStarted());
+            const tools = this.tools.filter(tool => tool.isEnabled());
             tools.forEach(tool => this._enableToolDraggable(tool));
         },
         _removeDraggables: function () {
@@ -528,14 +528,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
         **/
         stop: function () {
             this._editToolLayoutOff();
-            this.tools.forEach(tool => {
-                // just call stop for the tools that haven't already been shut down by the tool panel
-                if (tool.isStarted()) {
-                    tool.stop();
-                    tool.setEnabled(false);
-                }
-            });
-
             Object.keys(this.eventHandlers)
                 .forEach(eventName => this.sandbox.unregisterFromEventByName(this, eventName));
         },

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -112,7 +112,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                     const toolPanel = Oskari.clazz.create('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
                         group, tools, this.instance, this.loc
                     );
-                    var hasToolsToShow = toolPanel.init(this.data);
+                    const hasToolsToShow = toolPanel.init(this.data);
                     this.panels.push(toolPanel);
                     if (hasToolsToShow) {
                         const panel = toolPanel.getPanel();
@@ -252,10 +252,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
             // group tools per tool-group
             definedTools.forEach(toolname => {
                 const tool = Oskari.clazz.create(toolname, sandbox, mapmodule, this.loc);
-                /*
-                if (tool.isDisplayed(this.data) !== true) {
-                    return;
-                }*/
                 var group = tool.getGroup();
                 if (!grouping[group]) {
                     grouping[group] = [];

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -112,12 +112,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                     const toolPanel = Oskari.clazz.create('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
                         group, tools, this.instance, this.loc
                     );
-                    toolPanel.init(this.data);
+                    var hasToolsToShow = toolPanel.init(this.data);
                     this.panels.push(toolPanel);
-                    const panel = toolPanel.getPanel();
-                    panel.addClass('t_tools');
-                    panel.addClass('t_' + group);
-                    accordion.addPanel(panel);
+                    if (hasToolsToShow) {
+                        const panel = toolPanel.getPanel();
+                        panel.addClass('t_tools');
+                        panel.addClass('t_' + group);
+                        accordion.addPanel(panel);
+                    }
                 }
             });
             if (rpcPanel) {
@@ -250,9 +252,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
             // group tools per tool-group
             definedTools.forEach(toolname => {
                 const tool = Oskari.clazz.create(toolname, sandbox, mapmodule, this.loc);
+                /*
                 if (tool.isDisplayed(this.data) !== true) {
                     return;
-                }
+                }*/
                 var group = tool.getGroup();
                 if (!grouping[group]) {
                     grouping[group] = [];

--- a/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol.js
@@ -36,6 +36,11 @@ Oskari.clazz.define(
         me._baseLayerId = null;
     },
     {
+        _startPluginImpl: function () {
+            this._element = this._createControlElement();
+            this.renderButton();
+            this.addToPluginContainer(this._element);
+        },
         _stopPluginImpl: function () {
             this._removeIndexMap();
             this.teardownUI();

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -33,6 +33,14 @@ Oskari.clazz.define(
         _initImpl: function () {
             this._loc = Oskari.getLocalization('MapModule', Oskari.getLang() || Oskari.getDefaultLanguage()).plugin.LogoPlugin;
         },
+        /**
+         * While this plugin DOES have a UI we don't want publisher stopping it on startup so
+         * we are returning false to stay on screen for the duration of publisher.
+         * @returns false
+         */
+        hasUI: function () {
+            return false;
+        },
         getService: function () {
             if (!this._service) {
                 this._service = Oskari.clazz.create('Oskari.map.DataProviderInfoService', this.getSandbox());

--- a/bundles/mapping/mapmodule/plugin/scalebar/ScaleBarPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/scalebar/ScaleBarPlugin.ol.js
@@ -40,24 +40,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.ScaleBarPlugin'
             return container;
         }
 
-        /**
-         * @method _createEventHandlers
-         * Create eventhandlers.
-         *
-         *
-         * @return {Object.<string, Function>} EventHandlers
-         */
-        /*
-        _createEventHandlers: function () {
-            return {
-                'AfterMapMoveEvent': function (event) {
-                    if (this._scalebar) {
-                        this._scalebar.render(event);
-                    }
-                }
-            };
-        }
-        */
     }, {
         'extend': ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],
         /**

--- a/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
@@ -30,9 +30,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractStatsPluginTool'
         }
         return Oskari.util.keyExists(data, 'configuration.statsgrid.conf');
     },
-    isStarted: function () {
-        return !!this.getPlugin();
-    },
     getPlugin: function () {
         var stats = this.getStatsgridBundle();
         return stats?.togglePlugin;


### PR DESCRIPTION
- Remove isStarted() from tool and use isEnabled() instead. This is no longer required as setEnabled is only called once and not multiple times when publisher starts.
- Removed tool.groupedSiblings as it was not referenced anywhere anymore
- Tool.init() is now called even for tools that aren't displayed so plugins like the LogoPlugin can prepare for being used in publisher (set initial location etc)
- PanelMapTools.init() now returns boolean that is used to detect if the panel has any tools. For example tools for thematic maps are now initialized even if they are not displayed due to statistical data is not on the map. In this case the panel.init() returns false and is not shown on the UI.
- As init() is always called for tools, stop() will also be always called. This makes it possible for plugins like the LogoPlugin to restore it's position on the map after possibly being dragged to another plugin container while using the publisher functionality.