### PR TITLE
sticky header and scrollable content for the user permissions table

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionsTabPane/PermissionRow.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionsTabPane/PermissionRow.jsx
@@ -24,6 +24,7 @@ const TextColumn = styled.div`
     width: ${TEXT_COLUMN_SIZE.width}px;
     padding-left: ${TEXT_COLUMN_SIZE.padding}px;
     align-self: ${props => props.isHeaderRow ? 'flex-end' : 'stretch'};
+    font-weight: ${props => props.isHeaderRow ? 'bold' : 'normal'};
 `;
 
 const StyledPermissionDiv = styled.div`

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionsTabPane/PermissionsTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/PermissionsTabPane/PermissionsTabPane.jsx
@@ -7,9 +7,6 @@ import { LocaleConsumer, Controller } from 'oskari-ui/util';
 import { UnorderedListOutlined, EyeOutlined, ImportOutlined, ExportOutlined } from '@ant-design/icons';
 
 const StyledListItem = styled(ListItem)`
-    &:first-child > div {
-        font-weight: bold;
-    }
     &:not(:first-child) {
         &:nth-child(even) {
             background-color: #ffffff;
@@ -28,7 +25,18 @@ const StyledIcon = styled('div')`
 // But most instances don't have them so it's not a huge issue for first version of the UI
 const ListDiv = styled.div`
     margin-bottom: 20px;
-    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    max-height: 50vh;
+`;
+
+const ListDivHeader = styled('div')`
+    flex 0 0 auto;
+`;
+
+const ListDivContent = styled('div')`
+    flex 1 1 auto;
+    overflow-y: auto;
 `;
 
 const getPermissionTableHeader = (permission) => {
@@ -98,7 +106,8 @@ const PermissionsTabPane = ({ rolesAndPermissionTypes, permissions = {}, control
         permissions: getHeaderPermissions(dataRows, roles),
         permissionTypes: localizedPermissionTypes
     };
-    const permissionDataModel = [headerRow, ...dataRows];
+    const headerDataModel = [headerRow];
+    const permissionDataModel = [...dataRows];
 
     const renderRow = (modelRow) => {
         const checkboxes = modelRow.permissionTypes.map(permission => {
@@ -138,7 +147,12 @@ const PermissionsTabPane = ({ rolesAndPermissionTypes, permissions = {}, control
 
     return (
         <ListDiv>
-            <List bordered={false} dataSource={permissionDataModel} renderItem={renderRow}/>
+            <ListDivHeader>
+                <List bordered={false} dataSource={headerDataModel} renderItem={renderRow}/>
+            </ListDivHeader>
+            <ListDivContent>
+                <List bordered={false} dataSource={permissionDataModel} renderItem={renderRow}/>
+            </ListDivContent>
         </ListDiv>
     );
 };


### PR DESCRIPTION
Sticky header row & scrollable content. Limited max-height for the tab pane as well so the footer will also remain in the viewport and no scrollbar should appear on the tabpane.

![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/bce6e878-b3e9-4496-bfa2-fa826e65fe01)

