### PR TITLE
Fix an issue with publisher 'swap sides' button

### DIFF
--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -118,7 +118,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
                 .filter(tool => tool.isEnabled())
                 .forEach(tool => {
                     const plugin = tool.getPlugin();
-                    if (typeof plugin.getLocation !== 'function') {
+                    if (!plugin || typeof plugin.getLocation !== 'function') {
+                        // for example center cross on map does not have a plugin
                         return;
                     }
                     const currentLoc = plugin.getLocation();


### PR DESCRIPTION
Having the map center cross enabled resulted in a JS error.