### PR TITLE
Add error handling to layer admin visualization tab

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VisualizationTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VisualizationTabPane.jsx
@@ -1,6 +1,6 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { Controller } from 'oskari-ui/util';
+import { Controller, ErrorBoundary } from 'oskari-ui/util';
 import { Opacity } from './Opacity';
 import { Hover } from './Hover';
 import { DynamicScreensPaceErrorOptions } from './DynamicScreensSpaceErrorOptions';
@@ -30,6 +30,7 @@ const {
     DECLUTTER
 } = Oskari.clazz.get('Oskari.mapframework.domain.LayerComposingModel');
 
+
 export const VisualizationTabPane = ({ layer, scales, propertyFields, controller }) => {
     const isLayerTypeSupported = propertyFields.length > 0;
     if (!isLayerTypeSupported) {
@@ -37,8 +38,7 @@ export const VisualizationTabPane = ({ layer, scales, propertyFields, controller
     }
     const showExternalVectorStyle = propertyFields.includes(EXTERNAL_VECTOR_STYLES);
     const showVectorStyle = propertyFields.includes(VECTOR_STYLES) || showExternalVectorStyle;
-
-    return (<Fragment>
+    return (<ErrorBoundary>
         <StyledColumn.Left>
             { propertyFields.includes(OPACITY) &&
                 <Opacity layer={layer} controller={controller} />
@@ -76,7 +76,7 @@ export const VisualizationTabPane = ({ layer, scales, propertyFields, controller
                 <Scale layer={layer} scales={scales} controller={controller} />
             }
         </StyledColumn.Right>
-    </Fragment>);
+    </ErrorBoundary>);
 };
 
 VisualizationTabPane.propTypes = {

--- a/src/react/util/ErrorBoundary.jsx
+++ b/src/react/util/ErrorBoundary.jsx
@@ -1,8 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { WarningOutlined } from '@ant-design/icons';
 import { getMsg } from './locale';
 
-const DefaultError = () => (<h1>{getMsg('error.generic')}</h1>);
+export const getGenericMsg = () => getMsg('error.generic');
+
+const ErrorTag = styled('h2')`
+    color: red;
+`;
+const DefaultError = () => (
+    <ErrorTag>
+        <WarningOutlined /> {getGenericMsg()}
+    </ErrorTag>);
 /**
  * Usage:
  * 1) Wrap components to "try/catch" with:


### PR DESCRIPTION
The tab now shows an error message and allows to change tabs even on error instead of completely breaking:

![errorboundary](https://user-images.githubusercontent.com/2210335/233982872-a4197835-fd3b-4928-8914-dfd9aeafde5b.gif)

-> 

![errorboundary_fix](https://user-images.githubusercontent.com/2210335/233982896-2515326a-f256-4195-8ddd-0bff95202bd5.gif)

ErrorBoundary also adds a message to developer tools:
![image](https://user-images.githubusercontent.com/2210335/233984007-cc43ed83-3cc0-4115-bf30-75e89f860e1d.png)

