### PR TITLE
Vector layer current style fix for embedded maps

### DIFF
--- a/bundles/framework/mapfull/instance.js
+++ b/bundles/framework/mapfull/instance.js
@@ -388,7 +388,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
                 ...this.getMapModule().getState()
             };
             const styleService = sandbox.getService('Oskari.mapframework.userstyle.service.UserStyleService');
-            const getUserStylesForLayer = (layerId) => styleService && styleService.getStylesByLayer(layerId).map(s => s.id);
+            const getUserStylesForLayer = (layerId) => styleService && styleService.getStyleNamesForLayer(layerId);
             state.selectedLayers = map.getLayers().map(layer => {
                 const json = {
                     id: layer.getId(),

--- a/bundles/mapping/mapmodule/domain/AbstractVectorLayer.js
+++ b/bundles/mapping/mapmodule/domain/AbstractVectorLayer.js
@@ -18,6 +18,7 @@ export class AbstractVectorLayer extends AbstractLayer {
         if (this.getStyles().length === 0) {
             return;
         }
+        // select style (defaults to first)
         super.selectStyle(name);
     }
 
@@ -79,7 +80,7 @@ export class AbstractVectorLayer extends AbstractLayer {
 
     removeStyle (name) {
         const styles = this.getStyles();
-        const index = styles.findIndex(s => Number.parseInt(s.getName(), 10) === name);
+        const index = styles.findIndex(s => s.getName() === name);
         if (index !== -1) {
             styles.splice(index, 1);
         }

--- a/bundles/mapping/mapmodule/domain/AbstractVectorLayer.js
+++ b/bundles/mapping/mapmodule/domain/AbstractVectorLayer.js
@@ -63,7 +63,9 @@ export class AbstractVectorLayer extends AbstractLayer {
         if (vs.length) {
             // override all styles as create map layer if there were any
             this.setStyles(vs);
-            // this is done on maplayer add, so try select style (defaults to first)
+            // update current style (defaults to first)
+            super.selectStyle(this._storedStyleName);
+            // request notifies change
             Oskari.getSandbox().postRequestByName('ChangeMapLayerStyleRequest', [this.getId(), this._storedStyleName]);
         }
     }

--- a/bundles/mapping/userstyle/service/UserStyleService.js
+++ b/bundles/mapping/userstyle/service/UserStyleService.js
@@ -173,7 +173,7 @@ export class UserStyleService {
         return 'Oskari.mapframework.userstyle.service.UserStyleService';
     }
 
-    _getStyleName(style) {
+    _getStyleName (style) {
         // id is used for VectorStyle name (string)
         return style?.id.toString();
     }

--- a/bundles/mapping/userstyle/service/UserStyleService.js
+++ b/bundles/mapping/userstyle/service/UserStyleService.js
@@ -173,25 +173,37 @@ export class UserStyleService {
         return 'Oskari.mapframework.userstyle.service.UserStyleService';
     }
 
+    _getStyleName(style) {
+        // id is used for VectorStyle name (string)
+        return style?.id.toString();
+    }
+
+    getStyleNamesForLayer (layerId) {
+        return this.getStylesByLayer(layerId).map(style => this._getStyleName(style));
+    }
+
     applyStyleToLayer (style) {
-        const { layerId, id } = style || {};
+        const { layerId } = style || {};
         // Users own styles are loaded (overrides) via DescribeLayer when layer is added first time on the map
         // Find layer from all available to be sure that style is added to layer
         // Note that style is selected only when layer is on the map (is selected)
         const layer = this.sandbox.findMapLayerFromAllAvailable(layerId);
         if (layer) {
             layer.addStyle(new VectorStyle(style));
-            layer.selectStyle(id);
-            this.sandbox.postRequestByName('ChangeMapLayerStyleRequest', [layerId, id]);
+            const name = this._getStyleName(style);
+            layer.selectStyle(name);
+            // request notifies change if layer is selected
+            this.sandbox.postRequestByName('ChangeMapLayerStyleRequest', [layerId, name]);
             this.notifyLayerUpdate(layerId);
         }
     }
 
     removeStyleFromLayer (style) {
-        const { layerId, id } = style || {};
+        const { layerId } = style || {};
         const layer = this.sandbox.findMapLayerFromAllAvailable(layerId);
         if (layer) {
-            layer.removeStyle(id);
+            const name = this._getStyleName(style);
+            layer.removeStyle(name);
             this.notifyLayerUpdate(layerId);
         }
     }


### PR DESCRIPTION
Tries to fix issue where vector layer current style isn't updated after describe layer. Also changes to handle style names as String instead of Number.

The main problem is that after  describe layer sometimes ChangeMapLayerStyleRequest doesn't find layer from selected layers and current style isn't updated:
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/mapping/mapmodule/request/map.layer.handler.js#L61

Vector style selection for embedded vector layer:
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/mapping/mapmodule/service/map.layer.js#L1414
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/framework/mapfull/instance.js#L324
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/mapping/mapmodule/domain/AbstractVectorLayer.js#L66

First two selectStyle only stores style name because them are called before describe layer:
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/mapping/mapmodule/domain/AbstractVectorLayer.js#L19

Also getCurrentStyle may be called before describe layer. For safety uses now selectStyle and request (triggers event) in handleDescribe.

![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/0363950a-5a14-4da4-9755-4fe32d060e8b)

getCurrentStyle creates empty style if no styles is available to avoid NPE.