### PR TITLE
Define text color for additional options on Thematic maps -tile

### DIFF
--- a/bundles/statistics/statsgrid2016/resources/scss/style.scss
+++ b/bundles/statistics/statsgrid2016/resources/scss/style.scss
@@ -613,6 +613,7 @@ div.oskari-flyout {
             background-position: center;
         }
         .text {
+            color: rgba(0,0,0,.85);
             float: left;
             margin-left: 4px;
             font-weight: bold;


### PR DESCRIPTION
Same as #2399 for Thematic Maps to prevent text color from changing based on color defined for the main nav-element.