### PR TITLE
Admin layereditor attributes data constants

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -117,7 +117,7 @@ Oskari.registerLocalization(
                 "presentationTooltip": "Presentation affects GetFeatureInfo request and feature data table.",
                 "showAll": "Show all properties",
                 "idProperty": "Use feature property as identifier",
-                "idPropertyTooltip": "Service should return unique identifier for features. Firstly ask service provider to use unique identifiers.",
+                "idPropertyTooltip": "Service should return unique identifier for features. Firstly ask service provider to use unique identifiers. Works only for 'Big objects' type (GeoJSON).",
                 "geometryType": {
                     "label": "Geometry type",
                     "sourceAttributes": "Source: layer attributes",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -118,7 +118,7 @@ Oskari.registerLocalization(
                 "presentationTooltip": "Esitystapa vaikuttaa kohdetietojen kyselyyn ja kohdetietotaulukkoon.",
                 "showAll": "Näytä kaikki ominaisuustiedot",
                 "idProperty": "Käytä ominaisuustietoa kohteiden yksilöimiseen",
-                "idPropertyTooltip": "Rajapinnan tulee palauttaa yksilöivä tunniste kohteille. Pyydä ensisijaisesti palveluntarjoajaa ottamaan käyttöön yksilöivät tunnisteet.",
+                "idPropertyTooltip": "Rajapinnan tulee palauttaa yksilöivä tunniste kohteille. Pyydä ensisijaisesti palveluntarjoajaa ottamaan käyttöön yksilöivät tunnisteet. Toimii vain 'Suuria kohteita' tyypille (GeoJSON).",
                 "geometryType": {
                     "label": "Geometriatyyppi",
                     "sourceAttributes": "Lähde: tason attribuutit",

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/VectorLayerAttributes.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/VectorLayerAttributes.jsx
@@ -8,7 +8,7 @@ import { InfoIcon } from 'oskari-ui/components/icons';
 import { Controller, Messaging } from 'oskari-ui/util';
 import { PropertiesFilter, PropertiesLocale, PropertiesFormat } from './VectorLayerAttributes/';
 import { StyledFormField, Border } from '../styled';
-import { GEOMETRY_TYPES, getGeometryType } from '../../LayerHelper';
+import { GEOMETRY_TYPES, DATA, getGeometryType } from '../../LayerHelper';
 
 const Buttons = styled.div`
     display: inline-flex;
@@ -60,10 +60,11 @@ export const VectorLayerAttributes = ({ layer, controller }) => {
     };
 
     const onGeometryTypeChange = value => {
+        const key = DATA.GEOMETRY;
         if (GEOMETRY_TYPES[0] === value) {
-            controller.setAttributesData('geometryType');
+            controller.setAttributesData(key);
         } else {
-            controller.setAttributesData('geometryType', value);
+            controller.setAttributesData(key, value);
         }
     };
     const onModalOk = () => {
@@ -106,7 +107,7 @@ export const VectorLayerAttributes = ({ layer, controller }) => {
     };
     const properties = featureProperties.filter(prop => prop.name !== geomName);
     const propNames = properties.map(prop => prop.name);
-    const geometryTypeSource = data.geometryType ? 'Attributes' : 'Capabilities';
+    const geometryTypeSource = data[DATA.GEOMETRY] ? 'Attributes' : 'Capabilities';
     const propLabels = Oskari.getLocalized(data.locale) || {};
     // gather selected properties from all (localized) filters
     const selectedProperties = state.filter ? [...new Set([].concat(...Object.values(state.filter)))] : [];
@@ -142,8 +143,8 @@ export const VectorLayerAttributes = ({ layer, controller }) => {
                 <Message messageKey='attributes.idProperty'/>
                 <InfoIcon title={<Message messageKey='attributes.idPropertyTooltip'/>}/>
                 <StyledFormField>
-                    <Select allowClear value={data.idProperty}
-                        onChange={value => controller.setAttributesData('idProperty', value)}
+                    <Select allowClear value={data[DATA.REPLACE_ID]}
+                        onChange={value => controller.setAttributesData(DATA.REPLACE_ID, value)}
                         options={propNames.map(value => ({value}))}/>
                 </StyledFormField>
             </Border>

--- a/bundles/admin/admin-layereditor/view/LayerHelper.js
+++ b/bundles/admin/admin-layereditor/view/LayerHelper.js
@@ -1,10 +1,19 @@
+// oskari-server WFSLayerAttributes
+export const DATA = {
+    GEOMETRY: 'simpleGeometryType',
+    REPLACE_ID: 'replaceFeatureId',
+    NO_DATA: 'noDataValue',
+    COMMON_ID: 'commonId'
+};
+
 export const GEOMETRY_TYPES = ['unknown', 'point', 'line', 'area', 'collection'];
 const AREA_TYPES = ['surface', 'polygon'];
 
 export const getGeometryType = layer => {
     const { attributes, capabilities } = layer;
-    if (attributes?.data?.geometryType) {
-        return attributes.data.geometryType;
+    const attrGeometry = attributes.data?.[DATA.GEOMETRY];
+    if (attrGeometry) {
+        return attrGeometry;
     }
     const { geomName, featureProperties = [] } = capabilities;
     const capaType = featureProperties.find(prop => prop.name === geomName)?.type.toLowerCase() || '';

--- a/bundles/mapping/mapmodule/domain/AbstractVectorLayer.js
+++ b/bundles/mapping/mapmodule/domain/AbstractVectorLayer.js
@@ -47,8 +47,8 @@ export class AbstractVectorLayer extends AbstractLayer {
     }
 
     /* override */
-    getStyleType () {
-        return this._controlData.styleType;
+    getGeometryType () {
+        return this._controlData.simpleGeometryType;
     }
 
     /* override */

--- a/bundles/mapping/mapwfs2/domain/WFSLayer.js
+++ b/bundles/mapping/mapwfs2/domain/WFSLayer.js
@@ -33,10 +33,16 @@ export class WFSLayer extends AbstractVectorLayer {
         super.handleDescribeLayer(info);
         this._properties = info.properties || [];
     }
+    getGeometryType (raw) {
+        if (raw) {
+            return this._properties.find(p => p.type === 'geometry')?.rawType;
+        }
+        return super.getGeometryType();
+    }
 
     /* Layer type specifics */
 
-    getIdProperty () {
+    replaceFeatureId () {
         return this._controlData.idProperty;
     }
 


### PR DESCRIPTION
Use constants
`geometryType` -> ` simpleGeometryType`
`idProperty` -> `replaceFeatureId`

`getStyleType()` -> `getGeometryType(raw)` 
returns simple type (point,line.area,collection) by default