### PR TITLE
WFS not unique feature id workaround

### DIFF
--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
@@ -180,7 +180,18 @@ export class VectorLayerHandler extends AbstractLayerHandler {
                         }
                     });
                     const features = source.getFormat().readFeatures(resp);
-                    features.forEach(ftr => ftr.set(WFS_ID_KEY, ftr.getId()));
+                    features.forEach(ftr => {
+                        // workaround for layers which returns generated id for features.
+                        // "The feature id is considered stable and may be used when requesting features or comparing identifiers returned from a remote source."
+                        const idProperty = layer.getIdProperty();
+                        if (idProperty) {
+                            const id = ftr.getProperties()[idProperty];
+                            if (id) {
+                                ftr.setId(id);
+                            }
+                        }
+                        ftr.set(WFS_ID_KEY, ftr.getId())
+                    });
                     source.addFeatures(features);
                     updateLoadingStatus(LOADING_STATUS_VALUE.COMPLETE);
                 },


### PR DESCRIPTION
Use property value as feature id if overriding id is defined.

TODO: rename 