### PR TITLE
UserStyle geom typed style editor

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VectorStyle.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VectorStyle.jsx
@@ -10,7 +10,6 @@ import { EditOutlined, BgColorsOutlined } from '@ant-design/icons';
 import { Modal } from 'oskari-ui/components/Modal';
 import { StyleEditor } from 'oskari-ui/components/StyleEditor';
 import styled from 'styled-components';
-import { SUPPORTED_FORMATS } from 'oskari-ui/components/StyleEditor/constants';
 import { getGeometryType } from '../../LayerHelper';
 
 
@@ -114,7 +113,6 @@ export const VectorStyle = LocaleConsumer(({ layer, getMessage, controller, exte
     const visible = !!state.modal;
     const externalType = external ? getExternalStyleType(layer) : null;
     const geometryType = getGeometryType(layer);
-    const styleTabs = SUPPORTED_FORMATS.includes(geometryType) ? [geometryType] : SUPPORTED_FORMATS;
     return (
         <FullWidthSpace direction='vertical'>
             <Space direction='horizontal'>
@@ -155,7 +153,7 @@ export const VectorStyle = LocaleConsumer(({ layer, getMessage, controller, exte
                 { state.modal === 'editor' &&
                     <StyleEditor
                         oskariStyle={ state.style.featureStyle }
-                        tabs={styleTabs}
+                        geometryType={geometryType}
                         onChange={ (featureStyle) => updateStyle({ featureStyle })}
                     />
                 }
@@ -187,7 +185,7 @@ export const VectorStyle = LocaleConsumer(({ layer, getMessage, controller, exte
                 editOptional={setStyleForOptional}
             />
             { styleForOptional &&
-                <OptionalStyleModal vectorStyle={styleForOptional} controller={controller} styleTabs={styleTabs}
+                <OptionalStyleModal vectorStyle={styleForOptional} controller={controller} geometryType={geometryType}
                     properties={layer.capabilities.featureProperties}
                     onClose={() => setStyleForOptional()} />
             }

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VectorStyle/OptionalStyleModal.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VectorStyle/OptionalStyleModal.jsx
@@ -39,7 +39,7 @@ const PanelExtra = ({ onRemove}) => {
     );
 };
 
-export const OptionalStyleModal = ({ vectorStyle, styleTabs, controller, onClose, properties = [] }) => {
+export const OptionalStyleModal = ({ vectorStyle, geometryType, controller, onClose, properties = [] }) => {
     const { featureStyle, optionalStyles = [] } = vectorStyle?.style || {};
     const [ styles, setStyles ] = useState(optionalStyles.length ? optionalStyles : [{}]);
 
@@ -102,7 +102,7 @@ export const OptionalStyleModal = ({ vectorStyle, styleTabs, controller, onClose
                             <FeatureFilter filter={filterDef} types={properties} properties={propertyNames}
                                 onChange={ updated => update({ ...styleDef, ...updated }, i)}/>
                             <Divider><Message messageKey='styles.vector.featureStyle' /></Divider>
-                            <StyleEditor tabs={styleTabs}
+                            <StyleEditor geometryType={geometryType}
                                 oskariStyle={ Object.keys(styleDef).length ? styleDef : featureStyle }
                                 onChange={updated => update({ ...filterDef, ...updated }, i)}/>
                         </CollapsePanel>

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
@@ -15,7 +15,7 @@ import '../../event/MarkerClickEvent';
 import '../../event/AfterRemoveMarkersEvent';
 import { showAddMarkerPopup } from './view/MarkersForm';
 import { showMarkerPopup } from './view/MarkerPopup';
-import { ID_PREFIX, PLUGIN_NAME, TOOL_GROUP, DEFAULT_STYLE, STYLE_TYPE, DEFAULT_DATA, SEPARATORS } from './constants';
+import { ID_PREFIX, PLUGIN_NAME, TOOL_GROUP, DEFAULT_STYLE, GEOMETRY_TYPE, DEFAULT_DATA, SEPARATORS } from './constants';
 
 /**
  * @class Oskari.mapframework.mapmodule.MarkersPlugin
@@ -361,7 +361,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
 
         _addMarkerToMap: function (id, coord, style) {
             const layerSource = this.getMarkersLayer().getSource();
-            const olStyle = this.getMapModule().getStyle(style, STYLE_TYPE);
+            const olStyle = this.getMapModule().getStyle(style, GEOMETRY_TYPE);
 
             const feature = new olFeature(new olGeom.Point(coord));
             feature.setId(id);

--- a/bundles/mapping/mapmodule/plugin/markers/constants.js
+++ b/bundles/mapping/mapmodule/plugin/markers/constants.js
@@ -2,7 +2,7 @@ export const ID_PREFIX = 'M_';
 export const BUNDLE_KEY = 'MapModule';
 export const PLUGIN_NAME = 'MarkersPlugin';
 export const TOOL_GROUP = 'selectiontools';
-export const STYLE_TYPE = 'point';
+export const GEOMETRY_TYPE = 'point';
 
 export const SEPARATORS = {
     FIELD: '|',

--- a/bundles/mapping/mapmodule/plugin/markers/view/MarkersForm.jsx
+++ b/bundles/mapping/mapmodule/plugin/markers/view/MarkersForm.jsx
@@ -5,7 +5,7 @@ import { showPopup } from 'oskari-ui/components/window';
 import { Message, TextInput, Tooltip, Divider } from 'oskari-ui';
 import { SecondaryButton, PrimaryButton, ButtonContainer } from 'oskari-ui/components/buttons';
 import { StyleEditor } from 'oskari-ui/components/StyleEditor';
-import { PLUGIN_NAME, BUNDLE_KEY, DEFAULT_STYLE, STYLE_TYPE } from '../constants';
+import { PLUGIN_NAME, BUNDLE_KEY, DEFAULT_STYLE, GEOMETRY_TYPE } from '../constants';
 
 const Content = styled('div')`
     padding: 24px;
@@ -42,7 +42,7 @@ const Form = ({ onAdd, onClose }) => {
             <StyleEditor
                 oskariStyle={state.style}
                 onChange={ updateStyle }
-                tabs = {[STYLE_TYPE]}
+                geometryType = {GEOMETRY_TYPE}
             />
             <ButtonContainer>
                 <SecondaryButton type='close' onClick={onClose}/>

--- a/bundles/mapping/userstyle/instance.js
+++ b/bundles/mapping/userstyle/instance.js
@@ -66,6 +66,10 @@ Oskari.clazz.define('Oskari.mapframework.userstyle.UserStyleBundleInstance', fun
             layerId: requestedLayer,
             showEditor
         };
+        if (showEditor) {
+            options.geometryType = this.getSandbox().getService('Oskari.mapframework.service.MapLayerService')
+                ?.findMapLayer(requestedLayer)?.getGeometryType();
+        }
         if (this.popupController) {
             this.popupController.update(options);
         } else {

--- a/bundles/mapping/userstyle/view/UserStyles/UserStyleEditor.jsx
+++ b/bundles/mapping/userstyle/view/UserStyles/UserStyleEditor.jsx
@@ -5,7 +5,7 @@ import { SecondaryButton, PrimaryButton, ButtonContainer } from 'oskari-ui/compo
 import { StyleEditor } from 'oskari-ui/components/StyleEditor';
 import { BUNDLE_KEY } from '../../constants';
 
-export const UserStyleEditor = ({ style, onAdd, onCancel }) => {
+export const UserStyleEditor = ({ style, geometryType, onAdd, onCancel }) => {
     const { style: { featureStyle = {} } = {}, name } = style;
     const defaultStyle = Oskari.custom.generateBlankStyle();
     const [state, setState] = useState({
@@ -30,6 +30,7 @@ export const UserStyleEditor = ({ style, onAdd, onCancel }) => {
             </Divider>
             <StyleEditor
                 oskariStyle={ state.featureStyle }
+                geometryType={ geometryType }
                 onChange={ updateStyle }
             />
             <ButtonContainer>
@@ -43,5 +44,6 @@ export const UserStyleEditor = ({ style, onAdd, onCancel }) => {
 UserStyleEditor.propTypes = {
     onAdd: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
-    style: PropTypes.object.isRequired
+    style: PropTypes.object.isRequired,
+    geometryType: PropTypes.string
 };

--- a/bundles/mapping/userstyle/view/index.js
+++ b/bundles/mapping/userstyle/view/index.js
@@ -17,7 +17,7 @@ const Info = styled(Alert)`
 `;
 
 const getContent = (service, options, onClose) => {
-    const { layerId, id, showEditor } = options;
+    const { layerId, id, showEditor, geometryType } = options;
     let content;
     if (showEditor) {
         const wasEditor = true;
@@ -32,7 +32,8 @@ const getContent = (service, options, onClose) => {
             });
             onClose(wasEditor);
         };
-        content = <UserStyleEditor style={ style } onAdd={ onAdd } onCancel={ () => onClose(wasEditor) }/>;
+        content = <UserStyleEditor style={ style } onAdd={ onAdd }
+            geometryType={geometryType} onCancel={ () => onClose(wasEditor) }/>;
     } else {
         const styles = service.getStylesByLayer(layerId);
         const onDelete = (id) => service.removeUserStyle(id);

--- a/src/react/components/StyleEditor.jsx
+++ b/src/react/components/StyleEditor.jsx
@@ -65,7 +65,7 @@ const styleExceptionHandler = (exceptionStyle, oldStyle) => {
     return exceptionStyle;
 };
 
-export const StyleEditor = ({ oskariStyle, onChange, format, tabs }) => {
+export const StyleEditor = ({ oskariStyle, onChange, format, geometryType }) => {
     let [form] = Form.useForm();
     // if we don't clone the input here the mappings
     //  between form <> style, the values can get mixed up due to mutability
@@ -74,7 +74,8 @@ export const StyleEditor = ({ oskariStyle, onChange, format, tabs }) => {
         ...oskariStyle
     };
 
-    const formats = tabs || constants.SUPPORTED_FORMATS;
+    const formats = constants.SUPPORTED_FORMATS.includes(geometryType)
+        ? [geometryType] : constants.SUPPORTED_FORMATS;
 
     // initialize state with propvided style settings to show preview correctly and set default format as point
     const fieldValuesForForm = FormToOskariMapper.createFlatFormObjectFromStyle(style);
@@ -122,6 +123,6 @@ export const StyleEditor = ({ oskariStyle, onChange, format, tabs }) => {
 StyleEditor.propTypes = {
     oskariStyle: PropTypes.object,
     format: PropTypes.oneOf(constants.SUPPORTED_FORMATS),
-    tabs: PropTypes.array,
+    geometryType: PropTypes.string,
     onChange: PropTypes.func.isRequired
 };


### PR DESCRIPTION
Show only one style/geometry tab for userstyle if layer has geometry type defined.

StyleEditor changed `tabs` -> `geometryType`. I think that the usage is always one or all so don't need to check formats include geom type in every component.