### PR TITLE
admin-layereditor WFS attributes part 1 - geometry type

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -110,6 +110,17 @@ Oskari.registerLocalization(
                     "globalWithStyles": "The layer has more than one style available in the service. However, the layer has been defined with a single default legend. Consider removing the current default legend to be able to use the style based legends."
                 }
             },
+            "attributes": {
+                "label": "Attributes",
+                "geometryType": {
+                    "label": "Geometry type",
+                    "unknown":"Unknown",
+                    "point": "Point",
+                    "line": "Line",
+                    "area":"Area",
+                    "collection":"Collection"
+                }
+            },
             "styles": {
                 "default": "Default style",
                 "desc": "Select a default style from the list. If there are several options, users can select a theme in the ‘Selected Layers’ menu.",
@@ -159,7 +170,6 @@ Oskari.registerLocalization(
             "gfiTypeDesc": "Select a format for Get Feature Information (GFI). Possible formats are fetched automatically from the GetCapabilities response.",
             "gfiStyle": "GFI style (XSLT)",
             "gfiStyleDesc": "Define a style for Get Feature Information (GFI) as XSLT transformation.",
-            "attributes": "Attributes",
             "clusteringDistance": "Point distance in cluster",
             "forcedSRS": "Forced SRS",
             "forcedSRSInfo": "View projections override compared to capabilities",

--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -114,6 +114,8 @@ Oskari.registerLocalization(
                 "label": "Attributes",
                 "geometryType": {
                     "label": "Geometry type",
+                    "sourceAttributes": "Source: layer attributes",
+                    "sourceCapabilities": "Source: layer capabilities",
                     "unknown":"Unknown",
                     "point": "Point",
                     "line": "Line",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -115,10 +115,10 @@ Oskari.registerLocalization(
                 "label": "Attribuutit",
                 "geometryType": {
                     "label": "Geometriatyyppi",
+                    "unknown":"Ei tiedossa",
                     "point": "Piste",
                     "line": "Viiva",
-                    "polygon":"Alue",
-                    "unknown":"Ei tiedossa",
+                    "area":"Alue",
                     "collection":"Kaikki"
                 }
             },

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -111,6 +111,17 @@ Oskari.registerLocalization(
                     "globalWithStyles": "Tasolle on määritetty vain yksi yleinen oletuskarttaselite, vaikka sillä olisi rajapintapalvelusta useita tyylejä käytettävissä. Poista oletuskarttaselite ja määritä mahdolliset tyylikohtaiset karttaselitteet."
                 }
             },
+            "attributes": {
+                "label": "Attribuutit",
+                "geometryType": {
+                    "label": "Geometriatyyppi",
+                    "point": "Piste",
+                    "line": "Viiva",
+                    "polygon":"Alue",
+                    "unknown":"Ei tiedossa",
+                    "collection":"Kaikki"
+                }
+            },
             "styles": {
                 "default": "Oletustyyli",
                 "desc": "Taso lisätään kartalle oletustyylillä. Käyttäjä voi vaihtaa tyyliä ”Valitut tasot”-valikon kautta.",
@@ -160,7 +171,6 @@ Oskari.registerLocalization(
             "gfiTypeDesc": "Valitse listalta formaatti, jossa kohdetiedot (GFI) haetaan. Mahdolliset formaatit on määritelty WMS-palvelun GetCapabilities-vastausviestissä.",
             "gfiStyle": "GFI-tyyli (XSLT)",
             "gfiStyleDesc": "Määrittele kohdetietojen esitystapa XSLT-muunnoksen avulla.",
-            "attributes": "Attribuutit",
             "clusteringDistance": "Pisteiden etäisyys klusteroidessa",
             "forcedSRS": "Pakotetut projektiot",
             "forcedSRSInfo": "Pakotetut projektiot verrattuna GetCapabilites-määritykseen",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -115,6 +115,8 @@ Oskari.registerLocalization(
                 "label": "Attribuutit",
                 "geometryType": {
                     "label": "Geometriatyyppi",
+                    "sourceAttributes": "Lähde: tason attribuutit",
+                    "sourceCapabilities": "Lähde: tason Capabilities-tiedot",
                     "unknown":"Ei tiedossa",
                     "point": "Piste",
                     "line": "Viiva",

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -109,6 +109,17 @@ Oskari.registerLocalization(
                     "globalWithStyles": "Till kartlagret har endast en standard teckenförklaring fastställts, men det finns ytterliga stilar med förklaringar tillgängliga på gränssnittet. Du kan ta bort standardvalet för att kunna utnyttja dessa."
                 }
             },
+            "attributes": {
+                "label": "Attribut",
+                "geometryType": {
+                    "label": "Typ av geometri",
+                    "unknown":"Okänd",
+                    "point": "Punkten",
+                    "line": "Linje",
+                    "area":"Området",
+                    "collection":"All"
+                }
+            },
             "styles": {
                 "default": "Förvald utseende",
                 "desc": "Välj en standardstil från listan. Om det finns flera alternativ kan användare välja ett tema i menyn 'Valda lager'.",
@@ -157,7 +168,6 @@ Oskari.registerLocalization(
             "gfiTypeDesc": "Svarets typ dvs Get Feature Info (GFI)",
             "gfiStyle": "GFI stil",
             "gfiStyleDesc": "GFI stil (XSLT)",
-            "attributes": "Attribut",
             "clusteringDistance": "Punktavstånd i kluster",
             "forcedSRS": "Tvingade SRS",
             "forcedSRSInfo": "Tvångs SRS jämfört med GetCapabilites",

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -113,6 +113,8 @@ Oskari.registerLocalization(
                 "label": "Attribut",
                 "geometryType": {
                     "label": "Typ av geometri",
+                    "sourceAttributes": "Källa: kartlagrets attribut",
+                    "sourceCapabilities": "Källa: kartlagrets capabilities",
                     "unknown":"Okänd",
                     "point": "Punkten",
                     "line": "Linje",

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/AdditionalTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/AdditionalTabPane.jsx
@@ -8,6 +8,7 @@ import { GfiType } from './GfiType';
 import { GfiContent } from './GfiContent';
 import { GfiStyle } from './GfiStyle';
 import { Attributes } from './Attributes';
+import { VectorLayerAttributes } from './VectorLayerAttributes';
 import { Attributions } from './Attributions';
 import { MetadataId } from './MetadataId';
 import { Capabilities } from './Capabilities';
@@ -24,7 +25,8 @@ const {
     GFI_TYPE,
     GFI_XSLT,
     ATTRIBUTIONS,
-    ATTRIBUTES
+    ATTRIBUTES,
+    VECTOR_LAYER
 } = LayerComposingModel;
 
 export const AdditionalTabPane = ({ layer, propertyFields, metadata, controller }) => {
@@ -61,6 +63,9 @@ export const AdditionalTabPane = ({ layer, propertyFields, metadata, controller 
             }
             { isQueryable && propertyFields.includes(GFI_XSLT) &&
                 <GfiStyle layer={layer} controller={controller} />
+            }
+            { propertyFields.includes(VECTOR_LAYER) &&
+                <VectorLayerAttributes layer={layer} controller={controller} />
             }
             { propertyFields.includes(ATTRIBUTES) &&
                 <Attributes layer={layer} controller={controller} />

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/Attributes.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/Attributes.jsx
@@ -31,7 +31,7 @@ export const Attributes = ({ layer, controller }) => {
     }
     return (
         <Fragment>
-            <Message messageKey='attributes'/>
+            <Message messageKey='attributes.label'/>
             { !isValid && <AttributeInfo attributes={layer.attributes} /> }
             <StyledFormField>
                 <JsonInput

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/VectorLayerAttributes.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/VectorLayerAttributes.jsx
@@ -1,0 +1,23 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { Message, Select } from 'oskari-ui';
+import { Controller } from 'oskari-ui/util';
+import { StyledFormField } from '../styled';
+
+export const VectorLayerAttributes = ({ layer, controller }) => {
+    const { attributes, capabilities } = layer;
+    return (
+        <Fragment>
+            <Message messageKey='attributes.geometryType.label'/>
+            <StyledFormField>
+                <Select
+                    onChange={evt => controller.setAttributes(evt.target.value)} />
+            </StyledFormField>
+        </Fragment>
+    );
+};
+
+VectorLayerAttributes.propTypes = {
+    layer: PropTypes.object.isRequired,
+    controller: PropTypes.instanceOf(Controller).isRequired
+};

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/VectorLayerAttributes.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/VectorLayerAttributes.jsx
@@ -8,6 +8,13 @@ import { InfoTooltip } from '../InfoTooltip';
 
 export const VectorLayerAttributes = ({ layer, controller }) => {
     const geometryTypeSource = layer.attributes.data?.geometryType ? 'Attributes' : 'Capabilities';
+    const onGeometryTypeChange = value => {
+        if (GEOMETRY_TYPES[0] === value) {
+            controller.setAttributesData('geometryType');
+        } else {
+            controller.setAttributesData('geometryType', value);
+        }
+    };
     return (
         <Fragment>
             <Message messageKey='attributes.geometryType.label'/>
@@ -15,7 +22,7 @@ export const VectorLayerAttributes = ({ layer, controller }) => {
             <StyledFormField>
                 <Select
                     value={getGeometryType(layer)}
-                    onChange={value => controller.setAttributesData('geometryType', value)}>
+                    onChange={onGeometryTypeChange}>
                     { GEOMETRY_TYPES.map(type => (
                         <Option key={type} value={type}>
                             <Message messageKey={`attributes.geometryType.${type}`} />

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/VectorLayerAttributes.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/VectorLayerAttributes.jsx
@@ -1,17 +1,35 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Message, Select } from 'oskari-ui';
+import { Message, Select, Option } from 'oskari-ui';
 import { Controller } from 'oskari-ui/util';
 import { StyledFormField } from '../styled';
 
+export const TYPES = ['unknown', 'point', 'line', 'area', 'collection'];
+
+const fromCapa = capa => {
+    const { geomName, featureProperties = []} = capa;
+    const { type } = featureProperties.find(prop => prop.name === geomName) || {};
+    // TODO: map capa type to types
+    return TYPES.includes(type) ? type : null;
+};
+
 export const VectorLayerAttributes = ({ layer, controller }) => {
-    const { attributes, capabilities } = layer;
+    const { attributes , capabilities } = layer;
+    const { data = {} } = attributes;
+    const geometryType = data.geometryType || fromCapa(capabilities) || 'unknown';
     return (
         <Fragment>
             <Message messageKey='attributes.geometryType.label'/>
             <StyledFormField>
                 <Select
-                    onChange={evt => controller.setAttributes(evt.target.value)} />
+                    value={geometryType}
+                    onChange={value => controller.setAttributesData('geometryType', value)}>
+                    { TYPES.map(type => (
+                        <Option key={type} value={type}>
+                            <Message messageKey={`attributes.geometryType.${type}`} />
+                        </Option>
+                    )) }
+                </Select>
             </StyledFormField>
         </Fragment>
     );

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/VectorLayerAttributes.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/VectorLayerAttributes.jsx
@@ -3,28 +3,17 @@ import PropTypes from 'prop-types';
 import { Message, Select, Option } from 'oskari-ui';
 import { Controller } from 'oskari-ui/util';
 import { StyledFormField } from '../styled';
-
-export const TYPES = ['unknown', 'point', 'line', 'area', 'collection'];
-
-const fromCapa = capa => {
-    const { geomName, featureProperties = []} = capa;
-    const { type } = featureProperties.find(prop => prop.name === geomName) || {};
-    // TODO: map capa type to types
-    return TYPES.includes(type) ? type : null;
-};
+import { GEOMETRY_TYPES, getGeometryType } from '../../LayerHelper';
 
 export const VectorLayerAttributes = ({ layer, controller }) => {
-    const { attributes , capabilities } = layer;
-    const { data = {} } = attributes;
-    const geometryType = data.geometryType || fromCapa(capabilities) || 'unknown';
     return (
         <Fragment>
             <Message messageKey='attributes.geometryType.label'/>
             <StyledFormField>
                 <Select
-                    value={geometryType}
+                    value={getGeometryType(layer)}
                     onChange={value => controller.setAttributesData('geometryType', value)}>
-                    { TYPES.map(type => (
+                    { GEOMETRY_TYPES.map(type => (
                         <Option key={type} value={type}>
                             <Message messageKey={`attributes.geometryType.${type}`} />
                         </Option>

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/VectorLayerAttributes.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/VectorLayerAttributes.jsx
@@ -4,11 +4,14 @@ import { Message, Select, Option } from 'oskari-ui';
 import { Controller } from 'oskari-ui/util';
 import { StyledFormField } from '../styled';
 import { GEOMETRY_TYPES, getGeometryType } from '../../LayerHelper';
+import { InfoTooltip } from '../InfoTooltip';
 
 export const VectorLayerAttributes = ({ layer, controller }) => {
+    const geometryTypeSource = layer.attributes.data?.geometryType ? 'Attributes' : 'Capabilities';
     return (
         <Fragment>
             <Message messageKey='attributes.geometryType.label'/>
+            <InfoTooltip messageKeys={`attributes.geometryType.source${geometryTypeSource}`}/>
             <StyledFormField>
                 <Select
                     value={getGeometryType(layer)}

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -293,7 +293,11 @@ class UIHandler extends StateHandler {
     setAttributesData (key, value) {
         const layer = { ...this.getState().layer };
         const { data = {} } = layer.attributes || {};
-        data[key] = value;
+        if (typeof value === 'undefined') {
+            delete data[key];
+        } else {
+            data[key] = value;
+        }
         this.updateLayerAttributes({ ...layer.attributes, data }, layer);
     }
 

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -290,6 +290,13 @@ class UIHandler extends StateHandler {
         this.updateLayerAttributes(attributes, layer);
     }
 
+    setAttributesData (key, value) {
+        const layer = { ...this.getState().layer };
+        const { data = {} } = layer.attributes || {};
+        data[key] = value;
+        this.updateLayerAttributes({ ...layer.attributes, data }, layer);
+    }
+
     setLocalizedNames (locale) {
         this.updateState({
             layer: { ...this.getState().layer, locale }
@@ -452,7 +459,7 @@ class UIHandler extends StateHandler {
         }
 
         // Delete missing attibute keys but keep managed attributes
-        const managedAttributes = ['forcedSRS'];
+        const managedAttributes = ['forcedSRS', 'data'];
         Object.keys(layer.attributes)
             .filter(key => !managedAttributes.includes(key))
             .forEach(key => delete layer.attributes[key]);
@@ -1190,6 +1197,7 @@ const wrapped = controllerMixin(UIHandler, [
     'removeVectorStyleFromLayer',
     'saveVectorStyleToLayer',
     'setAttributes',
+    'setAttributesData',
     'setAttributionsJSON',
     'setCapabilitiesUpdateRate',
     'setClusteringDistance',

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VectorStyle.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VectorStyle.jsx
@@ -11,6 +11,8 @@ import { StyleEditor } from 'oskari-ui/components/StyleEditor';
 import styled from 'styled-components';
 import { ThemeConsumer } from 'oskari-ui/util';
 import { generateBlankStyle } from 'oskari-ui/components/StyleEditor/index';
+import { SUPPORTED_FORMATS } from 'oskari-ui/components/StyleEditor/constants';
+import { getGeometryType } from '../../LayerHelper';
 
 const FullWidthSpace = styled(Space)`
     & {
@@ -109,6 +111,8 @@ export const VectorStyle = ThemeConsumer(LocaleConsumer(({ theme = {}, layer, ge
     };
     const visible = !!state.modal;
     const externalType = external ? getExternalStyleType(layer) : null;
+    const geometryType = getGeometryType(layer);
+    const styleTabs = SUPPORTED_FORMATS.includes(geometryType) ? [geometryType] : SUPPORTED_FORMATS;
     return (
         <FullWidthSpace direction='vertical'>
             <Space direction='horizontal'>
@@ -153,6 +157,7 @@ export const VectorStyle = ThemeConsumer(LocaleConsumer(({ theme = {}, layer, ge
                 { state.modal === 'editor' &&
                     <StyleEditor
                         oskariStyle={ state.style.featureStyle }
+                        tabs={styleTabs}
                         onChange={ (featureStyle) => updateStyle({ featureStyle })}
                     />
                 }

--- a/bundles/admin/admin-layereditor/view/LayerHelper.js
+++ b/bundles/admin/admin-layereditor/view/LayerHelper.js
@@ -1,3 +1,20 @@
+export const GEOMETRY_TYPES = ['unknown', 'point', 'line', 'area', 'collection'];
+const AREA_TYPES = ['surface', 'polygon'];
+
+export const getGeometryType = layer => {
+    const { attributes, capabilities } = layer;
+    if (attributes?.data?.geometryType) {
+        return attributes.data.geometryType;
+    }
+    const { geomName, featureProperties = []} = capabilities;
+    const capaType = featureProperties.find(prop => prop.name === geomName)?.type.toLowerCase() || '';
+    // SurfacePropertyType, GeometryPropertyType, PointPropertyType, MultiLineStringPropertyType, MultiPolygon,...
+    if (AREA_TYPES.find(type => capaType.includes(type))) {
+        return 'area';
+    }
+    return GEOMETRY_TYPES.find(type => capaType.includes(type)) || 'unknown';
+};
+
 // keys are the server side expected keys and values are the keys used by frontend
 const APIMapping = {
     dataprovider_id: 'dataProviderId',

--- a/bundles/admin/admin-layereditor/view/LayerHelper.js
+++ b/bundles/admin/admin-layereditor/view/LayerHelper.js
@@ -6,7 +6,7 @@ export const getGeometryType = layer => {
     if (attributes?.data?.geometryType) {
         return attributes.data.geometryType;
     }
-    const { geomName, featureProperties = []} = capabilities;
+    const { geomName, featureProperties = [] } = capabilities;
     const capaType = featureProperties.find(prop => prop.name === geomName)?.type.toLowerCase() || '';
     // SurfacePropertyType, GeometryPropertyType, PointPropertyType, MultiLineStringPropertyType, MultiPolygon,...
     if (AREA_TYPES.find(type => capaType.includes(type))) {

--- a/bundles/mapping/mapmodule/domain/LayerComposingModel.js
+++ b/bundles/mapping/mapmodule/domain/LayerComposingModel.js
@@ -31,7 +31,8 @@ const PROPERTY_FIELDS = [
     'URL',
     'VERSION',
     'WFS_RENDER_MODE',
-    'DECLUTTER'
+    'DECLUTTER',
+    'VECTOR_LAYER'
 ];
 
 // Common fields are enforced on composing model.

--- a/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/vectortilelayer/VectorTileLayerPlugin.js
@@ -46,7 +46,8 @@ class VectorTileLayerPlugin extends AbstractVectorLayerPlugin {
                 LayerComposingModel.VECTOR_STYLES,
                 LayerComposingModel.TILE_GRID,
                 LayerComposingModel.URL,
-                LayerComposingModel.DECLUTTER
+                LayerComposingModel.DECLUTTER,
+                LayerComposingModel.VECTOR_LAYER
             ], null, [LayerComposingModel.NAME]); // common field name is not used in vectortilelayers so it is skipped on LayerComposingModel
 
             mapLayerService.registerLayerModel(this.layertype + 'layer', this._getLayerModelClass(), composingModel);

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin.ol.js
@@ -91,7 +91,8 @@ export class WfsVectorLayerPlugin extends AbstractVectorLayerPlugin {
             LayerComposingModel.VECTOR_STYLES,
             LayerComposingModel.URL,
             LayerComposingModel.VERSION,
-            LayerComposingModel.WFS_RENDER_MODE
+            LayerComposingModel.WFS_RENDER_MODE,
+            LayerComposingModel.VECTOR_LAYER
         ], ['1.1.0', '2.0.0', '3.0.0']);
 
         const layerClass = 'Oskari.mapframework.bundle.mapwfs2.domain.WFSLayer';

--- a/bundles/mapping/tiles3d/plugin/Tiles3DLayerPlugin.js
+++ b/bundles/mapping/tiles3d/plugin/Tiles3DLayerPlugin.js
@@ -60,7 +60,8 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.Tiles3DLayerPlugin',
                     LayerComposingModel.SRS,
                     LayerComposingModel.VECTOR_STYLES,
                     LayerComposingModel.EXTERNAL_VECTOR_STYLES,
-                    LayerComposingModel.URL
+                    LayerComposingModel.URL,
+                    LayerComposingModel.VECTOR_LAYER
                 ]);
                 mapLayerService.registerLayerModel(registerType, clazz, composingModel);
                 mapLayerService.registerLayerModelBuilder(registerType, new Tiles3DModelBuilder());


### PR DESCRIPTION
Add geometry type select to additional tab. Select's value is from attributes || capabilities geometry type and InfoToolip show the source. Selected value is stored to `layer.attributes.data.geometryType`. When unknown is selected value from attributes is removed and value from capabilities is shown.

![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/2cc48406-acd0-4d74-a363-3050b6f4c36d)
![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/c0692f5f-7502-42f4-a37f-4b7992097c5b)

![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/7e038031-c366-4ed4-9923-83b136c776b8)
