### PR TITLE
Featuredata publisher fix

### DIFF
--- a/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
+++ b/bundles/framework/featuredata2/plugin/FeaturedataPlugin.js
@@ -44,6 +44,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata2.plugin.FeaturedataP
         _startPluginImpl: function () {
             this.setElement(this._createControlElement());
             this.addToPluginContainer(this.getElement());
+            this.refresh();
         },
         /**
          * @method _createControlElement


### PR DESCRIPTION
Render React-content after starting plugin. Fixes an issue where toggling featuredata off and on again didn't bring back the button on map.