### PR TITLE
Make sure layer url is always parseable with js URL

### DIFF
--- a/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
@@ -372,13 +372,18 @@ Oskari.clazz.define(
 
             me._cancelAjaxRequest();
             me._startAjaxRequest(dteMs);
-            const featureInfoUrl = this._getFeatureInfoUrl(lonlat);
+            let featureInfoUrl = this._getFeatureInfoUrl(lonlat);
             let x = Math.round(px.x);
             let y = Math.round(px.y);
             let width = mapVO.getWidth();
             let height = mapVO.getHeight();
             let bbox = mapVO.getBboxAsString();
             if (featureInfoUrl) {
+                if (featureInfoUrl.startsWith('/')) {
+                    // fixes urls starting with /action or one without protocol in general //somedomain.com
+                    // we don't really care about the domain, we are only interested in getting parts of the querystring
+                    featureInfoUrl = 'https://' + window.location.hostname + featureInfoUrl;
+                }
                 const url = new URL(featureInfoUrl);
                 if (url.searchParams.get('I')) {
                     x = Number.parseInt(url.searchParams.get('I'), 10);


### PR DESCRIPTION
Fixes an issue where trying to show GFI for WMS layers results in JS error:
```
logger.es6.js:26 Sandbox: Error notifying MainMapModuleGetInfoPlugin about MapClickedEvent Oskari.clazz.define.__name {_lonlat: {…}, _mouseX: 498, _mouseY: 560, _ctrlKeyDown: false} TypeError: Failed to construct 'URL': Invalid URL
    at superClass.r.classConstructor.handleGetInfo (GetInfoPlugin.js:382:29)
    at superClass.r.classConstructor.MapClickedEvent (GetInfoPlugin.js:140:26)
    at superClass.r.classConstructor.onEvent (AbstractMapModulePlugin.js:343:32)