### PR TITLE
Fix see-through bg on mobile infobox

### DIFF
--- a/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
+++ b/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
@@ -231,8 +231,6 @@ Oskari.clazz.define(
                 popup.onClose(function () {
                     me.close(id);
                 });
-                // clear the ugly backgroundcolor from the popup content
-                jQuery(popup.dialog).css('background-color', 'inherit');
             } else {
                 popupType = 'desktop';
                 popupElement.html(popupContentHtml);


### PR DESCRIPTION
Probably some old relic from mobile toolbar coloring. 

Before:
![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/5571f026-0cfe-4fc1-906e-5f157c143bec)

After:
![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/bb580225-0315-4379-894e-63d96723a0c2)
