### PR TITLE
Publisher drag mode: Disable clicks to plugins with CSS

### DIFF
--- a/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
+++ b/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
@@ -35,7 +35,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
     }, {
         _setLayerToolsEditModeImpl: function () {
             if (this.handler && this.inLayerToolsEditMode() && this.popupOpen) {
-                this.handler.getController().showPopup();
+                this.handler.getController().popupCleanup();
             }
         },
         _createControlElement: function () {
@@ -145,11 +145,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
                     className='t_coordinatetool'
                     title={this._locale('display.tooltip.tool')}
                     icon={<CoordinateIcon />}
-                    onClick={() => {
-                        if (!this.inLayerToolsEditMode()) {
-                            this.handler.getController().showPopup();
-                        }
-                    }}
+                    onClick={() => this.handler.getController().showPopup()}
                     iconActive={!!this.popupOpen}
                     position={this.getLocation()}
                 />,

--- a/bundles/mapping/mapmodule/resources/scss/mapmodule.ol.scss
+++ b/bundles/mapping/mapmodule/resources/scss/mapmodule.ol.scss
@@ -20,8 +20,13 @@ $pluginMargin: 10px;
     margin: 0 !important;
 }
 
+/* Disable usual pointer events when we are in publisher edit mode */
+.mapplugin.toollayoutedit.ui-draggable > div {
+    pointer-events: none;
+}
+
 /* This is the drag-n-drop handle on publisher */
-.mapplugin.toollayoutedit.ui-draggable-handle > div::after {
+.mapplugin.ui-draggable-handle > div::after {
     content: url("../images/holder-icon.svg");
     width: 24px;
     height: 24px;
@@ -31,6 +36,8 @@ $pluginMargin: 10px;
     right: -24px;
     opacity: 0.7;
     top: 20%;
+    /* Since we disable pointer events to buttons, we need to enable them for the handle */
+    pointer-events: auto;
     cursor: pointer;
     filter: drop-shadow(1px 1px 1px rgba(0, 0, 0, 1));
 }


### PR DESCRIPTION
So we don't need to handle it in plugin code at all.