### PR TITLE
Fix the default Point symboliser (point/circle) for vector features

### DIFF
--- a/bundles/mapping/mapmodule/oskariStyle/generator.ol.js
+++ b/bundles/mapping/mapmodule/oskariStyle/generator.ol.js
@@ -34,7 +34,8 @@ export const useStyleFunction = layer => {
     const styleType = geometryTypeToStyleType(layer.getGeometryType());
     const hasPropertyLabel = Oskari.util.keyExists(current.getFeatureStyle(), 'text.labelProperty');
     const hasOptionalStyles = current.getOptionalStyles().length > 0;
-    const hasCluster = typeof layer.getClusteringDistance() !== 'undefined';
+    // TODO: should we check for -1 or undefined type? Seems it defaults to -1 and not 'undefined'
+    const hasCluster = layer.getClusteringDistance() !== -1 && typeof layer.getClusteringDistance() !== 'undefined';
     return hasOptionalStyles || hasCluster || hasPropertyLabel ||
         !styleType || styleType === STYLE_TYPE.COLLECTION;
 };
@@ -53,7 +54,10 @@ export const geometryTypeToStyleType = type => {
         styleType = STYLE_TYPE.POINT; break;
     case 'GeometryCollection':
         styleType = STYLE_TYPE.COLLECTION; break;
+    default:
+        styleType = STYLE_TYPE.COLLECTION;
     }
+
     return styleType;
 };
 
@@ -463,7 +467,7 @@ const getImageStyle = (mapModule, styleDef, requestedStyle) => {
     const opacity = styleDef.image.opacity || 1;
     // Oskari marker
     if (!isNaN(styleDef.image.shape)) {
-        const { src, scale, offsetX, offsetY } = Oskari.custom.getSvg(styleDef.image);
+        const { src, scale, offsetX = 16, offsetY = 16 } = Oskari.custom.getSvg(styleDef.image);
         return new olStyleIcon({
             src,
             scale,

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/impl/VectorLayerHandler.ol.js
@@ -53,7 +53,8 @@ export class VectorLayerHandler extends AbstractLayerHandler {
         const olLayers = [vectorLayer];
 
         // Setup clustering
-        if (this._isClusteringSupported() && layer.getClusteringDistance()) {
+        const hasClusterDist = layer.getClusteringDistance() !== -1 && typeof layer.getClusteringDistance() !== 'undefined';
+        if (this._isClusteringSupported() && hasClusterDist) {
             const clusterSource = new olCluster({
                 distance: layer.getClusteringDistance(),
                 source,

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/util/style.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/util/style.js
@@ -31,7 +31,8 @@ export const DEFAULT_STYLES = { ...defaults };
 
 const isClusteredLayer = (mapmodule, layer) => {
     // mvt rendering isn't supported in 3D, no need to check layer's render mode
-    return !mapmodule.getSupports3D() && typeof layer.getClusteringDistance() !== 'undefined';
+    // TODO: should we check for -1 or undefined type? Seems it defaults to -1 and not 'undefined'
+    return !mapmodule.getSupports3D() && layer.getClusteringDistance() !== -1 && typeof layer.getClusteringDistance() !== 'undefined';
 };
 
 const defaultStyleGenerator = (mapmodule, layer) => {

--- a/src/BasicBundle.js
+++ b/src/BasicBundle.js
@@ -60,7 +60,7 @@ Oskari.clazz.define('Oskari.BasicBundle', function () {
      */
     init: function () { },
 
-    /** 
+    /**
      * Called from sandbox.
      * @memberof BasicBundle
      */


### PR DESCRIPTION
The default symboliser doesn't have an offset so passing undefined values to OL seems to break the visualization completely. The other point symbolizers work even without these changes. Defaulting missing offsets to 16 for now to fix the issue.

However there's something funky going on with clustering distance checks. It looks like the value is always -1, but the checks were for missing or truthy values. This needs some more investigating. Without these changes the code follows the clustered styling path that creates two ol layers and creates styles multiple times so it's better than it was. Would prefer the distance to always being a number OR undefined + positive number when clustering is activated.