### PR TITLE
Fix crosshair through RPC

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -473,7 +473,7 @@ Oskari.clazz.define(
             'RPCUIEvent': function (event) {
                 var me = this;
                 if (event.getBundleId() === 'mapmodule.crosshair') {
-                    me.toggleCrosshair(isCrosshairActive(this.getMapDOMEl()));
+                    me.toggleCrosshair(!isCrosshairActive(this.getMapDOMEl()));
                 }
             }
         },


### PR DESCRIPTION
With current code the "show" parameter is false if the crosshair is not active, meaning that the toggle will try to hide it when it's not on screen etc.