### PR TITLE
Handle large legend images

### DIFF
--- a/bundles/framework/maplegend/LegendImage.jsx
+++ b/bundles/framework/maplegend/LegendImage.jsx
@@ -1,13 +1,20 @@
 import React, { useState } from 'react';
 import { Message } from 'oskari-ui';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const Image = styled('img')`
+    max-width: 100%;
+`;
 
 export const LegendImage = ({ url }) => {
     const [hasError, setError] = useState(false);
     if (hasError) {
         return (<Message messageKey='invalidLegendUrl' />);
     }
-    return (<img src={ url } onError={ () => setError(true) } />);
+    return (<a href={ url } target='_blank' rel='noopener noreferrer'>
+        <Image src={ url } onError={ () => setError(true) } />
+    </a>);
 };
 
 LegendImage.propTypes = {


### PR DESCRIPTION
Make large legend images scale to maximum size that can be shown and add a link to open the legend image in another tab.

Currently:
![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/14333d28-3405-422b-9046-ba9e6ab31462)

After PR:
![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/62d66b42-7351-4bed-bf0d-5eb893a2b569)
