### PR TITLE
Featuredata localized field names

### DIFF
--- a/bundles/framework/featuredata/plugin/FeatureDataPluginHandler.js
+++ b/bundles/framework/featuredata/plugin/FeatureDataPluginHandler.js
@@ -296,7 +296,6 @@ class FeatureDataPluginUIHandler extends StateHandler {
     applyFilters () {
         const { selectByPropertiesSettings } = this.getState();
         const { filters } = selectByPropertiesSettings;
-
         let hasErrors = false;
         filters.forEach((filter) => {
             if (!filter?.value?.length) {
@@ -325,13 +324,13 @@ class FeatureDataPluginUIHandler extends StateHandler {
                 filterArray.push({ boolean: filter.logicalOperator });
             }
         });
-        this.filterSelector.selectWithProperties(filters, activeLayerId);
+        this.filterSelector.selectWithProperties(filterArray, activeLayerId);
     }
 
     initEmptyFilter (columnName) {
         return {
             attribute: columnName,
-            operator: FilterTypes.equals,
+            operator: FilterTypes.ALL.equals,
             value: '',
             error: null,
             logicalOperator: LogicalOperators.AND,

--- a/bundles/framework/featuredata/view/FeatureDataContainer.jsx
+++ b/bundles/framework/featuredata/view/FeatureDataContainer.jsx
@@ -92,13 +92,13 @@ const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, 
 };
 
 const createColumnSettingsFromFeatures = (features, selectedFeatureIds, showSelectedFirst, sorting, visibleColumnsSettings) => {
-    const { visibleColumns } = visibleColumnsSettings;
+    const { visibleColumns, activeLayerPropertyLabels } = visibleColumnsSettings;
     return Object.keys(features[0].properties)
         .filter(key => !FEATUREDATA_DEFAULT_HIDDEN_FIELDS.includes(key) && visibleColumns.includes(key))
         .map(key => {
             return {
                 align: 'left',
-                title: key,
+                title: activeLayerPropertyLabels && activeLayerPropertyLabels[key] ? activeLayerPropertyLabels[key] : key,
                 key,
                 dataIndex: key,
                 showSorterTooltip: sorterTooltipOptions,

--- a/bundles/framework/featuredata/view/FilterVisibleColumns.jsx
+++ b/bundles/framework/featuredata/view/FilterVisibleColumns.jsx
@@ -34,7 +34,7 @@ BlurredMessage.propTypes = {
 
 };
 
-const createOptions = (allColumns) => {
+const createOptions = (allColumns, activeLayerPropertyLabels) => {
     if (!allColumns || !allColumns.length) {
         return;
     }
@@ -43,16 +43,15 @@ const createOptions = (allColumns) => {
         .filter(key => !FEATUREDATA_DEFAULT_HIDDEN_FIELDS.includes(key))
         .map(key => {
             return {
-                label: key,
+                label: activeLayerPropertyLabels && activeLayerPropertyLabels[key] ? activeLayerPropertyLabels[key] : key,
                 value: key
             };
         });
 };
 
-
 export const FilterVisibleColumns = (props) => {
-    const { allColumns, visibleColumns, updateVisibleColumns } = props;
-    const options = createOptions(allColumns);
+    const { allColumns, visibleColumns, updateVisibleColumns, activeLayerPropertyLabels } = props;
+    const options = createOptions(allColumns, activeLayerPropertyLabels);
     const [focused, setFocused] = useState();
 
     return <FilterVisibleColumnsContainer>
@@ -74,5 +73,6 @@ export const FilterVisibleColumns = (props) => {
 FilterVisibleColumns.propTypes = {
     allColumns: PropTypes.array,
     visibleColumns: PropTypes.array,
+    activeLayerPropertyLabels: PropTypes.object,
     updateVisibleColumns: PropTypes.func
 };


### PR DESCRIPTION
-use localized fieldnames in featuredata where those are available
-delimit the set of filters based on property type in "select by properties" - dialog (currently only for number or string)
-also fixed a bug in select by properties when multiple conditions were applied