### PR TITLE
Navigation toggle & fullscreen plugin logic

### DIFF
--- a/bundles/framework/divmanazer/plugin/ToggleNavigation.js
+++ b/bundles/framework/divmanazer/plugin/ToggleNavigation.js
@@ -114,6 +114,23 @@ Oskari.clazz.define('Oskari.userinterface.plugin.ToggleNavigationPlugin',
         },
         isVisible: function () {
             return this._isVisible;
+        },
+        /**
+         * @method _createEventHandlers
+         * Create eventhandlers.
+         *
+         *
+         * @return {Object.<string, Function>} EventHandlers
+         */
+        _createEventHandlers: function () {
+            return {
+                MapSizeChangedEvent: function (evt) {
+                    if (Oskari.util.isMobile()) {
+                        this._isVisible = true;
+                        this.refresh();
+                    }
+                }
+            };
         }
     },
     {

--- a/bundles/framework/divmanazer/plugin/ToggleNavigation.js
+++ b/bundles/framework/divmanazer/plugin/ToggleNavigation.js
@@ -125,8 +125,10 @@ Oskari.clazz.define('Oskari.userinterface.plugin.ToggleNavigationPlugin',
         _createEventHandlers: function () {
             return {
                 MapSizeChangedEvent: function (evt) {
-                    if (Oskari.util.isMobile()) {
+                    // Hide navigation when moving from desktop to mobile
+                    if (Oskari.dom.isNavigationVisible() && !this._isVisible && Oskari.util.isMobile()) {
                         this._isVisible = true;
+                        Oskari.dom.showNavigation(false);
                         this.refresh();
                     }
                 }

--- a/bundles/mapping/mapmodule/plugin/fullscreen/FullScreen.js
+++ b/bundles/mapping/mapmodule/plugin/fullscreen/FullScreen.js
@@ -57,9 +57,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugi
          * @method _startPluginImpl
          */
         _startPluginImpl: function () {
-            this.setElement(this._createControlElement());
-            this.addToPluginContainer(this.getElement());
-            this.refresh();
+            if (!Oskari.util.isMobile()) {
+                this.setElement(this._createControlElement());
+                this.addToPluginContainer(this.getElement());
+                this.refresh();
+            }
         },
 
         /**
@@ -76,9 +78,15 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugi
          */
         refresh: function () {
             const el = this.getElement();
-            if (!el || Oskari.util.isMobile()) {
+            if (!el) {
                 return;
             }
+
+            if (Oskari.util.isMobile()) {
+                this.teardownUI();
+                return;
+            }
+
             const isFullscreen = !!this.state.fullscreen;
             ReactDOM.render(
                 <StyledButton
@@ -118,6 +126,20 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugi
         createRequestHandlers: function () {
             return {
                 'MapModulePlugin.ToggleFullScreenControlRequest': this
+            };
+        },
+        /**
+         * @method _createEventHandlers
+         * Create eventhandlers.
+         *
+         *
+         * @return {Object.<string, Function>} EventHandlers
+         */
+        _createEventHandlers: function () {
+            return {
+                MapSizeChangedEvent: function (evt) {
+                    this.refresh();
+                }
             };
         },
         /**


### PR DESCRIPTION
- Hide fullscreen plugin when switching to small screen, don't show when moving back to desktop from mobile.
- Show navigation toggle when switching to small screen & hide nav.