### PR TITLE
Pass embedded map data to tool.isDiplayed()

### DIFF
--- a/bundles/framework/publisher2/handler/MapLayersHandler.js
+++ b/bundles/framework/publisher2/handler/MapLayersHandler.js
@@ -39,7 +39,7 @@ class UIHandler extends StateHandler {
             layerTools
         });
         this.updateSelectedLayers(true);
-        return this.tools.some(tool => tool.isDisplayed());
+        return this.tools.some(tool => tool.isDisplayed(data));
     }
 
     updateSelectedLayers (silent) {

--- a/bundles/framework/publisher2/handler/RpcPanelHandler.js
+++ b/bundles/framework/publisher2/handler/RpcPanelHandler.js
@@ -31,7 +31,7 @@ class UIHandler extends StateHandler {
                 ]
             });
         });
-        return this.tools.some(tool => tool.isDisplayed());
+        return this.tools.some(tool => tool.isDisplayed(data));
     }
 
     updateField (field, value) {

--- a/bundles/framework/publisher2/view/PanelMapTools.js
+++ b/bundles/framework/publisher2/view/PanelMapTools.js
@@ -45,7 +45,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
                         .error('Error initializing publisher tool:', tool.getTool().id);
                 }
             });
-            return this.tools.some(tool => tool.isDisplayed());
+            return this.tools.some(tool => tool.isDisplayed(pData));
         },
         getName: function () {
             return 'Oskari.mapframework.bundle.publisher2.view.PanelMapTools';


### PR DESCRIPTION
To fix an issue with statsgrid tools not showing up even when the embedded map that is being edited has statsgrid.