### PR TITLE
add featuredata tool to vector layers

### DIFF
--- a/bundles/framework/featuredata/plugin/FeatureDataPluginHandler.js
+++ b/bundles/framework/featuredata/plugin/FeatureDataPluginHandler.js
@@ -63,6 +63,12 @@ class FeatureDataPluginUIHandler extends StateHandler {
     }
 
     setActiveTab (layerId) {
+        // when clicking on a tab directly, layerId will be a number.
+        // When clicked in the "show more" menu of the tablist, it will be a String and no features are found.
+        // so we gotta make a conversion for a numeric layerid just in case. :(
+        if (Oskari.util.isNumber(layerId)) {
+            layerId = +layerId;
+        }
         const features = layerId ? this.getFeaturesByLayerId(layerId) : null;
         const selectedFeatureIds = layerId ? this.getSelectedFeatureIdsByLayerId(layerId) : null;
         this.updateState({

--- a/bundles/framework/featuredata/plugin/FeatureDataPluginHandler.js
+++ b/bundles/framework/featuredata/plugin/FeatureDataPluginHandler.js
@@ -164,6 +164,10 @@ class FeatureDataPluginUIHandler extends StateHandler {
         this.selectionService.toggleFeatureSelection(this.getState().activeLayerId, featureId);
     }
 
+    isFlyoutOpen () {
+        return this.getState().flyoutOpen;
+    }
+
     openFlyout () {
         if (this.flyoutController) {
             this.closeFlyout();
@@ -499,6 +503,7 @@ class FeatureDataPluginUIHandler extends StateHandler {
 }
 
 const wrapped = controllerMixin(FeatureDataPluginUIHandler, [
+    'isFlyoutOpen',
     'openFlyout',
     'closeFlyout',
     'setActiveTab',

--- a/bundles/framework/featuredata/request/ShowFeatureDataRequest.js
+++ b/bundles/framework/featuredata/request/ShowFeatureDataRequest.js
@@ -1,0 +1,42 @@
+/**
+ * @class Oskari.mapframework.bundle.featuredata.request.ShowFeatureDataRequest
+ * Requests a WFS feature data to be shown
+ *
+ * Requests are build and sent through Oskari.Sandbox.
+ * Oskari.mapframework.request.Request superclass documents how to send one.
+ */
+Oskari.clazz
+    .define('Oskari.mapframework.bundle.featuredata.request.ShowFeatureDataRequest',
+    /**
+     * @method create called automatically on construction
+     * @static
+     *
+     * @param {String}
+     *            id layer identifier so we can select correct tab
+     */
+        function (id) {
+            this._id = id;
+        }, {
+        /** @static @property __name request name */
+            __name: 'Featuredata.ShowFeatureDataRequest',
+            /**
+         * @method getName
+         * @return {String} request name
+         */
+            getName: function () {
+                return this.__name;
+            },
+            /**
+         * @method getId
+         * @return {String} identifier so we can manage select correct tab
+         */
+            getId: function () {
+                return this._id;
+            }
+        }, {
+        /**
+         * @property {String[]} protocol array of superclasses as {String}
+         * @static
+         */
+            protocol: ['Oskari.mapframework.request.Request']
+        });

--- a/bundles/framework/featuredata/request/ShowFeatureDataRequestHandler.js
+++ b/bundles/framework/featuredata/request/ShowFeatureDataRequestHandler.js
@@ -1,0 +1,40 @@
+/**
+ * @class Oskari.mapframework.bundle.featuredata.request.ShowFeatureDataRequestHandler
+ * Handles Oskari.mapframework.bundle.featuredata.request.ShowFeatureDataRequest to show WFS feature data.
+ */
+Oskari.clazz.define('Oskari.mapframework.bundle.featuredata.request.ShowFeatureDataRequestHandler',
+    /**
+     * @method create called automatically on construction
+     * @static
+     * @param {Oskari.mapframework.bundle.featuredata.plugin.mapmodule.OpenlayersPopupPlugin} featureData
+     *          reference to featureData
+     */
+    function (featureData) {
+        this.featureData = featureData;
+    }, {
+        /**
+         * @method handleRequest
+         * Shows WFS feature data with requested properties
+         * @param {Oskari.mapframework.core.Core} core
+         *      reference to the application core (reference sandbox core.getSandbox())
+         * @param {Oskari.mapframework.bundle.featuredata.request.ShowFeatureDataRequest} request
+         *      request to handle
+         */
+        handleRequest: function (core, request) {
+            const controller = this.featureData?.plugin?.handler?.getController() || null;
+            if (!controller) {
+                Oskari.log('FeatureData').warn('No plugin controller found. Cannot handle ShowFeatureData - request.');
+            }
+            const id = request.getId();
+            controller.setActiveTab(id);
+            if (!controller.isFlyoutOpen()) {
+                controller.openFlyout();
+            }
+        }
+    }, {
+        /**
+         * @property {String[]} protocol array of superclasses as {String}
+         * @static
+         */
+        protocol: ['Oskari.mapframework.core.RequestHandler']
+    });

--- a/bundles/framework/featuredata/resources/locale/en.js
+++ b/bundles/framework/featuredata/resources/locale/en.js
@@ -5,7 +5,8 @@ Oskari.registerLocalization(
         "value": {
             "title": "Feature Data",
             "layer": {
-                "outOfContentArea": "The map layer has no features at the map view area."
+                "outOfContentArea": "The map layer has no features at the map view area.",
+                "featureData": "Feature data",
             },
             "flyout": {
                 "sorterTooltip": "Click to sort descending/ascending",

--- a/bundles/framework/featuredata/resources/locale/fi.js
+++ b/bundles/framework/featuredata/resources/locale/fi.js
@@ -5,7 +5,8 @@ Oskari.registerLocalization(
         "value": {
             "title": "Kohdetiedot",
             "layer": {
-                "outOfContentArea": "Karttatasolla ei ole kohteita karttanäkymän alueella."
+                "outOfContentArea": "Karttatasolla ei ole kohteita karttanäkymän alueella.",
+                "featureData": "Kohdetiedot",
             },
             "flyout": {
                 "sorterTooltip": "Järjestä laskevasti/nousevasti",

--- a/bundles/framework/featuredata/resources/locale/sv.js
+++ b/bundles/framework/featuredata/resources/locale/sv.js
@@ -5,7 +5,8 @@ Oskari.registerLocalization(
         "value": {
             "title": "Objektuppgifter",
             "layer": {
-                "outOfContentArea": "Detta kartlager saknar innehåll vid dessa koordinater."
+                "outOfContentArea": "Detta kartlager saknar innehåll vid dessa koordinater.",
+                "featureData": "Objektdata",
             },
             "flyout": {
                 "sorterTooltip": "Sortera fallande / stigande",

--- a/bundles/framework/featuredata/view/FeatureDataContainer.jsx
+++ b/bundles/framework/featuredata/view/FeatureDataContainer.jsx
@@ -19,6 +19,9 @@ const sorterTooltipOptions = {
     title: <Message bundleKey={FEATUREDATA_BUNDLE_ID} messageKey='flyout.sorterTooltip' />
 };
 
+// max-height: 50vh;
+// max-width: 50vw;
+
 const StyledTable = styled(Table)`
     .ant-table-tbody > tr.ant-table-row-selected > td {
         background-color: ${theme.getBgColor()};
@@ -29,8 +32,6 @@ const StyledTable = styled(Table)`
         display: none;
     }
 
-    max-height: 50vh;
-    max-width: 50vw;
     overflow-y: auto;
 
 `;
@@ -146,8 +147,10 @@ const createLayerTabs = (layerId, layers, features, selectedFeatureIds, showSele
 };
 
 const ContainerDiv = styled('div')`
-    padding: 1em;
-    min-width: 35em; //prevents ant-tabs from entering flickering mode
+    margin: 1em;
+    min-width: 20vw;
+    max-width: 100vw;
+
     .ant-table-selection-col, .ant-table-selection-column {
         display: none;
     }
@@ -160,7 +163,8 @@ export const FeatureDataContainer = ({ state, controller }) => {
             <Tabs
                 activeKey = { activeLayerId }
                 items={ tabs }
-                onChange={(key) => controller.setActiveTab(key)}/>
+                onChange={(key) => controller.setActiveTab(key) }
+            />
         </ContainerDiv>
     );
 };

--- a/packages/framework/bundle/featuredata/bundle.js
+++ b/packages/framework/bundle/featuredata/bundle.js
@@ -41,6 +41,12 @@ Oskari.clazz.define("Oskari.mapframework.bundle.featuredata.FeatureDataBundle", 
         }, {
             "type": "text/javascript",
             "src": "../../../../bundles/framework/featuredata/plugin/FeatureDataPlugin.js"
+        }, {
+            "type": "text/javascript",
+            "src": "../../../../bundles/framework/featuredata/request/ShowFeatureDataRequest.js"
+        }, {
+            "type": "text/javascript",
+            "src": "../../../../bundles/framework/featuredata/request/ShowFeatureDataRequestHandler.js"
         }],
         "locales": [{
             "lang": "en",


### PR DESCRIPTION
Enable opening (the new react implementation of) featuredata from the maplayer list's three dot menu.

![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/2449cadf-27ad-4cba-a485-5e7cc1e44c9e)
