### PR TITLE
Fix layer admin general tab flickering.

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/styled.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/styled.jsx
@@ -4,7 +4,8 @@ export { StyledFormField, StyledAlert, StyledButton } from '../styled';
 
 export const StyledRoot = styled('div')`
     padding: 20px;
-    max-width: 700px;
+    max-width: 100%;
+    min-width: 451px;
 `;
 
 export const Border = styled('div')`


### PR DESCRIPTION
Antd Tabs component starts flickering at a certain width, fixed min-width fixes that.