### PR TITLE
Fix issues with plugins and moving between mobile/desktop modes with browser window size changes

### DIFF
--- a/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
+++ b/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
@@ -39,14 +39,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
             }
         },
         _createControlElement: function () {
-            var me = this,
-                el = me._templates.coordinatetool.clone();
-
-            if (me._config.noUI) {
-                return null;
-            }
-
-            return el;
+            return this._templates.coordinatetool.clone();
+        },
+        _startPluginImpl: function () {
+            this.setElement(this._createControlElement());
+            this.addToPluginContainer(this.getElement());
+            this.refresh();
         },
         teardownUI: function () {
             // remove old element
@@ -63,16 +61,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
          * @param {Boolean} forced application has started and ui should be rendered with assets that are available
          */
         redrawUI: function (mapInMobileMode, forced) {
-            if (!this.hasUI()) {
-                return;
-            }
-
-            this.teardownUI();
-            if (!this._config.noUI) {
-                this._element = this._createControlElement();
-                this.refresh();
-                this.addToPluginContainer(this._element);
-            }
+            this.refresh();
         },
 
         hasUI: function () {
@@ -99,6 +88,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
             ReactDOM.render(
                 <MapModuleButton
                     className='t_coordinatetool'
+                    visible={this.hasUI()}
                     title={this._locale('display.tooltip.tool')}
                     icon={<CoordinateIcon />}
                     onClick={() => this.handler.getController().showPopup()}

--- a/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
+++ b/bundles/mapping/camera-controls-3d/plugin/CameraControls3dPlugin.js
@@ -14,10 +14,9 @@ Oskari.clazz.define(className,
         this._toolOpen = false;
         this._index = 80;
         this._log = Oskari.log(shortName);
-        this._mountPoint = jQuery('<div class="camera-controls-3d"><div></div></div>');
+        this._template = jQuery('<div class="mapplugin camera-controls-3d"><div></div></div>');
         // plugin index 25. Insert after panbuttons.
         this._index = 25;
-        this.inMobileMode = false;
         this.handler = new CameraControls3dHandler(state => this._render(state));
     }, {
         getName: function () {
@@ -33,15 +32,13 @@ Oskari.clazz.define(className,
         isRotating: function () {
             return this.handler.getActiveMapMoveMethod() === 'rotate';
         },
-        /**
-         * Handle plugin UI and change it when desktop / mobile mode
-         * @method  @public redrawUI
-         * @param  {Boolean} mapInMobileMode is map in mobile mode
-         */
-        redrawUI: function (mapInMobileMode, forced) {
-            this.teardownUI();
-            this.inMobileMode = mapInMobileMode;
-            return this._createUI();
+        _startPluginImpl: function () {
+            this.setElement(this._createControlElement());
+            this.addToPluginContainer(this.getElement());
+            this.refresh();
+        },
+        _createControlElement: function () {
+            return this._template.clone();
         },
         teardownUI: function () {
             if (!this.getElement()) {
@@ -50,13 +47,6 @@ Oskari.clazz.define(className,
             ReactDOM.unmountComponentAtNode(this.getElement().get(0));
             this.getElement().detach();
             this._element = undefined;
-        },
-        /**
-         * Get jQuery element.
-         * @method @public getElement
-         */
-        getElement: function () {
-            return this._element;
         },
         stopPlugin: function () {
             this.teardownUI();
@@ -74,7 +64,7 @@ Oskari.clazz.define(className,
             const ui = (
                 <LocaleProvider value={{ bundleKey: 'CameraControls3d' }}>
                     <CameraControls3d
-                        mapInMobileMode={this.inMobileMode}
+                        mapInMobileMode={Oskari.util.isMobile()}
                         activeMapMoveMethod={activeMapMoveMethod}
                         controller={this.handler.getController()}
                         location={this.getLocation()}
@@ -82,23 +72,6 @@ Oskari.clazz.define(className,
                 </LocaleProvider>
             );
             ReactDOM.render(ui, el[0]);
-        },
-        _createUI: function () {
-            this._element = this._mountPoint.clone();
-            this.addToPluginContainer(this._element);
-            this._element.addClass('mapplugin');
-            this.refresh();
-        },
-        /**
-         * @public @method getIndex
-         * Returns the plugin's preferred position in the container
-         *
-         *
-         * @return {Number} Plugin's preferred position in container
-         */
-        getIndex: function () {
-            // i.e. position
-            return this._index;
         }
     }, {
         'extend': ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -1303,7 +1303,7 @@ Oskari.clazz.define(
             return this._isInMobileMode;
         },
 
-        _handleMapSizeChanges: function (newSize, pluginName) {
+        _handleMapSizeChanges: function () {
             const isMobile = Oskari.util.isMobile();
             const modeChanged = this.getMobileMode() !== isMobile;
             this.setMobileMode(isMobile);

--- a/bundles/mapping/mapmodule/plugin/panbuttons/PanButtons.js
+++ b/bundles/mapping/mapmodule/plugin/panbuttons/PanButtons.js
@@ -25,7 +25,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
         this._index = 20;
         this._name = 'PanButtons';
         this._panPxs = 100;
-        this.inMobileMode = false;
         this.showArrows = !!this.getConfig().showArrows;
         this.resetPopup = null;
     }, {
@@ -76,7 +75,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
                     <PanButton
                         resetClicked={() => this._resetClicked()}
                         panClicked={(x, y) => this._panClicked(x, y)}
-                        isMobile={this.inMobileMode}
+                        isMobile={Oskari.util.isMobile()}
                         showArrows={this.showArrows}
                     />
                 </ThemeProvider>,
@@ -98,9 +97,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PanButtons',
             // don't do anything now if request is not available.
             // When returning false, this will be called again when the request is available
             this.teardownUI();
-
-            this.inMobileMode = mapInMobileMode;
-
             this._element = this._createControlElement();
             this.refresh();
             this.addToPluginContainer(this._element);

--- a/bundles/mapping/mapmodule/plugin/search/SearchPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/search/SearchPlugin.js
@@ -36,7 +36,6 @@ Oskari.clazz.define(
         _initImpl: function () {
             this.fieldPlaceHolder = Oskari.getMsg('MapModule', 'plugin.SearchPlugin.placeholder');
             this.template = jQuery('<div class="mapplugin search default-search-div" />');
-            this.inMobileMode = false;
         },
 
         /**
@@ -96,7 +95,6 @@ Oskari.clazz.define(
          * @param {Boolean} modeChanged is the ui mode changed (mobile/desktop)
          */
         redrawUI: function (mapInMobileMode, modeChanged) {
-            var isMobile = mapInMobileMode || Oskari.util.isMobile();
             if (!this.isVisible()) {
                 // no point in drawing the ui if we are not visible
                 return;
@@ -108,7 +106,6 @@ Oskari.clazz.define(
 
             // remove old element
             this.teardownUI();
-            this.inMobileMode = isMobile;
             this.addToPluginContainer(me._element);
             me.refresh();
         }

--- a/bundles/mapping/mapmodule/plugin/zoombar/Portti2Zoombar.js
+++ b/bundles/mapping/mapmodule/plugin/zoombar/Portti2Zoombar.js
@@ -33,7 +33,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar'
         this._index = 30;
         this._name = 'Portti2Zoombar';
         this._suppressEvents = false;
-        this.inMobileMode = false;
     }, {
         /**
          * @private @method _createControlElement
@@ -61,7 +60,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar'
                     changeZoom={(value) => this.getMapModule().setZoomLevel(value)}
                     zoom={this.getMapModule().getMapZoom()}
                     maxZoom={this.getMapModule().getMaxZoomLevel()}
-                    isMobile={this.inMobileMode}
+                    isMobile={Oskari.util.isMobile()}
                 />,
                 el[0]
             );
@@ -97,8 +96,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar'
             }
             var me = this;
             this.teardownUI();
-
-            this.inMobileMode = mapInMobileMode;
 
             me._element = me._createControlElement();
             this.refresh();

--- a/bundles/mapping/time-control-3d/plugin/TimeControl3dPlugin.js
+++ b/bundles/mapping/time-control-3d/plugin/TimeControl3dPlugin.js
@@ -59,7 +59,6 @@ class TimeControl3dPlugin extends BasicMapModulePlugin {
     }
 
     redrawUI (mapInMobileMode, forced) {
-        this._isMobile = mapInMobileMode;
         if (this.getElement()) {
             this.teardownUI();
         } else {


### PR DESCRIPTION
Fixes an issue where plugins stored initial "isMobileMode" boolean that was never updated after set initially by redrawUI() since currently changing the map size calls plugin.refresh().

At least `bundles\framework\timeseries\view\TimeseriesControlPlugin.js` still needs updating for mobile mode detection. Most plugins should initialize their UI in `_startPluginImpl()`, handle any changes in `refresh()` and check mobile mode using `Oskari.util.isMobile()` (or even `mapmodule.getMobileMode()`).

However there's lots of jQuery based code still that removes the plugin UI from DOM and reattaches it on redrawUI(). These still need some updating to make them work nicely with current "mobile mode" functionality (=mobile toolbar no longer used).

TODO: we probably should get rid of redrawUI() from plugins as most just call refresh() or teardown() + buildUI().