### PR TITLE
Fix JS error when modifying user roles

### DIFF
--- a/bundles/framework/admin-users/handler/AdminUsersHandler.js
+++ b/bundles/framework/admin-users/handler/AdminUsersHandler.js
@@ -294,7 +294,7 @@ class UIHandler extends StateHandler {
 
     async saveUser () {
         this.validateUserForm();
-        const { errors, passwordErrors, roles, ...userParams } = this.state.userFormState;
+        const { errors, passwordErrors = {}, roles, ...userParams } = this.state.userFormState;
         if (errors.length > 0 || Object.keys(passwordErrors).length > 0) {
             return;
         }


### PR DESCRIPTION
Default to empty errors object to prevent js error on next line when external user management is configured to be used (password fields are not shown -> password validation returns undefined -> js error on Object.keys(undefined)).