### PR TITLE
Flickering fix for tabs/scrollbar combo on Firefox

### DIFF
--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -541,3 +541,12 @@ So confirm doesn't open behind flyouts (in admin for example)
 .ant-popconfirm {
   z-index: 999998 !important;
 }
+
+/*
+Fixes flickering when tabs reach the right side of the container element AND a scrollbar is shown on the container
+The tabs flicker between showing the last tab name as whole and/or switching it to the "..." icon.
+This seems to only happen on the Firefox browser
+*/
+.ant-tabs .ant-tabs-nav-wrap {
+    padding-right: 2em;
+}

--- a/src/react/components/Tabs.jsx
+++ b/src/react/components/Tabs.jsx
@@ -2,20 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs as AntTabs } from 'antd';
 import 'antd/es/tabs/style/index.js';
-import styled from 'styled-components';
 
-// Fixes flickering when tabs reach the right side of the container element AND a scrollbar is shown on the container
-// The tabs flicker between showing the last tab name as whole and/or switching it to the "..." icon.
-// This seems to only happen on the Firefox browser
-const StyledTabs = styled(AntTabs)`
-.ant-tabs-nav-wrap {
-    padding-right: 2em;
-}
-`;
+// Note! There's CSS related to this under
+//  oskari-frontend/resources/css/portal.css
+//  to fix flickering on Firefox
 export const Tabs = ({ children, ...other }) => (
-    <StyledTabs {...other}>
+    <AntTabs {...other}>
         {children}
-    </StyledTabs>
+    </AntTabs>
 );
 
 Tabs.propTypes = {

--- a/src/react/components/Tabs.jsx
+++ b/src/react/components/Tabs.jsx
@@ -2,11 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs as AntTabs } from 'antd';
 import 'antd/es/tabs/style/index.js';
+import styled from 'styled-components';
 
+// Fixes flickering when tabs reach the right side of the container element AND a scrollbar is shown on the container
+// The tabs flicker between showing the last tab name as whole and/or switching it to the "..." icon.
+// This seems to only happen on the Firefox browser
+const StyledTabs = styled(AntTabs)`
+.ant-tabs-nav-wrap {
+    padding-right: 2em;
+}
+`;
 export const Tabs = ({ children, ...other }) => (
-    <AntTabs {...other}>
+    <StyledTabs {...other}>
         {children}
-    </AntTabs>
+    </StyledTabs>
 );
 
 Tabs.propTypes = {


### PR DESCRIPTION
The AntD tab implementation starts to flicker (on Firefox mostly) when the last tab reaches the right edge of the container AND the container changes to having a scrollbar. The last tab title is continuosly being switched between the "..." more tabs icon and showing the last tab title:

![flicker](https://github.com/oskariorg/oskari-frontend/assets/2210335/39ef4f24-7d5c-4cf3-b419-a28570c05953)

Adding padding to the tab container fixes the issue. The padding should probably be at least as wide as the width of the scrollbar.