### PR TITLE
Statsgrid publisher fixes

### DIFF
--- a/bundles/mapping/mapmodule/plugin/pluginPopupHelper.js
+++ b/bundles/mapping/mapmodule/plugin/pluginPopupHelper.js
@@ -23,6 +23,8 @@ const getPlacementFromPluginLocation = (pluginLocation) => {
         return PLACEMENTS.TOP;
     case 'top center':
         return PLACEMENTS.TOP;
+    case 'bottom center':
+        return PLACEMENTS.BOTTOM;
     case 'bottom right':
         return PLACEMENTS.BR;
     case 'bottom left':

--- a/bundles/statistics/statsgrid2016/publisher/ClassificationToggleTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/ClassificationToggleTool.js
@@ -34,6 +34,9 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationToggleTool
             stats.addMapPluginToggleTool(this.id);
         } else {
             stats.togglePlugin.removeTool(this.id);
+            // if we have hidden classification and then remove the option to hide/show it
+            // -> update visibility to show it
+            stats.updateClassficationViewVisibility();
         }
     },
     getValues: function () {


### PR DESCRIPTION
- Enable plugins to open popups to bottom center if they are located there instead of defaulting top left.
- If user hides classification in publisher and then removes the option for showing/hiding it -> bring classification back on screen