### PR TITLE
ArcgisLayerPlugin opacity fix

### DIFF
--- a/bundles/mapping/maparcgis/plugin/ArcGisLayerPlugin.ol.js
+++ b/bundles/mapping/maparcgis/plugin/ArcGisLayerPlugin.ol.js
@@ -124,7 +124,7 @@ Oskari.clazz.define('Oskari.arcgis.bundle.maparcgis.plugin.ArcGisLayerPlugin',
                 layerType = 'ol3 Arcgis CACHE';
             }
 
-            openlayer.opacity = layer.getOpacity() / 100;
+            openlayer.setOpacity(layer.getOpacity() / 100);
             const zoomLevelHelper = getZoomLevelHelper(this.getMapModule().getScaleArray());
             // Set min max zoom levels that layer should be visible in
             zoomLevelHelper.setOLZoomLimits(openlayer, layer.getMinScale(), layer.getMaxScale());


### PR DESCRIPTION
Use function to set opacity. Fixes opacity issue when layer is added to map without default opacity. Issue appears when mapfull adds layer from state (embedded, view, link, selected + refresh).

Before adding layers async mapfull used change opacity request.
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/mapping/mapmodule/plugin/AbstractMapLayerPlugin.js#L297
Now it sets opacity to oskari layer before adding layer to map.