### PR TITLE
Vs userdata update

### DIFF
--- a/bundles/framework/myplaces3/service/MyPlacesService.js
+++ b/bundles/framework/myplaces3/service/MyPlacesService.js
@@ -165,6 +165,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplaces3.service.MyPlacesServic
             }
             layer.setLocale(locale);
             layer.setOptions(options);
+            layer.setStylesFromOptions(options);
             const evt = Oskari.eventBuilder('MapLayerEvent')(id, 'update');
             this.sandbox.notifyAll(evt);
             if (this.sandbox.isLayerAlreadySelected(id)) {

--- a/bundles/framework/myplacesimport/service/MyPlacesImportService.js
+++ b/bundles/framework/myplacesimport/service/MyPlacesImportService.js
@@ -207,6 +207,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.myplacesimport.MyPlacesImportSer
         }
         layer.setLocale(locale);
         layer.setOptions(options);
+        layer.setStylesFromOptions(options);
         const sandbox = this.instance.getSandbox();
         const evt = Oskari.eventBuilder('MapLayerEvent')(id, 'update');
         sandbox.notifyAll(evt);

--- a/bundles/mapping/mapmodule/domain/AbstractVectorLayer.js
+++ b/bundles/mapping/mapmodule/domain/AbstractVectorLayer.js
@@ -73,6 +73,8 @@ export class AbstractVectorLayer extends AbstractLayer {
         this.setStyles(styles);
         // Remove styles from options to be sure that VectorStyle is used
         delete options.styles;
+        // update current style
+        this.selectStyle(this.getCurrentStyle().getName());
     }
 
     removeStyle (name) {


### PR DESCRIPTION
Previously AbstractVectorLayer had setOptions which parsed styles. For now only user related layers have styles in options so have to parse/set updated styles on update.

https://github.com/oskariorg/oskari-frontend/blob/master/bundles/mapping/mapmodule/domain/AbstractVectorLayer.js#L29-L46