### PR TITLE
Add "no UI" to announcements plugin

### DIFF
--- a/bundles/admin/admin-announcements/publisher/AnnouncementsTool.js
+++ b/bundles/admin/admin-announcements/publisher/AnnouncementsTool.js
@@ -35,12 +35,16 @@ Oskari.clazz.define('Oskari.admin.bundle.admin-announcements.publisher.Announcem
                 '</div>'),
             inputCheckbox: jQuery('<div><input type="checkbox" name="announcement"/><label></label></div>')
         };
+        this.noUI = null;
+        this.noUiIsCheckedInModifyMode = false;
     }, {
 
         init: function (data) {
             const me = this;
             me.data = data;
             me.selectedAnnouncements = [];
+
+            me.noUiIsCheckedInModifyMode = (data.configuration && data.configuration.announcements && data.configuration.announcements.conf && data.configuration.announcements.conf && data.configuration.announcements.conf.plugin && data.configuration.announcements.conf.plugin.config && data.configuration.announcements.conf.plugin.config.noUI === true);
 
             const service = me.sandbox.getService('Oskari.framework.announcements.service.AnnouncementsService');
 
@@ -125,6 +129,37 @@ Oskari.clazz.define('Oskari.admin.bundle.admin-announcements.publisher.Announcem
                 }
             });
 
+            const labelNoUI = me.localization.publisher.noUI;
+            console.log(labelNoUI)
+
+            var input = Oskari.clazz.create(
+                'Oskari.userinterface.component.CheckboxInput'
+            );
+
+            input.setTitle(labelNoUI);
+            input.setHandler(function (checked) {
+                if (checked === 'on') {
+                    me.noUI = true;
+                    me.getPlugin().teardownUI();
+                } else {
+                    me.noUI = null;
+                    me.getPlugin().redrawUI(Oskari.util.isMobile());
+                }
+            });
+            console.log(input)
+
+
+            if (me.noUiIsCheckedInModifyMode) {
+                input.setChecked(true);
+                me.noUI = true;
+            }
+            var inputEl = input.getElement();
+            if (inputEl.style) {
+                inputEl.style.width = 'auto';
+            }
+
+            template.append(inputEl);
+            
             return template;
         },
 
@@ -244,6 +279,11 @@ Oskari.clazz.define('Oskari.admin.bundle.admin-announcements.publisher.Announcem
             if (announcementsSelection && !jQuery.isEmptyObject(announcementsSelection)) {
                 pluginConfig.config.announcements = announcementsSelection.announcements;
             }
+            
+            if (me.noUI) {
+                pluginConfig.config.noUI = me.noUI;
+            }
+
             return {
                 configuration: {
                     announcements: {

--- a/bundles/admin/admin-announcements/publisher/AnnouncementsTool.js
+++ b/bundles/admin/admin-announcements/publisher/AnnouncementsTool.js
@@ -130,7 +130,6 @@ Oskari.clazz.define('Oskari.admin.bundle.admin-announcements.publisher.Announcem
             });
 
             const labelNoUI = me.localization.publisher.noUI;
-            console.log(labelNoUI)
 
             var input = Oskari.clazz.create(
                 'Oskari.userinterface.component.CheckboxInput'
@@ -146,7 +145,6 @@ Oskari.clazz.define('Oskari.admin.bundle.admin-announcements.publisher.Announcem
                     me.getPlugin().redrawUI(Oskari.util.isMobile());
                 }
             });
-            console.log(input)
 
 
             if (me.noUiIsCheckedInModifyMode) {

--- a/bundles/admin/admin-announcements/resources/locale/en.js
+++ b/bundles/admin/admin-announcements/resources/locale/en.js
@@ -52,6 +52,9 @@ Oskari.registerLocalization(
             },
             "announcementsName": "Title",
             "announcementsTime": "Valid"
+        },
+        "publisher": {
+            "noUI": "Hide user interface (Use RPC interface)"
         }
     }
 });

--- a/bundles/admin/admin-announcements/resources/locale/fi.js
+++ b/bundles/admin/admin-announcements/resources/locale/fi.js
@@ -52,6 +52,9 @@ Oskari.registerLocalization(
                 },
                 "announcementsName": "Otsikko",
                 "announcementsTime": "Voimasssa"
+            },
+            "publisher": {
+                "noUI": "Piilota käyttöliittymä (käytä RPC-rajapinnan kautta)"
             }
         }
     });

--- a/bundles/admin/admin-announcements/resources/locale/sv.js
+++ b/bundles/admin/admin-announcements/resources/locale/sv.js
@@ -52,6 +52,9 @@ Oskari.registerLocalization(
                 },
                 "announcementsName": "Titel",
                 "announcementsTime": "Datumintervall"
+            },
+            "publisher": {
+                "noUI": "Dölj användargränsnittet (Använd via RPC gränssnitt)"
             }
         }
     });

--- a/bundles/framework/announcements/plugin/AnnouncementsPlugin.js
+++ b/bundles/framework/announcements/plugin/AnnouncementsPlugin.js
@@ -73,6 +73,24 @@ Oskari.clazz.define('Oskari.framework.announcements.plugin.AnnouncementsPlugin',
                 }
             });
         },
+
+        /**
+         * @private @method registerRPCFunctions
+         * Register RPC functions
+         */
+        _registerRPCFunctions () {
+            var me = this;
+
+            const rpcService = Oskari.getSandbox().getService('Oskari.mapframework.bundle.rpc.service.RpcService');
+            if (!rpcService) {
+                return;
+            }
+            rpcService.addFunction('getSelectedAnnouncements', function () {
+                const announcementsIds = me._config.announcements;
+                const announcements = me.allAnnouncements.filter(ann => announcementsIds.includes(ann.id));
+                return announcements;
+            });
+        },
         
         /**
          * Check at has UI configured to shown
@@ -171,7 +189,7 @@ Oskari.clazz.define('Oskari.framework.announcements.plugin.AnnouncementsPlugin',
             var me = this;
             const announcementsIds = me._config.announcements;
 
-            const announcements = this.allAnnouncements.filter(ann => announcementsIds.includes(ann.id));
+            const announcements = me.allAnnouncements.filter(ann => announcementsIds.includes(ann.id));
 
             if (!me.open) {
                 delete me.announcementsContent;

--- a/bundles/framework/announcements/plugin/AnnouncementsPlugin.js
+++ b/bundles/framework/announcements/plugin/AnnouncementsPlugin.js
@@ -73,6 +73,15 @@ Oskari.clazz.define('Oskari.framework.announcements.plugin.AnnouncementsPlugin',
                 }
             });
         },
+        
+        /**
+         * Check at has UI configured to shown
+         * @method @private _hasUI
+         * @returns {Boolean} has UI visible
+         */
+        _hasUI: function () {
+            return !this._config.noUI;
+        },
 
         /**
         * @method openSelection
@@ -118,7 +127,11 @@ Oskari.clazz.define('Oskari.framework.announcements.plugin.AnnouncementsPlugin',
             var me = this,
                 el = me.templates.main.clone(),
                 header = el.find('div.announcements-header');
-
+            
+            if (me._config.noUI) {
+                return null;
+            }
+            
             header.append(me._loc.plugin.title);
             me._bindHeader(header);
             return el;


### PR DESCRIPTION
Add "noUI" checkbox option to Announcements tool/plugin so we don't have to always use the provided UI on apps using published maps. Also added a function that provides the app the selected Announcements so we can access just the certain Announcements that were selected with the publisher tool.

function: _getSelectedAnnouncements()_