### PR TITLE
Modal z-index update

### DIFF
--- a/src/react/ant-theme.less
+++ b/src/react/ant-theme.less
@@ -4,6 +4,10 @@
 @background-color-light: hsv(0, 0, 96%); // background of header and selected item
 @background-color-base: hsv(0, 0, 86%); // Default grey background color
 
+// Banner.jsx: 18000
+// Flyout.jsx: 20009
+// Popup.jsx: 30000
+// Modal.jsx: 30005
 @zindex-message: 30010;
 @zindex-notification: 30010;
 @zindex-popover: 30030;

--- a/src/react/components/ColorPicker.jsx
+++ b/src/react/components/ColorPicker.jsx
@@ -5,9 +5,6 @@ import { Button, Popover, TextInput, Tooltip, Message } from 'oskari-ui'
 import { constants, SvgRadioButton } from './StyleEditor/index';
 import { BgColorsOutlined } from '@ant-design/icons';
 
-// Use z-index to render popover top of the Modal
-const zIndex = 55500;
-
 // Hide input softly to render color picker to correct place
 const HiddenInput = styled('input')`
     opacity: 0;
@@ -82,7 +79,6 @@ export const ColorPicker = (props) => {
                 trigger="click"
                 placement="bottom"
                 open={visible}
-                zIndex={zIndex}
                 onOpenChange = {setVisible}
                 >
             <Tooltip title={chooseTooltip}>

--- a/src/react/components/Modal.jsx
+++ b/src/react/components/Modal.jsx
@@ -15,7 +15,7 @@ export const Modal = ({ children, title, bodyStyle={}, ...other }) => {
         'overflow': 'auto'
     };
     return (
-        <AntModal zIndex={ 55500 } title={title} bodyStyle={{
+        <AntModal zIndex={ 30005 } title={title} bodyStyle={{
             ...defaultBodyStyle,
             ...bodyStyle
         }} {...other}>


### PR DESCRIPTION
Antd compents that are rendered outside of parent ( opened select list, popover...) uses z-index +30k. However modal used 55500 so dropdown wasn't shown over modal.

I think is more safety to decrease modal than increase ant-theme's because them are used also with react popup, flyout,...

Only jQuery popup +50k and jQuery modal popup 100k uses higher z-index.

Removed workaround from ColorPicker. Also same workaround didn't work with select.