### PR TITLE
Statistics remove indicator event fix

### DIFF
--- a/bundles/statistics/statsgrid2016/view/DiagramFlyout.js
+++ b/bundles/statistics/statsgrid2016/view/DiagramFlyout.js
@@ -98,7 +98,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.view.DiagramFlyout', function (
             }
         });
         this.service.on('StatsGrid.IndicatorEvent', function (event) {
-            if (event.isRemoved() && !me.hasIndicators()) {
+            if (event.isRemoved()) {
                 me.setSortingDisabled();
             }
         });


### PR DESCRIPTION
If more than one indicator is selected, removing indicator triggers remove indicator event which caused JS error.

I think that there is no need to check if there is still indicators as disable/enable sorting uses has active indicator => disable/enable.

`me.hasIndicators() => me.service.getStateService().hasIndicators()`