### PR TITLE
AddMapLayerRequest 

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -746,8 +746,7 @@ class UIHandler extends StateHandler {
         // if layer was found from the selected layers remove it from map and re-add it
         // this handles everything that needs to be updated on the map without separate code to update and potentially changed data separately
         if (originalLayerIndex !== -1) {
-            this.sandbox.postRequestByName('AddMapLayerRequest', [layerId]);
-            this.sandbox.postRequestByName('RearrangeSelectedMapLayerRequest', [layerId, originalLayerIndex]);
+            this.sandbox.postRequestByName('AddMapLayerRequest', [layerId, { toPosition: originalLayerIndex }]);
         }
     }
 

--- a/bundles/framework/mapfull/instance.js
+++ b/bundles/framework/mapfull/instance.js
@@ -309,8 +309,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
             const sandbox = this.getSandbox();
             const mapModuleName = this.getMapModule().getName();
             const rbAdd = Oskari.requestBuilder('AddMapLayerRequest');
-            const rbOpacity = Oskari.requestBuilder('ChangeMapLayerOpacityRequest');
-            const rbVisible = Oskari.requestBuilder('MapModulePlugin.MapLayerVisibilityRequest');
             const isGuest = !Oskari.user().isLoggedIn();
             const layersNotAvailable = [];
             selectedLayers.forEach(layer => {
@@ -323,6 +321,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
                 if (layer.style) {
                     oskariLayer.selectStyle(layer.style);
                 }
+                if (layer.opacity || layer.opacity === 0) {
+                    oskariLayer.setOpacity(layer.opacity);
+                }
                 const options = {};
                 if (isGuest) {
                     // for logged in users styles will be populated based on the logged in user
@@ -331,10 +332,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapfull.MapFullBundleInstance',
                     options.userStyles = layer.userStyles;
                 }
                 sandbox.request(mapModuleName, rbAdd(layer.id, options));
-                sandbox.request(mapModuleName, rbVisible(layer.id, !layer.hidden));
-                if (layer.opacity || layer.opacity === 0) {
-                    sandbox.request(mapModuleName, rbOpacity(layer.id, layer.opacity));
-                }
             });
 
             if (!this._initialStateInit || !layersNotAvailable.length) {

--- a/bundles/framework/publishedstatehandler/instance.js
+++ b/bundles/framework/publishedstatehandler/instance.js
@@ -482,7 +482,6 @@ Oskari.clazz.define(
         _setMapState: function (mapmodule, state, currentState) {
             var sandbox = this.getSandbox(),
                 cmpResult = this._compareState(currentState, state, false);
-
             // setting state
             if (state.selectedLayers && cmpResult.rulesMatched.layers) {
                 this._log.debug('restoring LAYER state');
@@ -497,7 +496,7 @@ Oskari.clazz.define(
                     layer;
                 for (i = 0; i < len; i += 1) {
                     layer = state.selectedLayers[i];
-                    sandbox.request(mapmodule.getName(), rbAdd(layer.id, true));
+                    sandbox.request(mapmodule.getName(), rbAdd(layer.id));
                     if (layer.hidden) {
                         sandbox.request(mapmodule.getName(), visibilityRequestBuilder(layer.id, false));
                     } else {

--- a/bundles/framework/publisher2/service/PublisherService.js
+++ b/bundles/framework/publisher2/service/PublisherService.js
@@ -76,7 +76,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.PublisherService',
         addLayers: function () {
             var sandbox = this.__sandbox;
             this.getNonPublisherLayers().forEach(layer => {
-                sandbox.postRequestByName('AddMapLayerRequest', [layer.getId(), true]);
+                sandbox.postRequestByName('AddMapLayerRequest', [layer.getId()]);
             });
         },
 

--- a/bundles/mapping/mapmodule/plugin/layers/BackgroundLayerSelectionPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/layers/BackgroundLayerSelectionPlugin.js
@@ -175,76 +175,42 @@ Oskari.clazz.define(
          * @return {Oskari.mapframework.domain.WmsLayer[]/Oskari.mapframework.domain.WfsLayer[]/Oskari.mapframework.domain.VectorLayer[]/Mixed}
          */
         _getBottomLayer: function () {
-            var bottomIdx = 0,
-                allSelectedLayers =
-                    this.getSandbox().findAllSelectedMapLayers();
-
-            if (allSelectedLayers && allSelectedLayers.length) {
-                return allSelectedLayers[bottomIdx];
-            }
-            return null;
+            return this.getSandbox().findAllSelectedMapLayers()[0];
         },
 
         /**
          * Does the actual layer selection update
-         * @param  {Number} newSelectionId Id of the new base layer
+         * @param  {String} newId Id of the new base layer
          * @private
          */
-        _updateSelection: function (newSelectionId) {
+        _updateSelection: function (newId) {
             if (this.error) {
                 return;
             }
-            var me = this,
-                conf = me.getConfig(),
-                currentBottom = me._getBottomLayer(),
-                currentBottomId = '',
-                currentSelection = me.getElement().find('div.currentSelection'),
-                newSelection =
-                    me.getSandbox().findMapLayerFromSelectedMapLayers(
-                        newSelectionId
-                    );
-
-            if (newSelectionId === currentSelection.attr('data-layerId')) {
+            const currentId = this.getElement().find('div.currentSelection').attr('data-layerId');
+            if (newId === currentId) {
                 // user clicked already selected option, do nothing
                 return;
             }
+            const sb = this.getSandbox();
+            const { baseLayers = [] } = this.getConfig();
+            const currentBottomId = this._getBottomLayer()?.getId();
+
             // switch bg layer (no need to call update on ui, we should catch the event)
             // - check if current bottom layer exists & is in our list (if so, remove)
-            if (currentBottom) {
-                currentBottomId += currentBottom.getId();
-                if (jQuery.inArray(currentBottomId, conf.baseLayers) > -1) {
-                    me.getSandbox().postRequestByName(
-                        'RemoveMapLayerRequest',
-                        [currentBottomId]
-                    );
-                }
+            if (currentBottomId && baseLayers.includes(currentBottomId.toString())) {
+                    sb.postRequestByName('RemoveMapLayerRequest', [currentBottomId]);
             }
             // - check if new selection is already selected, remove if so as rearrange doesn't seem to work
-            if (newSelection) {
-                me.getSandbox().postRequestByName(
-                    'RemoveMapLayerRequest',
-                    [newSelectionId]
-                );
-            } else {
-                newSelection =
-                    me.getSandbox().findMapLayerFromAllAvailable(
-                        newSelectionId
-                    );
+            if (sb.isLayerAlreadySelected(newId)) {
+                sb.postRequestByName('RemoveMapLayerRequest', [newId]);
             }
+            // - add to bottom
+            sb.postRequestByName('AddMapLayerRequest', [newId, { toPosition: 0 }]);
 
-            me.getSandbox().postRequestByName(
-                'AddMapLayerRequest',
-                [newSelectionId]
-            );
-
-            // - move new selection to bottom (see layerselection._layerOrderChanged(item))
-            me.getSandbox().postRequestByName(
-                'RearrangeSelectedMapLayerRequest',
-                [newSelectionId, 0]
-            );
             // toggle dropdown open/closed.
             // won't bother with dropdown being on or off here
-            me._toggleSelection();
+            this._toggleSelection();
         },
 
         /**

--- a/bundles/mapping/mapmodule/request/map.layer.handler.js
+++ b/bundles/mapping/mapmodule/request/map.layer.handler.js
@@ -95,10 +95,14 @@ Oskari.clazz.define('map.layer.handler',
                 // add layers from front of queue to map
                 this.__processLayerQueue();
                 // zoom to content or center/supported zoom level
+                const sandbox = this.layerService.getSandbox();
                 if (opts.zoomContent) {
-                    const sandbox = this.layerService.getSandbox();
                     sandbox.postRequestByName('MapModulePlugin.MapMoveByLayerContentRequest', [layerId, opts.zoomContent]);
                 }
+                if (typeof opts.toPosition === 'number') {
+                    sandbox.postRequestByName('RearrangeSelectedMapLayerRequest', [layerId, opts.toPosition]);
+                }
+
             };
             this._loadLayerInfo(layer, opts, done);
         },

--- a/bundles/mapping/userstyle/handler/UserStyleHandler.js
+++ b/bundles/mapping/userstyle/handler/UserStyleHandler.js
@@ -71,10 +71,20 @@ class Handler extends StateHandler {
     }
 
     addLayerToMap (layerId, styleId) {
-        this.sandbox.postRequestByName('AddMapLayerRequest', [layerId]);
-        if (styleId) {
-            this.sandbox.postRequestByName('ChangeMapLayerStyleRequest', [layerId, styleId]);
+        const styleName = styleId?.toString();
+        if (this.sandbox.isLayerAlreadySelected(layerId)) {
+            if (styleName) {
+                // use request to trigger event
+                this.sandbox.postRequestByName('ChangeMapLayerStyleRequest', [layerId, styleName]);
+            }
+            return;
         }
+        if (styleName) {
+            // AddMapLayerRequest is asynchoronous so style has to be selected before request
+            // ChangeMapLayerStyleRequest doesn't work properly as layer isn't selected immediately
+            this.sandbox.findMapLayerFromAllAvailable(layerId)?.selectStyle(styleName);
+        }
+        this.sandbox.postRequestByName('AddMapLayerRequest', [layerId]);
     }
 
     showLayerStyles (layerId) {


### PR DESCRIPTION
Some requests doesn't work properly if them are requested instantly after AddMapLayerRequest. Problems occur only when layer is added first time to map (DescribeLayer isn't loaded). The reason is that request handler tries to find layer from selected layers (not all available).

https://github.com/oskariorg/oskari-frontend/blob/master/bundles/mapping/mapmodule/request/map.layer.handler.js#L45-L62

Set opacity and style before request. Add option to rearrange layers after add is completed.
