### PR TITLE
limit size of json when trying to export to excel and build csv-optio…

### DIFF
--- a/bundles/framework/featuredata/resources/locale/en.js
+++ b/bundles/framework/featuredata/resources/locale/en.js
@@ -36,6 +36,7 @@ Oskari.registerLocalization(
                 "openButtonLabel": "Export data",
                 "exportButtonLabel": "Export",
                 "exportFailed": "Exporting the data failed.",
+                "datasetTooLargeForExcel": "Dataset is too large for generating an excel file. Limit the number of features or choose csv as format.",
                 "fileFormat": {
                     "title": "File format",
                     "excel": "Excel",

--- a/bundles/framework/featuredata/resources/locale/fi.js
+++ b/bundles/framework/featuredata/resources/locale/fi.js
@@ -36,6 +36,7 @@ Oskari.registerLocalization(
                 "openButtonLabel": "Aineiston vienti",
                 "exportButtonLabel": "Vie",
                 "exportFailed": "Aineiston vienti epäonnistui.",
+                "datasetTooLargeForExcel": "Dataset is too large for generating an excel file. Limit the number of features or choose csv as format.",
                 "fileFormat": {
                     "title": "Tiedostomuoto",
                     "excel": "Excel",

--- a/bundles/framework/featuredata/resources/locale/sv.js
+++ b/bundles/framework/featuredata/resources/locale/sv.js
@@ -36,6 +36,7 @@ Oskari.registerLocalization(
                 "openButtonLabel": "Exportera data",
                 "exportButtonLabel": "Exportera",
                 "exportFailed": "Exporting the data failed.",
+                "datasetTooLargeForExcel": "Dataset is too large for generating an excel file. Limit the number of features or choose csv as format.",
                 "fileFormat": {
                     "title": "Filformat",
                     "excel": "Excel",

--- a/bundles/framework/featuredata/view/ExportData.jsx
+++ b/bundles/framework/featuredata/view/ExportData.jsx
@@ -45,8 +45,7 @@ const ColumnHeader = styled('h3')`
     padding-bottom: 0.25em;
 `;
 
-
-const SEPARATORS = {
+export const SEPARATORS = {
     semicolon: ';',
     comma: ',',
     tabulator: 'tab'


### PR DESCRIPTION
…n in fe

-Don't allow sending data to server to generate xlsx when data size exceeds given limit (currently 120000 bytes). Json larger than that will cause server failure. In that case show an error message. The message itself needs some work and also it's not translated yet. 

-generate csv-file in front end. Currently we don't have the `service.metadata.url` - system property available for frontend(?) so for additional ino metadata only the given id is provided in csv.

![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/48275117-5a2d-411b-a43b-f1b0f125084a)
