### PR TITLE
Markers cluster

### DIFF
--- a/bundles/mapping/mapmodule/oskariStyle/generator.ol.js
+++ b/bundles/mapping/mapmodule/oskariStyle/generator.ol.js
@@ -108,31 +108,30 @@ export const getStylesForGeometry = (geometry, styleTypes) => {
 
 // Style for cluster circles
 const clusterStyleCache = {};
-const clusterStyleFunc = feature => {
-    const size = feature.get('features').length;
-    const cacheKey = `${size}`;
-    let style = clusterStyleCache[cacheKey];
-    if (!style) {
-        style = new olStyleStyle({
-            image: new olStyleCircle({
-                radius: size > 9 ? 14 : 12,
-                stroke: new olStyleStroke({
-                    color: '#fff'
-                }),
-                fill: new olStyleFill({
-                    color: '#3399CC' // isSelected '#005d90'
-                })
-            }),
-            text: new olStyleText({
-                text: size.toString(),
-                font: 'bold 14px sans-serif',
-                fill: new olStyleFill({
-                    color: '#fff'
-                })
-            })
-        });
-        clusterStyleCache[cacheKey] = style;
+export const getClusterStyle = size => {
+    const cached = clusterStyleCache[size];
+    if (cached) {
+        return cached;
     }
+    const style = new olStyleStyle({
+        image: new olStyleCircle({
+            radius: size > 9 ? 14 : 12,
+            stroke: new olStyleStroke({
+                color: '#fff'
+            }),
+            fill: new olStyleFill({
+                color: '#3399CC' // isSelected '#005d90'
+            })
+        }),
+        text: new olStyleText({
+            text: size.toString(),
+            font: 'bold 14px sans-serif',
+            fill: new olStyleFill({
+                color: '#fff'
+            })
+        })
+    });
+    clusterStyleCache[size] = style;
     return style;
 };
 
@@ -160,7 +159,7 @@ export const wrapClusterStyleFunction = styleFunction => {
         const feats = feature.get('features');
         if (feats) {
             if (feats.length > 1) {
-                return clusterStyleFunc(feature);
+                return getClusterStyle(feats.length);
             } else {
                 // Only single point in cluster. Use it in styling.
                 feature = feature.get('features')[0];


### PR DESCRIPTION
Enable clustering for markers. Changed mapmodule generator cluster style to return style instead  of function to use same cache and style than others (WFS). WFS uses wrapClusterStyleFunction.

Not sure if cluestered markers are wanted everywhere so made it configurable. Maybe we should add prop + plugin modifier for backend.

One problem might be that nearest address markers can be very close.

![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/091d64df-7d84-4cbd-b8e8-eb75d68b1064)
