### PR TITLE
AdminUsers fix external validation

### DIFF
--- a/bundles/framework/admin-users/handler/AdminUsersHandler.js
+++ b/bundles/framework/admin-users/handler/AdminUsersHandler.js
@@ -229,8 +229,8 @@ class UIHandler extends StateHandler {
             if (!this.state.userFormState.roles || !this.state.userFormState.roles.length > 0) {
                 errors.push('roles');
                 Messaging.error(Oskari.getMsg('AdminUsers', 'flyout.adminusers.form_invalid'));
-                return errors;
             }
+            return errors;
         }
         Object.keys(this.state.userFormState).forEach(key => {
             if (key !== 'password' && key !== 'rePassword') {

--- a/bundles/framework/admin-users/handler/AdminUsersHandler.js
+++ b/bundles/framework/admin-users/handler/AdminUsersHandler.js
@@ -226,10 +226,6 @@ class UIHandler extends StateHandler {
         });
         const errors = [];
         if (this.isExternal) {
-            if (!this.state.userFormState.roles || !this.state.userFormState.roles.length > 0) {
-                errors.push('roles');
-                Messaging.error(Oskari.getMsg('AdminUsers', 'flyout.adminusers.form_invalid'));
-            }
             return errors;
         }
         Object.keys(this.state.userFormState).forEach(key => {

--- a/bundles/framework/admin-users/handler/AdminUsersHandler.js
+++ b/bundles/framework/admin-users/handler/AdminUsersHandler.js
@@ -15,7 +15,6 @@ class UIHandler extends StateHandler {
             roleFormState: this.initRoleForm(),
             users: [],
             roles: [],
-            roleOptions: [],
             userFormErrors: [],
             roleFormErrors: false,
             editingRoleError: false,
@@ -126,10 +125,7 @@ class UIHandler extends StateHandler {
             if (guestRole) {
                 roles = roles.filter(r => r.name !== guestRole);
             }
-            this.updateState({
-                roles: roles || [],
-                roleOptions: result.rolelist
-            });
+            this.updateState({ roles });
         } catch (e) {
             Messaging.error(Oskari.getMsg('AdminUsers', 'failed_to_get_roles_title'));
             this.updateState({

--- a/bundles/framework/admin-users/view/UserForm.jsx
+++ b/bundles/framework/admin-users/view/UserForm.jsx
@@ -123,7 +123,7 @@ export const UserForm = ({ state, controller, isExternal }) => {
                     onChange={(value) => controller.updateUserFormState('roles', value)}
                     defaultValue={state.userFormState.roles}
                     status={state.userFormErrors.includes('roles') ? 'error' : null}
-                    options={state.roleOptions.map(role => (
+                    options={state.roles.map(role => (
                         {
                             label: role.name,
                             value: role.id


### PR DESCRIPTION
Fields are disabled for external user source so no need to validate fields. Fixes issue where external source doesn't have content for all fields and mandatory validation didn't allow to save user (roles).

Also external source may handle user's system role (not in db). So removing last additional role gives empty role array. To allow removing last role had to remove role length check. 

So external doesn't have any validation for now.

Changed to use role array (doesn't include guest role) for user form