### PR TITLE
Fix tooltips on disabled icon buttons

### DIFF
--- a/src/react/components/buttons/IconButton.jsx
+++ b/src/react/components/buttons/IconButton.jsx
@@ -33,6 +33,14 @@ const BorderedButton = styled(Button)`
     }
 `;
 
+/**
+ * This + pointer-events style on button components are used to fix tooltip
+ * not disappearing if the button is disabled. Probably caused by styled-components + antd problem.
+ */
+const DisabledWrapper = styled('div')`
+    cursor: ${props => props.$disabled ? 'not-allowed' : 'default'};
+`;
+
 const getPredefinedIcon = (type) => {
     if (type === 'add') {
         return <PlusOutlined/>;
@@ -108,11 +116,11 @@ export const IconButton = ({
                 placement={title ? 'bottom' : 'top'}
                 { ...getConfirmProps(type) }>
                     <Tooltip title={title}>
-                        <div>
+                        <DisabledWrapper $disabled={disabled}>
                             <ThemeButton disabled={disabled} onClick={onClick} { ...rest }>
                                 {icon}
                             </ThemeButton>
-                        </div>
+                        </DisabledWrapper>
                     </Tooltip>
             </Confirm>
         );
@@ -120,11 +128,11 @@ export const IconButton = ({
     if (title) {
         return (
             <Tooltip title={title}>
-                <div>
+                <DisabledWrapper $disabled={disabled}>
                     <ThemeButton disabled={disabled} onClick={onClick} { ...rest }>
                         {icon}
                     </ThemeButton>
-                </div>
+                </DisabledWrapper>
             </Tooltip>
         );
     }

--- a/src/react/components/buttons/IconButton.jsx
+++ b/src/react/components/buttons/IconButton.jsx
@@ -16,6 +16,7 @@ const BorderlessButton = styled(Button)`
     border: none;
     background: none;
     padding: 0px;
+    pointer-events: ${props => props.disabled ? 'none' : 'auto'};
     &:hover {
         color: ${props => props.color};
         background: none;
@@ -25,6 +26,7 @@ const BorderlessButton = styled(Button)`
     }
 `;
 const BorderedButton = styled(Button)`
+    pointer-events: ${props => props.disabled ? 'none' : 'auto'};
     &:hover {
         color: ${props => props.color};
         border-color: ${props => props.color};
@@ -105,20 +107,24 @@ export const IconButton = ({
                 disabled={disabled}
                 placement={title ? 'bottom' : 'top'}
                 { ...getConfirmProps(type) }>
-                <Tooltip title={title}>
-                    <ThemeButton disabled={disabled} onClick={onClick} { ...rest }>
-                        {icon}
-                    </ThemeButton>
-                </Tooltip>
+                    <Tooltip title={title}>
+                        <div>
+                            <ThemeButton disabled={disabled} onClick={onClick} { ...rest }>
+                                {icon}
+                            </ThemeButton>
+                        </div>
+                    </Tooltip>
             </Confirm>
         );
     }
     if (title) {
         return (
             <Tooltip title={title}>
-                <ThemeButton disabled={disabled} onClick={onClick} { ...rest }>
-                    {icon}
-                </ThemeButton>
+                <div>
+                    <ThemeButton disabled={disabled} onClick={onClick} { ...rest }>
+                        {icon}
+                    </ThemeButton>
+                </div>
             </Tooltip>
         );
     }


### PR DESCRIPTION
Fixes tooltip not disappearing on disabled icon buttons. Probably caused by styled components and antd not getting along.