### PR TITLE
LogoPlugin fixes

### DIFF
--- a/bundles/framework/publisher2/tools/LogoTool.js
+++ b/bundles/framework/publisher2/tools/LogoTool.js
@@ -40,7 +40,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.LogoTool',
         stop: function () {
             // when we exit publisher:
             // move plugin back to bottom left if it was dragged during publisher
-            this.getPlugin().setLocation('bottom left');
+            this.getPlugin()?.setLocation('bottom left');
         },
         /**
         * Get values.
@@ -50,6 +50,10 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.LogoTool',
         * @returns {Object} tool value object
         */
         getValues: function () {
+            const plugin = this.getPlugin();
+            if (!plugin) {
+                return null;
+            }
             return {
                 configuration: {
                     mapfull: {
@@ -57,7 +61,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.LogoTool',
                             plugins: [{
                                 id: this.getTool().id,
                                 config: {
-                                    location: this.getPlugin().getConfig()?.location
+                                    location: plugin.getConfig()?.location
                                 }
                             }]
                         }

--- a/bundles/statistics/statsgrid2016/instance.js
+++ b/bundles/statistics/statsgrid2016/instance.js
@@ -251,8 +251,10 @@ Oskari.clazz.define(
             this.statsService.getUILabels({ datasource, indicator, selections }, callback);
         },
         clearDataProviderInfo: function () {
-            var service = this.getSandbox().getService('Oskari.map.DataProviderInfoService');
-            service.removeGroup('indicators');
+            const service = this.getDataProviderInfoService();
+            if (service) {
+                service.removeGroup('indicators');
+            }
         },
         /**
          * Add vectorlayer to map for features. Layer is empty on module start.


### PR DESCRIPTION
If geoportal appsetup doesn't have LogoPlugin, publisher and statsgrid causes JS error.