### PR TITLE
IconButton padding

### DIFF
--- a/src/react/components/buttons/IconButton.jsx
+++ b/src/react/components/buttons/IconButton.jsx
@@ -15,8 +15,12 @@ import { Backward } from '../icons/Backward'
 const BorderlessButton = styled(Button)`
     border: none;
     background: none;
+    padding: 0px;
     &:hover {
         color: ${props => props.color};
+        background: none;
+    }
+    &:disabled {
         background: none;
     }
 `;


### PR DESCRIPTION
Remove padding from button and background from disabled. Maybe we could use default icon size and button height & width could be something like size + 8 etc to get little bigger click area and padding.

Maybe padding and antd-icon-only caused clipping in Safari?

![image](https://user-images.githubusercontent.com/22147092/225335640-3bace152-5575-4cec-8255-affee915e09a.png)
