### PR TITLE
Make sure layers are added to map in specified order

### DIFF
--- a/bundles/mapping/mapmodule/request/map.layer.handler.js
+++ b/bundles/mapping/mapmodule/request/map.layer.handler.js
@@ -66,8 +66,8 @@ Oskari.clazz.define('map.layer.handler',
             }
         },
         /**
-         * Triggers loading additional info for layers (if needed)
-         * and adds the layer asynchronously, but in the order the method is called
+         * Triggers loading additional info for layers (when needed) and adding them to a queue to be added to map.
+         * Adding can be asynchronous for some layers, but the order the method is called will be respected
          * @param {String} layerId id for layer to add
          * @param {String} triggeredBy (optional) what triggered the add
          */
@@ -91,8 +91,8 @@ Oskari.clazz.define('map.layer.handler',
         },
         /**
          * Processes the queue for layers to add to map in the order they were requested to be added.
-         * The queue is used so layers can be added in the order that they were requested to be added
-         * even when theres some asynchronous loading happening between request and actual adding to the map
+         * The queue is used to ensure order even when theres some asynchronous loading happening between
+         * request and actual adding to the map
          */
         __processLayerQueue: function () {
             let nextLayer = this.layerQueue[0];

--- a/bundles/mapping/mapmodule/request/map.layer.handler.js
+++ b/bundles/mapping/mapmodule/request/map.layer.handler.js
@@ -16,6 +16,7 @@ Oskari.clazz.define('map.layer.handler',
         this.mapState = mapState;
         this.layerService = layerService;
         this.log = Oskari.log('map.layer.handler');
+        this.layerQueue = [];
     }, {
         /**
          * @method handleRequest
@@ -26,59 +27,93 @@ Oskari.clazz.define('map.layer.handler',
          *      request to handle
          */
         handleRequest: function (core, request) {
-            var sandbox = this.layerService.getSandbox();
-            var layer;
-            var evt;
+            const sandbox = this.layerService.getSandbox();
 
             if (request.getName() === 'activate.map.layer') {
-                var layerId = request.getLayerId();
+                const layerId = request.getLayerId();
                 if (request.isActivated()) {
                     this.mapState.activateLayer(layerId, request._creator);
                 } else {
                     this.mapState.deactivateLayer(layerId, request._creator);
                 }
             } else if (request.getName() === 'AddMapLayerRequest') {
-                layer = this.layerService.findMapLayer(request.getMapLayerId());
-                const addLayer = () => this.mapState.addLayer(layer, request._creator);
-                this._loadLayerInfo(layer, addLayer);
+                this._addToMap(request.getMapLayerId(), request._creator);
             } else if (request.getName() === 'RemoveMapLayerRequest') {
                 this.mapState.removeLayer(request.getMapLayerId(), request._creator);
             } else if (request.getName() === 'RearrangeSelectedMapLayerRequest') {
                 this.mapState.moveLayer(request.getMapLayerId(), request.getToPosition(), request._creator);
             } else if (request.getName() === 'ChangeMapLayerOpacityRequest') {
-                layer = this.mapState.getSelectedLayer(request.getMapLayerId());
+                const layer = this.mapState.getSelectedLayer(request.getMapLayerId());
                 const opacity = request.getOpacity();
                 if (!layer || isNaN(opacity)) {
                     return;
                 }
                 layer.setOpacity(Number(opacity));
 
-                evt = Oskari.eventBuilder('AfterChangeMapLayerOpacityEvent')(layer);
+                const evt = Oskari.eventBuilder('AfterChangeMapLayerOpacityEvent')(layer);
                 evt._creator = request._creator;
                 sandbox.notifyAll(evt);
             } else if (request.getName() === 'ChangeMapLayerStyleRequest') {
-                layer = this.mapState.getSelectedLayer(request.getMapLayerId());
+                const layer = this.mapState.getSelectedLayer(request.getMapLayerId());
                 if (!layer) {
                     return;
                 }
                 layer.selectStyle(request.getStyle());
 
-                evt = Oskari.eventBuilder('AfterChangeMapLayerStyleEvent')(layer);
+                const evt = Oskari.eventBuilder('AfterChangeMapLayerStyleEvent')(layer);
                 evt._creator = request._creator;
                 sandbox.notifyAll(evt);
             }
         },
-        _loadLayerInfo: function (layer, addLayer) {
+        /**
+         * Triggers loading additional info for layers (if needed)
+         * and adds the layer asynchronously, but in the order the method is called
+         * @param {String} layerId id for layer to add
+         * @param {String} triggeredBy (optional) what triggered the add
+         */
+        _addToMap: function (layerId, triggeredBy) {
+            const layer = this.layerService.findMapLayer(layerId);
+            const layerStatus = {
+                layer,
+                triggeredBy,
+                ready: false
+            };
+            // use queue so the layers are added to map in the same order as they are added with the request
+            // otherwise layers would be added to map in the order where the additional metadata loading was completed
+            this.layerQueue.push(layerStatus);
+            const done = () => {
+                // change status for this layer
+                layerStatus.ready = true;
+                // add layers from front of queue to map
+                this.__processLayerQueue();
+            };
+            this._loadLayerInfo(layer, done);
+        },
+        /**
+         * Processes the queue for layers to add to map in the order they were requested to be added.
+         * The queue is used so layers can be added in the order that they were requested to be added
+         * even when theres some asynchronous loading happening between request and actual adding to the map
+         */
+        __processLayerQueue: function () {
+            let nextLayer = this.layerQueue[0];
+            while (nextLayer && nextLayer.ready) {
+                this.mapState.addLayer(nextLayer.layer, nextLayer.triggeredBy);
+                this.layerQueue.shift();
+                nextLayer = this.layerQueue[0];
+            }
+        },
+
+        _loadLayerInfo: function (layer, done) {
             if (typeof layer.getDescribeLayerStatus !== 'function') {
                 // layer type doesn't support this
-                addLayer();
+                done();
                 return;
             }
             const layerId = layer.getId();
             const status = layer.getDescribeLayerStatus();
             // only layers that have numeric ids can have reasonable response for DescribeLayer
             if (isNaN(layerId) || status === DESCRIBE_LAYER.LOADED) {
-                addLayer();
+                done();
                 return;
             }
             if (status === DESCRIBE_LAYER.PENDING) {
@@ -100,7 +135,7 @@ Oskari.clazz.define('map.layer.handler',
                 sandbox.findRegisteredModuleInstance('MainMapModule').handleDescribeLayer(layer, info);
                 const event = Oskari.eventBuilder('MapLayerEvent')(layerId, 'update');
                 sandbox.notifyAll(event);
-                addLayer();
+                done();
             });
         }
     }, {


### PR DESCRIPTION
This is needed because some layers need to load additional metadata before they can be added to map. WMTS-layers load their tilematrix, vectorlayers load for example styles.

This changes the logic to use a queue to ensure the layers stay in the order they are added and not in the order in which their metadata loads.