### PR TITLE
Sanity check draggable when dropped on plugin container

### DIFF
--- a/bundles/framework/publisher2/view/PanelToolLayout.js
+++ b/bundles/framework/publisher2/view/PanelToolLayout.js
@@ -172,7 +172,18 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelToolLayout'
                 // TODO see if this can be done in hover? Would it even be wanted behaviour?
                 drop: function (event, ui) {
                     const pluginClazz = ui.draggable.attr('data-clazz');
-                    const plugin = me.getToolById(pluginClazz).getPlugin();
+                    if (!pluginClazz) {
+                        // we might have dropped a non-plugin element on this like the layerlist flyout
+                        return;
+                    }
+                    const tool = me.getToolById(pluginClazz);
+                    if (!tool) {
+                        // just in case if no tool matches this
+                        // we might have dropped a non-plugin element on this like the layerlist flyout
+                        return;
+                    }
+                    const plugin = tool.getPlugin();
+
                     const source = ui.draggable.parents('.mapplugins');
                     const target = jQuery(this);
 


### PR DESCRIPTION
Fixes an issue where an unfortunately placed layer listing flyout is released on top of a plugin container while the plugin drag-n-drop mode is active in publisher.

Fix problem if dragging of the flyout is released on circled area (plugin container):
![image](https://user-images.githubusercontent.com/2210335/228512984-05dde0d7-bf2e-4f8d-b847-8f56c86798d5.png)
