### PR TITLE
Userlayer extent

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -13,7 +13,9 @@ Some extra tags:
 
 ###  [mod] AddMapLayerRequest
 
-Introduced a second parameter for the request called `options`. This is used to restore vector layer styles on embedded maps for guest users in a way the user that published the map sees them on the publisher functionality.
+The layer is no longer added to map synchronously. Additional metadata is loaded from the server when a layer is added to map so sending additional requests directly after sending `AddMapLayerRequest` might not work as they did before.
+
+Introduced a second parameter for the request called `options`. This is used to restore vector layer styles on embedded maps for guest users in a way the user that published the map sees them on the publisher functionality. It can also be used to trigger `MapModulePlugin.MapMoveByLayerContentRequest` after the layer has been added to map (workaround for asynchronous operation).
 
 ## 2.10.0
 

--- a/api/mapping/mapmodule/request/addmaplayerrequest.md
+++ b/api/mapping/mapmodule/request/addmaplayerrequest.md
@@ -18,9 +18,25 @@ Requests a map layer to be added on the map. Note that the layer details are req
   <td> \* mapLayerId </td><td> String </td><td> id for map layer to be added (Oskari.mapframework.service.MapLayerService) </td><td> </td>
 </tr>
 <tr>
-  <td> options </td><td> Object </td><td> additional options for the layer to be added. The only currently handled key is `userStyles` which is passed on to DescribeLayer to get any styles associated for the layer when using it on a published map. If userStyles is not passed (for guest users) the layer only has the styles added by admin and the style that is referenced as current style. </td><td> </td>
+  <td> options </td><td> Object </td><td> additional options for the layer to be added. See details below.</td><td> </td>
 </tr>
+</table>
 
+### Options
+
+<table class="table">
+<tr>
+  <th> Name</th><th> Description</th><th> Default value</th>
+</tr>
+<tr>
+  <td> \* mapLayerId </td><td> String </td><td> id for map layer to be added (Oskari.mapframework.service.MapLayerService) </td><td> </td>
+</tr>
+<tr>
+  <td> userStyles </td><td> String </td><td> Passed on to DescribeLayer to get any styles associated for the layer when using it on a published map. If userStyles is not passed (for guest users) the layer only has the styles added by admin and the style that is referenced as current style. </td><td> </td>
+</tr>
+<tr>
+  <td> zoomContent </td><td> boolean / any </td><td> If the key is present, a `MapModulePlugin.MapMoveByLayerContentRequest` is triggered directly after layer is added to the map. This is a workaround for AddMapLayerRequest no longer being synchoronous operation on Oskari 2.11. As the layer extent is loaded as a part of adding the layer to map, sending a MapMoveByLayerContentRequest manually right after requesting the layer to be added to map is not working properly. The value of this key is passed as a parameter to `MapModulePlugin.MapMoveByLayerContentRequest`. This requires the layer to have coverage information available and might not work properly if the service the layer is from has incorrect metadata/coverage information.</td><td> </td>
+</tr>
 </table>
 
 ## Examples

--- a/bundles/framework/myplacesimport/PersonalDataUserLayersTab.js
+++ b/bundles/framework/myplacesimport/PersonalDataUserLayersTab.js
@@ -36,29 +36,28 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.PersonalDataUserL
          * @return {jQuery} container reference
          */
         getContent: function () {
-            var me = this;
-            var sandbox = me.instance.getSandbox();
-            var grid = Oskari.clazz.create('Oskari.userinterface.component.Grid');
-            var addMLrequestBuilder = Oskari.requestBuilder('AddMapLayerRequest');
-            var mapMoveByContentReqBuilder = Oskari.requestBuilder('MapModulePlugin.MapMoveByLayerContentRequest');
+            const me = this;
+            const sandbox = me.instance.getSandbox();
+            const grid = Oskari.clazz.create('Oskari.userinterface.component.Grid');
+            const addMLrequestBuilder = Oskari.requestBuilder('AddMapLayerRequest');
 
             grid.setVisibleFields(this.visibleFields);
             // set up the link from name field
             grid.setColumnValueRenderer('name', function (name, data) {
-                var link = me.template.link.clone();
+                const link = me.template.link.clone();
 
                 link.append(name).on('click', function () {
                     // add myplacesimport layer to map on name click
-                    var request = addMLrequestBuilder(data.id);
-                    sandbox.request(me.instance, request);
-                    request = mapMoveByContentReqBuilder(data.id, true);
+                    const request = addMLrequestBuilder(data.id, {
+                        zoomContent: true
+                    });
                     sandbox.request(me.instance, request);
                     return false;
                 });
                 return link;
             });
             grid.setColumnValueRenderer('edit', function (name, data) {
-                var link = me.template.link.clone();
+                const link = me.template.link.clone();
 
                 link.append(me.loc('tab.grid.editButton')).on('click', function () {
                     me._editUserLayer(data);

--- a/bundles/framework/myplacesimport/handler/UserLayersHandler.js
+++ b/bundles/framework/myplacesimport/handler/UserLayersHandler.js
@@ -72,11 +72,13 @@ class UserLayersHandler extends StateHandler {
 
     openLayer (id) {
         const addMLrequestBuilder = Oskari.requestBuilder('AddMapLayerRequest');
-        const mapMoveByContentReqBuilder = Oskari.requestBuilder('MapModulePlugin.MapMoveByLayerContentRequest');
-        const addMlRequest = addMLrequestBuilder(id);
+        // const mapMoveByContentReqBuilder = Oskari.requestBuilder('MapModulePlugin.MapMoveByLayerContentRequest');
+        const addMlRequest = addMLrequestBuilder(id, {
+            zoomContent: true
+        });
         this.sandbox.request(this.instance, addMlRequest);
-        const mapMoveByContentRequest = mapMoveByContentReqBuilder(id, true);
-        this.sandbox.request(this.instance, mapMoveByContentRequest);
+        // const mapMoveByContentRequest = mapMoveByContentReqBuilder(id, true);
+        // this.sandbox.request(this.instance, mapMoveByContentRequest);
     }
 
     refreshLayersList () {
@@ -109,7 +111,7 @@ class UserLayersHandler extends StateHandler {
 
     createEventHandlers () {
         const handlers = {
-            'MapLayerEvent': (event) => {
+            MapLayerEvent: (event) => {
                 const operation = event.getOperation();
                 if (operation === 'add' || operation === 'update' || operation === 'remove') {
                     this.refreshLayersList();
@@ -121,7 +123,7 @@ class UserLayersHandler extends StateHandler {
     }
 
     onEvent (e) {
-        var handler = this.eventHandlers[e.getName()];
+        const handler = this.eventHandlers[e.getName()];
         if (!handler) {
             return;
         }

--- a/bundles/framework/myplacesimport/handler/UserLayersHandler.js
+++ b/bundles/framework/myplacesimport/handler/UserLayersHandler.js
@@ -41,6 +41,7 @@ class UserLayersHandler extends StateHandler {
         }
         const conf = {
             maxSize: this.getMaxSize(),
+            unzippedMaxSize: this.getMaxSize() * 15,
             isImport
         };
         const onSuccess = () => this.popupCleanup();
@@ -66,19 +67,16 @@ class UserLayersHandler extends StateHandler {
     }
 
     getMaxSize () {
-        const confMax = this.instance.conf.maxFileSizeMb;
+        const confMax = this.instance.conf?.maxFileSizeMb;
         return isNaN(confMax) ? MAX_SIZE : parseInt(confMax);
     }
 
     openLayer (id) {
         const addMLrequestBuilder = Oskari.requestBuilder('AddMapLayerRequest');
-        // const mapMoveByContentReqBuilder = Oskari.requestBuilder('MapModulePlugin.MapMoveByLayerContentRequest');
         const addMlRequest = addMLrequestBuilder(id, {
             zoomContent: true
         });
         this.sandbox.request(this.instance, addMlRequest);
-        // const mapMoveByContentRequest = mapMoveByContentReqBuilder(id, true);
-        // this.sandbox.request(this.instance, mapMoveByContentRequest);
     }
 
     refreshLayersList () {

--- a/bundles/framework/myplacesimport/service/MyPlacesImportService.js
+++ b/bundles/framework/myplacesimport/service/MyPlacesImportService.js
@@ -208,7 +208,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
         layer.setLocale(locale);
         layer.setOptions(options);
         const sandbox = this.instance.getSandbox();
-        var evt = Oskari.eventBuilder('MapLayerEvent')(id, 'update');
+        const evt = Oskari.eventBuilder('MapLayerEvent')(id, 'update');
         sandbox.notifyAll(evt);
         this.notifyUpdate();
         if (sandbox.isLayerAlreadySelected(id)) {
@@ -222,9 +222,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
             const sandbox = this.instance.getSandbox();
             const layerId = mapLayer.getId();
             // Request the layer to be added to the map.
-            sandbox.postRequestByName('AddMapLayerRequest', [layerId]);
+            sandbox.postRequestByName('AddMapLayerRequest', [layerId, {
+                zoomContent: true
+            }]);
             // Request to move and zoom map to layer's content
-            sandbox.postRequestByName('MapModulePlugin.MapMoveByLayerContentRequest', [layerId, true]);
+            // sandbox.postRequestByName('MapModulePlugin.MapMoveByLayerContentRequest', [layerId, true]);
             this.notifyUpdate();
         };
         const { warning } = layerJson;

--- a/bundles/mapping/mapmodule/plugin/layers/request/MapLayerVisibilityRequestHandler.ol.js
+++ b/bundles/mapping/mapmodule/plugin/layers/request/MapLayerVisibilityRequestHandler.ol.js
@@ -24,8 +24,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.MapLayerVisibi
          *      request to handle
          */
         handleRequest: function (core, request) {
-            var layerId = request.getMapLayerId();
-            var layer = this.sandbox.findMapLayerFromSelectedMapLayers(layerId);
+            const layerId = request.getMapLayerId();
+            const layer = this.sandbox.findMapLayerFromSelectedMapLayers(layerId);
             if (!layer) {
                 this.tryVectorLayers(layerId, request.getVisible());
                 // no need to notify other components if it was a vector layer
@@ -42,8 +42,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.MapLayerVisibi
             this.layersPlugin.handleMapLayerVisibility(layer, true);
         },
         tryVectorLayers: function (id, blnVisible) {
-            var module = this.layersPlugin.getMapModule();
-            var plugin = module.getLayerPlugins('vectorlayer');
+            const module = this.layersPlugin.getMapModule();
+            const plugin = module.getLayerPlugins('vectorlayer');
             if (!plugin || typeof plugin.setVisibleByLayerId !== 'function') {
                 return;
             }

--- a/bundles/mapping/mapmodule/plugin/layers/request/MapMoveByLayerContentRequestHandler.js
+++ b/bundles/mapping/mapmodule/plugin/layers/request/MapMoveByLayerContentRequestHandler.js
@@ -30,9 +30,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.MapMoveByLayer
          *      request to handle
          */
         handleRequest: function (core, request) {
-            var layerId = request.getMapLayerId();
-            var zoomToExtent = request.getZoomToExtent();
-            var layer = this.sandbox.findMapLayerFromSelectedMapLayers(layerId);
+            const layerId = request.getMapLayerId();
+            const zoomToExtent = request.getZoomToExtent();
+            const layer = this.sandbox.findMapLayerFromSelectedMapLayers(layerId);
             if (!layer) {
                 return;
             }
@@ -40,7 +40,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.MapMoveByLayer
             if (zoomToExtent) {
                 // move and zoom map to layer extent
                 if (layer.getGeometry().length > 0) {
-                    var bounds = this.layersPlugin.getGeometryBounds(layer.getGeometry()[0]);
+                    const bounds = this.layersPlugin.getGeometryBounds(layer.getGeometry()[0]);
                     // suppress mapmove-event
                     this.layersPlugin.getMapModule().zoomToExtent(bounds, true, true);
                     const center = this.layersPlugin.getGeometryCenter(layer.getGeometry()[0]);
@@ -61,7 +61,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.request.MapMoveByLayer
                 // move map to geometries if available
                 // this needs to be done after the zoom since it's comparing to viewport which changes in zoom
                 if (layer.getGeometry().length > 0) {
-                    var containsGeometry = this.layersPlugin.isInGeometry(layer);
+                    const containsGeometry = this.layersPlugin.isInGeometry(layer);
                     // only move if not currently in geometry
                     if (!containsGeometry) {
                         const center = this.layersPlugin.getGeometryCenter(layer.getGeometry()[0]);

--- a/bundles/mapping/mapmodule/request/map.layer.handler.js
+++ b/bundles/mapping/mapmodule/request/map.layer.handler.js
@@ -94,6 +94,11 @@ Oskari.clazz.define('map.layer.handler',
                 }
                 // add layers from front of queue to map
                 this.__processLayerQueue();
+                // zoom to content or center/supported zoom level
+                if (opts.zoomContent) {
+                    const sandbox = this.layerService.getSandbox();
+                    sandbox.postRequestByName('MapModulePlugin.MapMoveByLayerContentRequest', [layerId, opts.zoomContent]);
+                }
             };
             this._loadLayerInfo(layer, opts, done);
         },
@@ -117,6 +122,8 @@ Oskari.clazz.define('map.layer.handler',
                 done();
                 return;
             }
+            const sandbox = this.layerService.getSandbox();
+            const mapModule = sandbox.findRegisteredModuleInstance('MainMapModule');
             const layerId = layer.getId();
             const status = layer.getDescribeLayerStatus();
             // only layers that have numeric ids can have reasonable response for DescribeLayer
@@ -138,9 +145,8 @@ Oskari.clazz.define('map.layer.handler',
                     }
                 }
                 layer.setDescribeLayerStatus(DESCRIBE_LAYER.LOADED);
-                const sandbox = this.layerService.getSandbox();
                 layer.handleDescribeLayer(info);
-                sandbox.findRegisteredModuleInstance('MainMapModule').handleDescribeLayer(layer, info);
+                mapModule.handleDescribeLayer(layer, info);
                 const event = Oskari.eventBuilder('MapLayerEvent')(layerId, 'update');
                 sandbox.notifyAll(event);
                 done();

--- a/bundles/mapping/mapmodule/request/map.layer.handler.js
+++ b/bundles/mapping/mapmodule/request/map.layer.handler.js
@@ -128,6 +128,11 @@ Oskari.clazz.define('map.layer.handler',
             const status = layer.getDescribeLayerStatus();
             // only layers that have numeric ids can have reasonable response for DescribeLayer
             if (isNaN(layerId) || status === DESCRIBE_LAYER.LOADED) {
+                if (layerId.startsWith('userlayer')) {
+                    mapModule.handleDescribeLayer(layer, {
+                        coverage: layer.getGeometryWKT()
+                    });
+                }
                 done();
                 return;
             }


### PR DESCRIPTION
After AddMapLayerRequest became async, userlayers no longer zoom the map to where the features are when a userlayer is added to map through mydata or import.

DescribeLayer calls now try to setup the geometry that is used to center the map, but it's only called for layers with numbers as ids. So we need to do something fix this for userlayers where DescribeLayer isn't called because id is string BUT we do have the WKT geometry on the layer itself directly. With it we should be able to go ahead with the DescribeLayer response parsing and craft a payload for those functions to fix the issue.