### PR TITLE
HoverHandler content/tooltip fix

### DIFF
--- a/bundles/mapping/mapmodule/service/HoverHandler.js
+++ b/bundles/mapping/mapmodule/service/HoverHandler.js
@@ -124,6 +124,7 @@ export class HoverHandler {
     }
 
     registerLayer (layer) {
+        this.setTooltipContent(layer);
         this._styleCache[layer.getId()] = this._styleGenerator(layer);
     }
 


### PR DESCRIPTION
set tooltip content on register layer. Fixes issue where content/tooltip is set but not shown and layer has only default style (doesn't use updateStyle from HoverHandler).

setTooltipContent was called for WFS layer only on updateLayerStyle 
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/mapping/mapmodule/service/HoverHandler.js#L144

If 2.11.2 is temporal fix which isn't merged to develop/master this could be merged also to develop