### PR TITLE
New ES base class for publisher tools

### DIFF
--- a/bundles/catalogue/metadatacatalogue/publisher/MetadataSearchTool.js
+++ b/bundles/catalogue/metadatacatalogue/publisher/MetadataSearchTool.js
@@ -1,71 +1,47 @@
-Oskari.clazz.define('Oskari.mapframework.publisher.tool.MetadataSearchTool',
-    function () {
-        this.handler = null;
-    }, {
-        index: 9,
-        templates: {},
-        noUI: null,
-        noUiIsCheckedInModifyMode: false,
-        group: 'rpc',
-        getName: function () {
-            return 'Oskari.mapframework.publisher.tool.MetadataSearchTool';
-        },
-        /**
-         * Get tool object.
-         * @method getTool
-         *
-         * @returns {Object} tool description
-         */
-        getTool: function () {
-            return {
-                // doesn't actually map to anything real, just need this in order to not break stuff in publisher
-                // and provide a cleaner selector for selenium testing
-                id: 'metadatacatalogue.MetadataSearchRPCTool',
-                title: Oskari.getMsg('catalogue.bundle.metadatacatalogue', 'tool.label'),
-                config: {},
-                hasNoPlugin: true
-            };
-        },
+import { AbstractPublisherTool } from '../../../framework/publisher2/tools/AbstractPublisherTool';
 
-        // Key in view config non-map-module-plugin tools (for returning the state when modifying an existing published map).
-        bundleName: 'metadatacatalogue',
-
-        /**
-         * Initialise tool
-         * @method init
-         */
-        init: function (data) {
-            const conf = data?.configuration[this.bundleName]?.conf || {};
-            this.setEnabled(!!conf.noUI);
-        },
-
-        getComponent: function () {
-            return {};
-        },
-
-        /**
-        * Get values.
-        * @method getValues
-        * @public
-        *
-        * @returns {Object} tool value object
-        */
-        getValues: function () {
-            if (!this.isEnabled()) {
-                return null;
-            }
-            return {
-                configuration: {
-                    metadatacatalogue: {
-                        conf: {
-                            noUI: true
-                        }
+const BUNDLE_ID = 'metadatacatalogue';
+class MetadataSearchTool extends AbstractPublisherTool {
+    constructor (...args) {
+        super(...args);
+        this.index = 9;
+        this.group = 'rpc';
+    }
+    getTool () {
+        return {
+            id: 'metadatacatalogue.MetadataSearchRPCTool',
+            title: Oskari.getMsg('catalogue.bundle.metadatacatalogue', 'tool.label'),
+            config: {},
+            hasNoPlugin: true
+        };
+    }
+    getComponent () {
+        return {};
+    }
+    init (data) {
+        const conf = data?.configuration[BUNDLE_ID]?.conf || {};
+        this.setEnabled(!!conf.noUI);
+    }
+    getValues () {
+        if (!this.isEnabled()) {
+            return null;
+        }
+        return {
+            configuration: {
+                [BUNDLE_ID]: {
+                    conf: {
+                        noUI: true
                     }
                 }
-            };
-        }
-    }, {
+            }
+        };
+    }
+}
 
-        extend: ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],
-        protocol: ['Oskari.mapframework.publisher.Tool']
-    });
+// Attach protocol to make this discoverable by Oskari publisher
+Oskari.clazz.defineES('Oskari.publisher.MetadataSearchTool',
+    MetadataSearchTool,
+    {
+        'protocol': ['Oskari.mapframework.publisher.Tool']
+    }
+);

--- a/bundles/framework/feedbackService/publisher/FeedbackServiceTool.js
+++ b/bundles/framework/feedbackService/publisher/FeedbackServiceTool.js
@@ -1,78 +1,59 @@
+import { AbstractPublisherTool } from '../../../framework/publisher2/tools/AbstractPublisherTool';
 import { FeedbackServiceForm } from './FeedbackServiceForm';
 import { FeedbackServiceToolHandler } from './FeedbackServiceToolHandler';
 
-Oskari.clazz.define('Oskari.mapframework.publisher.tool.FeedbackServiceTool',
-    function () {
-        this.handler = null;
-    }, {
-        index: 9,
-        group: 'rpc',
-        getName: function () {
-            return 'Oskari.mapframework.publisher.tool.FeedbackServiceTool';
-        },
-        /**
-         * Get tool object.
-         * @method getTool
-         *
-         * @returns {Object} tool description
-         */
-        getTool: function () {
-            return {
-                // doesn't actually map to anything real, just need this in order to not break stuff in publisher
-                // and provide a cleaner selector for selenium testing
-                id: 'feedbackService.FeedbackServiceRPCTool',
-                title: Oskari.getMsg('feedbackService', 'display.publisher.label'),
-                config: {},
-                hasNoPlugin: true
-            };
-        },
-
-        // Key in view config non-map-module-plugin tools (for returning the state when modifying an existing published map).
-        bundleName: 'feedbackService',
-
-        /**
-         * Initialise tool
-         * @method init
-         */
-        init: function (data) {
-            this.handler = new FeedbackServiceToolHandler(data?.metadata?.feedbackService);
-            this.setEnabled(!!data?.configuration?.feedbackService);
-        },
-        getComponent: function () {
-            return {
-                component: FeedbackServiceForm,
-                handler: this.handler
-            };
-        },
-        /**
-        * Get values.
-        * @method getValues
-        * @public
-        *
-        * @returns {Object} tool value object
-        */
-        getValues: function () {
-            if (!this.isEnabled()) {
-                return null;
-            }
-
-            const state = this.handler.getState() || {};
-            return {
-                configuration: {
-                    feedbackService: {
-                        conf: {}
-                    }
-                },
-                metadata: {
-                    feedbackService: {
-                        url: state.feedbackBaseUrl && state.feedbackBaseUrl !== '' ? state.feedbackBaseUrl : null,
-                        key: state.feedbackApiKey && state.feedbackApiKey !== '' ? state.feedbackApiKey : null,
-                        extensions: state.feedbackExtensions && state.feedbackExtensions !== '' ? state.feedbackExtensions : null
-                    }
-                }
-            };
+const BUNDLE_ID = 'feedbackService';
+class FeedbackServiceTool extends AbstractPublisherTool {
+    constructor (...args) {
+        super(...args);
+        this.index = 9;
+        this.group = 'rpc';
+    }
+    getTool () {
+        return {
+            id: 'feedbackService.FeedbackServiceRPCTool',
+            title: Oskari.getMsg(BUNDLE_ID, 'display.publisher.label'),
+            config: {},
+            hasNoPlugin: true
+        };
+    }
+    getComponent () {
+        return {
+            component: FeedbackServiceForm,
+            handler: this.handler
+        };
+    }
+    init (data) {
+        this.handler = new FeedbackServiceToolHandler(data?.metadata?.feedbackService);
+        this.setEnabled(!!data?.configuration?.feedbackService);
+    }
+    getValues () {
+        if (!this.isEnabled()) {
+            return null;
         }
-    }, {
-        'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],
+
+        const state = this.handler.getState() || {};
+        return {
+            configuration: {
+                [BUNDLE_ID]: {
+                    conf: {}
+                }
+            },
+            metadata: {
+                [BUNDLE_ID]: {
+                    url: state.feedbackBaseUrl && state.feedbackBaseUrl !== '' ? state.feedbackBaseUrl : null,
+                    key: state.feedbackApiKey && state.feedbackApiKey !== '' ? state.feedbackApiKey : null,
+                    extensions: state.feedbackExtensions && state.feedbackExtensions !== '' ? state.feedbackExtensions : null
+                }
+            }
+        };
+    }
+}
+
+// Attach protocol to make this discoverable by Oskari publisher
+Oskari.clazz.defineES('Oskari.publisher.FeedbackServiceTool',
+    FeedbackServiceTool,
+    {
         'protocol': ['Oskari.mapframework.publisher.Tool']
-    });
+    }
+);

--- a/bundles/framework/maplegend/publisher/MapLegendTool.js
+++ b/bundles/framework/maplegend/publisher/MapLegendTool.js
@@ -1,60 +1,56 @@
-Oskari.clazz.define('Oskari.mapframework.publisher.tool.MapLegendTool',
-    function () {
-        this.handler = null;
-    }, {
-        index: 10,
-        group: 'layers',
-        bundleName: 'maplegend',
-        getComponent: function () {
-            return {};
-        },
-        getTool: function () {
-            return {
-                id: 'Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin',
-                title: Oskari.getMsg('maplegend', 'tool.label'),
-                config: this.state.pluginConfig || {},
-                disabledReason: Oskari.getMsg('maplegend', 'noLegendsText')
-            };
-        },
-        /**
-         * Initialise tool
-         * @method init
-         */
-        init: function (data) {
-            const myData = data?.configuration[this.bundleName];
-            if (myData) {
-                this.storePluginConf(myData.conf);
-                this.setEnabled(true);
-            }
-        },
-        isDisabled: function () {
-            // should we filter layers with isVisibleOnMap()?
-            return !this.getSandbox().findAllSelectedMapLayers().some(l => l.getLegendImage());
-        },
-        onLayersChanged: function () {
-            if (this.isEnabled() && this.isDisabled()) {
-                // disable if layers changed and there is no longer layers with legends on map
-                this.setEnabled(false);
-            }
-        },
-        /**
-         * Get values.
-         * @method getValues
-         * @public
-         *
-         * @returns {Object} tool value object
-         */
-        getValues: function () {
-            if (!this.isEnabled()) {
-                return null;
-            }
-            return {
-                [this.bundleName]: {
-                    conf: this.getPlugin().getConfig()
-                }
-            };
+import { AbstractPublisherTool } from '../../../framework/publisher2/tools/AbstractPublisherTool';
+
+const BUNDLE_ID = 'maplegend';
+class MapLegendTool extends AbstractPublisherTool {
+    constructor (...args) {
+        super(...args);
+        this.index = 10;
+        this.group = 'layers';
+    }
+    getTool () {
+        return {
+            id: 'Oskari.mapframework.bundle.maplegend.plugin.MapLegendPlugin',
+            title: Oskari.getMsg(BUNDLE_ID, 'tool.label'),
+            config: this.state.pluginConfig || {},
+            disabledReason: Oskari.getMsg(BUNDLE_ID, 'noLegendsText')
+        };
+    }
+    getComponent () {
+        return {};
+    }
+    init (data) {
+        const myData = data?.configuration[BUNDLE_ID];
+        if (myData) {
+            this.storePluginConf(myData.conf);
+            this.setEnabled(true);
         }
-    }, {
-        'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],
+    }
+    isDisabled () {
+        // should we filter layers with isVisibleOnMap()?
+        return !this.getSandbox().findAllSelectedMapLayers().some(l => l.getLegendImage());
+    }
+    onLayersChanged () {
+        if (this.isEnabled() && this.isDisabled()) {
+            // disable if layers changed and there is no longer layers with legends on map
+            this.setEnabled(false);
+        }
+    }
+    getValues () {
+        if (!this.isEnabled()) {
+            return null;
+        }
+        return {
+            [BUNDLE_ID]: {
+                conf: this.getPlugin().getConfig()
+            }
+        };
+    }
+}
+
+// Attach protocol to make this discoverable by Oskari publisher
+Oskari.clazz.defineES('Oskari.publisher.MapLegendTool',
+    MapLegendTool,
+    {
         'protocol': ['Oskari.mapframework.publisher.LayerTool']
-    });
+    }
+);

--- a/bundles/framework/publisher2/tools/AbstractPluginTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPluginTool.js
@@ -51,16 +51,6 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractPluginTool', fun
         return this.__mapmodule;
     },
     /**
-     * If the tool requires space for the UI next to the map return the required height/width
-     * @return {Object} object with keys height and width used for map size calculation
-     */
-    getAdditionalSize: function () {
-        return {
-            height: 0,
-            width: 0
-        };
-    },
-    /**
     * Get tool object.
     * @method getTool
     * @rivate

--- a/bundles/framework/publisher2/tools/AbstractPublisherTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPublisherTool.js
@@ -29,7 +29,7 @@ export class AbstractPublisherTool {
             this.setEnabled(true);
         }
     }
-    
+
     // override per tool
     getTool () {
         return {
@@ -157,7 +157,6 @@ export class AbstractPublisherTool {
         return null;
     }
 };
-
 
 /*
 Make base class discoverable through Oskari.clazz.get('Oskari.publisher.AbstractPublisherTool')

--- a/bundles/framework/publisher2/tools/AbstractPublisherTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPublisherTool.js
@@ -1,0 +1,176 @@
+
+export class AbstractPublisherTool {
+    constructor (sandbox, mapmodule, localization = {}) {
+        // override to change group (tool panel is created for each unique group)
+        this.group = 'maptools';
+        // index defines order in which the tools are listed on the group panel
+        this.index = 0;
+        // '*' means any, can be restricted to 'bottom left', 'bottom right' etc
+        this.allowedLocations = ['*'];
+        // List of plugin classes that can reside in same container like 'Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin'
+        // '*' means no restrictions
+        this.allowedSiblings = ['*'];
+        // boilerplate
+        this.__sandbox = sandbox;
+        this.__mapmodule = mapmodule;
+        this.__plugin = null;
+        this.state = {
+            // This variable is used to save tool state (is checked) and if it's true then we get tool json when saving published map.
+            enabled: false,
+            pluginConfig: null
+        };
+        this.__loc = localization[this.group];
+    }
+
+    init (data) {
+        const plugin = this.findPluginFromInitData(data);
+        if (plugin) {
+            this.storePluginConf(plugin.config);
+            this.setEnabled(true);
+        }
+    }
+    
+    // override per tool
+    getTool () {
+        return {
+            id: 'N/A',
+            title: 'N/A',
+            config: this.state.pluginConfig || {}
+        };
+    }
+    // deprecated - new (React based) tools should use getTool().title instead
+    getTitle () {
+        return this.__loc[this.getTool().title];
+    }
+    getGroup () {
+        return this.group;
+    }
+    getIndex () {
+        return this.index;
+    }
+
+    findPluginFromInitData (data) {
+        const toolId = this.getTool().id;
+        // assume it's in mapfull bundles plugins array as most of the default tools are stored there
+        return data?.configuration?.mapfull?.conf?.plugins?.find(plugin => toolId === plugin.id);
+    }
+    storePluginConf (conf) {
+        this.state.pluginConfig = conf || {};
+    }
+    setEnabled (enabled) {
+        var tool = this.getTool();
+
+        // state actually hasn't changed -> do nothing
+        if (this.isEnabled() === enabled) {
+            return false;
+        }
+        if (!enabled) {
+            this.stop();
+        } else if (tool.hasNoPlugin !== true) {
+            let plugin = this.getPlugin();
+            if (!plugin) {
+                plugin = Oskari.clazz.create(tool.id, tool.config);
+                this.__plugin = plugin;
+            }
+            this.getMapmodule().registerPlugin(plugin);
+            plugin.startPlugin(this.getSandbox());
+        }
+        // Stop checks if we are already disabled so toggle the value after
+        this.state.enabled = enabled;
+        // notify publisher tool layout panel in case tool placement dragging needs to be toggled
+        var event = Oskari.eventBuilder('Publisher2.ToolEnabledChangedEvent')(this);
+        this.getSandbox().notifyAll(event);
+        return true;
+    }
+
+    isEnabled () {
+        return !!this.state.enabled;
+    }
+    getValues () {
+        // override
+        return null;
+    }
+    stop () {
+        if (!this.isEnabled()) {
+            return;
+        }
+        var tool = this.getTool();
+        if (tool.hasNoPlugin !== true) {
+            const plugin = this.getPlugin();
+            if (!plugin) {
+                return;
+            }
+            if (this.getSandbox()) {
+                plugin.stopPlugin(this.getSandbox());
+            }
+            this.getMapmodule().unregisterPlugin(plugin);
+            this.__plugin = null;
+        }
+    }
+    /**
+    * Is displayed. We can use this to tell when tool is displayed.
+    * For example if stats layers are added to map when opening publisher we can tell at then this tool need to be shown (ShowStatsTableTool).
+    * Is there is no stats layer then not show the tool.
+    *
+    * @method isDisplayed
+    * @public
+    *
+    * @returns {Boolean} is tool displayed
+    */
+    isDisplayed () {
+        return true;
+    }
+    /**
+    * Is this tool available.
+    * @method isDisabled
+    * @public
+    *
+    * @returns {Boolean} is tool disabled
+    */
+    isDisabled (data) {
+        return false;
+    }
+    validate () {
+        // always valid by default
+        // could return false if there's something wrong that should require stopping the user from saving
+        return true;
+    }
+
+    getPlugin () {
+        return this.__plugin;
+    }
+    getSandbox () {
+        return this.__sandbox;
+    }
+    getMapmodule () {
+        return this.__mapmodule;
+    }
+    getAllowedLocations () {
+        return this.allowedLocations;
+    }
+    // old tools return jQuery object that renders the extra options for this tool
+    getExtraOptions () {
+        return null;
+    }
+};
+
+
+/*
+Make base class discoverable through Oskari.clazz.get('Oskari.publisher.AbstractPublisherTool')
+
+Usage:
+
+const AbstractPublisherTool = Oskari.clazz.get('Oskari.publisher.AbstractPublisherTool')
+class MyTool extends AbstractPublisherTool {
+    // TODO: impl specifics for tool
+}
+
+// Attach protocol to make this discoverable by Oskari publisher
+Oskari.clazz.defineES('Oskari.publisher.MyTool',
+    MyTool,
+    {
+        'protocol': ['Oskari.mapframework.publisher.Tool']
+    }
+);
+ */
+Oskari.clazz.defineES('Oskari.publisher.AbstractPublisherTool', AbstractPublisherTool);

--- a/bundles/framework/publisher2/tools/AbstractPublisherTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPublisherTool.js
@@ -40,7 +40,11 @@ export class AbstractPublisherTool {
     }
     // deprecated - new (React based) tools should use getTool().title instead
     getTitle () {
-        return this.__loc[this.getTool().title];
+        const toolTitle = this.getTool().title;
+        if (!this.__loc) {
+            return toolTitle;
+        }
+        return this.__loc[toolTitle];
     }
     getGroup () {
         return this.group;

--- a/bundles/framework/publisher2/tools/AbstractPublisherTool.js
+++ b/bundles/framework/publisher2/tools/AbstractPublisherTool.js
@@ -159,7 +159,8 @@ export class AbstractPublisherTool {
 };
 
 /*
-Make base class discoverable through Oskari.clazz.get('Oskari.publisher.AbstractPublisherTool')
+Make base class discoverable through Oskari.clazz.get('Oskari.publisher.AbstractPublisherTool');
+NOTE! This might not work for bundles that are bundled _before_ the publisher bundle
 
 Usage:
 

--- a/bundles/framework/publisher2/tools/ControlsTool.js
+++ b/bundles/framework/publisher2/tools/ControlsTool.js
@@ -1,78 +1,83 @@
-Oskari.clazz.define('Oskari.mapframework.publisher.tool.ControlsTool',
-    function () {
-    }, {
-        index: 5,
-        pluginName: 'ControlsPlugin',
-        init: function (data) {
-            const plugin = this.findPluginFromInitData(data);
-            if (plugin) {
-                var hasConfig = typeof plugin.config === 'object';
-                if (hasConfig) {
-                    this.storePluginConf(plugin.config);
-                }
-                // enabled if either no config OR has config with false flag
-                this.setEnabled(!hasConfig || (hasConfig && plugin.config.keyboardControls !== false));
-            }
-        },
-        // override since we want to use the instance we currently have, not create a new one
-        setEnabled: function (enabled) {
-            // state actually hasn't changed -> do nothing
-            if (this.isEnabled() === enabled) {
-                return;
-            }
-            this.state.enabled = enabled;
-            this.allowPanning(!!enabled);
+import { AbstractPublisherTool } from './AbstractPublisherTool';
 
-            var event = Oskari.eventBuilder('Publisher2.ToolEnabledChangedEvent')(this);
-            this.getSandbox().notifyAll(event);
-        },
-        getTool: function () {
-            return {
-                id: 'Oskari.mapframework.mapmodule.ControlsPlugin',
-                title: 'ControlsPlugin',
-                config: this.state.pluginConfig || {}
-            };
-        },
-        getPlugin: function () {
-            // always use the instance on map, not a new copy
-            return this.getMapmodule().getPluginInstances('ControlsPlugin');
-        },
-        getConfig: function () {
-            // NOTE! isEnabled returning null is ON PURPOSE!
-            // Usually this is reversed
-            if (this.isEnabled()) {
-                return null;
+class ControlsTool extends AbstractPublisherTool {
+    getIndex () {
+        return 5;
+    }
+    getTool () {
+        return {
+            id: 'Oskari.mapframework.mapmodule.ControlsPlugin',
+            title: 'ControlsPlugin',
+            config: this.state.pluginConfig || {},
+            hasNoPlugin: true
+        };
+    }
+    init (data) {
+        const plugin = this.findPluginFromInitData(data);
+        if (plugin) {
+            var hasConfig = typeof plugin.config === 'object';
+            if (hasConfig) {
+                this.storePluginConf(plugin.config);
             }
-            // In this one we want to have the plugin always present but we configure it to disable controls
-            return {
-                keyboardControls: false,
-                mouseControls: false
-            };
-        },
-        allowPanning: function (enabled) {
-            if (!enabled) {
-                this.getSandbox().postRequestByName('DisableMapKeyboardMovementRequest', []);
-                this.getSandbox().postRequestByName('DisableMapMouseMovementRequest', []);
-            } else {
-                this.getSandbox().postRequestByName('EnableMapKeyboardMovementRequest', []);
-                this.getSandbox().postRequestByName('EnableMapMouseMovementRequest', []);
-            }
-        },
-        getValues: function () {
-            return {
-                configuration: {
-                    mapfull: {
-                        conf: {
-                            plugins: [{ id: this.getTool().id, config: this.getConfig() }]
-                        }
+            // enabled if either no config OR has config with false flag
+            this.setEnabled(!hasConfig || (hasConfig && plugin.config.keyboardControls !== false));
+        }
+    }
+    // override since we want to use the instance we currently have, not create a new one
+    setEnabled (enabled) {
+        const changed = super.setEnabled(enabled);
+        if (!changed) {
+            return;
+        }
+        this.allowPanning(!!enabled);
+    }
+    getPlugin () {
+        // always use the instance on map, not a new copy
+        return this.getMapmodule().getPluginInstances('ControlsPlugin');
+    }
+    allowPanning (enabled) {
+        if (!enabled) {
+            this.getSandbox().postRequestByName('DisableMapKeyboardMovementRequest', []);
+            this.getSandbox().postRequestByName('DisableMapMouseMovementRequest', []);
+        } else {
+            this.getSandbox().postRequestByName('EnableMapKeyboardMovementRequest', []);
+            this.getSandbox().postRequestByName('EnableMapMouseMovementRequest', []);
+        }
+    }
+    getValues () {
+        return {
+            configuration: {
+                mapfull: {
+                    conf: {
+                        plugins: [{ id: this.getTool().id, config: this.getConfig() }]
                     }
                 }
-            };
-        },
-        stop: function () {
-            this.allowPanning(true);
+            }
+        };
+    }
+    getConfig () {
+        // NOTE! returning null when isEnabled() is ON PURPOSE!
+        // Usually this is reversed
+        if (this.isEnabled()) {
+            return null;
         }
-    }, {
-        'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],
+        // In this one we want to have the plugin always present but we configure it to disable controls
+        return {
+            keyboardControls: false,
+            mouseControls: false
+        };
+    }
+    stop () {
+        super.stop();
+        // resume panning on map
+        this.allowPanning(true);
+    }
+}
+
+// Attach protocol to make this discoverable by Oskari publisher
+Oskari.clazz.defineES('Oskari.publisher.ControlsTool',
+    ControlsTool,
+    {
         'protocol': ['Oskari.mapframework.publisher.Tool']
-    });
+    }
+);

--- a/bundles/framework/publisher2/tools/CrosshairTool.js
+++ b/bundles/framework/publisher2/tools/CrosshairTool.js
@@ -1,64 +1,60 @@
-Oskari.clazz.define('Oskari.mapframework.publisher.tool.CrosshairTool',
-    function () {
-    }, {
-        getName: function () {
-            return 'Oskari.mapframework.publisher.tool.CrosshairTool';
-        },
-        /**
-        * Get tool object.
-        * @method getTool
-        *
-        * @returns {Object} tool description
-        */
-        getTool: function () {
-            return {
-                id: 'Oskari.mapframework.publisher.tool.CrosshairTool',
-                title: 'CrosshairTool',
-                config: this.state.pluginConfig || {},
-                hasNoPlugin: true
-            };
-        },
-        init: function (data) {
-            if (Oskari.util.keyExists(data, 'configuration.mapfull.conf.mapOptions.crosshair')) {
-                this.setEnabled(!!data?.configuration?.mapfull?.conf?.mapOptions?.crosshair);
-            }
-        },
-        /**
-        * Get values.
-        * @method getValues
-        * @public
-        *
-        * @returns {Object} tool value object
-        */
-        getValues: function () {
-            if (!this.isEnabled()) {
-                return null;
-            }
-            return {
-                configuration: {
-                    mapfull: {
-                        conf: {
-                            mapOptions: {
-                                crosshair: true
-                            }
+import { AbstractPublisherTool } from './AbstractPublisherTool';
+
+class CrosshairTool extends AbstractPublisherTool {
+    getTool () {
+        return {
+            id: 'Oskari.mapframework.publisher.tool.CrosshairTool',
+            title: 'CrosshairTool',
+            config: this.state.pluginConfig || {},
+            hasNoPlugin: true
+        };
+    }
+    init (data) {
+        if (Oskari.util.keyExists(data, 'configuration.mapfull.conf.mapOptions.crosshair')) {
+            this.setEnabled(!!data?.configuration?.mapfull?.conf?.mapOptions?.crosshair);
+        }
+    }
+    // override since we want to use the instance we currently have, not create a new one
+    setEnabled (enabled) {
+        const changed = super.setEnabled(enabled);
+        if (!changed) {
+            return;
+        }
+        const mapModule = this.getMapmodule();
+        if (mapModule) {
+            mapModule.toggleCrosshair(enabled);
+        }
+    }
+    getValues () {
+        if (!this.isEnabled()) {
+            return null;
+        }
+        return {
+            configuration: {
+                mapfull: {
+                    conf: {
+                        mapOptions: {
+                            crosshair: true
                         }
                     }
                 }
-            };
-        },
-        _setEnabledImpl: function (enabled) {
-            const mapModule = this.getMapmodule();
-            if (mapModule) {
-                mapModule.toggleCrosshair(enabled);
             }
-        },
-        _stopImpl: function () {
-            const mapModule = this.getMapmodule();
-            if (mapModule) {
-                mapModule.toggleCrosshair(false);
-            }
+        };
+    }
+    stop () {
+        super.stop();
+        // remove crosshair from map
+        const mapModule = this.getMapmodule();
+        if (mapModule) {
+            mapModule.toggleCrosshair(false);
         }
-    }, {
-        'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],
+    }
+}
+
+// Attach protocol to make this discoverable by Oskari publisher
+Oskari.clazz.defineES('Oskari.publisher.CrosshairTool',
+    CrosshairTool,
+    {
         'protocol': ['Oskari.mapframework.publisher.Tool']
-    });
+    }
+);

--- a/bundles/framework/publisher2/tools/IndexMapTool.js
+++ b/bundles/framework/publisher2/tools/IndexMapTool.js
@@ -1,57 +1,37 @@
-Oskari.clazz.define('Oskari.mapframework.publisher.tool.IndexMapTool',
-    function () {
-    }, {
-        index: 1,
-        lefthanded: 'bottom right',
-        righthanded: 'bottom left',
+import { AbstractPublisherTool } from './AbstractPublisherTool';
 
-        /**
-        * Get tool object.
-        * @method getTool
-        *
-        * @returns {Object} tool description
-        */
-        getTool: function () {
-            return {
-                id: 'Oskari.mapframework.bundle.mapmodule.plugin.IndexMapPlugin',
-                title: 'IndexMapPlugin',
-                config: this.state.pluginConfig || {}
-            };
-        },
-
-        /**
-        * Is displayed.
-        * @method isDisplayed
-        * @public
-        *
-        * @returns {Boolean} is tool displayed
-        */
-        isDisplayed: function () {
-            return !Oskari.getSandbox().getMap().getSupports3D();
-        },
-
-        /**
-        * Get values.
-        * @method getValues
-        * @public
-        *
-        * @returns {Object} tool value object
-        */
-        getValues: function () {
-            if (!this.isEnabled()) {
-                return null;
-            }
-            return {
-                configuration: {
-                    mapfull: {
-                        conf: {
-                            plugins: [{ id: this.getTool().id, config: this.getPlugin().getConfig() }]
-                        }
+class IndexMapTool extends AbstractPublisherTool {
+    getTool () {
+        return {
+            id: 'Oskari.mapframework.bundle.mapmodule.plugin.IndexMapPlugin',
+            title: 'IndexMapPlugin',
+            config: this.state.pluginConfig || {}
+        };
+    }
+    isDisplayed () {
+        // not shown on 3d maps
+        return !Oskari.getSandbox().getMap().getSupports3D();
+    }
+    getValues () {
+        if (!this.isEnabled()) {
+            return null;
+        }
+        return {
+            configuration: {
+                mapfull: {
+                    conf: {
+                        plugins: [{ id: this.getTool().id, config: this.getPlugin().getConfig() }]
                     }
                 }
-            };
-        }
-    }, {
-        'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],
+            }
+        };
+    }
+}
+
+// Attach protocol to make this discoverable by Oskari publisher
+Oskari.clazz.defineES('Oskari.publisher.IndexMapTool',
+IndexMapTool,
+    {
         'protocol': ['Oskari.mapframework.publisher.Tool']
-    });
+    }
+);

--- a/bundles/framework/publisher2/tools/IndexMapTool.js
+++ b/bundles/framework/publisher2/tools/IndexMapTool.js
@@ -30,7 +30,7 @@ class IndexMapTool extends AbstractPublisherTool {
 
 // Attach protocol to make this discoverable by Oskari publisher
 Oskari.clazz.defineES('Oskari.publisher.IndexMapTool',
-IndexMapTool,
+    IndexMapTool,
     {
         'protocol': ['Oskari.mapframework.publisher.Tool']
     }

--- a/bundles/framework/publisher2/tools/MapLayerListTool.js
+++ b/bundles/framework/publisher2/tools/MapLayerListTool.js
@@ -57,7 +57,7 @@ class MapLayerListTool extends AbstractPublisherTool {
 
 // Attach protocol to make this discoverable by Oskari publisher
 Oskari.clazz.defineES('Oskari.publisher.MapLayerListTool',
-MapLayerListTool,
+    MapLayerListTool,
     {
         'protocol': ['Oskari.mapframework.publisher.LayerTool']
     }

--- a/bundles/framework/publisher2/tools/MapLayerListTool.js
+++ b/bundles/framework/publisher2/tools/MapLayerListTool.js
@@ -1,60 +1,64 @@
+import { AbstractPublisherTool } from './AbstractPublisherTool';
 import { MapLayerListToolComponent } from '../view/MapLayers/MapLayerListToolComponent';
 import { MapLayerListHandler } from '../handler/MapLayerListHandler';
 
 export const LAYERLIST_ID = 'Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionPlugin';
 
-Oskari.clazz.define('Oskari.mapframework.publisher.tool.MapLayerListTool',
-    function () {
+class MapLayerListTool extends AbstractPublisherTool {
+    constructor (...args) {
+        super(...args);
+        this.index = 5;
+        this.group = 'layers';
         this.handler = new MapLayerListHandler(this);
-    }, {
-        index: 5,
-        group: 'layers',
-        getComponent: function () {
-            return {
-                component: MapLayerListToolComponent,
-                handler: this.handler
-            };
-        },
-        getTool: function () {
-            return {
-                id: LAYERLIST_ID,
-                title: Oskari.getMsg('Publisher2', 'BasicView.layerselection.label'),
-                config: this.state.pluginConfig || {}
-            };
-        },
-        init: function (data) {
-            const plugin = this.findPluginFromInitData(data);
-            if (plugin) {
-                this.storePluginConf(plugin.config);
-                // we need some way of restoring state to handler -> passing init data to it
-                this.handler.init(plugin.config);
-                this.setEnabled(true);
-            }
-        },
-        getValues: function () {
-            if (!this.isEnabled()) {
-                return null;
-            }
-            const pluginConfig = this.getPlugin().getConfig();
-            const value = {
-                configuration: {
-                    mapfull: {
-                        conf: {
-                            plugins: [{ id: this.getTool().id, config: pluginConfig }]
-                        }
+    }
+    getTool () {
+        return {
+            id: LAYERLIST_ID,
+            title: Oskari.getMsg('Publisher2', 'BasicView.layerselection.label'),
+            config: this.state.pluginConfig || {}
+        };
+    }
+    getComponent () {
+        return {
+            component: MapLayerListToolComponent,
+            handler: this.handler
+        };
+    }
+    init (data) {
+        super.init(data);
+        // restore state to handler -> passing init data to it
+        this.handler.init(this.getTool().config);
+    }
+    getValues () {
+        if (!this.isEnabled()) {
+            return null;
+        }
+        const pluginConfig = this.getPlugin().getConfig();
+        const value = {
+            configuration: {
+                mapfull: {
+                    conf: {
+                        plugins: [{ id: this.getTool().id, config: pluginConfig }]
                     }
                 }
-            };
-            if (pluginConfig.showMetadata) {
-                // we need to add metadataflyout bundle as well for links to work properly
-                value.configuration.metadataflyout = {};
             }
-            return value;
-        },
-        _stopImpl: function () {
-            this.handler.clearState();
+        };
+        if (pluginConfig.showMetadata) {
+            // we need to add metadataflyout bundle as well for links to work properly
+            value.configuration.metadataflyout = {};
         }
-    }, {
-        'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],
+        return value;
+    }
+    stop () {
+        super.stop();
+        this.handler.clearState();
+    }
+}
+
+// Attach protocol to make this discoverable by Oskari publisher
+Oskari.clazz.defineES('Oskari.publisher.MapLayerListTool',
+MapLayerListTool,
+    {
         'protocol': ['Oskari.mapframework.publisher.LayerTool']
-    });
+    }
+);


### PR DESCRIPTION
Usage:
```
// or import directly from under publisher
const AbstractPublisherTool = Oskari.clazz.get('Oskari.publisher.AbstractPublisherTool')

class MyTool extends AbstractPublisherTool {
    // TODO: impl specifics for tool
}

// Attach protocol to make this discoverable by Oskari publisher
Oskari.clazz.defineES('Oskari.publisher.MyTool',
    MyTool,
    {
        'protocol': ['Oskari.mapframework.publisher.Tool']
    }
);
```

The base class could still use some tuning. It would probably be less error-prone overriding getIndex() etc as functions than overriding constructor to assign index.