### PR TITLE
Layerlist black badge and layereditor fixes

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/VectorLayerAttributes.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/VectorLayerAttributes.jsx
@@ -100,7 +100,7 @@ export const VectorLayerAttributes = ({ layer, controller }) => {
         setState({ ...state, [modal]: value });
     };
     const onModalCancel = () => {
-        const attr = modal === 'featureFilter' ? featureFilter : data[modal];
+        const attr = modal === 'featureFilter' ? featureFilter : data[modal] || {};
         setState({ ...state, [modal]: attr });
         setModal(null);
     };

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/VectorLayerAttributes/PropertiesFilter.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/VectorLayerAttributes/PropertiesFilter.jsx
@@ -128,7 +128,7 @@ export const PropertiesFilter = ({ filter = {}, update, properties, labels }) =>
                                 ? <Message messageKey='attributes.filter.default'/>
                                 : <Message messageKey={`LocalizationComponent.locale.${opt}`} bundleKey='oskariui' />
                             }
-                            { Array.isArray(filter[opt]) && <StyledBadge count={filter[opt].length} themed showZero={false} /> }
+                            { Array.isArray(filter[opt]) && <StyledBadge count={filter[opt].length} showZero={false} /> }
                         </Option>)) 
                     }
                 </Select>

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCountBadge.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCountBadge.jsx
@@ -7,7 +7,7 @@ export const LayerCountBadge = ({ layerCount = 0, unfilteredLayerCount }) => {
     const badgeText = unfilteredLayerCount
         ? layerCount + ' / ' + unfilteredLayerCount
         : layerCount;
-    return <Badge count={badgeText} />;
+    return <Badge color='#333' count={badgeText} />;
 };
 
 LayerCountBadge.propTypes = {


### PR DESCRIPTION
- Revert themed badge to black (https://github.com/oskariorg/oskari-frontend/pull/2394)
- attributes.data filter|locale|format are deep cloned before clening, so them can't be undefined. Set empty object to state on cancel if attributes doesn't have value. Fixes issue where cancel + save without definitions caused JS error
- remove themed prop -> caused react error as it isn't handled anymore (gets passed to antd badge inside ...rest)
