### PR TITLE
Fix layer group toggle when no layers in group

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
@@ -170,7 +170,7 @@ const LayerCollapsePanel = (props) => {
     const { group, selectedLayerIds, openGroupTitles, opts, controller, ...propsNeededForPanel } = props;
     const layerRows = getLayerRowModels(group.getLayers(), selectedLayerIds, controller, opts);
     // set group switch active if all layers in group are selected
-    const allLayersOnMap = layerRows.every(layer => selectedLayerIds.includes(layer.id));
+    const allLayersOnMap = layerRows.length > 0 && layerRows.every(layer => selectedLayerIds.includes(layer.id));
     // Note! Not rendering layerlist/subgroups when the panel is closed is a trade-off for performance
     //   between render as whole vs render when the panel is opened.
     const isPanelOpen = propsNeededForPanel.isActive;


### PR DESCRIPTION
Fixes an issue where the toggle for adding all layers on the group to map is left to selected / "all layers on map" mode if there are no layers in the group (since checking if all items are truthful in an empty array is always true `[].every(i => false) === true`). 