### PR TITLE
Fix subgroups piling in columns

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
@@ -140,7 +140,6 @@ const SubGroupList = ({ subgroups = [], selectedLayerIds, openGroupTitles, opts,
 const StyledCollapsePanel = styled(CollapsePanel)`
     > .ant-collapse-content > .ant-collapse-content-box {
         padding: 0px;
-        display: flex;
         & > .ant-list {
             width: 100%;
         }


### PR DESCRIPTION
Without change in dev.oskari.org:
![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/3b4d0386-48f4-41a0-8f39-0b7ce144bd87)

With the change:
![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/3ea227d4-df06-4052-9199-4edfd443d08b)
