### PR TITLE
Add margin for flyout title to add gap to close icon when empty/small content

### DIFF
--- a/bundles/framework/divmanazer/resources/scss/divman.scss
+++ b/bundles/framework/divmanazer/resources/scss/divman.scss
@@ -40,6 +40,7 @@ body {
 .oskari-flyout-title {
     float: left;
     margin-left: 20px;
+    margin-right: 20px;
     margin-top: 12px;
     height: 20px;
     display: inline-block;


### PR DESCRIPTION
Current:
![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/a2bc4ece-ddab-4be5-b60e-65546205ef78)

After PR:
![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/f292ce1f-d20b-4f12-873e-b4f9741c16c2)
