### PR TITLE
Map plugin cleaning

### DIFF
--- a/bundles/framework/coordinatetool/instance.js
+++ b/bundles/framework/coordinatetool/instance.js
@@ -97,10 +97,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.CoordinateToolBun
             this.plugin = plugin;
             sandbox.register(me);
 
-            // get the plugin order straight in mobile toolbar even for the tools coming in late
-            if (Oskari.util.isMobile() && this.plugin.hasUI()) {
-                mapModule.redrawPluginUIs(true);
-            }
             this._registerForGuidedTour();
         },
         /**

--- a/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
+++ b/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
@@ -79,14 +79,34 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
             return !this._config.noUI;
         },
         /**
-         * Updates the given coordinates to the UI
          * @method @public refresh
-         *
-         * @param {Object} data contains lat/lon information to show on UI
          */
-        refresh: function (data) {
-            this.renderButton();
-            return data;
+        refresh: function () {
+            const el = this.getElement();
+            if (!el) {
+                return;
+            }
+            if (!this.handler) {
+                // init handler here so we can be sure we have a sandbox for this instance
+                this.handler = new CoordinatePluginHandler(this, this.getMapModule(), this.getConfig());
+                this.popupOpen = false;
+                this.handler.addPopupListener((isOpen) => {
+                    this.popupOpen = isOpen;
+                    this.refresh();
+                });
+            }
+
+            ReactDOM.render(
+                <MapModuleButton
+                    className='t_coordinatetool'
+                    title={this._locale('display.tooltip.tool')}
+                    icon={<CoordinateIcon />}
+                    onClick={() => this.handler.getController().showPopup()}
+                    iconActive={!!this.popupOpen}
+                    position={this.getLocation()}
+                />,
+                el[0]
+            );
         },
 
         /**
@@ -115,41 +135,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
             };
         },
 
-        /**
-         * @public @method changeToolStyle
-         * Changes the tool style of the plugin
-         */
-        changeToolStyle: function () {
-            this.renderButton();
-        },
-
-        renderButton: function () {
-            const el = this.getElement();
-            if (!el) {
-                return;
-            }
-            if (!this.handler) {
-                // init handler here so we can be sure we have a sandbox for this instance
-                this.handler = new CoordinatePluginHandler(this, this.getMapModule(), this.getConfig());
-                this.popupOpen = false;
-                this.handler.addPopupListener((isOpen) => {
-                    this.popupOpen = isOpen;
-                    this.renderButton();
-                });
-            }
-
-            ReactDOM.render(
-                <MapModuleButton
-                    className='t_coordinatetool'
-                    title={this._locale('display.tooltip.tool')}
-                    icon={<CoordinateIcon />}
-                    onClick={() => this.handler.getController().showPopup()}
-                    iconActive={!!this.popupOpen}
-                    position={this.getLocation()}
-                />,
-                el[0]
-            );
-        },
         /**
          * @method _stopPluginImpl BasicMapModulePlugin method override
          * @param {Oskari.Sandbox} sandbox

--- a/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
+++ b/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
@@ -33,7 +33,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
             coordinatetool: jQuery('<div class="mapplugin coordinatetool"></div>')
         };
     }, {
-        resetUI: function() {
+        resetUI: function () {
             if (this.handler && this.popupOpen) {
                 this.handler.getController().popupCleanup();
             }

--- a/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
+++ b/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
@@ -33,8 +33,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
             coordinatetool: jQuery('<div class="mapplugin coordinatetool"></div>')
         };
     }, {
-        _setLayerToolsEditModeImpl: function () {
-            if (this.handler && this.inLayerToolsEditMode() && this.popupOpen) {
+        resetUI: function() {
+            if (this.handler && this.popupOpen) {
                 this.handler.getController().popupCleanup();
             }
         },
@@ -66,8 +66,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
             if (!this.hasUI()) {
                 return;
             }
-
-            this.inMobileMode = mapInMobileMode;
 
             this.teardownUI();
             if (!this._config.noUI) {

--- a/bundles/framework/featuredata2/instance.js
+++ b/bundles/framework/featuredata2/instance.js
@@ -432,11 +432,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.FeatureDataBundleIn
             this.plugin = Oskari.clazz.create('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataPlugin', this.conf);
             this.mapModule.registerPlugin(this.plugin);
             this.mapModule.startPlugin(this.plugin);
-
-            // get the plugin order straight in mobile toolbar even for the tools coming in late
-            if (Oskari.util.isMobile()) {
-                this.mapModule.redrawPluginUIs(true);
-            }
         }
     }, {
         /**

--- a/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
+++ b/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
@@ -90,7 +90,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
             this._flyoutOpen = undefined;
             var flyout = this.getInstance().plugins['Oskari.userinterface.Flyout'];
             jQuery(flyout.container.parentElement.parentElement).removeClass('mobile');
-            this.renderButton();
+            this.refresh();
         },
         /**
          * @method refresh
@@ -100,30 +100,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
             this.setVisible(this._hasFeaturedataLayers());
             this.renderButton();
         },
-        resetUI: function () {
-            if (this._flyoutOpen) {
-                // actually closes flyout when it's open...
-                this.openFlyout();
-            }
-        },
-        /**
-         * @method _hasFeaturedataLayers
-         * @private
-         * Check whether there are layers with featuredata present -> determine the control element's visibility
-         */
-        _hasFeaturedataLayers: function () {
-            // see if there's any wfs layers, show element if so
-            return this.getSandbox()
-                .findAllSelectedMapLayers()
-                .filter(layer => layer.isVisibleOnMap())
-                .some(layer => layer.hasFeatureData && layer.hasFeatureData());
-        },
-        /**
-         * @public @method changeToolStyle
-         * Changes the tool style of the plugin
-         */
-        changeToolStyle: function () {
-            this.renderButton();
+        showLoadingIndicator: function (blnLoad) {
+            this.renderButton(!!blnLoad);
         },
         renderButton: function (loading = false) {
             const el = this.getElement();
@@ -144,6 +122,24 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
                 el[0]
             );
         },
+        resetUI: function () {
+            if (this._flyoutOpen) {
+                // actually closes flyout when it's open...
+                this.openFlyout();
+            }
+        },
+        /**
+         * @method _hasFeaturedataLayers
+         * @private
+         * Check whether there are layers with featuredata present -> determine the control element's visibility
+         */
+        _hasFeaturedataLayers: function () {
+            // see if there's any wfs layers, show element if so
+            return this.getSandbox()
+                .findAllSelectedMapLayers()
+                .filter(layer => layer.isVisibleOnMap())
+                .some(layer => layer.hasFeatureData && layer.hasFeatureData());
+        },
         openFlyout: function () {
             const sandbox = this.getSandbox();
             if (!this._flyoutOpen) {
@@ -158,10 +154,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
                 sandbox.postRequestByName('userinterface.UpdateExtensionRequest', [this.getInstance(), 'close']);
                 this._flyoutOpen = undefined;
             }
-            this.renderButton();
-        },
-        showLoadingIndicator: function (blnLoad) {
-            this.renderButton(!!blnLoad);
+            this.refresh();
         },
         showErrorIndicator: function (blnLoad) {
             if (!this.getElement()) {

--- a/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
+++ b/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
@@ -41,7 +41,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
             }
             return this._instance;
         },
-        _startPluginImpl: function() {
+        _startPluginImpl: function () {
             this._element = this._createControlElement();
             this.addToPluginContainer(this.getElement());
         },

--- a/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
+++ b/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
@@ -100,6 +100,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
             this.setVisible(this._hasFeaturedataLayers());
             this.renderButton();
         },
+        resetUI: function () {
+            if (this._flyoutOpen) {
+                // actually closes flyout when it's open...
+                this.openFlyout();
+            }
+        },
         /**
          * @method _hasFeaturedataLayers
          * @private

--- a/bundles/framework/maplegend/plugin/MapLegendPlugin.js
+++ b/bundles/framework/maplegend/plugin/MapLegendPlugin.js
@@ -19,7 +19,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
         },
         _startPluginImpl: function () {
             this.addToPluginContainer(this._createControlElement());
-            this.renderButton();
+            this.refresh();
             return true;
         },
         _stopPluginImpl: function () {
@@ -35,18 +35,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
                 this._popupControls.close();
             }
             this._popupControls = null;
-            this.renderButton();
+            this.refresh();
         },
 
-        /**
-         * @public @method changeToolStyle
-         * Changes the tool style of the plugin
-         */
-        changeToolStyle: function () {
-            this.renderButton();
-        },
-
-        renderButton: function () {
+        refresh: function () {
             const el = this.getElement();
             if (!el) {
                 return;
@@ -65,6 +57,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
                 el[0]
             );
         },
+
         getLegend: function (legendId) {
             const layer = Oskari.getSandbox().findMapLayerFromSelectedMapLayers(legendId);
             if (!layer) {
@@ -79,7 +72,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
             }
             const legends = this.getLegends();
             this._popupControls = showMapLegendPopup(legends, (id) => this.getLegend(id), () => this.clearPopup());
-            this.renderButton();
+            this.refresh();
         },
         getLegends: function () {
             return this.getSandbox().findAllSelectedMapLayers()

--- a/bundles/framework/maplegend/plugin/MapLegendPlugin.js
+++ b/bundles/framework/maplegend/plugin/MapLegendPlugin.js
@@ -12,7 +12,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
         this._index = 90;
         this._popupControls = null;
     }, {
-        resetUI: function() {
+        resetUI: function () {
             if (this.isOpen()) {
                 this.clearPopup();
             }

--- a/bundles/framework/maplegend/plugin/MapLegendPlugin.js
+++ b/bundles/framework/maplegend/plugin/MapLegendPlugin.js
@@ -12,8 +12,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
         this._index = 90;
         this._popupControls = null;
     }, {
-        _setLayerToolsEditModeImpl: function () {
-            if (this.inLayerToolsEditMode() && this.isOpen()) {
+        resetUI: function() {
+            if (this.isOpen()) {
                 this.clearPopup();
             }
         },
@@ -58,11 +58,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin
                     className='t_maplegend'
                     title={title}
                     icon={<QuestionOutlined />}
-                    onClick={() => {
-                        if (!this.inLayerToolsEditMode()) {
-                            this.togglePopup();
-                        }
-                    }}
+                    onClick={() => this.togglePopup()}
                     iconActive={this.isOpen()}
                     position={this.getLocation()}
                 />,

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -125,6 +125,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                     accordion.addPanel(panel);
                 }
             });
+            // add RPC panel if there are tools for it
             if (rpcTools) {
                 const rpcPanel = this._createRpcPanel(rpcTools);
                 rpcPanel.getPanel().addClass('t_rpc');

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -471,7 +471,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
             const sandbox = this.instance.sandbox;
             const mapModule = sandbox.findRegisteredModuleInstance('MainMapModule');
             Object.values(mapModule.getPluginInstances())
-                .filter(plugin => plugin.hasUI && plugin.hasUI())
+                .filter(plugin => plugin.isShouldStopForPublisher && plugin.isShouldStopForPublisher())
                 .forEach(plugin => {
                     try {
                         plugin.stopPlugin(sandbox);

--- a/bundles/framework/timeseries/view/TimeSeriesRangeControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeSeriesRangeControlPlugin.js
@@ -26,6 +26,9 @@ class TimeSeriesRangeControlPlugin extends BasicMapModulePlugin {
     }
 
     hasUI () {
+        return true;
+    }
+    isShouldStopForPublisher () {
         // prevent publisher to stop this plugin and start it again when leaving the publisher
         return false;
     }

--- a/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
@@ -65,7 +65,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
             { key: 'week', value: 'weeks' },
             { key: 'month', value: 'months' }
         ],
-        hasUI: function () {
+        isShouldStopForPublisher: function () {
             // prevent publisher to stop this plugin and start it again when leaving the publisher
             return false;
         },

--- a/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
+++ b/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
@@ -70,9 +70,6 @@ Oskari.clazz.define(className,
                 return;
             }
             this._render();
-            this._setLayerToolsEditMode(
-                this.getMapModule().isInLayerToolsEditMode()
-            );
         },
         _createUI: function () {
             this._element = this._mountPoint.clone();

--- a/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
+++ b/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
@@ -61,25 +61,14 @@ Oskari.clazz.define(className,
         stopPlugin: function () {
             this.teardownUI();
         },
-        /**
-         * Changes the tool style of the plugin
-         * @method changeToolStyle
-         */
-        changeToolStyle: function () {
-            if (!this.getElement()) {
-                return;
-            }
-            this._render();
-        },
-        _createUI: function () {
-            this._element = this._mountPoint.clone();
-            this.addToPluginContainer(this._element);
-            this._element.addClass('mapplugin');
+        refresh: function () {
             this._render();
         },
         _render (state = this.handler.getState()) {
             let el = this.getElement();
-            if (!el) return;
+            if (!el) {
+                return;
+            }
 
             const { activeMapMoveMethod } = state;
             const ui = (
@@ -93,6 +82,12 @@ Oskari.clazz.define(className,
                 </LocaleProvider>
             );
             ReactDOM.render(ui, el[0]);
+        },
+        _createUI: function () {
+            this._element = this._mountPoint.clone();
+            this.addToPluginContainer(this._element);
+            this._element.addClass('mapplugin');
+            this.refresh();
         },
         /**
          * @public @method getIndex

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -2150,13 +2150,13 @@ Oskari.clazz.define(
             // let the actual layerplugins find the layer since the name depends on
             // type
             return Object.values(this.getLayerPlugins()).map(plugin => {
-                    if (!plugin || typeof plugin.getOLMapLayers !== 'function') {
-                        // can there be null plugins?
-                        return [];
-                    }
-                    return plugin.getOLMapLayers(layer) || [];
-                })
-                .flatMap(layers => layers);
+                if (!plugin || typeof plugin.getOLMapLayers !== 'function') {
+                    // can there be null plugins?
+                    return [];
+                }
+                return plugin.getOLMapLayers(layer) || [];
+            })
+            .flatMap(layers => layers);
         },
         /**
          * Adds the layer to the map through the correct plugin for the layer's type.

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -103,6 +103,7 @@ import { monitorResize, unmonitorResize } from 'oskari-ui/components/window';
 import { getSortedPlugins, refreshPluginsWithUI } from './util/PluginHelper';
 import { getDefaultMapTheme, setFont } from './util/MapThemeHelper';
 import { addCrosshair, isCrosshairActive, removeCrosshair } from './util/Crosshair';
+import { generatePluginContainers } from './util/PluginContainerHelper';
 
 /**
  * @class Oskari.mapping.mapmodule.AbstractMapModule
@@ -309,7 +310,7 @@ Oskari.clazz.define(
             me._calculateScalesImpl(me._mapResolutions);
 
             // TODO remove this whenever we're ready to add the containers when needed
-            this._addMapControlPluginContainers();
+            generatePluginContainers(this.getMapEl());
             return me._initImpl(me._sandbox, me._options, me._map);
         },
         /**
@@ -2040,93 +2041,11 @@ Oskari.clazz.define(
             this.log.deprecated('getToolColourScheme');
             return null;
         },
-        _getContainerWithClasses: function (containerClasses) {
-            var containerDiv = jQuery(
-                '<div class="mapplugins">' +
-                    '  <div class="mappluginsContainer">' +
-                    '    <div class="mappluginsContent"></div>' +
-                    '  </div>' +
-                    '</div>'
-            );
-
-            containerDiv.addClass(containerClasses);
-            containerDiv.attr('data-location', containerClasses);
-            return containerDiv;
-        },
-
-        _getContainerClasses: function () {
-            return [
-                'bottom center',
-                'center top',
-                'center right',
-                'center left',
-                'bottom right',
-                'bottom left',
-                'right top',
-                'left top'
-            ];
-        },
-
-        /**
-         * Adds containers for map control plugins
-         */
-        _addMapControlPluginContainers: function () {
-            var containerClasses = this._getContainerClasses();
-            var mapDiv = this.getMapEl();
-
-            for (var i = 0; i < containerClasses.length; i += 1) {
-                mapDiv.append(
-                    this._getContainerWithClasses(containerClasses[i])
-                );
-            }
-        },
 
         _getMapControlPluginContainer: function (containerClasses) {
-            var splitClasses = (containerClasses + '').split(' ');
-            var selector = '.mapplugins.' + splitClasses.join('.');
-            var containerDiv;
-            var mapDiv = this.getMapEl();
-
-            containerDiv = mapDiv.find(selector);
-            if (!containerDiv.length) {
-                var containersClasses = this._getContainerClasses(),
-                    currentClasses,
-                    previousFound = null,
-                    current,
-                    classesMatch,
-                    i,
-                    j;
-
-                for (i = 0; i < containersClasses.length; i += 1) {
-                    currentClasses = containersClasses[i].split(' ');
-                    current = mapDiv.find('.mapplugins.' + currentClasses.join('.'));
-                    if (current.length) {
-                        // container was found in DOM
-                        previousFound = current;
-                    } else {
-                        // container not in DOM, see if it's the one we're supposed to add
-                        classesMatch = true;
-                        for (j = 0; j < currentClasses.length; j += 1) {
-                            if (jQuery.inArray(currentClasses[j], splitClasses) < 0) {
-                                classesMatch = false;
-                                break;
-                            }
-                        }
-                        if (classesMatch) {
-                            // It's the one we're supposed to add
-                            containerDiv = this._getContainerWithClasses(
-                                currentClasses
-                            );
-                            if (previousFound !== null && previousFound.length) {
-                                previousFound.after(containerDiv);
-                            } else {
-                                mapDiv.prepend(containerDiv);
-                            }
-                        }
-                    }
-                }
-            }
-            return containerDiv;
+            const splitClasses = (containerClasses + '').split(' ');
+            const selector = '.mapplugins.' + splitClasses.join('.');
+            return this.getMapEl().find(selector);
         },
 
         /**
@@ -2139,12 +2058,11 @@ Oskari.clazz.define(
 
         setMapControlPlugin: function (element, containerClasses, position) {
             // Get the container
-            var container = this._getMapControlPluginContainer(containerClasses);
-            var content = container.find('.mappluginsContainer .mappluginsContent');
+            const container = this._getMapControlPluginContainer(containerClasses);
+            const content = container.find('.mappluginsContainer .mappluginsContent');
             // bottom corner container?
-            var inverted = /^(?=.*\bbottom\b)((?=.*\bleft\b)|(?=.*\bright\b)).+/.test(containerClasses);
-            var precedingPlugin = null;
-            var curr;
+            const inverted = (containerClasses + '').includes('bottom');
+            let precedingPlugin = null;
 
             if (!element) {
                 throw new Error('Element is non-existent.');
@@ -2166,7 +2084,7 @@ Oskari.clazz.define(
             // Get container's children, iterate through them
             if (position !== null && position !== undefined) {
                 content.find('.mapplugin').each(function () {
-                    curr = jQuery(this);
+                    const curr = jQuery(this);
                     // if plugin's slot isn't bigger (or smaller for bottom corners) than ours, store it to precedingPlugin
                     if ((!inverted && parseInt(curr.attr('data-position')) <= position) ||
                         (inverted && parseInt(curr.attr('data-position')) > position)) {
@@ -2220,38 +2138,22 @@ Oskari.clazz.define(
          * @return {OpenLayers.Layer[]}
          */
         getOLMapLayers: function (layerId) {
-            var me = this;
-            var sandbox = me._sandbox;
+            var sandbox = this.getSandbox();
             var layer = sandbox.findMapLayerFromSelectedMapLayers(layerId);
             if (!layer) {
                 // not found
                 return null;
             }
-            var lps = this.getLayerPlugins(),
-                p,
-                layersPlugin,
-                layerList,
-                results = [];
             // let the actual layerplugins find the layer since the name depends on
             // type
-            for (p in lps) {
-                if (lps.hasOwnProperty(p)) {
-                    layersPlugin = lps[p];
-                    if (!layersPlugin) {
-                        me.log.warn(
-                            'LayerPlugins has no entry for "' + p + '"'
-                        );
+            return Object.values(this.getLayerPlugins()).map(plugin => {
+                    if (!plugin || typeof plugin.getOLMapLayers !== 'function') {
+                        // can there be null plugins?
+                        return [];
                     }
-                    // find the actual openlayers layers (can be many)
-                    layerList = layersPlugin ? layersPlugin.getOLMapLayers(layer) : null;
-                    if (layerList) {
-                        // if found -> add to results
-                        // otherwise continue looping
-                        results = results.concat(layerList);
-                    }
-                }
-            }
-            return results;
+                    return plugin.getOLMapLayers(layer) || [];
+                })
+                .flatMap(layers => layers);
         },
         /**
          * Adds the layer to the map through the correct plugin for the layer's type.

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -100,7 +100,7 @@ import './event/UserLocationEvent';
 import { filterFeaturesByExtent } from './util/vectorfeatures/filter';
 import { FEATURE_QUERY_ERRORS } from './domain/constants';
 import { monitorResize, unmonitorResize } from 'oskari-ui/components/window';
-import { getSortedPlugins, refreshPluginsWithUI } from './util/PluginHelper';
+import { getSortedPlugins, resetPluginsWithUI, refreshPluginsWithUI } from './util/PluginHelper';
 import { getDefaultMapTheme, setFont } from './util/MapThemeHelper';
 import { addCrosshair, isCrosshairActive, removeCrosshair } from './util/Crosshair';
 import { generatePluginContainers } from './util/PluginContainerHelper';
@@ -456,6 +456,10 @@ Oskari.clazz.define(
                 this._isInLayerToolsEditMode = event.isInMode();
                 // Disable feature hover when tools are being dragged
                 this.getSandbox().getService('Oskari.mapframework.service.VectorFeatureService').setHoverEnabled(!this._isInLayerToolsEditMode);
+                if (this._isInLayerToolsEditMode) {
+                    // when entering edit/drag mode -> allow plugins to close popups etc reset their UIs
+                    resetPluginsWithUI(this.getPluginInstances());
+                }
             },
             AfterRearrangeSelectedMapLayerEvent: function (event) {
                 this.afterRearrangeSelectedMapLayerEvent(event);
@@ -2122,7 +2126,7 @@ Oskari.clazz.define(
             } else {
                 element.remove();
             }
-            if (!keepContainerVisible && content.children().length === 0) {
+            if (!this.inLayerToolsEditMode() && content.children().length === 0) {
                 container.css('display', 'none');
             }
         },

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1308,7 +1308,7 @@ Oskari.clazz.define(
             const modeChanged = this.getMobileMode() !== isMobile;
             this.setMobileMode(isMobile);
             if (modeChanged) {
-                // previously called redrawUI() -> now calls changeToolStyle()
+                // previously called redrawUI() -> now calls refresh()
                 refreshPluginsWithUI(this.getPluginInstances());
             }
         },

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -2147,16 +2147,16 @@ Oskari.clazz.define(
                 // not found
                 return null;
             }
-            // let the actual layerplugins find the layer since the name depends on
-            // type
-            return Object.values(this.getLayerPlugins()).map(plugin => {
-                if (!plugin || typeof plugin.getOLMapLayers !== 'function') {
-                    // can there be null plugins?
-                    return [];
-                }
-                return plugin.getOLMapLayers(layer) || [];
-            })
-            .flatMap(layers => layers);
+            // let the actual layerplugins find the layer since the impl depends on type
+            return Object.values(this.getLayerPlugins())
+                .map(plugin => {
+                    if (!plugin || typeof plugin.getOLMapLayers !== 'function') {
+                        // can there be null plugins?
+                        return [];
+                    }
+                    return plugin.getOLMapLayers(layer) || [];
+                })
+                .flatMap(layers => layers);
         },
         /**
          * Adds the layer to the map through the correct plugin for the layer's type.

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -2114,10 +2114,9 @@ Oskari.clazz.define(
          * @method removeMapControlPlugin
          * Removes a map control plugin instance from the map DOM
          * @param  {Object} element Control container (jQuery)
-         * @param  {Boolean} keepContainerVisible Keep container visible even if there's no children left.
          * @param {Boolean} detachOnly true to detach and preserve event handlers, false to remove element
          */
-        removeMapControlPlugin: function (element, keepContainerVisible, detachOnly) {
+        removeMapControlPlugin: function (element, detachOnly) {
             var container = element.parents('.mapplugins');
             var content = element.parents('.mappluginsContent');
             // TODO take this into use in all UI plugins so we can hide unused containers...
@@ -2126,7 +2125,7 @@ Oskari.clazz.define(
             } else {
                 element.remove();
             }
-            if (!this.inLayerToolsEditMode() && content.children().length === 0) {
+            if (!this.isInLayerToolsEditMode() && content.children().length === 0) {
                 container.css('display', 'none');
             }
         },

--- a/bundles/mapping/mapmodule/AbstractMapModule.test.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.test.js
@@ -14,13 +14,13 @@ const dummyPlugin = {
     register: () => {},
     setMapModule: () => {}
 };
-let changeStyleCalls = 0;
+let refreshCalls = 0;
 const nonUIPlugin = {
     getName: () => 'Non UI plugin',
     register: () => {},
     setMapModule: () => {},
     hasUI: () => false,
-    changeToolStyle: () => { changeStyleCalls++; },
+    refresh: () => { refreshCalls++; },
     getIndex: () => 10
 };
 const uiPlugin = {
@@ -28,7 +28,7 @@ const uiPlugin = {
     register: () => {},
     setMapModule: () => {},
     hasUI: () => true,
-    changeToolStyle: () => { changeStyleCalls++; },
+    refresh: () => { refreshCalls++; },
     getIndex: () => 20
 };
 afterAll(() => mapModule.stop());
@@ -40,15 +40,15 @@ describe('MapModule', () => {
     test('has 3 plugins', () => {
         expect(Object.keys(mapModule.getPluginInstances()).length).toEqual(3);
     });
-    describe('changeToolStyle', () => {
+    describe('refresh', () => {
         test('only called for plugin with UI and with value [undefined]', () => {
             mapModule.setMapTheme();
-            expect(changeStyleCalls).toEqual(1);
-            expect(changeStyleCalls[0]).toBeUndefined();
+            expect(refreshCalls).toEqual(1);
+            expect(refreshCalls[0]).toBeUndefined();
         });
         test('only called for plugin with UI and with style "3d-light" and font [undefined]', () => {
             mapModule.setMapTheme({ primary: '#FFFFFF' });
-            expect(changeStyleCalls).toEqual(2);
+            expect(refreshCalls).toEqual(2);
         });
     });
     describe('_getSortedPlugins', () => {

--- a/bundles/mapping/mapmodule/plugin/AbstractMapLayerPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/AbstractMapLayerPlugin.js
@@ -66,7 +66,6 @@ Oskari.clazz.define(
          * @method hasUI
          * This plugin doesn't have an UI that we would want to ever hide so always returns false
          *
-         *
          * @return {Boolean}
          */
         hasUI: function () {

--- a/bundles/mapping/mapmodule/plugin/AbstractMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/AbstractMapModulePlugin.js
@@ -180,19 +180,10 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.AbstractMapModulePlugin',
 
         _setLayerToolsEditMode: function (isInEditMode) {
             this._isInLayerToolsEditMode = isInEditMode;
-            this._setLayerToolsEditModeImpl();
             if (this.isFixedLocation()) {
                 this.handleDragDisabled();
             }
         },
-
-        /**
-         * @method _setLayerToolsEditModeImpl
-         * Called after layerToolsEditMode is set, implement if needed.
-         *
-         *
-         */
-        _setLayerToolsEditModeImpl: function () {},
 
         /**
          * @method handleDragDisabled
@@ -243,9 +234,6 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.AbstractMapModulePlugin',
             } catch (e) {
                 Oskari.log('AbstractMapModulePlugin').error('Error starting plugin impl ' + this.getName());
             }
-            // Make sure plugin's edit mode is set correctly
-            // (we might already be in edit mode)
-            this._setLayerToolsEditMode(this.getMapModule().isInLayerToolsEditMode());
             return waitingForToolbar;
         },
 
@@ -378,7 +366,14 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.AbstractMapModulePlugin',
         hasUI: function () {
             return false;
         },
-
+        isShouldStopForPublisher: function () {
+            return this.hasUI();
+        },
+        // Note! This is only called by mapmodule when it LayerToolsEditModeEvent is received/publisher enters drag mode
+        // This provides a hook for plugins to close their popups etc
+        resetUI: function () {
+            // map module should call this when for example publisher goes to dragging mode
+        },
         /**
          * @public @method onEvent
          * Event is handled forwarded to correct #eventHandlers if found or

--- a/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
@@ -96,7 +96,6 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
             var mapModule = this.getMapModule();
             mapModule.removeMapControlPlugin(
                 element,
-                this.inLayerToolsEditMode(),
                 !!preserve
             );
             if (!preserve) {

--- a/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
@@ -1,4 +1,5 @@
 import './AbstractMapModulePlugin';
+// import { AbstractMapPlugin } from './AbstractMapPlugin';
 /**
  * @class Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin
  */

--- a/bundles/mapping/mapmodule/plugin/fullscreen/FullScreen.js
+++ b/bundles/mapping/mapmodule/plugin/fullscreen/FullScreen.js
@@ -64,13 +64,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugi
         },
 
         /**
-         * @public @method changeToolStyle
-         * Changes the tool style of the plugin
-         */
-        changeToolStyle: function () {
-            this.refresh();
-        },
-        /**
          * Handle plugin UI and change it when desktop / mobile mode
          * @method  @public createPluginUI
          * @param  {Boolean} mapInMobileMode is map in mobile mode

--- a/bundles/mapping/mapmodule/plugin/fullscreen/FullScreen.js
+++ b/bundles/mapping/mapmodule/plugin/fullscreen/FullScreen.js
@@ -105,11 +105,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugi
                     icon={isFullscreen ? <FullscreenExitOutlined /> : <FullscreenOutlined />}
                     iconActive={isFullscreen}
                     onClick={() => {
-                        if (!this.inLayerToolsEditMode()) {
-                            this.setState({
-                                fullscreen: !isFullscreen
-                            });
-                        }
+                        this.setState({
+                            fullscreen: !isFullscreen
+                        });
                     }}
                     position={this.getLocation()}
                 />

--- a/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol.js
@@ -38,7 +38,7 @@ Oskari.clazz.define(
     {
         _startPluginImpl: function () {
             this._element = this._createControlElement();
-            this.renderButton();
+            this.refresh();
             this.addToPluginContainer(this._element);
         },
         _stopPluginImpl: function () {
@@ -136,10 +136,7 @@ Oskari.clazz.define(
                 this._removeIndexMap();
             }
         },
-        changeToolStyle: function () {
-            this.renderButton();
-        },
-        renderButton: function () {
+        refresh: function () {
             let el = this.getElement();
             if (!el) {
                 return;

--- a/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol.js
@@ -162,7 +162,7 @@ Oskari.clazz.define(
                 el[0]
             );
         },
-        resetUI: function() {
+        resetUI: function () {
             if (this._indexMap) {
                 this._removeIndexMap();
             }

--- a/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/indexmap/IndexMapPlugin.ol.js
@@ -157,11 +157,7 @@ Oskari.clazz.define(
                 <div className={`indexmapToggle ${styleName}`}>
                     <MapModuleButton
                         className='t_indexmap'
-                        onClick={() => {
-                            if (!this.inLayerToolsEditMode()) {
-                                this._handleClick();
-                            }
-                        }}
+                        onClick={() => this._handleClick()}
                         size='48px'
                         icon={<div className='icon' />}
                     />
@@ -169,20 +165,11 @@ Oskari.clazz.define(
                 el[0]
             );
         },
-        _setLayerToolsEditModeImpl: function () {
-            const el = this.getElement();
-            if (!el) {
-                return;
-            }
-
-            if (this.inLayerToolsEditMode()) {
-                // close map
-                if (this._indexMap) {
-                    this._removeIndexMap();
-                }
+        resetUI: function() {
+            if (this._indexMap) {
+                this._removeIndexMap();
             }
         }
-
     },
     {
         extend: ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],

--- a/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPlugin.js
@@ -31,7 +31,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionP
         me._showMetadata = !!this.getConfig().showMetadata;
         me._layers = [];
         me._baseLayers = [];
-        me.inMobileMode = false;
     }, {
         _toggleToolState: function () {
             if (this.popupControls) {
@@ -58,7 +57,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionP
                 (layerId, style) => this._selectStyle(layerId, style),
                 this.getLocation()
             );
-            this.renderButton(null, null);
+            this.refresh();
         },
         _updateLayerSelectionPopup: function () {
             if (!this.popupControls) {
@@ -78,7 +77,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionP
             this.popupControls = null;
             const div = this.getElement();
             if (!div) return;
-            this.renderButton(null, null);
+            this.refresh();
         },
         /**
          * @private @method _initImpl
@@ -346,36 +345,16 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionP
             }
 
             this.teardownUI();
-
-            this.inMobileMode = mapInMobileMode;
-
             this._element = this._createControlElement();
             this.refresh();
             this.addToPluginContainer(this._element);
         },
 
         refresh: function () {
-            const me = this;
-            const conf = me.getConfig();
-            this._updateLayerSelectionPopup();
-            if (!conf) {
+            let el = this.getElement();
+            if (!el) {
                 return;
             }
-            me.renderButton();
-        },
-
-        /**
-         * Changes the tool style of the plugin
-         *
-         * @method changeToolStyle
-         */
-        changeToolStyle: function () {
-            this.renderButton();
-        },
-
-        renderButton: function () {
-            let el = this.getElement();
-            if (!el) return;
 
             ReactDOM.render(
                 <MapModuleButton

--- a/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPlugin.js
@@ -154,13 +154,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionP
                 me.layerContent.find('div.layers-content').css('max-height', (0.75 * size.height) + 'px');
             }
         },
-        _setLayerToolsEditModeImpl: function () {
-            if (!this.getElement()) {
-                return;
-            }
-            if (this.inLayerToolsEditMode()) {
-                this.popupCleanup();
-            }
+        resetUI: function() {
+            this.popupCleanup();
         },
 
         /**
@@ -375,15 +370,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionP
          * @method changeToolStyle
          */
         changeToolStyle: function () {
-            if (!this.getElement()) {
-                return;
-            }
-
             this.renderButton();
-
-            this._setLayerToolsEditMode(
-                this.getMapModule().isInLayerToolsEditMode()
-            );
         },
 
         renderButton: function () {
@@ -395,11 +382,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionP
                     className='t_layerselect'
                     icon={<LayersIcon />}
                     title={this._loc.title}
-                    onClick={(e) => {
-                        if (!this.inLayerToolsEditMode()) {
-                            this._togglePopup();
-                        }
-                    }}
+                    onClick={(e) => this._togglePopup()}
                     iconActive={this.popupControls ? true : false}
                     position={this.getLocation()}
                 />,

--- a/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/layers/LayerSelectionPlugin.js
@@ -153,7 +153,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionP
                 me.layerContent.find('div.layers-content').css('max-height', (0.75 * size.height) + 'px');
             }
         },
-        resetUI: function() {
+        resetUI: function () {
             this.popupCleanup();
         },
 

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -38,7 +38,7 @@ Oskari.clazz.define(
          * we are returning false to stay on screen for the duration of publisher.
          * @returns false
          */
-        hasUI: function () {
+        isShouldStopForPublisher: function () {
             return false;
         },
         getService: function () {
@@ -135,23 +135,9 @@ Oskari.clazz.define(
             };
         },
 
-        /**
-         * @method _setLayerToolsEditModeImpl
-         * Called after layerToolsEditMode is set.
-         *
-         *
-         */
-        _setLayerToolsEditModeImpl: function () {
-            var me = this;
-            // TODO document why this is done...
-            if (!me.inLayerToolsEditMode() && me.getElement()) {
-                me.setLocation(
-                    me.getElement().parents('.mapplugins').attr(
-                        'data-location'
-                    )
-                );
-            } else if (me._popupControls) {
-                me.clearPopup();
+        resetUI: function() {
+            if (this._popupControls) {
+                this.clearPopup();
             }
         },
 
@@ -190,7 +176,7 @@ Oskari.clazz.define(
                 id: 'logo',
                 src: logoUrl,
                 callback: () => {
-                    if (!this.inLayerToolsEditMode() && geoportalLink) {
+                    if (geoportalLink) {
                         const mapUrl = this.__getMapUrl();
                         const linkParams = this.getSandbox().generateMapLinkParameters({});
                         window.open(mapUrl + linkParams, '_blank');
@@ -222,9 +208,7 @@ Oskari.clazz.define(
                 id: 'terms',
                 callback: function (evt) {
                     evt.preventDefault();
-                    if (!me.inLayerToolsEditMode()) {
-                        window.open(termsUrl, '_blank');
-                    }
+                    window.open(termsUrl, '_blank');
                 }
             };
 
@@ -242,9 +226,9 @@ Oskari.clazz.define(
             var options = {
                 id: 'data-sources',
                 callback: function (e) {
-                    if (!me.inLayerToolsEditMode() && !me._popupControls) {
-                        me._openDataSourcesDialog(e.target);
-                    } else if (me._popupControls) {
+                    if (!me._popupControls) {
+                        me._openDataSourcesDialog();
+                    } else {
                         me.clearPopup();
                     }
                 }

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -135,7 +135,7 @@ Oskari.clazz.define(
             };
         },
 
-        resetUI: function() {
+        resetUI: function () {
             if (this._popupControls) {
                 this.clearPopup();
             }

--- a/bundles/mapping/mapmodule/plugin/mylocation/MyLocationPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/mylocation/MyLocationPlugin.js
@@ -92,11 +92,7 @@ Oskari.clazz.define(
                     className='t_mylocation'
                     icon={<AimOutlined />}
                     title={this.loc('plugin.MyLocationPlugin.tooltip')}
-                    onClick={(e) => {
-                        if (!this.inLayerToolsEditMode()) {
-                            this._setupRequest();
-                        }
-                    }}
+                    onClick={() => this._setupRequest()}
                     position={this.getLocation()}
                 />
                 ,

--- a/bundles/mapping/mapmodule/plugin/mylocation/MyLocationPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/mylocation/MyLocationPlugin.js
@@ -73,13 +73,6 @@ Oskari.clazz.define(
             this._setTracking(false);
         },
         /**
-         * @public @method changeToolStyle
-         * Changes the tool style of the plugin
-         */
-        changeToolStyle: function () {
-            this.refresh();
-        },
-        /**
          * @public @method refresh
          */
         refresh: function () {

--- a/bundles/mapping/mapmodule/plugin/panbuttons/PanButtons.js
+++ b/bundles/mapping/mapmodule/plugin/panbuttons/PanButtons.js
@@ -18,7 +18,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
      *
      *
      */
-    function (config) {
+    function () {
         this._clazz =
             'Oskari.mapframework.bundle.mapmodule.plugin.PanButtons';
         this._defaultLocation = 'top right';
@@ -65,26 +65,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
             const pxY = this._panPxs * y;
             this.getMapModule().panMapByPixels(pxX, pxY, true);
         },
-        /**
-         * @public  @method _refresh
-         * Called after a configuration change.
-         *
-         *
-         */
         refresh: function () {
-            this.renderButton();
-        },
-
-        /**
-         * @method changeToolStyle
-         * Changes the tool style of the plugin
-         */
-        changeToolStyle: function () {
-            this.renderButton();
-        },
-        renderButton: function () {
             let el = this.getElement();
-            if (!el) return;
+            if (!el) {
+                return;
+            }
 
             ReactDOM.render(
                 <ThemeProvider value={this.getMapModule().getMapTheme()}>
@@ -140,7 +125,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
                 showArrows: !!showArrows
             });
             this.showArrows = !!showArrows;
-            this.renderButton(null, null);
+            this.refresh();
         }
     }, {
         'extend': ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],

--- a/bundles/mapping/mapmodule/plugin/panbuttons/PanButtons.js
+++ b/bundles/mapping/mapmodule/plugin/panbuttons/PanButtons.js
@@ -50,9 +50,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
             this.resetPopup = null;
         },
         _resetClicked: function () {
-            if (this.inLayerToolsEditMode()) {
-                return;
-            }
             if (this.resetPopup) return;
             const cb = () => {
                 if (this.getSandbox().hasHandler('StateHandler.SetStateRequest')) {
@@ -64,9 +61,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
             this.resetPopup = showResetPopup(() => cb(), () => this.clearPopup());
         },
         _panClicked: function (x, y) {
-            if (this.inLayerToolsEditMode()) {
-                return;
-            }
             const pxX = this._panPxs * x;
             const pxY = this._panPxs * y;
             this.getMapModule().panMapByPixels(pxX, pxY, true);

--- a/bundles/mapping/mapmodule/plugin/publishertoolbar/PublisherToolbarPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/publishertoolbar/PublisherToolbarPlugin.js
@@ -10,7 +10,6 @@ import './request/ToolContainerRequestHandler';
 /**
  * @class Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolbarPlugin
  * Provides publisher toolbar container
- * See http://www.oskari.org/trac/wiki/DocumentationBundleMapModulePublisherToolbarPlugin
  */
 Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolbarPlugin',
     /**
@@ -26,21 +25,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolba
         me._index = 2;
         me._name = 'PublisherToolbarPlugin';
         me._toolButtons = conf.buttons || [];
-        me.inMobileMode = false;
     }, {
         // templates for tools-mapplugin
         templates: {
             main: '<div class="mapplugin tools"></div>'
-        },
-
-        /**
-         * @private @method _initImpl
-         * Interface method for the module protocol.
-         *
-         *
-         */
-        _initImpl: function () {
-            this.inMobileMode = false;
         },
 
         _createRequestHandlers: function () {
@@ -63,27 +51,27 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolba
                 const toolbarRequest = Oskari.requestBuilder('Toolbar.SelectToolButtonRequest')(null, 'PublisherToolbar-basictools');
                 sb.request(this, toolbarRequest);
                 this.activeTool = undefined;
-                this.renderButton();
+                this.refresh();
                 return;
             }
             const toolRequest = Oskari.requestBuilder('ToolSelectionRequest')(requestName);
             sb.request(this, toolRequest);
             this.activeTool = tool;
-            this.renderButton();
+            this.refresh();
         },
 
         addToolButton: function (name) {
             if (this._toolButtons.indexOf(name) < 0) {
                 this._toolButtons.push(name);
             }
-            this.renderButton();
+            this.refresh();
         },
         removeToolButton: function (name) {
             const index = this._toolButtons.indexOf(name);
             if (index > -1) {
                 this._toolButtons.splice(index, 1);
             }
-            this.renderButton();
+            this.refresh();
         },
 
         /**
@@ -105,7 +93,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolba
          * @param {Boolean} forced application has started and ui should be rendered with assets that are available
          */
         redrawUI: function (mapInMobileMode, forced) {
-            var isMobile = mapInMobileMode || Oskari.util.isMobile();
             if (!this.isVisible()) {
                 // no point in drawing the ui if we are not visible
                 return;
@@ -113,14 +100,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolba
 
             var me = this;
             this.teardownUI();
-            this.inMobileMode = isMobile;
 
             me._element = me._createControlElement();
             this.addToPluginContainer(me._element);
-            this.renderButton();
+            this.refresh();
         },
 
-        renderButton: function () {
+        refresh: function () {
             let el = this.getElement();
             if (!el) {
                 return;
@@ -220,15 +206,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolba
                 }
             });
             return buttons;
-        },
-
-        /**
-         * Changes the tool style of the plugin
-         *
-         * @method changeToolStyle
-         */
-        changeToolStyle: function () {
-            this.redrawUI();
         },
 
         _isPublisherActive: function () {

--- a/bundles/mapping/mapmodule/plugin/publishertoolbar/PublisherToolbarPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/publishertoolbar/PublisherToolbarPlugin.js
@@ -63,36 +63,27 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolba
                 const toolbarRequest = Oskari.requestBuilder('Toolbar.SelectToolButtonRequest')(null, 'PublisherToolbar-basictools');
                 sb.request(this, toolbarRequest);
                 this.activeTool = undefined;
-                this.renderButton(null, null);
+                this.renderButton();
                 return;
             }
             const toolRequest = Oskari.requestBuilder('ToolSelectionRequest')(requestName);
             sb.request(this, toolRequest);
             this.activeTool = tool;
-            this.renderButton(null, null);
-        },
-
-        _setLayerToolsEditModeImpl: function () {
-            if (!this.getElement()) {
-                return;
-            }
-            if (this.inLayerToolsEditMode()) {
-                this.renderButton(null, null);
-            }
+            this.renderButton();
         },
 
         addToolButton: function (name) {
             if (this._toolButtons.indexOf(name) < 0) {
                 this._toolButtons.push(name);
             }
-            this.renderButton(null, null);
+            this.renderButton();
         },
         removeToolButton: function (name) {
             const index = this._toolButtons.indexOf(name);
             if (index > -1) {
                 this._toolButtons.splice(index, 1);
             }
-            this.renderButton(null, null);
+            this.renderButton();
         },
 
         /**
@@ -131,7 +122,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PublisherToolba
 
         renderButton: function () {
             let el = this.getElement();
-            if (!el) return;
+            if (!el) {
+                return;
+            }
 
             ReactDOM.render(
                 <MapModuleButton

--- a/bundles/mapping/mapmodule/plugin/search/SearchPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/search/SearchPlugin.js
@@ -49,19 +49,6 @@ Oskari.clazz.define(
         },
 
         refresh: function () {
-            this.changeToolStyle();
-        },
-
-        /**
-         * Changes the tool style of the plugin
-         *
-         * @method changeToolStyle
-         */
-        changeToolStyle: function () {
-            this.renderSearchBar();
-        },
-
-        renderSearchBar: function () {
             let el = this.getElement();
             if (!el) {
                 return;

--- a/bundles/mapping/mapmodule/plugin/search/SearchPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/search/SearchPlugin.js
@@ -38,13 +38,6 @@ Oskari.clazz.define(
             this.template = jQuery('<div class="mapplugin search default-search-div" />');
             this.inMobileMode = false;
         },
-        _setLayerToolsEditModeImpl: function () {
-            const el = this.getElement();
-            if (!el) {
-                return;
-            }
-            this.renderSearchBar(!!this.inLayerToolsEditMode());
-        },
 
         /**
          * @private @method _createControlElement
@@ -65,18 +58,14 @@ Oskari.clazz.define(
          * @method changeToolStyle
          */
         changeToolStyle: function () {
-            if (!this.getElement()) {
-                return;
-            }
             this.renderSearchBar();
-            this._setLayerToolsEditMode(
-                this.getMapModule().isInLayerToolsEditMode()
-            );
         },
 
-        renderSearchBar: function (disabled = false) {
+        renderSearchBar: function () {
             let el = this.getElement();
-            if (!el) return;
+            if (!el) {
+                return;
+            }
             if (!this.handler) {
                 // init handler here so we can be sure we have a sandbox for this instance
                 this.handler = new SearchHandler(this);
@@ -88,7 +77,6 @@ Oskari.clazz.define(
                     <SearchBar
                         state={this.handler.getState()}
                         controller={this.handler.getController()}
-                        disabled={disabled}
                         placeholder={this.fieldPlaceHolder}
                     />
                 </ThemeProvider>,

--- a/bundles/mapping/mapmodule/plugin/zoombar/Portti2Zoombar.js
+++ b/bundles/mapping/mapmodule/plugin/zoombar/Portti2Zoombar.js
@@ -68,7 +68,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar'
                 }
             };
         },
-        _setLayerToolsEditModeImpl: function () {},
         /**
          * @public @method changeToolStyle
          * Changes the tool style of the plugin

--- a/bundles/mapping/mapmodule/plugin/zoombar/Portti2Zoombar.js
+++ b/bundles/mapping/mapmodule/plugin/zoombar/Portti2Zoombar.js
@@ -51,7 +51,20 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar'
          * Called after a configuration change.
          */
         refresh: function () {
-            this.renderButton();
+            const el = this.getElement();
+            if (!el) {
+                return;
+            }
+
+            ReactDOM.render(
+                <ZoomSlider
+                    changeZoom={(value) => this.getMapModule().setZoomLevel(value)}
+                    zoom={this.getMapModule().getMapZoom()}
+                    maxZoom={this.getMapModule().getMaxZoomLevel()}
+                    isMobile={this.inMobileMode}
+                />,
+                el[0]
+            );
         },
 
         /**
@@ -64,34 +77,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar'
             var me = this;
             return {
                 AfterMapMoveEvent: function () {
-                    me.renderButton();
+                    me.refresh();
                 }
             };
-        },
-        /**
-         * @public @method changeToolStyle
-         * Changes the tool style of the plugin
-         *
-         * @param {Object} styleId
-         * @param {jQuery} div
-         *
-         */
-        changeToolStyle: function () {
-            this.renderButton();
-        },
-        renderButton: function () {
-            const el = this.getElement();
-            if (!el) return;
-
-            ReactDOM.render(
-                <ZoomSlider
-                    changeZoom={(value) => this.getMapModule().setZoomLevel(value)}
-                    zoom={this.getMapModule().getMapZoom()}
-                    maxZoom={this.getMapModule().getMaxZoomLevel()}
-                    isMobile={this.inMobileMode}
-                />,
-                el[0]
-            );
         },
         teardownUI: function () {
             this.removeFromPluginContainer(this.getElement());
@@ -113,7 +101,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar'
             this.inMobileMode = mapInMobileMode;
 
             me._element = me._createControlElement();
-            this.renderButton();
+            this.refresh();
             this.addToPluginContainer(me._element);
         },
         /**

--- a/bundles/mapping/mapmodule/util/PluginContainerHelper.js
+++ b/bundles/mapping/mapmodule/util/PluginContainerHelper.js
@@ -1,0 +1,31 @@
+
+export const PLUGIN_CONTAINER_CLASSES = [
+    'bottom center',
+    'center top',
+    'center right',
+    'center left',
+    'bottom right',
+    'bottom left',
+    'right top',
+    'left top'
+];
+
+export const createPluginContainerElement = (containerClasses) => {
+    const containerDiv = jQuery(
+        `<div class="mapplugins">
+            <div class="mappluginsContainer">
+            <div class="mappluginsContent"></div>
+            </div>
+        </div>`);
+
+    containerDiv.addClass(containerClasses);
+    containerDiv.attr('data-location', containerClasses);
+    return containerDiv;
+};
+
+// assumes jQuery is present and mapEl is a jQuery object to #mapdiv
+export const generatePluginContainers = (mapEl) => {
+    PLUGIN_CONTAINER_CLASSES
+        .map(cssClasses => createPluginContainerElement(cssClasses))
+        .forEach(jQueryEl => mapEl.append(jQueryEl));
+};

--- a/bundles/mapping/mapmodule/util/PluginHelper.js
+++ b/bundles/mapping/mapmodule/util/PluginHelper.js
@@ -33,7 +33,17 @@ export const refreshPluginsWithUI = (pluginInstances = {}) => {
     return getPluginsWithUI(pluginInstances).forEach((plugin) => {
         if (typeof plugin.changeToolStyle === 'function') {
             // TODO: is this the function that we should use?
+            // TODO: call refresh()
             plugin.changeToolStyle();
+        }
+    });
+};
+
+export const resetPluginsWithUI = (pluginInstances = {}) => {
+    return getPluginsWithUI(pluginInstances).forEach((plugin) => {
+        if (typeof plugin.resetUI === 'function') {
+            // TODO: is this the function that we should use?
+            plugin.resetUI();
         }
     });
 };

--- a/bundles/mapping/mapmodule/util/PluginHelper.js
+++ b/bundles/mapping/mapmodule/util/PluginHelper.js
@@ -31,10 +31,8 @@ export const getPluginsWithUI = (pluginInstances = {}) => {
 
 export const refreshPluginsWithUI = (pluginInstances = {}) => {
     return getPluginsWithUI(pluginInstances).forEach((plugin) => {
-        if (typeof plugin.changeToolStyle === 'function') {
-            // TODO: is this the function that we should use?
-            // TODO: call refresh()
-            plugin.changeToolStyle();
+        if (typeof plugin.refresh === 'function') {
+            plugin.refresh();
         }
     });
 };

--- a/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
+++ b/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
@@ -78,26 +78,10 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
         rotateIcon: function (degrees) {
             this._renderButton(degrees);
         },
-        _renderButton: function (degrees = this.getDegrees()) {
-            let el = this.getElement();
-            if (!el) return;
-
-            ReactDOM.render(
-                <MapModuleButton
-                    className='t_maprotator'
-                    title={this._locale.tooltip.tool}
-                    icon={<StyledIcon degrees={degrees || 0}><NorthIcon /></StyledIcon>}
-                    onClick={() => this.setRotation(0)}
-                    iconActive={degrees !== 0}
-                    position={this.getLocation()}
-                />,
-                el[0]
-            );
-        },
         _createUI: function () {
             this._element = this._createControlElement();
             this.setDegrees(this.getRotation());
-            this._renderButton();
+            this.refresh();
             this.handleEvents();
             this.addToPluginContainer(this._element);
         },
@@ -116,12 +100,26 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
             var deg = Math.round(rot * 573) / 10;
             return deg;
         },
-        /**
-         * @public @method changeToolStyle
-         * Changes the tool style of the plugin
-         */
-        changeToolStyle: function () {
+        refresh: function () {
             this._renderButton();
+        },
+        _renderButton: function (degrees = this.getDegrees()) {
+            let el = this.getElement();
+            if (!el) {
+                return;
+            }
+
+            ReactDOM.render(
+                <MapModuleButton
+                    className='t_maprotator'
+                    title={this._locale.tooltip.tool}
+                    icon={<StyledIcon degrees={degrees || 0}><NorthIcon /></StyledIcon>}
+                    onClick={() => this.setRotation(0)}
+                    iconActive={degrees !== 0}
+                    position={this.getLocation()}
+                />,
+                el[0]
+            );
         },
         /**
          * Create event handlers.
@@ -151,7 +149,6 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
          */
         redrawUI: function (mapInMobileMode) {
             // we don't need to do anything here any more
-            // FIXME: remove calls to this OR changeToolStyle() and use one function to update UI
         },
         teardownUI: function () {
             // detach old element from screen

--- a/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
+++ b/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
@@ -87,11 +87,7 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
                     className='t_maprotator'
                     title={this._locale.tooltip.tool}
                     icon={<StyledIcon degrees={degrees || 0}><NorthIcon /></StyledIcon>}
-                    onClick={() => {
-                        if (!this.inLayerToolsEditMode()) {
-                            this.setRotation(0);
-                        }
-                    }}
+                    onClick={() => this.setRotation(0)}
                     iconActive={degrees !== 0}
                     position={this.getLocation()}
                 />,

--- a/bundles/mapping/time-control-3d/plugin/TimeControl3dPlugin.js
+++ b/bundles/mapping/time-control-3d/plugin/TimeControl3dPlugin.js
@@ -45,15 +45,9 @@ class TimeControl3dPlugin extends BasicMapModulePlugin {
         this._toolOpen = bln;
         this.renderButton();
     }
-    _setLayerToolsEditModeImpl () {
-        const el = this.getElement();
-        if (!el) {
-            return;
-        }
-        if (this.inLayerToolsEditMode()) {
-            if (this.isOpen()) {
-                this._toggleToolState();
-            }
+    resetUI () {
+        if (this.isOpen()) {
+            this._toggleToolState();
         }
     }
     /**
@@ -147,31 +141,21 @@ class TimeControl3dPlugin extends BasicMapModulePlugin {
     }
 
     changeToolStyle () {
-        const el = this.getElement();
-        if (!el) {
-            return;
-        }
-
         this.renderButton();
-        this._setLayerToolsEditMode(
-            this.getMapModule().isInLayerToolsEditMode()
-        );
     }
 
     renderButton () {
         const el = this.getElement();
-        if (!el) return;
+        if (!el) {
+            return;
+        }
 
         ReactDOM.render(
             <MapModuleButton
                 className='t_timecontrol'
                 title={this.loc('tooltip')}
                 icon={<ControlIcon isMobile={this._isMobile} controlIsActive={this.isOpen()} />}
-                onClick={() => {
-                    if (!this.inLayerToolsEditMode()) {
-                        this._toggleToolState();
-                    }
-                }}
+                onClick={() => this._toggleToolState()}
                 iconActive={this.isOpen()}
             />,
             el.get(0)

--- a/bundles/mapping/time-control-3d/plugin/TimeControl3dPlugin.js
+++ b/bundles/mapping/time-control-3d/plugin/TimeControl3dPlugin.js
@@ -43,7 +43,7 @@ class TimeControl3dPlugin extends BasicMapModulePlugin {
     }
     setOpen (bln) {
         this._toolOpen = bln;
-        this.renderButton();
+        this.refresh();
     }
     resetUI () {
         if (this.isOpen()) {
@@ -66,7 +66,7 @@ class TimeControl3dPlugin extends BasicMapModulePlugin {
             this._createUI(forced);
         }
 
-        this.changeToolStyle();
+        this.refresh();
     }
 
     _createEventHandlers () {
@@ -110,7 +110,7 @@ class TimeControl3dPlugin extends BasicMapModulePlugin {
         let el;
         el = this._createControlElement();
         this.addToPluginContainer(el);
-        this.renderButton();
+        this.refresh();
     }
     _createControlElement () {
         const el = this._mountPoint.clone();
@@ -126,25 +126,7 @@ class TimeControl3dPlugin extends BasicMapModulePlugin {
             popup.close(true);
         }
     }
-
-    render () {
-        const popupContent = this._popupTemplate.clone();
-        ReactDOM.render(
-            <LocaleProvider value={{ bundleKey: 'TimeControl3d' }}>
-                <TimeControl3d {... this.stateHandler.getState()}
-                    controller={this.stateHandler.getController()}
-                    isMobile = {Oskari.util.isMobile()}
-                />
-            </LocaleProvider>,
-            popupContent.get(0));
-        this._popupContent = popupContent;
-    }
-
-    changeToolStyle () {
-        this.renderButton();
-    }
-
-    renderButton () {
+    refresh () {
         const el = this.getElement();
         if (!el) {
             return;
@@ -162,6 +144,19 @@ class TimeControl3dPlugin extends BasicMapModulePlugin {
         );
     }
 
+    renderPopup () {
+        const popupContent = this._popupTemplate.clone();
+        ReactDOM.render(
+            <LocaleProvider value={{ bundleKey: 'TimeControl3d' }}>
+                <TimeControl3d {... this.stateHandler.getState()}
+                    controller={this.stateHandler.getController()}
+                    isMobile = {Oskari.util.isMobile()}
+                />
+            </LocaleProvider>,
+            popupContent.get(0));
+        this._popupContent = popupContent;
+    }
+
     _showPopup () {
         const me = this;
         const popupTitle = this.loc('title');
@@ -169,14 +164,14 @@ class TimeControl3dPlugin extends BasicMapModulePlugin {
         const popupService = this.getSandbox().getService('Oskari.userinterface.component.PopupService');
 
         this._popup = popupService.createPopup();
-        this.render();
+        this.renderPopup();
 
         // create close icon
         this._popup.createCloseIcon();
         this._popup.onClose(function () {
             me.unmountReactPopup();
             me.setOpen(false);
-            me.renderButton(null, null);
+            me.refresh();
         });
 
         const theme = mapmodule.getMapTheme();
@@ -203,7 +198,7 @@ class TimeControl3dPlugin extends BasicMapModulePlugin {
         }
         this._popup.moveTo(elem, popupLocation, true);
         this.setOpen(true);
-        this.renderButton(null, null);
+        this.refresh();
     }
 }
 

--- a/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
@@ -22,10 +22,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
         this._defaultLocation = 'right bottom';
         me._fixedLocation = true;
         me._name = 'ClassificationPlugin';
-        // for publisher dragndrop to work needs to have at least:
-        // -  mapplugin-class in parent template
-        // - _setLayerToolsEditModeImpl()
-        // - publisher tool needs to implement getPlugin()
 
         me.log = Oskari.log('Oskari.statistics.statsgrid.ClassificationPlugin');
         Oskari.makeObservable(this);

--- a/bundles/statistics/statsgrid2016/plugin/SeriesControlPlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/SeriesControlPlugin.js
@@ -33,10 +33,13 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SeriesControlPlugin',
             this.element ? this.teardownUI() : this._buildUI();
             return !!this.element;
         },
-        hasUI: function () {
-            // Plugin has ui element but returns false, because
-            // otherwise publisher would stop this plugin and start it again when leaving the publisher,
-            // instance updates visibility
+        /**
+         * While this plugin DOES have a UI we don't want publisher stopping it on startup so
+         * we are returning false to stay on screen for the duration of publisher.
+         * The instance updates visibility
+         * @returns false
+         */
+        isShouldStopForPublisher: function () {
             return false;
         },
         isVisible: function () {

--- a/bundles/statistics/statsgrid2016/plugin/TogglePlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/TogglePlugin.js
@@ -24,7 +24,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.TogglePlugin', function (flyout
     this.flyoutManager.on('hide', function (tool) {
         me.toggleTool(tool, false);
     });
-    this.handler = new PluginHandler(() => this.renderButtons());
+    this.handler = new PluginHandler(() => this.refresh());
 }, {
     getElement: function () {
         return this.element;
@@ -32,8 +32,18 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.TogglePlugin', function (flyout
     hasUI: function () {
         return true;
     },
-    changeToolStyle: function () {
-        this.renderButtons();
+    refresh: function () {
+        const el = this.getElement();
+        if (!el) {
+            return;
+        }
+
+        ReactDOM.render(
+            <ThematicControls
+                tools={this.handler.getState().plugins}
+            />,
+            el[0]
+        );
     },
     toggleTool: function (tool, shown) {
         this.handler.getController().toggleTool(tool, shown);
@@ -69,20 +79,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.TogglePlugin', function (flyout
         if (!this.element) {
             this.redrawUI();
         }
-    },
-    renderButtons: function (element) {
-        let el = element;
-        if (!el) {
-            el = this.getElement();
-        }
-        if (!el) return;
-
-        ReactDOM.render(
-            <ThematicControls
-                tools={this.handler.getState().plugins}
-            />,
-            el[0]
-        );
     },
     removeTool: function (toolId) {
         this.handler.getController().removeTool(toolId);

--- a/bundles/statistics/statsgrid2016/plugin/TogglePlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/TogglePlugin.js
@@ -26,7 +26,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.TogglePlugin', function (flyout
     });
     this.handler = new PluginHandler(() => this.renderButtons());
 }, {
-    _setLayerToolsEditModeImpl: function () {},
     getElement: function () {
         return this.element;
     },


### PR DESCRIPTION
Loads of changes to how mapmodule, publisher and plugins interact with each other.

`AbstractMapModulePlugin`:
Added: `resetUI()`, `isShouldStopForPublisher()`
Changed: `hasUI()`, `refresh()`
Removed: `_setLayerToolsEditModeImpl()`, `changeToolStyle()`, `inLayerToolsEditMode()`

- `resetUI()` is now a new map plugin API function. Plugins should implement it if they can open popups etc that should be closed when the user starts changing plugin locations in publisher functionality.
-  `isShouldStopForPublisher()` is now a new map plugin API function. This defaults to hasUI() call in the base class, but can be overridden in plugins when they don't want to be stopped by the publisher functionality. This is for those plugins that previously returned false from hasUI() even when they have a UI. 
- `hasUI()` is now used by map module to refresh the plugins that have an UI when for example the theme changes etc **Plugins should now return a truthful value if they do have an UI. See isShouldStopForPublisher()**
- `refresh()` is an existing map plugin API function that wasn't used consistently. The mapmodule now calls refresh() instead of changeToolStyle() for plugins when their UI needs to be updated.
- `_setLayerToolsEditModeImpl()` was used by some plugins to do the same as resetUI() is now intended to be used. With the current publisher changes, plugins should no longer care if the publisher is in the "plugin dragging mode" so this function is no longer called and was removed from the base class.
- `changeToolStyle()` has been removed from plugins as both changeToolStyle() and refresh() were essentially doing the same thing and it makes no sense anymore (toolstyles are now handled with theme).
- `inLayerToolsEditMode()` and _setLayerToolsEditMode() are due for removal as plugins no longer need to use it to detect if clicks should be handled or not. This is now handled outside plugins to make them easier to develop and remove noise from the code. The base class still has this, but it will be removed shortly.

All plugins under oskari-frontend that used these have been updated.

TODO: There is still a mixed bag of implementations using `plugin.redrawUI()` for some things instead of creating the UI on startPluginImpl() and updating it with refresh(). This is something that I intend to take a look at shortly.

