### PR TITLE
Fix visual issues on coordinatedisplay

### DIFF
--- a/bundles/framework/coordinatedisplay/resources/scss/coordinatedisplay.scss
+++ b/bundles/framework/coordinatedisplay/resources/scss/coordinatedisplay.scss
@@ -10,16 +10,18 @@
     background-clip: padding-box;
 }
 
-.mapplugin.coordinates {
+div.mapplugins .mappluginsContainer .mappluginsContent .mapplugin.coordinates {
     background: #fafafa;
     border: 1px solid #e6e6e6;
     @include border-radius(2px);
     box-sizing: border-box;
     font-size: 11px;
     line-height: 15px;
-    margin-bottom: 10px !important; // Damned mapmodule css has this set as 0 with a high-specificity selector...
+    margin-bottom: 10px;
     padding: 2px 5px 0;
     text-align: left;
+    display: block;
+    min-width: 90px;
 
     > div > div {
         display: inline-block;


### PR DESCRIPTION
Without this change the coordinatedisplay bundle looks like this:
![image](https://user-images.githubusercontent.com/2210335/236933838-40f9057b-9b30-4564-96c6-665c71dbc364.png)

With the changes in this PR;
![image](https://user-images.githubusercontent.com/2210335/236933902-dad010aa-1eeb-41e7-bf08-bbc8b4dd26ef.png)

Before the DOM/plugin changes it looked like this:
![image](https://user-images.githubusercontent.com/2210335/236934190-4df168d3-f6f8-48d2-9ff7-dc6e7a3517ee.png)

