### PR TITLE
Publisher tools cleanup / statistical maps tool fix for drag-n-drop

### DIFF
--- a/bundles/framework/publisher2/tools/AbstractPluginTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPluginTool.js
@@ -21,9 +21,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
     group: 'maptools',
     // 'bottom left', 'bottom right' etc
     allowedLocations: ['*'],
-    // default location in lefthanded / righthanded layouts. Override.
-    lefthanded: '',
-    righthanded: '',
     // List of plugin classes that can reside in same container(?) like 'Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin'
     allowedSiblings: ['*'],
 

--- a/bundles/framework/publisher2/tools/CrosshairTool.js
+++ b/bundles/framework/publisher2/tools/CrosshairTool.js
@@ -12,10 +12,10 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.CrosshairTool',
         */
         getTool: function () {
             return {
-            // doesn't actually map to anything real, just need this in order to not break stuff in publisher
                 id: 'Oskari.mapframework.publisher.tool.CrosshairTool',
                 title: 'CrosshairTool',
-                config: this.state.pluginConfig || {}
+                config: this.state.pluginConfig || {},
+                hasNoPlugin: true
             };
         },
         init: function (data) {
@@ -46,17 +46,17 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.CrosshairTool',
                 }
             };
         },
-        // override since it's not really a plugin but a method on mapmodule
-        setEnabled: function (enabled) {
+        _setEnabledImpl: function (enabled) {
             const mapModule = this.getMapmodule();
             if (mapModule) {
                 mapModule.toggleCrosshair(enabled);
             }
-            this.state.enabled = !!enabled;
         },
-        stop: function () {
-            // remove crosshair when exiting
-            this.setEnabled(false);
+        _stopImpl: function () {
+            const mapModule = this.getMapmodule();
+            if (mapModule) {
+                mapModule.toggleCrosshair(false);
+            }
         }
     }, {
         'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],

--- a/bundles/framework/publisher2/tools/LogoTool.js
+++ b/bundles/framework/publisher2/tools/LogoTool.js
@@ -2,8 +2,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.LogoTool',
     function () {
     }, {
         index: 1,
-        lefthanded: 'bottom left',
-        righthanded: 'bottom right',
 
         /**
         * Get tool object.

--- a/bundles/framework/publisher2/tools/MyLocationTool.js
+++ b/bundles/framework/publisher2/tools/MyLocationTool.js
@@ -2,8 +2,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.MyLocationTool',
     function () {
     }, {
         index: 4,
-        lefthanded: 'top left',
-        righthanded: 'top right',
 
         defaultExtraOptions: {
             mode: 'single',
@@ -29,14 +27,13 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.MyLocationTool',
             mobileOnly: null,
             centerMapAutomatically: null
         },
-        pluginSelected: false,
 
         /**
-    * Get tool object.
-    * @method getTool
-    *
-    * @returns {Object} tool description
-    */
+        * Get tool object.
+        * @method getTool
+        *
+        * @returns {Object} tool description
+        */
         getTool: function () {
             return {
                 id: 'Oskari.mapframework.bundle.mapmodule.plugin.MyLocationPlugin',
@@ -45,12 +42,12 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.MyLocationTool',
             };
         },
         /**
-    * Get values.
-    * @method getValues
-    * @public
-    *
-    * @returns {Object} tool value object
-    */
+        * Get values.
+        * @method getValues
+        * @public
+        *
+        * @returns {Object} tool value object
+        */
         getValues: function () {
             if (!this.isEnabled()) {
                 return null;
@@ -75,12 +72,12 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.MyLocationTool',
             };
         },
         /**
-     * Get extra options.
-     * @method getExtraOptions
-     * @public
-     *
-     * @returns {Object} jQuery element
-     */
+         * Get extra options.
+         * @method getExtraOptions
+         * @public
+         *
+         * @returns {Object} jQuery element
+         */
         getExtraOptions: function (toolContainer) {
             var me = this;
             var template = jQuery(me.templates.toolOptions).clone();

--- a/bundles/framework/publisher2/tools/PanButtonsTool.js
+++ b/bundles/framework/publisher2/tools/PanButtonsTool.js
@@ -2,8 +2,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.PanButtonsTool',
     function () {
     }, {
         index: 2,
-        lefthanded: 'top left',
-        righthanded: 'top right',
         _templates: {
             extraOptions: jQuery(`
                 <div class="publisher2 panbutton-options tool-options">

--- a/bundles/framework/publisher2/tools/ScalebarTool.js
+++ b/bundles/framework/publisher2/tools/ScalebarTool.js
@@ -2,8 +2,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ScalebarTool',
     function () {
     }, {
         index: 0,
-        lefthanded: 'bottom left',
-        righthanded: 'bottom right',
 
         /**
         * Get tool object.

--- a/bundles/framework/publisher2/tools/SearchTool.js
+++ b/bundles/framework/publisher2/tools/SearchTool.js
@@ -2,8 +2,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.SearchTool',
     function () {
     }, {
         index: 4,
-        lefthanded: 'top right',
-        righthanded: 'top left',
 
         /**
         * Get tool object.

--- a/bundles/framework/publisher2/tools/ToolbarTool.js
+++ b/bundles/framework/publisher2/tools/ToolbarTool.js
@@ -8,8 +8,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ToolbarTool',
         };
     }, {
         index: 3,
-        lefthanded: 'top right',
-        righthanded: 'top left',
 
         templates: {
             'toolOptions': '<div class="tool-options"></div>',

--- a/bundles/framework/publisher2/tools/ZoombarTool.js
+++ b/bundles/framework/publisher2/tools/ZoombarTool.js
@@ -2,15 +2,13 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ZoombarTool',
     function () {
     }, {
         index: 3,
-        lefthanded: 'top left',
-        righthanded: 'top right',
 
         /**
-    * Get tool object.
-    * @method getTool
-    *
-    * @returns {Object} tool description
-    */
+        * Get tool object.
+        * @method getTool
+        *
+        * @returns {Object} tool description
+        */
         getTool: function () {
             return {
                 id: 'Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar',
@@ -19,12 +17,12 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ZoombarTool',
             };
         },
         /**
-    * Get values.
-    * @method getValues
-    * @public
-    *
-    * @returns {Object} tool value object
-    */
+        * Get values.
+        * @method getValues
+        * @public
+        *
+        * @returns {Object} tool value object
+        */
         getValues: function () {
             if (!this.isEnabled()) {
                 return null;

--- a/bundles/framework/timeseries/view/TimeSeriesRangeControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeSeriesRangeControlPlugin.js
@@ -13,7 +13,7 @@ class TimeSeriesRangeControlPlugin extends BasicMapModulePlugin {
         super(conf);
         this._clazz = 'Oskari.mapframework.bundle.timeseries.TimeSeriesRangeControlPlugin';
         this._name = 'TimeSeriesRangeControlPlugin';
-        this._defaultLocation = conf.location || 'top left';
+        this._defaultLocation = 'top left';
         this._log = Oskari.log(this._name);
         this._toolOpen = false;
         this._element = null;

--- a/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
@@ -47,8 +47,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
         this._uiState.currentTime = delegate.getCurrentTime();
         this._validSkipOptions = this._filterSkipOptions(this._uiState.times);
 
-        me._isMobileVisible = true;
-        me._inMobileMode = false;
         me._isStopped = false;
     }, {
         __fullAxisYPos: 35,
@@ -286,60 +284,42 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
          * @param  {Boolean} mapInMobileMode is map in mobile mode
          * @param {Boolean} forced application has started and ui should be rendered with assets that are available
          */
-        redrawUI: function (mapInMobileMode, forced) {
-            var me = this;
-            var sandbox = me.getSandbox();
-            var mobileDefs = this.getMobileDefs();
+        redrawUI: function () {
+            this.refresh();
+        },
 
-            me._inMobileMode = mapInMobileMode;
-
-            // don't do anything now if request is not available.
-            // When returning false, this will be called again when the request is available
-            var toolbarNotReady = this.removeToolbarButtons(mobileDefs.buttons, mobileDefs.buttonGroup);
-            if (!forced && toolbarNotReady) {
-                return true;
-            }
+        refresh: function () {
             this.teardownUI();
-
-            if (!toolbarNotReady && mapInMobileMode) {
-                this.addToolbarButtons(mobileDefs.buttons, mobileDefs.buttonGroup);
-                var toolbarRequest = Oskari.requestBuilder('Toolbar.SelectToolButtonRequest')('mobile-timeseries', 'mobileToolbar-mobile-toolbar');
-                sandbox.request(me, toolbarRequest);
-            }
-            if (!mapInMobileMode) {
-                me._buildUI(mapInMobileMode);
-            }
+            this._buildUI();
         },
         /**
          * @method _buildUI Create element and construct DOM structure
          * @private
          * @param  {Boolean} isMobile is UI in mobile mode?
          */
-        _buildUI: function (isMobile) {
-            var me = this;
-            if (me._isStopped) {
+        _buildUI: function (isMobile = Oskari.util.isMobile()) {
+            if (this._isStopped) {
                 return;
             }
-            me._element = me._createControlElement();
-            this.addToPluginContainer(me._element);
+            this.setElement(this._createControlElement());
+            this.addToPluginContainer(this.getElement());
             var aux = '<div class="timeseries-aux"></div>';
-            var times = me._uiState.times;
+            var times = this._uiState.times;
             if (isMobile) {
-                me._timelineWidth = 260;
-                me._setRange(times[0], times[times.length - 1]);
-                me._element.toggleClass('mobile', isMobile);
-                me._element.append(aux);
-                me._isMobileVisible = true;
+                this._timelineWidth = 260;
+                this._setRange(times[0], times[times.length - 1]);
+                this._element.toggleClass('mobile', isMobile);
+                this._element.append(aux);
             } else {
-                me._setWidth(me.getSandbox().getMap().getWidth(), true);
-                me._applyTopMargin(this._topMargin);
-                me._element.prepend(aux);
-                me._initMenus();
-                me._makeDraggable();
+                this._setWidth(this.getSandbox().getMap().getWidth(), true);
+                this._applyTopMargin(this._topMargin);
+                this._element.prepend(aux);
+                this._initMenus();
+                this._makeDraggable();
             }
-            me._initStepper();
-            me._updateTimelines(isMobile);
-            me._updateTimeDisplay();
+            this._initStepper();
+            this._updateTimelines(isMobile);
+            this._updateTimeDisplay();
         },
         _makeDraggable: function () {
             this._element.prepend('<div class="timeseries-handle oskari-flyoutheading"></div>');
@@ -666,7 +646,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
          * @private
          */
         teardownUI: function () {
-            this._isMobileVisible = false;
             this.removeFromPluginContainer(this.getElement());
         },
         /**

--- a/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
+++ b/bundles/mapping/maprotator/plugin/MapRotatorPlugin.js
@@ -32,7 +32,6 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
             maprotatortool: jQuery('<div class="mapplugin maprotator"></div>')
         };
         me._log = Oskari.log('Oskari.mapping.maprotator.MapRotatorPlugin');
-        me.inMobileMode = false;
         this._dragRotate = null;
         this._removeListenerKey = null;
         this._name = 'MapRotatorPlugin';
@@ -61,26 +60,8 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
         getDegrees: function () {
             return this.previousDegrees || 0;
         },
-        /**
-         * Creates UI for coordinate display and places it on the maps
-         * div where this plugin registered.
-         * @private @method _createControlElement
-         *
-         * @return {jQuery}
-         */
-        _createControlElement: function () {
-            this._locale = Oskari.getLocalization('maprotator', Oskari.getLang() || Oskari.getDefaultLanguage()).display;
-            return this._templates.maprotatortool.clone();
-        },
         rotateIcon: function (degrees) {
             this._renderButton(degrees);
-        },
-        _createUI: function () {
-            this._element = this._createControlElement();
-            this.setDegrees(this.getRotation());
-            this.refresh();
-            this.handleEvents();
-            this.addToPluginContainer(this._element);
         },
         setRotation: function (deg) {
             // if deg is number then transform degrees to radians otherwise use 0
@@ -96,6 +77,17 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
             // radians to degrees with one decimal
             var deg = Math.round(rot * 573) / 10;
             return deg;
+        },
+        _startPluginImpl: function () {
+            this.setElement(this._createControlElement());
+            this.setDegrees(this.getRotation());
+            this.refresh();
+            this.handleEvents();
+            this.addToPluginContainer(this._element);
+        },
+        _createControlElement: function () {
+            this._locale = Oskari.getLocalization('maprotator', Oskari.getLang() || Oskari.getDefaultLanguage()).display;
+            return this._templates.maprotatortool.clone();
         },
         refresh: function () {
             this._renderButton();
@@ -136,9 +128,6 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
                 }
             };
         },
-        _startPluginImpl: function () {
-            this._createUI();
-        },
         /**
          * Handle plugin UI and change it when desktop / mobile mode
          * @method  @public redrawUI
@@ -158,13 +147,6 @@ Oskari.clazz.define('Oskari.mapping.maprotator.MapRotatorPlugin',
         },
         hasUI: function () {
             return !this._config.noUI;
-        },
-        /**
-         * Get jQuery element.
-         * @method @public getElement
-         */
-        getElement: function () {
-            return this._element;
         },
         _stopPluginImpl: function () {
             this.setRotation(0);

--- a/bundles/statistics/statsgrid2016/publisher/ClassificationToggleTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/ClassificationToggleTool.js
@@ -9,25 +9,18 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationToggleTool
         this.setEnabled(conf.classification === true);
     },
     getTool: function () {
-        var me = this;
-        if (!me.__tool) {
-            me.__tool = {
-                id: 'Oskari.statistics.statsgrid.TogglePlugin',
-                title: 'allowHidingClassification',
-                config: {
-                    classification: true
-                }
-            };
-        }
-        return me.__tool;
+        return {
+            id: 'Oskari.statistics.statsgrid.TogglePlugin',
+            title: 'allowHidingClassification',
+            config: {
+                classification: true
+            },
+            hasNoPlugin: true
+        };
     },
-    setEnabled: function (enabled) {
-        var me = this;
-        var changed = me.state.enabled !== enabled;
-        me.state.enabled = enabled;
-
+    _setEnabledImpl: function (enabled) {
         var stats = this.getStatsgridBundle();
-        if (!stats || !changed) {
+        if (!stats) {
             return;
         }
         if (enabled) {
@@ -42,7 +35,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationToggleTool
     getValues: function () {
         return this.getConfiguration({ classification: this.isEnabled() });
     },
-    stop: function () {
+    _stopImpl: function () {
         var stats = this.getStatsgridBundle();
         if (stats) {
             stats.togglePlugin.removeTool(this.id);

--- a/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
@@ -2,8 +2,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationTool', fun
 }, {
     index: 1,
     group: 'data',
-    lefthanded: 'bottom right',
-    righthanded: 'bottom right',
 
     init: function (data) {
         const conf = this.getStatsgridConf(data);
@@ -14,24 +12,17 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationTool', fun
         var stats = this.getStatsgridBundle();
         return stats.classificationPlugin;
     },
-    getTool: function (pdata) {
-        if (!this.__tool) {
-            this.__tool = {
-                id: 'Oskari.statistics.statsgrid.ClassificationPlugin',
-                title: 'allowClassification',
-                config: {
-                    allowClassification: false
-                }
-            };
-        }
-        return this.__tool;
+    getTool: function () {
+        return {
+            id: 'Oskari.statistics.statsgrid.ClassificationPlugin',
+            title: 'allowClassification',
+            config: {
+                allowClassification: false
+            },
+            hasNoPlugin: true
+        };
     },
-    setEnabled: function (enabled) {
-        if (typeof enabled !== 'boolean') {
-            enabled = false;
-        }
-
-        this.state.enabled = enabled;
+    _setEnabledImpl: function (enabled) {
         const service = Oskari.getSandbox().getService('Oskari.statistics.statsgrid.StatisticsService');
         if (service) {
             service.getStateService().updateClassificationPluginState('editEnabled', enabled);
@@ -63,7 +54,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationTool', fun
     * @method stop
     * @public
     */
-    stop: function () {
+    _stopImpl: function () {
         const service = Oskari.getSandbox().getService('Oskari.statistics.statsgrid.StatisticsService');
         if (service) {
             service.getStateService().resetClassificationPluginState('editEnabled');

--- a/bundles/statistics/statsgrid2016/publisher/DiagramTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/DiagramTool.js
@@ -8,26 +8,19 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.DiagramTool', function (
         const conf = this.getStatsgridConf(data);
         this.setEnabled(conf.diagram === true);
     },
-    getTool: function (stateData) {
-        var me = this;
-        if (!me.__tool) {
-            me.__tool = {
-                id: 'Oskari.statistics.statsgrid.TogglePlugin',
-                title: 'displayDiagram',
-                config: {
-                    diagram: true
-                }
-            };
-        }
-        return me.__tool;
+    getTool: function () {
+        return {
+            id: 'Oskari.statistics.statsgrid.TogglePlugin',
+            title: 'displayDiagram',
+            config: {
+                diagram: true
+            },
+            hasNoPlugin: true
+        };
     },
-    setEnabled: function (enabled) {
-        var me = this;
-        var changed = me.state.enabled !== enabled;
-        me.state.enabled = enabled;
-
+    _setEnabledImpl: function (enabled) {
         var stats = this.getStatsgridBundle();
-        if (!stats || !changed) {
+        if (!stats) {
             return;
         }
         if (enabled) {
@@ -39,7 +32,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.DiagramTool', function (
     getValues: function () {
         return this.getConfiguration({ diagram: this.isEnabled() });
     },
-    stop: function () {
+    _stopImpl: function () {
         var stats = this.getStatsgridBundle();
         if (stats) {
             stats.togglePlugin.removeTool(this.id);

--- a/bundles/statistics/statsgrid2016/publisher/OpacityTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/OpacityTool.js
@@ -8,24 +8,17 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.OpacityTool', function (
         const conf = this.getStatsgridConf(data);
         this.setEnabled(conf.transparent === true);
     },
-    getTool: function (stateData) {
-        var me = this;
-        if (!me.__tool) {
-            me.__tool = {
-                id: 'Oskari.statistics.statsgrid.ClassificationPlugin',
-                title: 'transparent',
-                config: {
-                    transparent: false
-                }
-            };
-        }
-        return me.__tool;
+    getTool: function () {
+        return {
+            id: 'Oskari.statistics.statsgrid.ClassificationPlugin',
+            title: 'transparent',
+            config: {
+                transparent: false
+            },
+            hasNoPlugin: true
+        };
     },
-    setEnabled: function (enabled) {
-        var me = this;
-
-        me.state.enabled = enabled;
-
+    _setEnabledImpl: function (enabled) {
         var stats = this.getStatsgridBundle();
         if (!stats) {
             return;
@@ -38,7 +31,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.OpacityTool', function (
     getValues: function () {
         return this.getConfiguration({ transparent: this.isEnabled() });
     },
-    stop: function () {
+    _stopImpl: function () {
         const service = Oskari.getSandbox().getService('Oskari.statistics.statsgrid.StatisticsService');
         if (service) {
             service.getStateService().resetClassificationPluginState('transparent');

--- a/bundles/statistics/statsgrid2016/publisher/SeriesToggleTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/SeriesToggleTool.js
@@ -8,26 +8,19 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.SeriesToggleTool', funct
         const conf = this.getStatsgridConf(data);
         this.setEnabled(conf.series === true);
     },
-    getTool: function (stateData) {
-        var me = this;
-        if (!me.__tool) {
-            me.__tool = {
-                id: 'Oskari.statistics.statsgrid.TogglePlugin',
-                title: 'allowHidingSeriesControl',
-                config: {
-                    series: true
-                }
-            };
-        }
-        return me.__tool;
+    getTool: function () {
+        return {
+            id: 'Oskari.statistics.statsgrid.TogglePlugin',
+            title: 'allowHidingSeriesControl',
+            config: {
+                series: true
+            },
+            hasNoPlugin: true
+        };
     },
-    setEnabled: function (enabled) {
-        var me = this;
-        var changed = me.state.enabled !== enabled;
-        me.state.enabled = enabled;
-
+    _setEnabledImpl: function (enabled) {
         var stats = this.getStatsgridBundle();
-        if (!stats || !changed) {
+        if (!stats) {
             return;
         }
         if (enabled) {
@@ -48,7 +41,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.SeriesToggleTool', funct
     getValues: function () {
         return this.getConfiguration({ series: this.isEnabled() });
     },
-    stop: function () {
+    _stopImpl: function () {
         var stats = this.getStatsgridBundle();
         if (stats) {
             stats.togglePlugin.removeTool(this.id);

--- a/bundles/statistics/statsgrid2016/publisher/StatsTableTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/StatsTableTool.js
@@ -24,18 +24,15 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.StatsTableTool', functio
     *
     * @returns {Object} tool
     */
-    getTool: function (pdata) {
-        var me = this;
-        if (!me.__tool) {
-            me.__tool = {
-                id: 'Oskari.statistics.statsgrid.StatsGridBundleInstance',
-                title: 'grid',
-                config: {
-                    grid: true
-                }
-            };
-        }
-        return me.__tool;
+    getTool: function () {
+        return {
+            id: 'Oskari.statistics.statsgrid.TogglePlugin',
+            title: 'grid',
+            config: {
+                grid: true
+            },
+            hasNoPlugin: true
+        };
     },
     /**
     * Set enabled.
@@ -44,13 +41,9 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.StatsTableTool', functio
     *
     * @param {Boolean} enabled is tool enabled or not
     */
-    setEnabled: function (enabled) {
-        var me = this;
-        var changed = me.state.enabled !== enabled;
-        me.state.enabled = enabled;
-
+    _setEnabledImpl: function (enabled) {
         var stats = this.getStatsgridBundle();
-        if (!stats || !changed) {
+        if (!stats) {
             return;
         }
         if (enabled) {
@@ -62,7 +55,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.StatsTableTool', functio
     getValues: function () {
         return this.getConfiguration({ grid: this.isEnabled() });
     },
-    stop: function () {
+    _stopImpl: function () {
         var stats = this.getStatsgridBundle();
         if (stats) {
             stats.togglePlugin.removeTool(this.id);


### PR DESCRIPTION
Use `getTool() -> hasNoPlugin: true` so we can use `_setEnabledImpl()` and `_stopImpl()` for statistical maps tools. This fixes  an issue where activating the a tool WHILE drag-n-drop mode on publisher was active didn't show the handle for the tool properly.

Also makes it possible to remove duplicated code as we don't need to override `setEnabled()`,

Cleaned up references to lefthanded/righthanded config in tools that are no longer used.