### PR TITLE
MarkerVisibilityRequest handling fix

### DIFF
--- a/api/mapping/mapmodule/request/markervisibilityrequest.md
+++ b/api/mapping/mapmodule/request/markervisibilityrequest.md
@@ -26,7 +26,7 @@ optional parameter is wanted marker id. If marker id is not defined then show/hi
   <td>/* visibility </td><td> Boolean </td><td> is marker visible (true/false)</td><td> </td>
 </tr>
 <tr>
-  <td> id </td><td> String </td><td> id for marker.</td><td> /td>
+  <td> id </td><td> String </td><td> id for marker.</td><td></td>
 </tr>
 </table>
 
@@ -34,22 +34,22 @@ optional parameter is wanted marker id. If marker id is not defined then show/hi
 
 Hide wanted marker from map:
 ```javascript
-channel.postRequest('MapModulePlugin.MarkerVisibilityRequest', [false, 'TEST_MARKER_ID']);
+Oskari.getSandbox().postRequestByName('MapModulePlugin.MarkerVisibilityRequest', [false, 'TEST_MARKER_ID']);
 ```
 
 Hide all markers from map:
 ```javascript
-channel.postRequest('MapModulePlugin.MarkerVisibilityRequest', [false]);
+Oskari.getSandbox().postRequestByName('MapModulePlugin.MarkerVisibilityRequest', [false]);
 ```
 
 Show wanted marker from map:
 ```javascript
-channel.postRequest('MapModulePlugin.MarkerVisibilityRequest', [true, 'TEST_MARKER_ID']);
+Oskari.getSandbox().postRequestByName('MapModulePlugin.MarkerVisibilityRequest', [true, 'TEST_MARKER_ID']);
 ```
 
 Show all markers from map:
 ```javascript
-channel.postRequest('MapModulePlugin.MarkerVisibilityRequest', [true]);
+Oskari.getSandbox().postRequestByName('MapModulePlugin.MarkerVisibilityRequest', [true]);
 ```
 
 ## Related api

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
@@ -390,8 +390,10 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
             const layerSource = this.getMarkersLayer().getSource();
             if (visible) {
                 const feature = this._hiddenMarkers[id];
-                layerSource.addFeature(feature);
-                delete this._hiddenMarkers[id];
+                if (feature) {
+                    layerSource.addFeature(feature);
+                    delete this._hiddenMarkers[id];
+                }
             } else {
                 const feature = layerSource.getFeatureById(id);
                 if (feature) {

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
@@ -383,23 +383,28 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
          * @param  {String} id  optional marker id for marker to change it's visibility, all markers visibility changed if not given.
          */
         changeMapMarkerVisibility: function (visible, id) {
-            if (!id) {
-                this.getMarkersLayer().setVisible(visible);
-                return;
-            }
             const layerSource = this.getMarkersLayer().getSource();
-            if (visible) {
-                const feature = this._hiddenMarkers[id];
-                if (feature) {
-                    layerSource.addFeature(feature);
-                    delete this._hiddenMarkers[id];
+            const update = feature => {
+                if (!feature) {
+                    // not found for requested id (invalid id or feature is visible/hidden already)
+                    return;
                 }
-            } else {
-                const feature = layerSource.getFeatureById(id);
-                if (feature) {
-                    this._hiddenMarkers[id] = feature;
+                const fid = feature.getId();
+                if (visible) {
+                    layerSource.addFeature(feature);
+                    delete this._hiddenMarkers[fid];
+                } else {
+                    this._hiddenMarkers[fid] = feature;
                     layerSource.removeFeature(feature);
                 }
+            };
+
+            if (id) {
+                const feature = visible ? this._hiddenMarkers[id] : layerSource.getFeatureById(id);
+                update(feature);
+            } else {
+                const features = visible ? Object.values(this._hiddenMarkers) : layerSource.getFeatures();
+                features.forEach(f => update(f));
             }
         },
         /**


### PR DESCRIPTION
MarkerVisibilityRequest (true, id) caused JS error if marker was visible already

Updated also show/hide all markers to work like single marker request (remove/add) instead of changing layer's visibility. 

According to documentation I think that it should work like:
- hide single marker => show all => marker should be visible
- hide all => show single marker => marker should be visible

https://oskari.org/api/requests#/unreleased/mapping/mapmodule/request/markervisibilityrequest.md