### PR TITLE
Add message for user when layer can't be shown

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -380,7 +380,7 @@ Oskari.clazz.define(
                 startUserLocationRequestHandler: Oskari.clazz.create('Oskari.mapframework.bundle.mapmodule.request.StartUserLocationTrackingRequestHandler', sandbox, this),
                 stopUserLocationRequestHandler: Oskari.clazz.create('Oskari.mapframework.bundle.mapmodule.request.StopUserLocationTrackingRequestHandler', sandbox, this),
                 registerStyleRequestHandler: Oskari.clazz.create('Oskari.mapframework.bundle.mapmodule.request.RegisterStyleRequestHandler', sandbox, this),
-                mapLayerHandler: Oskari.clazz.create('map.layer.handler', sandbox.getMap(), this._mapLayerService),
+                mapLayerHandler: Oskari.clazz.create('map.layer.handler', sandbox.getMap(), this._mapLayerService, this._loc),
                 mapTourRequestHandler: Oskari.clazz.create('Oskari.mapframework.bundle.mapmodule.request.MapTourRequestHandler', sandbox, this),
                 setTimeRequestHandler: Oskari.clazz.create('Oskari.mapframework.bundle.mapmodule.request.SetTimeRequestHandler', this)
             };

--- a/bundles/mapping/mapmodule/request/map.layer.handler.js
+++ b/bundles/mapping/mapmodule/request/map.layer.handler.js
@@ -132,7 +132,6 @@ Oskari.clazz.define('map.layer.handler',
                 if (!info) {
                     layer.setDescribeLayerStatus(DESCRIBE_LAYER.ERROR);
                     if (layer.requiresDescribeLayer()) {
-                        // notify user here or in implementations
                         this.log.error('Attempt to add layer that requires more info. Skipping id: ' + layerId);
                         done(true);
                         return;

--- a/bundles/mapping/mapmodule/request/map.layer.handler.js
+++ b/bundles/mapping/mapmodule/request/map.layer.handler.js
@@ -1,4 +1,5 @@
 import { DESCRIBE_LAYER } from '../domain/constants';
+import { Messaging } from 'oskari-ui/util';
 /**
  * @class map.layer.handler
  * Handles requests concerning map layers.
@@ -12,8 +13,9 @@ Oskari.clazz.define('map.layer.handler',
      *            mapState reference to state object
      */
 
-    function (mapState, layerService) {
+    function (mapState, layerService, getMsg) {
         this.mapState = mapState;
+        this.getMsg = getMsg;
         this.layerService = layerService;
         this.log = Oskari.log('map.layer.handler');
         this.layerQueue = [];
@@ -86,6 +88,7 @@ Oskari.clazz.define('map.layer.handler',
                 if (error) {
                     // filter layerStatus out from queue so it doesn't block other layers from being added to the map
                     this.layerQueue = this.layerQueue.filter(status => status !== layerStatus);
+                    Messaging.error(this.getMsg('layerUnsupported.unavailable', { name: layer.getName() }));
                 } else {
                     layerStatus.ready = true;
                 }


### PR DESCRIPTION
Due to DescribeLayer call failing.

To reproduce:
1) load geoportal page as normal
2) from dev tools: set network to offline
3) add a wmts-layer on the map

As the frontend can't get the tilematrix for the layer (critical for WMTS), this localized error message is shown with the name of the problematic layer:

![image](https://user-images.githubusercontent.com/2210335/234317346-59f9054a-c668-40f1-a934-13bda9f16120.png)

Previously the layer just wasn't added to the map. Now this kind of error gives an error message to the user as well.