### PR TITLE
Store refs to publishing users styles for the embedded map

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -9,6 +9,12 @@ Some extra tags:
 - [rpc] tag indicates that the change affects RPC API
 - [breaking] tag indicates that the change is not backwards compatible
 
+## 2.11.0
+
+###  [mod] AddMapLayerRequest
+
+Introduced a second parameter for the request called `options`. This is used to restore vector layer styles on embedded maps for guest users in a way the user that published the map sees them on the publisher functionality.
+
 ## 2.10.0
 
 ### [rem] MapResizeEnabledRequest

--- a/api/mapping/mapmodule/request/addmaplayerrequest.md
+++ b/api/mapping/mapmodule/request/addmaplayerrequest.md
@@ -17,6 +17,10 @@ Requests a map layer to be added on the map. Note that the layer details are req
 <tr>
   <td> \* mapLayerId </td><td> String </td><td> id for map layer to be added (Oskari.mapframework.service.MapLayerService) </td><td> </td>
 </tr>
+<tr>
+  <td> options </td><td> Object </td><td> additional options for the layer to be added. The only currently handled key is `userStyles` which is passed on to DescribeLayer to get any styles associated for the layer when using it on a published map. If userStyles is not passed (for guest users) the layer only has the styles added by admin and the style that is referenced as current style. </td><td> </td>
+</tr>
+
 </table>
 
 ## Examples

--- a/bundles/framework/mapfull/instance.js
+++ b/bundles/framework/mapfull/instance.js
@@ -311,7 +311,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
             const rbAdd = Oskari.requestBuilder('AddMapLayerRequest');
             const rbOpacity = Oskari.requestBuilder('ChangeMapLayerOpacityRequest');
             const rbVisible = Oskari.requestBuilder('MapModulePlugin.MapLayerVisibilityRequest');
-
+            const isGuest = !Oskari.user().isLoggedIn();
             const layersNotAvailable = [];
             selectedLayers.forEach(layer => {
                 const oskariLayer = sandbox.findMapLayerFromAllAvailable(layer.id);
@@ -323,8 +323,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
                 if (layer.style) {
                     oskariLayer.selectStyle(layer.style);
                 }
-
-                sandbox.request(mapModuleName, rbAdd(layer.id, true));
+                const options = {};
+                if (isGuest) {
+                    // for logged in users styles will be populated based on the logged in user
+                    // for guest users looking at embedded map these will hold references to the
+                    // styles the user that published the map had for the layer
+                    options.userStyles = layer.userStyles;
+                }
+                sandbox.request(mapModuleName, rbAdd(layer.id, options));
                 sandbox.request(mapModuleName, rbVisible(layer.id, !layer.hidden));
                 if (layer.opacity || layer.opacity === 0) {
                     sandbox.request(mapModuleName, rbOpacity(layer.id, layer.opacity));
@@ -367,12 +373,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
          * Returns bundle state as JSON. State is bundle specific, check the
          * bundle documentation for details.
          *
-         *
          * @return {Object}
          */
         getState: function () {
             // get applications current state
-            const map = this.getSandbox().getMap();
+            const sandbox = this.getSandbox();
+            const map = sandbox.getMap();
             const state = {
                 north: map.getY(),
                 east: map.getX(),
@@ -381,6 +387,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
                 selectedLayers: [],
                 ...this.getMapModule().getState()
             };
+            const styleService = sandbox.getService('Oskari.mapframework.userstyle.service.UserStyleService');
+            const getUserStylesForLayer = (layerId) => styleService && styleService.getStylesByLayer(layerId).map(s => s.id);
             state.selectedLayers = map.getLayers().map(layer => {
                 const json = {
                     id: layer.getId(),
@@ -389,6 +397,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
                 const style = this._getCurrentStyleName(layer);
                 if (style) {
                     json.style = style;
+                }
+                const userStyles = getUserStylesForLayer(json.id);
+                if (userStyles && userStyles.length) {
+                    // attach references to styles the user has for the layer
+                    // this will enable guest users for embedded map to see the styles
+                    // the user had when publishing the map
+                    json.userStyles = userStyles;
                 }
                 if (!layer.isVisible()) {
                     json.hidden = true;

--- a/bundles/mapping/mapmodule/request/add.map.layer.js
+++ b/bundles/mapping/mapmodule/request/add.map.layer.js
@@ -16,9 +16,10 @@ Oskari.clazz.define('Oskari.mapframework.request.common.AddMapLayerRequest',
      *            mapLayerId id of the map layer (matching one in Oskari.mapframework.service.MapLayerService)
      */
 
-    function (mapLayerId) {
+    function (mapLayerId, options) {
         this._creator = null;
         this._mapLayerId = mapLayerId;
+        this._options = options;
     }, {
         /** @static @property __name request name */
         __name: 'AddMapLayerRequest',
@@ -36,11 +37,14 @@ Oskari.clazz.define('Oskari.mapframework.request.common.AddMapLayerRequest',
          */
         getMapLayerId: function () {
             return this._mapLayerId;
+        },
+        getOptions: function () {
+            return this._options || {};
         }
     }, {
         /**
          * @property {String[]} protocol array of superclasses as {String}
          * @static
          */
-        'protocol': ['Oskari.mapframework.request.Request']
+        protocol: ['Oskari.mapframework.request.Request']
     });

--- a/bundles/mapping/mapmodule/request/map.layer.handler.js
+++ b/bundles/mapping/mapmodule/request/map.layer.handler.js
@@ -39,7 +39,7 @@ Oskari.clazz.define('map.layer.handler',
                     this.mapState.deactivateLayer(layerId, request._creator);
                 }
             } else if (request.getName() === 'AddMapLayerRequest') {
-                this._addToMap(request.getMapLayerId(), request._creator);
+                this._addToMap(request.getMapLayerId(), request.getOptions(), request._creator);
             } else if (request.getName() === 'RemoveMapLayerRequest') {
                 this.mapState.removeLayer(request.getMapLayerId(), request._creator);
             } else if (request.getName() === 'RearrangeSelectedMapLayerRequest') {
@@ -73,7 +73,7 @@ Oskari.clazz.define('map.layer.handler',
          * @param {String} layerId id for layer to add
          * @param {String} triggeredBy (optional) what triggered the add
          */
-        _addToMap: function (layerId, triggeredBy) {
+        _addToMap: function (layerId, opts = {}, triggeredBy) {
             const layer = this.layerService.findMapLayer(layerId);
             const layerStatus = {
                 layer,
@@ -95,7 +95,7 @@ Oskari.clazz.define('map.layer.handler',
                 // add layers from front of queue to map
                 this.__processLayerQueue();
             };
-            this._loadLayerInfo(layer, done);
+            this._loadLayerInfo(layer, opts, done);
         },
         /**
          * Processes the queue for layers to add to map in the order they were requested to be added.
@@ -111,7 +111,7 @@ Oskari.clazz.define('map.layer.handler',
             }
         },
 
-        _loadLayerInfo: function (layer, done) {
+        _loadLayerInfo: function (layer, opts, done) {
             if (typeof layer.getDescribeLayerStatus !== 'function') {
                 // layer type doesn't support this
                 done();
@@ -128,7 +128,7 @@ Oskari.clazz.define('map.layer.handler',
                 return;
             }
             layer.setDescribeLayerStatus(DESCRIBE_LAYER.PENDING);
-            this.layerService.getDescribeLayer(layer, info => {
+            this.layerService.getDescribeLayer(layer, opts, info => {
                 if (!info) {
                     layer.setDescribeLayerStatus(DESCRIBE_LAYER.ERROR);
                     if (layer.requiresDescribeLayer()) {

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -773,7 +773,7 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
          * @private
          */
         _loadLayersRecursive: function (layers, callbackSuccess) {
-            var me = this;
+            const me = this;
             // check if recursion should end
             if (layers.length === 0) {
                 me._allLayersAjaxLoaded = true;
@@ -783,8 +783,8 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
                 return;
             }
             // remove the first one for recursion
-            var json = layers.shift();
-            var mapLayer = me.createMapLayer(json);
+            const json = layers.shift();
+            const mapLayer = me.createMapLayer(json);
             // unsupported maplayer type returns null so check for it
             if (mapLayer && me._reservedLayerIds[mapLayer.getId()] !== true) {
                 me.addLayer(mapLayer, true);
@@ -806,10 +806,15 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
         * @param {Function} callback gets the describe info as parameter or undefined if it's not available
         * @returns callback is used for return value
         */
-        getDescribeLayer: function (layer, callback) {
+        getDescribeLayer: function (layer, opts, callback) {
+            // gather a list of possible user generated styles to load for layer
+            const userStyles = [
+                layer.getCurrentStyle().getName(),
+                ...(opts.userStyles || [])]
+                .join(',');
             const url = Oskari.urls.getRoute('DescribeLayer', {
                 id: layer.getId(),
-                styleId: layer.getCurrentStyle().getName(),
+                styleId: userStyles,
                 lang: Oskari.getLang(),
                 srs: this.getSandbox().getMap().getSrsName()
             });


### PR DESCRIPTION
Frontend changes for https://github.com/oskariorg/oskari-server/pull/958

Changes `mapfull` bundles state to store references to user generated styles. This allows the publisher functionality to store the styles as seen by the user who is publishing a map and restore styles by that user on an embedded map when viewed by an anonymous user.