### PR TITLE
Fix extra options state on map tools.

### DIFF
--- a/bundles/framework/publisher2/view/PanelMapTools.js
+++ b/bundles/framework/publisher2/view/PanelMapTools.js
@@ -84,6 +84,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelMapTools',
                         if (enabled) {
                             ui.find('.extraOptions').show();
                         } else {
+                            ui.find('.extraOptions').find('input').prop('checked', false);
                             ui.find('.extraOptions').hide();
                         }
                     });


### PR DESCRIPTION
Uncheck extra options checkboxes when tool is disabled.