### PR TITLE
Mapmodule plugins

### DIFF
--- a/bundles/framework/featuredata2/plugin/FeatureDataButton.jsx
+++ b/bundles/framework/featuredata2/plugin/FeatureDataButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Tooltip } from 'oskari-ui';
+import { Button } from 'oskari-ui';
 import styled from 'styled-components';
 import { ThemeConsumer } from 'oskari-ui/util';
 import { getNavigationTheme } from 'oskari-ui/theme';
@@ -52,7 +52,10 @@ const ThemedButton = ThemeConsumer(({ theme = {}, active, ...rest }) => {
     );
 });
 
-export const FeatureDataButton = ({ icon, active, onClick, disabled, iconActive, position, loading, ...rest }) => {
+export const FeatureDataButton = ({ visible = true, icon, active, onClick, disabled, iconActive, position, loading, ...rest }) => {
+    if (!visible) {
+        return null;
+    }
     let marginRight = '0px';
     let marginLeft = '0px';
     if (position.includes('right')) {

--- a/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
+++ b/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
@@ -42,7 +42,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
             return this._instance;
         },
         _startPluginImpl: function () {
-            this._element = this._createControlElement();
+            this.setElement(this._createControlElement());
             this.addToPluginContainer(this.getElement());
         },
         /**
@@ -60,7 +60,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
          * @param {Boolean} forced application has started and ui should be rendered with assets that are available
          */
         redrawUI: function (mapInMobileMode, forced) {
-            this.teardownUI();
             this.refresh();
         },
 
@@ -97,7 +96,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
          * Updates the plugins interface (hides if no featuredata layer selected)
          */
         refresh: function () {
-            this.setVisible(this._hasFeaturedataLayers());
             this.renderButton();
         },
         showLoadingIndicator: function (blnLoad) {
@@ -112,6 +110,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
             ReactDOM.render(
                 <ThemeProvider value={this.getMapModule().getMapTheme()}>
                     <FeatureDataButton
+                        visible={this._hasFeaturedataLayers()}
                         icon={<Message messageKey='title' bundleKey='FeatureData2'/>}
                         onClick={() => this.openFlyout()}
                         active={this._flyoutOpen}

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1469,11 +1469,7 @@ Oskari.clazz.define(
          * @return {Boolean} true if a plugin with given name is registered to the map
          */
         isPluginActivated: function (pluginName) {
-            var plugin = this.getPluginInstances(pluginName);
-            if (plugin) {
-                return true;
-            }
-            return false;
+            return !!this.getPluginInstances(pluginName);
         },
         /**
          * @method registerPlugin

--- a/bundles/mapping/mapmodule/MapModuleButton.jsx
+++ b/bundles/mapping/mapmodule/MapModuleButton.jsx
@@ -17,7 +17,10 @@ const Container = styled('div')`
 const StyledButton = styled(MapButton)`
     z-index: 1;
 `;
-export const MapModuleButton = ({ title, icon, onClick, size = '32px', noMargin = false, iconActive = false, withToolbar = false, iconSize = '18px', className, children, disabled = false, position, toolbarDirection }) => {
+export const MapModuleButton = ({ visible = true, title, icon, onClick, size = '32px', noMargin = false, iconActive = false, withToolbar = false, iconSize = '18px', className, children, disabled = false, position, toolbarDirection }) => {
+    if (!visible) {
+        return null;
+    }
     const [toolbarOpen, setToolbarOpen] = useState(false);
 
     let toolbarOpenDirection = 'right';

--- a/bundles/mapping/mapmodule/plugin/AbstractMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/AbstractMapModulePlugin.js
@@ -13,14 +13,12 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.AbstractMapModulePlugin',
         var me = this;
         me._config = config || {};
         me._eventHandlers = {};
-        me._isInLayerToolsEditMode = false;
         me._loc = {};
         me._mapModule = null;
         me._name = 'AbstractPlugin' + Math.floor(Math.random() * (1632960) + 46656).toString(36);
         me._pluginName = me._name;
         me._requestHandlers = {};
         me._sandbox = null;
-        me._fixedLocation = false;
     }, {
         /**
          * @public @method getName
@@ -169,43 +167,6 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.AbstractMapModulePlugin',
          */
         _createRequestHandlers: function () {
             return {};
-        },
-
-        inLayerToolsEditMode: function () {
-            return this._isInLayerToolsEditMode;
-        },
-        isFixedLocation: function () {
-            return this._fixedLocation;
-        },
-
-        _setLayerToolsEditMode: function (isInEditMode) {
-            this._isInLayerToolsEditMode = isInEditMode;
-            if (this.isFixedLocation()) {
-                this.handleDragDisabled();
-            }
-        },
-
-        /**
-         * @method handleDragDisabled
-         * Disable draggable inLayerToolsEditMode if plugin's location is fixed (publisher edit own tools layout)
-         */
-        handleDragDisabled: function (isInEditMode) {
-            const elem = this.getElement();
-            if (!elem) {
-                return;
-            }
-            const draggable = elem.hasClass('ui-draggable');
-            if (this.inLayerToolsEditMode()) {
-                elem.addClass('plugin-drag-disabled');
-                if (draggable) {
-                    elem.draggable('disable');
-                }
-            } else {
-                elem.removeClass('plugin-drag-disabled');
-                if (draggable) {
-                    elem.draggable('enable');
-                }
-            }
         },
 
         /**

--- a/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
@@ -39,17 +39,17 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
          *
          */
         setVisible: function (visible) {
-            var toolbarNotReady = false;
+            var notReadyToRender = false;
             var wasVisible = this._visible;
             this._visible = visible;
             if (!this.getElement() && visible) {
-                toolbarNotReady = this.redrawUI(this.getMapModule().getMobileMode());
+                notReadyToRender = this.redrawUI(this.getMapModule().getMobileMode());
             }
             // toggle element - wasVisible might not be in sync with the UI if the elements are recreated - so always hide on setVisible(false)
             if (this.getElement() && (wasVisible !== visible || !visible)) {
                 this.getElement().toggle(visible);
             }
-            return toolbarNotReady;
+            return notReadyToRender;
         },
         /**
          * Handle plugin UI and change it when desktop / mobile mode
@@ -62,13 +62,13 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
                 // no point in drawing the ui if we are not visible
                 return;
             }
-            var me = this;
             if (this.getElement()) {
-                // ui already in place no need to do anything, override in plugins to do responsive
+                // ui already in place, just call refresh to allow plugin to adjust if needed
+                this.refresh();
                 return;
             }
-            me._element = me._createControlElement();
-            this.addToPluginContainer(me._element);
+            const el = this._createControlElement();
+            this.addToPluginContainer(el);
         },
         addToPluginContainer: function (element) {
             // var element = this.getElement();
@@ -76,7 +76,7 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
                 // no element to place, log a warning
                 return;
             }
-            this._element = element;
+            this.setElement(element);
             element.attr('data-clazz', this.getClazz());
             try {
                 this.getMapModule().setMapControlPlugin(
@@ -138,7 +138,6 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
         /**
          * @public @method getElement
          *
-         *
          * @return {jQuery}
          * Plugin jQuery element or null/undefined if no element has been set
          */
@@ -146,6 +145,9 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
             // element should be created in startPlugin and only destroyed in
             // stopPlugin. I.e. don't start & stop the plugin to refresh it.
             return this._element;
+        },
+        setElement: function (el) {
+            this._element = el;
         },
 
         /**
@@ -224,18 +226,6 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
         _destroyControlElement: function () {},
 
         /**
-         * @method _toggleControls
-         * Enable/disable plugin controls. Used in map layout edit mode.
-         *
-         * @param {Boolean} enable Should the controls be enabled or disabled.
-         *
-         */
-        _toggleUIControls: function (enable) {
-            // implement if needed... don't trust this._enabled, set the state
-            // even if enable === this._enabled
-        },
-
-        /**
          * @public @method setEnabled
          * Enable/Disable plugin controls.
          *
@@ -244,8 +234,6 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
          *
          */
         setEnabled: function (enabled) {
-            // toggle controls
-            this._toggleUIControls(enabled);
             this._enabled = enabled;
         },
 

--- a/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
@@ -39,6 +39,8 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
          *
          */
         setVisible: function (visible) {
+            // this makes call to redrawUI() for plugins that don't override _startPluginImpl()
+            // TODO: if we migrate plugins to not rely on redrawUI() being called and implement _startPluginImpl() instead we can get rid of this
             var notReadyToRender = false;
             var wasVisible = this._visible;
             this._visible = visible;

--- a/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
+++ b/bundles/mapping/mapmodule/plugin/BasicMapModulePlugin.js
@@ -218,14 +218,6 @@ Oskari.clazz.define('Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin',
         _createControlElement: function () {},
 
         /**
-         * @method _destroyControlElement
-         * Called before _element is destroyed. Implement if needed.
-         *
-         *
-         */
-        _destroyControlElement: function () {},
-
-        /**
          * @public @method setEnabled
          * Enable/Disable plugin controls.
          *

--- a/bundles/mapping/mapmodule/plugin/fullscreen/FullScreen.js
+++ b/bundles/mapping/mapmodule/plugin/fullscreen/FullScreen.js
@@ -38,6 +38,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugi
         me._element = null;
         me.state = {};
         me._sandbox = null;
+        this._isVisible = true;
         me._templates = {
             plugin: jQuery('<div class="mapplugin fullscreen"></div>')
         };
@@ -56,7 +57,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugi
          * @method _startPluginImpl
          */
         _startPluginImpl: function () {
-            this._element = this._createControlElement();
+            this.setElement(this._createControlElement());
             this.addToPluginContainer(this.getElement());
             this.refresh();
         },
@@ -82,6 +83,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugi
             ReactDOM.render(
                 <StyledButton
                     className='t_fullscreen'
+                    visible={this.isVisible()}
                     icon={isFullscreen ? <FullscreenExitOutlined /> : <FullscreenOutlined />}
                     iconActive={isFullscreen}
                     onClick={() => {
@@ -129,7 +131,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugi
          *      Request to handle
          */
         handleRequest: function (core, request) {
-            this.setVisible(request.isVisible());
+            this._isVisible = request.isVisible();
+            this.refresh();
+        },
+        isVisible: function() {
+            return this._isVisible;
         },
         setState: function (state) {
             this.state = state || {};

--- a/bundles/mapping/mapmodule/plugin/fullscreen/FullScreen.js
+++ b/bundles/mapping/mapmodule/plugin/fullscreen/FullScreen.js
@@ -54,13 +54,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugi
         },
         /**
          * @method _startPluginImpl
-         *
-         * @param {Oskari.mapframework.sandbox.Sandbox} sandbox
-         *          reference to application sandbox
          */
-        _startPluginImpl: function (sandbox) {
-            this.setEnabled(this._enabled);
-            return this.setVisible(this._visible);
+        _startPluginImpl: function () {
+            this._element = this._createControlElement();
+            this.addToPluginContainer(this.getElement());
+            this.refresh();
         },
 
         /**
@@ -70,18 +68,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugi
          * @param {Boolean} forced application has started and ui should be rendered with assets that are available
          */
         redrawUI: function (mapInMobileMode, forced) {
-            if (!this.isVisible() || !this.isEnabled()) {
-                // no point in drawing the ui if we are not visible or enabled
-                return;
-            }
-
-            this.teardownUI();
-
-            this.inMobileMode = mapInMobileMode;
-
-            this._element = this._createControlElement();
             this.refresh();
-            this.addToPluginContainer(this.getElement());
         },
         /**
          * @public @method refresh

--- a/bundles/mapping/mapmodule/plugin/fullscreen/FullScreen.js
+++ b/bundles/mapping/mapmodule/plugin/fullscreen/FullScreen.js
@@ -134,7 +134,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugi
             this._isVisible = request.isVisible();
             this.refresh();
         },
-        isVisible: function() {
+        isVisible: function () {
             return this._isVisible;
         },
         setState: function (state) {

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
@@ -101,7 +101,9 @@ Oskari.clazz.define(
                 return;
             }
             // toggle controls
-            this._toggleUIControls(enabled);
+            if (!enabled) {
+                this._closeGfiInfo();
+            }
             this._enabled = enabled;
         },
 
@@ -190,10 +192,8 @@ Oskari.clazz.define(
             };
         },
 
-        _toggleUIControls: function (enabled) {
-            if (!enabled) {
-                this._closeGfiInfo();
-            }
+        resetUI: function () {
+            this._closeGfiInfo();
         },
 
         /**

--- a/bundles/mapping/mapmodule/plugin/mylocation/MyLocationPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/mylocation/MyLocationPlugin.js
@@ -36,7 +36,6 @@ Oskari.clazz.define(
         this._timeouts = 0; // timeouts for single location request
         this._tracking = false;
         this._trackingOptions = null;
-        this.inMobileMode = false;
     }, {
         /**
          * @private @method _createControlElement
@@ -45,8 +44,7 @@ Oskari.clazz.define(
          * Plugin jQuery element
          */
         _createControlElement: function () {
-            const el = this._templates.plugin.clone();
-            return el;
+            return this._templates.plugin.clone();
         },
         /**
          * @private @method _setWaiting
@@ -82,6 +80,7 @@ Oskari.clazz.define(
             }
             ReactDOM.render(
                 <MapModuleButton
+                    visible={this.isEnabled()}
                     className='t_mylocation'
                     icon={<AimOutlined />}
                     title={this.loc('plugin.MyLocationPlugin.tooltip')}
@@ -135,18 +134,7 @@ Oskari.clazz.define(
          * @param {Boolean} forced application has started and ui should be rendered with assets that are available
          */
         redrawUI: function (mapInMobileMode, forced) {
-            if (!this.isVisible() || !this.isEnabled()) {
-                // no point in drawing the ui if we are not visible or enabled
-                return;
-            }
-
-            this.teardownUI();
-
-            this.inMobileMode = mapInMobileMode;
-
-            this._element = this._createControlElement();
             this.refresh();
-            this.addToPluginContainer(this.getElement());
         },
         teardownUI: function () {
             this.removeFromPluginContainer(this.getElement());
@@ -160,14 +148,12 @@ Oskari.clazz.define(
          * @return {Boolean}
          * True if plugin's tools are enabled
          */
-        isEnabled: function (showOnlyMobile) {
-            var conf = this.getConfig();
-            var mobileOnly = showOnlyMobile || conf.mobileOnly;
-
+        isEnabled: function () {
+            var { mobileOnly } = this.getConfig() || {};
             if (mobileOnly === true && !Oskari.util.isMobile(true)) {
                 return false;
             }
-            return this._enabled;
+            return true;
         },
 
         /**
@@ -203,11 +189,10 @@ Oskari.clazz.define(
             this.teardownUI();
         },
         _startPluginImpl: function () {
-            var me = this;
-            me.setEnabled(me._enabled);
-            const toolbarNotReady = me.setVisible(me._visible);
-            me._handleStartMode();
-            return toolbarNotReady;
+            this.setElement(this._createControlElement());
+            this.addToPluginContainer(this.getElement());
+            this.refresh();
+            this._handleStartMode();
         },
         /**
          * Checks at if device is outside of map viewport when mode is tracking.

--- a/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/ClassificationPlugin.js
@@ -20,7 +20,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.ClassificationPlugin',
         me._clazz = 'Oskari.statistics.statsgrid.ClassificationPlugin';
         me._index = 9;
         this._defaultLocation = 'right bottom';
-        me._fixedLocation = true;
         me._name = 'ClassificationPlugin';
 
         me.log = Oskari.log('Oskari.statistics.statsgrid.ClassificationPlugin');

--- a/bundles/statistics/statsgrid2016/plugin/SeriesControlPlugin.js
+++ b/bundles/statistics/statsgrid2016/plugin/SeriesControlPlugin.js
@@ -11,7 +11,6 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SeriesControlPlugin',
         me._instance = instance;
         me._clazz = 'Oskari.statistics.statsgrid.SeriesControlPlugin';
         me._defaultLocation = 'center top';
-        me._fixedLocation = true;
         me._index = 5;
 
         me._name = 'SeriesControlPlugin';


### PR DESCRIPTION
- Remove layer tools edit mode functions from AbstractMapModulePlugin
- Remove _toggleUIControls() from mapmodule API as unused
- Remove _destroyControlElement() from mapmodule API as unused
- Refactor plugins in an effort to remove setEnabled()/setVisible() from base classes as these are way easier to implement per plugin than having some base class do something about these.
- Added `visible` prop for `MapModuleButton` component so the button can be used but not shown based on prop to make it easier for plugins to handle situation where they should not render anything to UI.