### PR TITLE
Metadata search layout

### DIFF
--- a/bundles/catalogue/metadatasearch/MetadataStateHandler.js
+++ b/bundles/catalogue/metadatasearch/MetadataStateHandler.js
@@ -2,6 +2,7 @@ import { StateHandler, controllerMixin } from 'oskari-ui/util';
 import { MetadataOptionService } from './service/MetadataOptionService';
 import { MetadataSearchService } from './service/MetadataSearchService';
 import { METADATA_BUNDLE_LOCALIZATION_ID } from './instance';
+import { CoverageHelper } from '../../mapping/mapmodule/plugin/layers/coveragetool/CoverageHelper';
 
 class MetadataStateHandler extends StateHandler {
     constructor (instance) {
@@ -10,6 +11,9 @@ class MetadataStateHandler extends StateHandler {
         this.optionsService = new MetadataOptionService(this.instance.optionAjaxUrl);
         this.searchService = new MetadataSearchService(this.instance.searchAjaxUrl);
         this.mapLayerService = this.getSandbox().getService('Oskari.mapframework.service.MapLayerService');
+        this.coverageHelper = new CoverageHelper();
+        this.coverageHelper.initCoverageToolPlugin();
+
         this.setState({
             query: '',
             advancedSearchExpanded: false,
@@ -96,19 +100,13 @@ class MetadataStateHandler extends StateHandler {
     }
 
     toggleCoverageArea (result) {
-        this.instance.removeFeaturesFromMap();
         const { displayedCoverageId } = this.getState();
         if (displayedCoverageId && displayedCoverageId === result.id) {
-            this.updateState({
-                displayedCoverageId: null
-            });
+            this.coverageHelper.clearLayerCoverage();
             return;
         }
 
-        this.updateState({
-            displayedCoverageId: result.id
-        });
-        this.instance.addCoverageFeatureToMap(result.geom);
+        this.coverageHelper.showMetadataCoverage(result.geom, result.id);
     }
 
     toggleLayerVisibility (checked, layerId) {
@@ -124,6 +122,12 @@ class MetadataStateHandler extends StateHandler {
     updateSelectedLayers () {
         this.updateState({
             selectedLayers: this.getSelectedLayers()
+        });
+    }
+
+    updateDisplayedCoverageId (id) {
+        this.updateState({
+            displayedCoverageId: id
         });
     }
 
@@ -241,7 +245,8 @@ const wrapped = controllerMixin(MetadataStateHandler, [
     'updateCoverageFeature',
     'toggleLayerVisibility',
     'updateSelectedLayers',
-    'updateSearchResults'
+    'updateSearchResults',
+    'updateDisplayedCoverageId'
 ]);
 
 export { wrapped as MetadataStateHandler };

--- a/bundles/catalogue/metadatasearch/resources/locale/fi.js
+++ b/bundles/catalogue/metadatasearch/resources/locale/fi.js
@@ -4,7 +4,7 @@ Oskari.registerLocalization({
     "value": {
         "tabTitle": "Metatietohaku",
         "metadataSearchDescription": "Hae paikkatietoresursseja eli paikkatietoaineistoja, -aineistosarjoja ja palveluja.",
-        "placeholder": "Kirjoita hakusana tähän.",
+        "placeholder": "Kirjoita hakusana tähän",
         "advancedSearch": {
             "showMore": "Lisää hakuehtoja",
             "showLess": "Piilota tarkennettu haku",

--- a/bundles/catalogue/metadatasearch/resources/locale/sv.js
+++ b/bundles/catalogue/metadatasearch/resources/locale/sv.js
@@ -4,7 +4,7 @@ Oskari.registerLocalization({
     "value": {
         "tabTitle": "Metadatasökning",
         "metadataSearchDescription": "Sök metadata för dataset, dataset-serier eller tjänster.",
-        "placeholder": "Skriv sökordet.",
+        "placeholder": "Skriv sökordet",
         "advancedSearch": {
             "showMore": "Visa sökalternativ",
             "showLess": "Dölj sökalternativ",

--- a/bundles/catalogue/metadatasearch/view/MetadataSearchContainer.jsx
+++ b/bundles/catalogue/metadatasearch/view/MetadataSearchContainer.jsx
@@ -18,9 +18,10 @@ const Description = () => {
 };
 
 const SearchContainer = (props) => {
-    const { query, onChange, onSearch } = props;
+    const { query, onChange, onSearch, disabled } = props;
     return <div>
         <SearchInput
+            disabled={disabled}
             enterButton={true}
             size='large'
             value={query}
@@ -33,7 +34,8 @@ const SearchContainer = (props) => {
 SearchContainer.propTypes = {
     query: PropTypes.string,
     onChange: PropTypes.func,
-    onSearch: PropTypes.func
+    onSearch: PropTypes.func,
+    disabled: PropTypes.bool
 };
 
 const Container = ({ state, controller }) => {
@@ -54,7 +56,11 @@ const Container = ({ state, controller }) => {
             !(loading || searchResultsVisible) &&
             <>
                 <Description/>
-                <SearchContainer query={query} onChange={controller.updateQuery} onSearch={controller.doSearch}/>
+                <SearchContainer
+                    disabled={drawing}
+                    query={query}
+                    onChange={controller.updateQuery}
+                    onSearch={controller.doSearch}/>
                 <AdvancedSearchContainer
                     isExpanded={advancedSearchExpanded}
                     toggleAdvancedSearch={controller.toggleAdvancedSearch}

--- a/bundles/catalogue/metadatasearch/view/MetadataSearchContainer.jsx
+++ b/bundles/catalogue/metadatasearch/view/MetadataSearchContainer.jsx
@@ -5,15 +5,24 @@ import { SearchInput, Spin, Message } from 'oskari-ui';
 import { AdvancedSearchContainer } from './advanced-search/AdvancedSearchContainer';
 import { MetadataSearchResultListContainer } from './resultlist/MetadataSearchResultListContainer';
 import { FlexRowCentered } from './advanced-search/AdvancedSearchStyledComponents';
+import styled from 'styled-components';
+
+const DescriptionContainer = styled('div')`
+    margin-bottom: 8px;
+`;
 
 const Description = () => {
-    return <Message bundleKey={METADATA_BUNDLE_LOCALIZATION_ID} messageKey='metadataSearchDescription'/>;
+    return <DescriptionContainer>
+        <Message bundleKey={METADATA_BUNDLE_LOCALIZATION_ID} messageKey='metadataSearchDescription'/>
+    </DescriptionContainer>;
 };
 
 const SearchContainer = (props) => {
     const { query, onChange, onSearch } = props;
     return <div>
         <SearchInput
+            enterButton={true}
+            size='large'
             value={query}
             onChange={(event) => onChange(event.target.value)}
             placeholder={Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'placeholder')}

--- a/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchCoverage.jsx
+++ b/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchCoverage.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { AdvancedSearchInputLabel, AdvancedSearchRowContainer } from './AdvancedSearchStyledComponents';
 import { Button } from 'oskari-ui/components/Button';
+import { SecondaryButton } from 'oskari-ui/components/buttons';
+
 import PropTypes from 'prop-types';
 import { METADATA_BUNDLE_LOCALIZATION_ID } from '../../instance';
 export const AdvancedSearchCoverage = (props) => {
@@ -8,7 +10,7 @@ export const AdvancedSearchCoverage = (props) => {
     return <AdvancedSearchRowContainer>
         <AdvancedSearchInputLabel>{Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'advancedSearch.searchArea')}</AdvancedSearchInputLabel>
         { !drawing && !coverageFeature && <Button onClick={startDrawing} type='primary'>{Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'advancedSearch.delimitArea')}</Button>}
-        { drawing && !coverageFeature && <Button disabled={true} type='primary'>{Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'advancedSearch.startDraw')}</Button>}
+        { drawing && !coverageFeature && <SecondaryButton onClick={cancelDrawing} type='cancel'/>}
         { coverageFeature && <Button onClick={cancelDrawing} type='primary'>{Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'advancedSearch.deleteArea')}</Button>}
     </AdvancedSearchRowContainer>;
 };

--- a/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchDropdown.jsx
+++ b/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchDropdown.jsx
@@ -3,14 +3,14 @@ import { AdvancedSearchInputLabel, AdvancedSearchRowContainer, AdvancedSearchSel
 import { Option } from 'oskari-ui';
 import PropTypes from 'prop-types';
 export const AdvancedSearchDropdown = (props) => {
-    const { title, options, onChange, selected } = props;
+    const { title, options, onChange, selected, disabled } = props;
     const hasOptions = options && options?.values?.length && options.values.length > 0;
     if (!hasOptions) {
         return null;
     }
     return <AdvancedSearchRowContainer>
         <AdvancedSearchInputLabel>{title}</AdvancedSearchInputLabel>
-        <AdvancedSearchSelect onChange={onChange} value={selected}>
+        <AdvancedSearchSelect onChange={onChange} value={selected} disabled={disabled}>
             { options.values.map(value => <Option key={value.val} value={value.value}>{value.val}</Option>) }
         </AdvancedSearchSelect>
     </AdvancedSearchRowContainer>;
@@ -20,5 +20,6 @@ AdvancedSearchDropdown.propTypes = {
     title: PropTypes.string,
     options: PropTypes.object,
     onChange: PropTypes.func,
-    selected: PropTypes.string
+    selected: PropTypes.string,
+    disabled: PropTypes.bool
 };

--- a/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchMulti.jsx
+++ b/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchMulti.jsx
@@ -5,7 +5,7 @@ import { PropTypes } from 'prop-types';
 import { Checkbox } from 'oskari-ui';
 
 export const AdvancedSearchMulti = (props) => {
-    const { title, options, onChange, selected } = props;
+    const { title, options, onChange, selected, disabled } = props;
     const hasOptions = options && options?.values?.length && options.values.length > 0;
     if (!hasOptions) {
         return null;
@@ -14,7 +14,13 @@ export const AdvancedSearchMulti = (props) => {
         <AdvancedSearchInputLabel>{title}</AdvancedSearchInputLabel>
         {
             <AdvancedSearchCheckboxGroupContainer>
-                {options.values.map(value => <Checkbox key={value.val} value={value.val} onChange={onChange} checked={isChecked(selected, value.val)}>{Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'advancedSearch.' + value.val)}</Checkbox>)}
+                {options.values.map(value => <Checkbox disabled={disabled}
+                    key={value.val}
+                    value={value.val}
+                    onChange={onChange}
+                    checked={isChecked(selected, value.val)}>
+                    {Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'advancedSearch.' + value.val)}
+                </Checkbox>)}
             </AdvancedSearchCheckboxGroupContainer>
         }
     </AdvancedSearchRowContainer>;
@@ -28,5 +34,6 @@ AdvancedSearchMulti.propTypes = {
     title: PropTypes.string,
     options: PropTypes.object,
     onChange: PropTypes.func,
-    selected: PropTypes.array
+    selected: PropTypes.array,
+    disabled: PropTypes.bool
 };

--- a/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchOptions.jsx
+++ b/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchOptions.jsx
@@ -16,6 +16,7 @@ export const AdvancedSearchOptions = (props) => {
                 if (field.multi) {
                     return <AdvancedSearchMulti
                         key={field.field}
+                        disabled={drawing}
                         title={Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'advancedSearch.' + field.field)}
                         options={getByField(field.field, advancedSearchOptions)}
                         selected={advancedSearchValues[field.field]}
@@ -24,6 +25,7 @@ export const AdvancedSearchOptions = (props) => {
 
                 return <AdvancedSearchDropdown
                     key={field.field}
+                    disabled={drawing}
                     title={Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'advancedSearch.' + field.field)}
                     options={getByField(field.field, advancedSearchOptions)}
                     selected={advancedSearchValues[field.field]}

--- a/bundles/catalogue/metadatasearch/view/resultlist/CoverageIcon.jsx
+++ b/bundles/catalogue/metadatasearch/view/resultlist/CoverageIcon.jsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
+import { METADATA_BUNDLE_LOCALIZATION_ID } from '../../instance';
 
 export const CoverageIcon = (props) => {
     const { active, item, toggleCoverageArea } = props;
-    return <div className={active ? 'icon-info-area-active' : 'icon-info-area'} onClick={() => toggleCoverageArea(item)}/>;
+    return <div className={active ? 'icon-info-area-active' : 'icon-info-area'}
+        onClick={() => toggleCoverageArea(item)}
+        title={active
+            ? Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'grid.removeBBOX')
+            : Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'grid.showBBOX') }
+    />;
 };
 
 CoverageIcon.propTypes = {

--- a/bundles/framework/search/resources/locale/fi.js
+++ b/bundles/framework/search/resources/locale/fi.js
@@ -8,7 +8,7 @@ Oskari.registerLocalization(
         "tabTitle": "Paikkahaku",
         "invalid_characters": "Hakusanassa on kiellettyjä merkkejä. Sallittuja merkkejä ovat aakkoset (a-ö, A-Ö), numerot (0-9) sekä piste (.), pilkku (,), yhdysviiva (-) ja huutomerkki (!). Voit myös korvata sanassa yhden merkin kysymysmerkillä (?) tai sana loppuosan jokerimerkillä (*).",
         "searchDescription": "Hae paikkoja paikannimen perusteella.",
-        "searchAssistance": "Anna hakusana",
+        "searchAssistance": "Kirjoita hakusana tähän",
         "searchResultCount": "Hakusanalla löytyi {count, plural, one {# hakutulos} other {# hakutulosta}}.",
         "searchMoreResults": "Haulla löytyi enemmän tuloksia kuin näytetään ({count}). Tarkenna hakusanaa rajataksesi tulosta.",
         "searchResultDescriptionOrdering": "Järjestä hakutulokset klikkaamalla sarakkeen otsikkoa alla olevassa taulukossa.",

--- a/bundles/mapping/mapmodule/plugin/layers/coveragetool/CoverageHelper.js
+++ b/bundles/mapping/mapmodule/plugin/layers/coveragetool/CoverageHelper.js
@@ -56,4 +56,17 @@ export class CoverageHelper {
         };
         Oskari.getSandbox().postRequestByName('MapModulePlugin.AddFeaturesToMapRequest', [layer.getGeometryWKT(), opts]);
     }
+
+    showMetadataCoverage (geometry, displayedMetadataCoverageId) {
+        const attributes = { displayedMetadataCoverageId };
+        this.clearLayerCoverage();
+        const opts = {
+            centerTo: true,
+            clearPrevious: true,
+            layerId: COVERAGE_LAYER_ID,
+            featureStyle: COVERAGE_FEATURE_STYLE,
+            attributes
+        };
+        Oskari.getSandbox().postRequestByName('MapModulePlugin.AddFeaturesToMapRequest', [geometry, opts]);
+    }
 }


### PR DESCRIPTION
-unified look with place search
-use common coverage tool plugin to display metadata coverage area
-labels, tooltips, less error-prone drawing tool etc.
-passing the info that we're dealing with a metadata coverage feature in a FeatureEvent turned out to be a bit messy/hacky -> hints toward cleaner solution would be appreciated (case getDisplayedMetadaCoverageIdFromFeatureEvent)

![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/de896da6-1459-4cd2-9fdc-bd128b42b295)

![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/54c0746d-db54-4c60-9054-467d55d57c63)
