### PR TITLE
Fix publisher tools that are not visible but still provided values for publish

### DIFF
--- a/bundles/framework/featuredata2/publisher/FeaturedataTool.js
+++ b/bundles/framework/featuredata2/publisher/FeaturedataTool.js
@@ -30,7 +30,11 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.FeaturedataTool',
             const { configuration = {} } = data;
             if (configuration[this.bundleName]) {
                 this.storePluginConf(configuration[this.bundleName].conf);
-                this.setEnabled(true);
+                // even if we have the config, we don't want to enable the tool if its not shown
+                // if we enable it the plugin won't show and everything looks ok, but getValues() will
+                // still return a non-null value which makes featuredata bundle to be
+                // started on the embedded map even if it's not used
+                this.setEnabled(this.isDisplayed(data));
             }
         },
         /**

--- a/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
@@ -37,8 +37,10 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractStatsPluginTool'
     getConfiguration: function (conf = {}) {
         // just to make sure if user removes the statslayer while in publisher
         // if there is no statslayer on map -> don't setup tools configuration
-        if (!this._isStatsActive) {
-            return {};
+        // otherwise the embedded map will get statsgrid config which means that editing the embedded
+        // map will show the thematic map tools panel even if the thematic maps is not used on the embedded map
+        if (!this._isStatsActive()) {
+            return null;
         }
         return {
             configuration: {

--- a/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
@@ -39,9 +39,8 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationTool', fun
     },
 
     getValues: function () {
-        const allowClassification = this.isEnabled();
         if (!this._isStatsActive()) {
-            return {};
+            return null;
         }
         var stats = this.getStatsgridBundle();
         const { location } = stats?.togglePlugin?.getConfig() || {};
@@ -49,7 +48,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationTool', fun
             configuration: {
                 statsgrid: {
                     conf: {
-                        allowClassification,
+                        allowClassification: this.isEnabled(),
                         location: location || {
                             classes: 'bottom right'
                         }


### PR DESCRIPTION
Featuredata was enabled even when it's not shown. This resulted in getValues() returning a value even when the tool was not shown. This is not an obvious problem, but leads to users of the embedded map running code for the featuredata bundle even when it does nothing for them.

In statistical map tools the check if values should be returned was broken so while the embedded map didn't have or show statistical data the configuration was saved on it. This resulted in the statistical map tools showing on publisher when the embedded map was opened for editing on the geoportal.