### PR TITLE
Fix popup positioning on mobile

### DIFF
--- a/bundles/mapping/toolbar/view/MapMeasurementPopup.jsx
+++ b/bundles/mapping/toolbar/view/MapMeasurementPopup.jsx
@@ -36,11 +36,9 @@ const PopupContent = ({ text, clearMeasurements, onClose }) => {
 export const showMapMeasurementPopup = (text, clearMeasurements, onClose) => {
     const dimensions = getNavigationDimensions();
     let placement = PLACEMENTS.BL;
-
     if (dimensions?.placement === 'right') {
         placement = PLACEMENTS.BR;
     }
-    
     const options = {
         id: 'oskari-measurements',
         placement

--- a/bundles/mapping/toolbar/view/MapMeasurementPopup.jsx
+++ b/bundles/mapping/toolbar/view/MapMeasurementPopup.jsx
@@ -36,8 +36,12 @@ const PopupContent = ({ text, clearMeasurements, onClose }) => {
 export const showMapMeasurementPopup = (text, clearMeasurements, onClose) => {
     const dimensions = getNavigationDimensions();
     let placement = PLACEMENTS.BL;
-    if (dimensions?.placement === 'right') {
-        placement = PLACEMENTS.BR;
+    if (Oskari.util.isMobile()) {
+        placement = PLACEMENTS.BOTTOM;
+    } else {
+        if (dimensions?.placement === 'right') {
+            placement = PLACEMENTS.BR;
+        }
     }
     const options = {
         id: 'oskari-measurements',

--- a/bundles/mapping/toolbar/view/MapMeasurementPopup.jsx
+++ b/bundles/mapping/toolbar/view/MapMeasurementPopup.jsx
@@ -36,13 +36,11 @@ const PopupContent = ({ text, clearMeasurements, onClose }) => {
 export const showMapMeasurementPopup = (text, clearMeasurements, onClose) => {
     const dimensions = getNavigationDimensions();
     let placement = PLACEMENTS.BL;
-    if (Oskari.util.isMobile()) {
-        placement = PLACEMENTS.BOTTOM;
-    } else {
-        if (dimensions?.placement === 'right') {
-            placement = PLACEMENTS.BR;
-        }
+
+    if (dimensions?.placement === 'right') {
+        placement = PLACEMENTS.BR;
     }
+    
     const options = {
         id: 'oskari-measurements',
         placement

--- a/src/react/components/window/Popup.jsx
+++ b/src/react/components/window/Popup.jsx
@@ -6,6 +6,7 @@ import { monitorResize, unmonitorResize } from './WindowWatcher';
 import { ThemeConsumer } from '../../util/contexts';
 import { getFontClass } from '../../theme/ThemeHelper';
 import { Header } from './Header';
+import { PLACEMENTS } from './';
 
 const Container = styled.div`
     position: absolute;
@@ -86,8 +87,17 @@ export const Popup = ThemeConsumer(( {title = '', children, onClose, bringToTop,
             return handleUnmounting;
         }
         // center after content has been rendered
+        let placement = options.placement;
+        // Open on bottom/top on mobile to prevent popup overflowing the screen
+        if (Oskari.util.isMobile()) {
+            if (placement && placement.indexOf('bottom') > -1) {
+                placement = PLACEMENTS.BOTTOM;
+            } else {
+                placement = PLACEMENTS.TOP;
+            }
+        }
         setPosition({
-            ...getPositionForCentering(elementRef, options.placement),
+            ...getPositionForCentering(elementRef, placement),
             centered: true
         });
         return handleUnmounting;


### PR DESCRIPTION
Always open popups top or bottom on mobile to prevent popup overflowing the screen.