### PR TITLE
Tool placement in publisher

### DIFF
--- a/bundles/framework/publisher2/resources/locale/en.js
+++ b/bundles/framework/publisher2/resources/locale/en.js
@@ -131,8 +131,7 @@ Oskari.registerLocalization(
             "toollayout": {
                 "label": "Tool Placement",
                 "tooltip": "Select a placement for map tools.",
-                "lefthanded": "Lefthanded",
-                "righthanded": "Righthanded",
+                "swapUI": "Swap sides",
                 "userlayout": "Custom placement",
                 "usereditmode": "Start editing",
                 "usereditmodeoff": "Finish editing"

--- a/bundles/framework/publisher2/resources/locale/fi.js
+++ b/bundles/framework/publisher2/resources/locale/fi.js
@@ -131,8 +131,7 @@ Oskari.registerLocalization(
             "toollayout": {
                 "label": "Työkalujen asettelu kartalla",
                 "tooltip": "Valitse, miten työkalut asetellaan kartalle.",
-                "lefthanded": "Vasenkätinen",
-                "righthanded": "Oikeakätinen",
+                "swapUI": "Vaihda puolet",
                 "userlayout": "Oma asettelu",
                 "usereditmode": "Muokkaa asettelua",
                 "usereditmodeoff": "Lopeta muokkaus"

--- a/bundles/framework/publisher2/resources/locale/sv.js
+++ b/bundles/framework/publisher2/resources/locale/sv.js
@@ -131,8 +131,7 @@ Oskari.registerLocalization(
             "toollayout": {
                 "label": "Verktygsplacering",
                 "tooltip": "Välj placering för det verktyg som ska visas på kartan.",
-                "lefthanded": "Vänsterhänt",
-                "righthanded": "Högerhänt",
+                "swapUI": "Swap sides",
                 "userlayout": "Anpassad layout",
                 "usereditmode": "Starta redigering",
                 "usereditmodeoff": "Sluta redigering"

--- a/bundles/framework/publisher2/tools/LogoTool.js
+++ b/bundles/framework/publisher2/tools/LogoTool.js
@@ -18,6 +18,15 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.LogoTool',
                 config: this.state.pluginConfig || {}
             };
         },
+        init: function (data) {
+            const plugin = this.findPluginFromInitData(data);
+            if (plugin) {
+                this.storePluginConf(plugin.config);
+                // when we enter publisher:
+                // restore saved location for plugin that is not stopped nor started
+                this.getPlugin().setLocation(plugin.config?.location?.classes);
+            }
+        },
         // not displayed on tool panels so user can't disable it
         isDisplayed: function () {
             return false;

--- a/bundles/framework/publisher2/tools/ScalebarTool.js
+++ b/bundles/framework/publisher2/tools/ScalebarTool.js
@@ -16,7 +16,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ScalebarTool',
             return {
                 id: 'Oskari.mapframework.bundle.mapmodule.plugin.ScaleBarPlugin',
                 title: 'ScaleBarPlugin',
-                config: {}
+                config: this.state.pluginConfig || {}
             };
         },
 

--- a/bundles/framework/publisher2/tools/SearchTool.js
+++ b/bundles/framework/publisher2/tools/SearchTool.js
@@ -15,7 +15,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.SearchTool',
             return {
                 id: 'Oskari.mapframework.bundle.mapmodule.plugin.SearchPlugin',
                 title: 'SearchPlugin',
-                config: {}
+                config: this.state.pluginConfig || {}
             };
         },
         /**

--- a/bundles/framework/publisher2/tools/ToolbarTool.js
+++ b/bundles/framework/publisher2/tools/ToolbarTool.js
@@ -77,6 +77,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ToolbarTool',
                 id: 'Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolbarPlugin',
                 title: 'PublisherToolbarPlugin',
                 config: {
+                    ...(this.state.pluginConfig || {}),
                     'toolbarId': 'PublisherToolbar',
                     buttons: this.state.pluginConfig?.buttons || []
                 }

--- a/bundles/framework/publisher2/tools/ZoombarTool.js
+++ b/bundles/framework/publisher2/tools/ZoombarTool.js
@@ -15,7 +15,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ZoombarTool',
             return {
                 id: 'Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar',
                 title: 'Portti2Zoombar',
-                config: {}
+                config: this.state.pluginConfig || {}
             };
         },
         /**

--- a/bundles/framework/publisher2/util/util.js
+++ b/bundles/framework/publisher2/util/util.js
@@ -30,7 +30,7 @@ export const mergeValues = (defaults, extend) => {
     } else if (Array.isArray(defaults)) {
         if (!Array.isArray(extend)) {
             // extension must be array also or the value is ignored
-            return [ ...defaults ];
+            return [...defaults];
         }
         return [...defaults, ...extend];
     // } else if (extend.constructor && extend.constructor === Object) {

--- a/bundles/framework/publisher2/util/util.js
+++ b/bundles/framework/publisher2/util/util.js
@@ -1,0 +1,53 @@
+
+export const isEmpty = (value) => {
+    if (value === null) {
+        return true;
+    } else if (typeof value === 'undefined') {
+        return true;
+    } else if (Array.isArray(value)) {
+        return !value.length;
+    } else if (value.constructor === Object) {
+        return !Object.keys(value).length;
+    }
+    return false;
+};
+
+/**
+* Extends object recursive for keeping defaults array.
+* @method _extendRecursive
+* @private
+*
+* @param {Object} defaults the default extendable object
+* @param {Object} extend extend object
+*
+* @return {Object} extended object
+*/
+export const mergeValues = (defaults, extend) => {
+    if (isEmpty(extend)) {
+        return defaults;
+    } else if (isEmpty(defaults)) {
+        return extend;
+    } else if (Array.isArray(defaults)) {
+        if (!Array.isArray(extend)) {
+            // extension must be array also or the value is ignored
+            return [ ...defaults ];
+        }
+        return [...defaults, ...extend];
+    // } else if (extend.constructor && extend.constructor === Object) {
+    } else if (extend.constructor === Object) {
+        const newBranch = {
+            ...defaults
+        };
+        Object.keys(extend).forEach(fromKey => {
+            const fromValue = extend[fromKey];
+            const isNewKey = isEmpty(defaults[fromKey]);
+            if (isNewKey) {
+                newBranch[fromKey] = fromValue;
+            } else {
+                newBranch[fromKey] = mergeValues(defaults[fromKey], fromValue);
+            }
+        });
+        return newBranch;
+    }
+    return extend;
+};

--- a/bundles/framework/publisher2/util/util.js
+++ b/bundles/framework/publisher2/util/util.js
@@ -13,9 +13,9 @@ export const isEmpty = (value) => {
 };
 
 /**
-* Extends object recursive for keeping defaults array.
-* @method _extendRecursive
-* @private
+* Extends object recursively. Keeps defaults if extend doesnt' have a new value for primitive.
+* Merges arrays by adding values from both default and extend.
+* @method mergeValues
 *
 * @param {Object} defaults the default extendable object
 * @param {Object} extend extend object

--- a/bundles/framework/publisher2/util/util.test.js
+++ b/bundles/framework/publisher2/util/util.test.js
@@ -104,5 +104,36 @@ describe('Publisher/util', () => {
     }
 }`);
         });
+        test('mergeValues(multiple merges)', () => {
+            const values = [{
+                testing: {
+                    test1: 'test1',
+                    test1Array: ['test1']
+                }
+            }, {
+                testing: {
+                    test2: 'test2',
+                }
+            }, {
+                testing: {
+                    test1Array: ['test3'],
+                    test2: 'test3'
+                }
+            }];
+
+            const merged = mergeValues(values[0], values[1]);
+            const merged2 = mergeValues(merged, values[2]);
+            expect(JSON.stringify(merged2, null, 4)).toEqual(
+`{
+    "testing": {
+        "test1": "test1",
+        "test1Array": [
+            "test1",
+            "test3"
+        ],
+        "test2": "test3"
+    }
+}`);
+        });
     });
 });

--- a/bundles/framework/publisher2/util/util.test.js
+++ b/bundles/framework/publisher2/util/util.test.js
@@ -26,7 +26,7 @@ describe('Publisher/util', () => {
             expect(isEmpty(['testing'])).toEqual(false);
         });
         test('{ testing: true }', () => {
-            expect(isEmpty({testing: true})).toEqual(false);
+            expect(isEmpty({ testing: true })).toEqual(false);
         });
     });
     describe('mergeValues', () => {
@@ -89,9 +89,10 @@ describe('Publisher/util', () => {
                 }
             }, {
                 testing: {
-                    test: [{'id': 'testingId'}]
+                    test: [{ 'id': 'testingId' }]
                 }
             });
+            /* eslint-disable indent */
             expect(JSON.stringify(merged, null, 4)).toEqual(
 `{
     "testing": {
@@ -104,6 +105,7 @@ describe('Publisher/util', () => {
     }
 }`);
         });
+        /* eslint-enable indent */
         test('mergeValues(multiple merges)', () => {
             const values = [{
                 testing: {
@@ -112,7 +114,7 @@ describe('Publisher/util', () => {
                 }
             }, {
                 testing: {
-                    test2: 'test2',
+                    test2: 'test2'
                 }
             }, {
                 testing: {
@@ -123,6 +125,7 @@ describe('Publisher/util', () => {
 
             const merged = mergeValues(values[0], values[1]);
             const merged2 = mergeValues(merged, values[2]);
+            /* eslint-disable indent */
             expect(JSON.stringify(merged2, null, 4)).toEqual(
 `{
     "testing": {
@@ -134,6 +137,7 @@ describe('Publisher/util', () => {
         "test2": "test3"
     }
 }`);
+        /* eslint-enable indent */
         });
     });
 });

--- a/bundles/framework/publisher2/util/util.test.js
+++ b/bundles/framework/publisher2/util/util.test.js
@@ -1,0 +1,108 @@
+import { mergeValues, isEmpty } from './util';
+
+describe('Publisher/util', () => {
+    describe('isEmpty === true', () => {
+        test('null', () => {
+            expect(isEmpty(null)).toEqual(true);
+        });
+        test('undefined', () => {
+            expect(isEmpty()).toEqual(true);
+        });
+        test('[]', () => {
+            expect(isEmpty([])).toEqual(true);
+        });
+        test('{}', () => {
+            expect(isEmpty({})).toEqual(true);
+        });
+    });
+    describe('isEmpty === false', () => {
+        test('0', () => {
+            expect(isEmpty(0)).toEqual(false);
+        });
+        test('45', () => {
+            expect(isEmpty(45)).toEqual(false);
+        });
+        test('["testing"]', () => {
+            expect(isEmpty(['testing'])).toEqual(false);
+        });
+        test('{ testing: true }', () => {
+            expect(isEmpty({testing: true})).toEqual(false);
+        });
+    });
+    describe('mergeValues', () => {
+        test('mergeValues({}, null)', () => {
+            const merged = mergeValues({}, null);
+            expect(Object.keys(merged).length).toEqual(0);
+        });
+        test('mergeValues({}, {})', () => {
+            const merged = mergeValues({}, {});
+            expect(Object.keys(merged).length).toEqual(0);
+        });
+        test('mergeValues({testing: 1}, null)', () => {
+            const merged = mergeValues({
+                testing: 1
+            }, null);
+            expect(merged.testing).toEqual(1);
+        });
+        test('mergeValues({testing: 1}, {})', () => {
+            const merged = mergeValues({
+                testing: 1
+            }, {});
+            expect(JSON.stringify(merged)).toEqual(`{"testing":1}`);
+        });
+        test('mergeValues({testing: 1}, {testing: 2})', () => {
+            const merged = mergeValues({
+                testing: 1
+            }, {
+                testing: 2
+            });
+            expect(JSON.stringify(merged)).toEqual(`{"testing":2}`);
+        });
+        test('mergeValues({testing: 1}, {testing2: 2})', () => {
+            const merged = mergeValues({
+                testing: 1
+            }, {
+                testing2: 2
+            });
+            expect(JSON.stringify(merged)).toEqual(`{"testing":1,"testing2":2}`);
+        });
+        test('mergeValues({testing: ["testing"]}, {testing: 2})', () => {
+            const merged = mergeValues({
+                testing: ['testing']
+            }, {
+                testing: 2
+            });
+            expect(JSON.stringify(merged)).toEqual(`{"testing":["testing"]}`);
+        });
+        test('mergeValues({testing: ["testing"]}, {testing: "testing"})', () => {
+            const merged = mergeValues({
+                testing: ['testing']
+            }, {
+                testing: ['testing']
+            });
+            expect(JSON.stringify(merged)).toEqual(`{"testing":["testing","testing"]}`);
+        });
+        test('mergeValues({testing.test = arrays})', () => {
+            const merged = mergeValues({
+                testing: {
+                    test: ['testing']
+                }
+            }, {
+                testing: {
+                    test: [{'id': 'testingId'}]
+                }
+            });
+            expect(JSON.stringify(merged, null, 4)).toEqual(
+`{
+    "testing": {
+        "test": [
+            "testing",
+            {
+                "id": "testingId"
+            }
+        ]
+    }
+}`);
+        });
+    });
+});

--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -1,3 +1,4 @@
+import { mergeValues } from '../util/util';
 /**
  * @class Oskari.mapframework.bundle.publisher.view.PanelToolLayout
  *
@@ -35,11 +36,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
         // This is publisher.sidebar.data
         me.data = me.instance.publisher.data;
         me.activeToolLayout = 'userlayout';
-        if (me.instance.publisher.data &&
-            me.instance.publisher.data.metadata &&
-            me.instance.publisher.data.metadata.toolLayout) {
-            me.activeToolLayout = me.instance.publisher.data.metadata.toolLayout;
-        }
         me.toolLayoutEditMode = false;
         me._addedDraggables = [];
     }, {
@@ -79,41 +75,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
         },
 
         /**
-        * Extends object recursive for keeping defaults array.
-        * @method _extendRecursive
-        * @private
-        *
-        * @param {Object} defaults the default extendable object
-        * @param {Object} extend extend object
-        *
-        * @return {Object} extended object
-        */
-        _extendRecursive: function (defaults, extend) {
-            var me = this;
-            if (extend === null || extend === undefined || jQuery.isEmptyObject(extend)) {
-                return defaults;
-            } else if (jQuery.isEmptyObject(defaults)) {
-                return jQuery.extend(true, defaults, extend);
-            } else if (jQuery.isArray(defaults)) {
-                if (jQuery.isArray(extend)) {
-                    jQuery.each(extend, function (key, value) {
-                        defaults.push(value);
-                    });
-                }
-                return defaults;
-            } else if (extend.constructor && extend.constructor === Object) {
-                jQuery.each(extend, function (key, value) {
-                    // not an array or an object -> just use the plain value
-                    if (defaults[key] === null || defaults[key] === undefined || !(defaults[key] instanceof Array || defaults[key] instanceof Object)) {
-                        defaults[key] = value;
-                    } else {
-                        defaults[key] = me._extendRecursive(defaults[key], value);
-                    }
-                });
-                return defaults;
-            }
-        },
-        /**
          * Returns the selections the user has done with the form inputs.
          * @method getValues
          * @return {Object}
@@ -122,19 +83,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
             let values = {};
 
             this.tools.forEach(tool => {
-                var value = tool.getValues();
-                if (value !== undefined && value !== null) {
-                    this._extendRecursive(values, value);
-                }
+                values = mergeValues(values, tool.getValues());
             });
-
-            var toolLayout = {
+            return mergeValues(values, {
                 metadata: {
                     toolLayout: this.activeToolLayout
                 }
-            };
-            this._extendRecursive(values, toolLayout);
-            return values;
+            });
         },
         /**
          * @method onEvent
@@ -164,11 +119,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
          * @private @method _populateToolLayoutPanel
          */
         _populateToolLayoutPanel: function () {
-            var me = this,
-                panel = Oskari.clazz.create('Oskari.userinterface.component.AccordionPanel'),
-                contentPanel = panel.getContainer(),
-                tooltipCont = me.templateHelp.clone(), // tooltip
-                i,
+            const me = this;
+            const panel = Oskari.clazz.create('Oskari.userinterface.component.AccordionPanel');
+            const contentPanel = panel.getContainer();
+            const tooltipCont = this.templateHelp.clone(); // tooltip
+            let i,
                 input,
                 layoutContainer,
                 changeListener = function (e) {

--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -135,7 +135,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
                         onSwitch={() => this._switchControlsInSides()}
                         isEdit={this.toolLayoutEditMode}
                         onEditMode={(isEdit) => {
-                            if(isEdit) {
+                            if (isEdit) {
                                 this._editToolLayoutOn();
                             } else {
                                 // remove edit mode
@@ -146,7 +146,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
                 </LocaleProvider>,
                 contentPanel[0]
             );
-
         },
         _switchControlsInSides: function () {
             // toggle left <> right
@@ -167,7 +166,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
                     } else if (currentLoc.includes('right')) {
                         plugin.setLocation(currentLoc.replace('right', 'left'));
                     }
-            });
+                });
         },
 
         /**
@@ -186,20 +185,22 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
             jQuery('.mappluginsContent').droppable({
                 // TODO see if this can be done in hover? Would it even be wanted behaviour?
                 drop: function (event, ui) {
-                    var pluginClazz = ui.draggable.attr('data-clazz'),
-                        plugin = me.getToolById(pluginClazz).getPlugin(),
-                        source = ui.draggable.parents('.mapplugins'),
-                        target = jQuery(this);
+                    const pluginClazz = ui.draggable.attr('data-clazz');
+                    const plugin = me.getToolById(pluginClazz).getPlugin();
+                    const source = ui.draggable.parents('.mapplugins');
+                    const target = jQuery(this);
 
                     me._moveSiblings(pluginClazz, source, target);
                     if (plugin && plugin.setLocation) {
                         plugin.setLocation(jQuery(this).parents('.mapplugins').attr('data-location'));
                         // Reset draggable's inline css... couldn't find a cleaner way to do this.
                         // Can't be removed as that breaks draggable, has to be zeroed because we're changing containers
+                        /*
                         plugin.getElement().css({
                             'top': '0px',
                             'left': '0px'
                         });
+                        */
                     }
                     // draggable.stop doesn't fire if dropped to a droppable so we have to do this here as well...
                     me._hideDroppable();
@@ -223,7 +224,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
             this.toolLayoutEditMode = false;
             jQuery('.mappluginsContent.ui-droppable').droppable('destroy');
             this._removeDraggables();
-
 
             var event = Oskari.eventBuilder('LayerToolsEditModeEvent')(false);
             this.sandbox.notifyAll(event);

--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -59,16 +59,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
             if (!this.panel) {
                 this.panel = this._populateToolLayoutPanel(data);
             }
-
-            // init the tools' plugins location infos
-            if (this.data && this.activeToolLayout === 'userlayout') {
-                // this is always true, however we should not call setLocation for plugins here.
-                // Instead they should start at the location they were when saved.
-                // Problem: getTool() returns empty config usually so plugin is created with empty config instead of actual config that was used to save the map.
-                this._initUserLayout();
-            } else {
-                this._changeToolLayout(this.activeToolLayout, null);
-            }
         },
         getName: function () {
             return 'Oskari.mapframework.bundle.publisher2.view.PanelToolLayout';
@@ -193,6 +183,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
                 button;
             // store location so we have easy access to it on save
             me.activeToolLayout = layout;
+            /*
             if (layout !== 'userlayout') {
                 // make sure we're not in edit mode
                 if (me.toolLayoutEditMode) {
@@ -234,32 +225,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
                     me._editToolLayoutOn();
                 }
             }
+            */
         },
 
-        /**
-         * Initialises the plugins' location info when restoring a published map that has a user defined layout
-         * @method _initToolLayout
-         */
-        _initUserLayout: function () {
-            const data = this.data;
-            const pluginsConfigExists = Oskari.util.keyExists(data, 'configuration.mapfull.conf.plugins');
-            const pluginConfigs = pluginsConfigExists ? data.configuration.mapfull.conf.plugins : [];
-            this.tools.forEach(tool => {
-                pluginConfigs.forEach(plugin => {
-                    if (tool.getTool().id !== plugin.id || !plugin.config) {
-                        return;
-                    }
-                    const { location = {} } = plugin.config;
-                    if (!location.classes) {
-                        return;
-                    }
-                    tool.getTool().config.location = location;
-                    if (tool.getPlugin() && tool.getPlugin().setLocation) {
-                        tool.getPlugin().setLocation(plugin.config.location.classes);
-                    }
-                });
-            });
-        },
         /**
          * @private @method _editToolLayoutOn
          *

--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -175,15 +175,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
          *
          */
         _editToolLayoutOn: function () {
-            var me = this,
-                sandbox = Oskari.getSandbox('sandbox');
-            if (me.toolLayoutEditMode) {
+            const me = this;
+            if (this.toolLayoutEditMode) {
                 return;
             }
-            me.toolLayoutEditMode = true;
-            jQuery('#editModeBtn').val(me.loc.toollayout.usereditmodeoff);
+            this.toolLayoutEditMode = true;
             jQuery('.mapplugins').show();
-            me._initDraggables();
+            this._initDraggables();
             // TODO create droppables on _showDroppable, destroy them on _hideDroppable
             jQuery('.mappluginsContent').droppable({
                 // TODO see if this can be done in hover? Would it even be wanted behaviour?
@@ -210,11 +208,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
                 tolerance: 'pointer' // bit of a compromise, we'd need a combination of pointer and intersect
             });
 
-            // Disable map hover effect when layout edit mode is active
-            sandbox.getService('Oskari.mapframework.service.VectorFeatureService').setHoverEnabled(false);
-
             var event = Oskari.eventBuilder('LayerToolsEditModeEvent')(true);
-            sandbox.notifyAll(event);
+            this.sandbox.notifyAll(event);
             this._renderPanel();
         },
 
@@ -222,21 +217,16 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
          * @private @method _editToolLayoutOff
          */
         _editToolLayoutOff: function () {
-            var me = this,
-                sandbox = Oskari.getSandbox('sandbox');
-            if (!me.toolLayoutEditMode) {
+            if (!this.toolLayoutEditMode) {
                 return;
             }
-            me.toolLayoutEditMode = false;
-            jQuery('#editModeBtn').val(me.loc.toollayout.usereditmode);
+            this.toolLayoutEditMode = false;
             jQuery('.mappluginsContent.ui-droppable').droppable('destroy');
             this._removeDraggables();
 
-            // Restore map hover effects
-            sandbox.getService('Oskari.mapframework.service.VectorFeatureService').setHoverEnabled(true);
 
             var event = Oskari.eventBuilder('LayerToolsEditModeEvent')(false);
-            sandbox.notifyAll(event);
+            this.sandbox.notifyAll(event);
             this._renderPanel();
         },
         _enableToolDraggable: function (tool) {

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -291,11 +291,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                 }
             };
 
-            this.panels.forEach((panel)  => {
+            this.panels.forEach((panel) => {
                 if (typeof panel.validate === 'function') {
                     errors = errors.concat(panel.validate());
                 }
-                selections = mergeValues(selections, panel.getValues())
+                selections = mergeValues(selections, panel.getValues());
             });
 
             if (errors.length > 0) {

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -1,4 +1,6 @@
+import { mergeValues } from '../util/util';
 import { Messaging } from 'oskari-ui/util';
+
 
 /**
  * @class Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
@@ -273,66 +275,29 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
             tool.toolConfig = conf.toolsConfig[tool.bundleName];
         },
         /**
-        * Extends object recursive for keeping defaults array.
-        * @method _extendRecursive
-        * @private
-        *
-        * @param {Object} defaults the default extendable object
-        * @param {Object} extend extend object
-        *
-        * @return {Object} extended object
-        */
-        _extendRecursive: function (defaults, extend) {
-            var me = this;
-            if (extend === null || extend === undefined || jQuery.isEmptyObject(extend)) {
-                return defaults;
-            } else if (jQuery.isEmptyObject(defaults)) {
-                return jQuery.extend(true, defaults, extend);
-            } else if (jQuery.isArray(defaults)) {
-                if (jQuery.isArray(extend)) {
-                    jQuery.each(extend, function (key, value) {
-                        defaults.push(value);
-                    });
-                }
-                return defaults;
-            } else if (extend.constructor && extend.constructor === Object) {
-                jQuery.each(extend, function (key, value) {
-                    // not an array or an object -> just use the plain value
-                    if (defaults[key] === null || defaults[key] === undefined || !(defaults[key] instanceof Array || defaults[key] instanceof Object)) {
-                        defaults[key] = value;
-                    } else {
-                        defaults[key] = me._extendRecursive(defaults[key], value);
-                    }
-                });
-                return defaults;
-            }
-        },
-        /**
         * Gather selections.
         * @method gatherSelections
         * @private
         */
         gatherSelections: function () {
-            var me = this,
-                sandbox = this.instance.getSandbox(),
-                selections = {
-                    configuration: {
+            const me = this;
+            const sandbox = this.instance.getSandbox();
+            const errors = [];
 
+            const mapFullState = sandbox.getStatefulComponents().mapfull.getState();
+            let selections = {
+                configuration: {
+                    mapfull: {
+                        state: mapFullState
                     }
-                },
-                errors = [];
-
-            var mapFullState = sandbox.getStatefulComponents().mapfull.getState();
-            selections.configuration.mapfull = {
-                state: mapFullState
+                }
             };
 
             jQuery.each(me.panels, function (index, panel) {
                 if (panel.validate && typeof panel.validate === 'function') {
                     errors = errors.concat(panel.validate());
                 }
-
-                me._extendRecursive(selections, panel.getValues());
+                selections = mergeValues(selections, panel.getValues())
             });
 
             if (errors.length > 0) {

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -1,7 +1,6 @@
 import { mergeValues } from '../util/util';
 import { Messaging } from 'oskari-ui/util';
 
-
 /**
  * @class Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
  * Renders the publishers "publish mode" sidebar view where the user can make
@@ -280,7 +279,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
         * @private
         */
         gatherSelections: function () {
-            const me = this;
             const sandbox = this.instance.getSandbox();
             let errors = [];
 
@@ -293,15 +291,15 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                 }
             };
 
-            jQuery.each(me.panels, function (index, panel) {
-                if (panel.validate && typeof panel.validate === 'function') {
+            this.panels.forEach((panel)  => {
+                if (typeof panel.validate === 'function') {
                     errors = errors.concat(panel.validate());
                 }
                 selections = mergeValues(selections, panel.getValues())
             });
 
             if (errors.length > 0) {
-                me._showValidationErrorMessage(errors);
+                this._showValidationErrorMessage(errors);
                 return null;
             }
             return selections;

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -282,7 +282,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
         gatherSelections: function () {
             const me = this;
             const sandbox = this.instance.getSandbox();
-            const errors = [];
+            let errors = [];
 
             const mapFullState = sandbox.getStatefulComponents().mapfull.getState();
             let selections = {

--- a/bundles/framework/publisher2/view/form/ToolLayout.jsx
+++ b/bundles/framework/publisher2/view/form/ToolLayout.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Button, Message } from 'oskari-ui';
+import { SwapOutlined, EditOutlined, EditFilled } from '@ant-design/icons';
+import styled from 'styled-components';
+
+const FieldWithInfo = styled('div')`
+    margin-top: 0.5em;
+    margin-bottom: 1em;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+    align-items: center;
+`;
+export const ToolLayout = ({ isEdit, onEditMode, onSwitch }) => {
+    return (
+        <FieldWithInfo>
+            <Button onClick={onSwitch}><SwapOutlined /> <Message messageKey='BasicView.toollayout.swapUI' /></Button>
+            <Button onClick={() => onEditMode(!isEdit)} danger={isEdit}><EditButtonContent isEdit={isEdit} /></Button>
+        </FieldWithInfo>
+    );
+};
+
+const EditButtonContent = ({isEdit}) => {
+    if (isEdit) {
+        return (<React.Fragment>
+            <EditFilled /> <Message messageKey='BasicView.toollayout.usereditmodeoff' />
+        </React.Fragment>);
+    }
+    return (<React.Fragment>
+        <EditOutlined /> <Message messageKey='BasicView.toollayout.userlayout' />
+    </React.Fragment>);
+};

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -453,6 +453,8 @@ Oskari.clazz.define(
             },
             'LayerToolsEditModeEvent': function (event) {
                 this._isInLayerToolsEditMode = event.isInMode();
+                // Disable feature hover when tools are being dragged
+                this.getSandbox().getService('Oskari.mapframework.service.VectorFeatureService').setHoverEnabled(!this._isInLayerToolsEditMode);
             },
             AfterRearrangeSelectedMapLayerEvent: function (event) {
                 this.afterRearrangeSelectedMapLayerEvent(event);

--- a/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
@@ -169,10 +169,8 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
          * Plugin's location
          */
         getLocation: function () {
-            if (this._config && this._config.location && this._config.location.classes) {
-                return this._config.location.classes;
-            }
-            return this._defaultLocation;
+            const location = this._config?.location?.classes || this._defaultLocation;
+            return location || 'top right';
         },
 
         /**


### PR DESCRIPTION
- Remove tool location handling initializers from PanelToolLayout and make each plugin use initialize to correct location on startup (in Tool.init()/setEnabled()/setEnabledImpl()).
- Rewrite PanelToolLayout: removed left/righthanded selection, replaced with a toggle button. 
- mapmodule/plugin/BasicMapModulePlugin.getLocation() now always returns a value.
- Moved the publisher payload gathering functions `merge` to a util file and added tests to it and removed jQuery usage from it.
- 
![image](https://user-images.githubusercontent.com/2210335/226373143-a3b0cf3f-f3ea-467f-ba87-380b4267b2c3.png)
![image](https://user-images.githubusercontent.com/2210335/226373214-747428df-02ed-4bf0-b73f-aca961191504.png)

