### PR TITLE
fix text overflow in mapmoduletextbutton, when content is a <Message/>

### DIFF
--- a/bundles/framework/featuredata/plugin/FeatureDataPlugin.js
+++ b/bundles/framework/featuredata/plugin/FeatureDataPlugin.js
@@ -92,7 +92,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata.plugin.FeatureDataPl
                 <ThemeProvider value={this.getMapModule().getMapTheme()}>
                     <MapModuleTextButton
                         visible={layers?.length > 0}
-                        text={<Message messageKey='title' bundleKey='FeatureData'/>}
                         onClick={() => this.handler.openFlyout()}
                         active={flyoutOpen}
                         loading={loadingStatus.loading}
@@ -100,7 +99,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata.plugin.FeatureDataPl
                         $marginRight={marginRight}
                         $marginLeft={marginLeft}
                         $marginTop={'10'}
-                    />
+                    >
+                        {<Message messageKey='title' bundleKey='FeatureData'/>}
+                    </MapModuleTextButton>
                 </ThemeProvider>,
                 el[0]
             );

--- a/bundles/framework/featuredata/plugin/FeatureDataPlugin.js
+++ b/bundles/framework/featuredata/plugin/FeatureDataPlugin.js
@@ -100,7 +100,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.featuredata.plugin.FeatureDataPl
                         $marginLeft={marginLeft}
                         $marginTop={'10'}
                     >
-                        {<Message messageKey='title' bundleKey='FeatureData'/>}
+                        <Message messageKey='title' bundleKey='FeatureData'/>
                     </MapModuleTextButton>
                 </ThemeProvider>,
                 el[0]

--- a/bundles/mapping/mapmodule/MapModuleTextButton.jsx
+++ b/bundles/mapping/mapmodule/MapModuleTextButton.jsx
@@ -55,7 +55,8 @@ const StyledButton = styled(Button)`
     }
 `;
 
-const ButtonText = styled('span')`
+const ButtonText = styled('div')`
+    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 `;

--- a/bundles/mapping/mapmodule/MapModuleTextButton.jsx
+++ b/bundles/mapping/mapmodule/MapModuleTextButton.jsx
@@ -55,12 +55,6 @@ const StyledButton = styled(Button)`
     }
 `;
 
-const ButtonText = styled('div')`
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-`;
-
 const ThemedButton = ThemeConsumer(({ theme = {}, active, ...rest }) => {
     const helper = getNavigationTheme(theme);
     // get button roundness factor instead of percentage as the component is not round itself
@@ -82,7 +76,7 @@ const ThemedButton = ThemeConsumer(({ theme = {}, active, ...rest }) => {
     );
 });
 
-export const MapModuleTextButton = ({ visible, onClick, icon, text, active, position, loading, ...rest }) => {
+export const MapModuleTextButton = ({ visible, onClick, icon, children, active, position, loading, ...rest }) => {
     if (!visible) {
         return null;
     };
@@ -95,7 +89,7 @@ export const MapModuleTextButton = ({ visible, onClick, icon, text, active, posi
         loading={loading}
         {...rest}
     >
-        <ButtonText>{text}</ButtonText>
+        {children}
     </ThemedButton>;
 };
 
@@ -103,8 +97,8 @@ MapModuleTextButton.propTypes = {
     visible: PropTypes.bool,
     onClick: PropTypes.func,
     icon: PropTypes.any,
-    text: PropTypes.any,
     active: PropTypes.bool,
     position: PropTypes.string,
-    loading: PropTypes.bool
+    loading: PropTypes.bool,
+    children: PropTypes.any
 };

--- a/bundles/mapping/mapmodule/plugin/layers/BackgroundLayerSelection.jsx
+++ b/bundles/mapping/mapmodule/plugin/layers/BackgroundLayerSelection.jsx
@@ -12,6 +12,11 @@ const ButtonsContainer = styled('div')`
     align-items: center;
 `;
 
+const BackgroundLayerSelectionButtonText = styled('div')`
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+`;
 const getDropDownItems = (layers = []) => {
     return layers.map(layer => ({
         title: layer.title,
@@ -35,7 +40,7 @@ export const BackgroundLayerSelection = ({ isMobile = false, layers, current, ma
                         data-layerid={current?.getId()}
                         {...rest}
                     >
-                        {current?.getName()}
+                        <BackgroundLayerSelectionButtonText>{current?.getName()}</BackgroundLayerSelectionButtonText>
                     </MapModuleTextButton>
                 </Dropdown>
             </ButtonsContainer>
@@ -56,7 +61,7 @@ export const BackgroundLayerSelection = ({ isMobile = false, layers, current, ma
                         data-layerid={layer.id}
                         {...rest}
                     >
-                        {layer.title}
+                        <BackgroundLayerSelectionButtonText>{layer.title}</BackgroundLayerSelectionButtonText>
                     </MapModuleTextButton>
                 </Tooltip>
             ))}

--- a/bundles/mapping/mapmodule/plugin/layers/BackgroundLayerSelection.jsx
+++ b/bundles/mapping/mapmodule/plugin/layers/BackgroundLayerSelection.jsx
@@ -33,9 +33,10 @@ export const BackgroundLayerSelection = ({ isMobile = false, layers, current, ma
                         icon={<LayersIcon />}
                         $isDropdown={true}
                         data-layerid={current?.getId()}
-                        text={current?.getName()}
                         {...rest}
-                    />
+                    >
+                        {current?.getName()}
+                    </MapModuleTextButton>
                 </Dropdown>
             </ButtonsContainer>
         );
@@ -48,14 +49,15 @@ export const BackgroundLayerSelection = ({ isMobile = false, layers, current, ma
                         visible={true}
                         onClick={() => layer.onClick(layer.id)}
                         icon={null}
-                        text={layer.title}
                         active={Number.parseInt(layer.id, 10) === current?.getId()}
                         loading={false}
                         $isDropdown={false}
                         $minWidth={BUTTON_WIDTH}
                         data-layerid={layer.id}
                         {...rest}
-                    />
+                    >
+                        {layer.title}
+                    </MapModuleTextButton>
                 </Tooltip>
             ))}
         </ButtonsContainer>

--- a/bundles/mapping/mapmodule/plugin/layers/coveragetool/CoverageToolPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/layers/coveragetool/CoverageToolPlugin.js
@@ -59,7 +59,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.CoverageToolPlu
                     <Tooltip key={'FeatureDataPluginButtonTooltip'} title={<Message bundleKey={LOCALIZATION_BUNDLE_ID} messageKey='layerCoverageTool.removeCoverageFromMap'/>}>
                         <MapModuleTextButton
                             visible={this.isVisible()}
-                            text={<Message bundleKey={LOCALIZATION_BUNDLE_ID} messageKey='layerCoverageTool.removeCoverageFromMap'/>}
+                            text={<Message bundleKey={LOCALIZATION_BUNDLE_ID} messageKey='layerCoverageTool.removeCoverageFromMap' allowTextEllipsis={true}/>}
                             onClick={() => {
                                 this._coverageButtonClicked();
                             }}

--- a/bundles/mapping/mapmodule/plugin/layers/coveragetool/CoverageToolPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/layers/coveragetool/CoverageToolPlugin.js
@@ -65,9 +65,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.CoverageToolPlu
                             active={false}
                             position={this.getLocation()}
                         >
-                            {<Message bundleKey={LOCALIZATION_BUNDLE_ID}
+                            <Message bundleKey={LOCALIZATION_BUNDLE_ID}
                                 messageKey='layerCoverageTool.removeCoverageFromMap'
-                                allowTextEllipsis={true}/>}
+                                allowTextEllipsis={true}/>
                         </MapModuleTextButton>
                     </Tooltip>
                 </ThemeProvider>,

--- a/bundles/mapping/mapmodule/plugin/layers/coveragetool/CoverageToolPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/layers/coveragetool/CoverageToolPlugin.js
@@ -59,13 +59,16 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.CoverageToolPlu
                     <Tooltip key={'FeatureDataPluginButtonTooltip'} title={<Message bundleKey={LOCALIZATION_BUNDLE_ID} messageKey='layerCoverageTool.removeCoverageFromMap'/>}>
                         <MapModuleTextButton
                             visible={this.isVisible()}
-                            text={<Message bundleKey={LOCALIZATION_BUNDLE_ID} messageKey='layerCoverageTool.removeCoverageFromMap' allowTextEllipsis={true}/>}
                             onClick={() => {
                                 this._coverageButtonClicked();
                             }}
                             active={false}
                             position={this.getLocation()}
-                        />
+                        >
+                            {<Message bundleKey={LOCALIZATION_BUNDLE_ID}
+                                messageKey='layerCoverageTool.removeCoverageFromMap'
+                                allowTextEllipsis={true}/>}
+                        </MapModuleTextButton>
                     </Tooltip>
                 </ThemeProvider>,
                 el[0]);

--- a/src/react/components/Message.jsx
+++ b/src/react/components/Message.jsx
@@ -5,9 +5,9 @@ import styled from 'styled-components';
 
 const Label = styled('div')`
     display: ${props => props.allowTextEllipsis ? 'inline': 'inline-block'};
-    overflow: ${props => props.allowTextEllipsis ? 'hidden': ''}
-    white-space: ${props => props.allowTextEllipsis ? 'nowrap': ''}
-    text-overflow: ${props => props.allowTextEllipsis ? 'ellipsis': ''}
+    overflow: ${props => props.allowTextEllipsis ? 'hidden': ''};
+    white-space: ${props => props.allowTextEllipsis ? 'nowrap': ''};
+    text-overflow: ${props => props.allowTextEllipsis ? 'ellipsis': ''};
 `;
 
 /**

--- a/src/react/components/Message.jsx
+++ b/src/react/components/Message.jsx
@@ -4,7 +4,10 @@ import { LocaleConsumer } from 'oskari-ui/util';
 import styled from 'styled-components';
 
 const Label = styled('div')`
-    display: inline-block;
+    display: ${props => props.allowTextEllipsis ? 'inline': 'inline-block'};
+    overflow: ${props => props.allowTextEllipsis ? 'hidden': ''}
+    white-space: ${props => props.allowTextEllipsis ? 'nowrap': ''}
+    text-overflow: ${props => props.allowTextEllipsis ? 'ellipsis': ''}
 `;
 
 /**
@@ -31,7 +34,7 @@ const Label = styled('div')`
  *     <Message messageKey="hello" messageArgs={['Jack']}/>
  * </LocaleProvider>
  */
-const Message = ({ bundleKey, messageKey, messageArgs, defaultMsg, getMessage, children, LabelComponent = Label, allowHTML = false }) => {
+const Message = ({ bundleKey, messageKey, messageArgs, defaultMsg, getMessage, children, LabelComponent = Label, allowHTML = false, allowTextEllipsis = false }) => {
     if (!messageKey) {
         return null;
     }
@@ -54,7 +57,8 @@ const Message = ({ bundleKey, messageKey, messageArgs, defaultMsg, getMessage, c
     }
 
     return (
-        <LabelComponent 
+        <LabelComponent
+            allowTextEllipsis={allowTextEllipsis}
             onClick={() => Oskari.log().debug(`Text clicked - ${bundleKey}: ${messageKey}`)}>
                 { message } { children }
         </LabelComponent>
@@ -68,7 +72,8 @@ Message.propTypes = {
     getMessage: PropTypes.func,
     children: PropTypes.node,
     LabelComponent: PropTypes.elementType,
-    allowHTML: PropTypes.bool
+    allowHTML: PropTypes.bool,
+    allowTextEllipsis: PropTypes.bool
 };
 
 function getMessageUsingOskariGlobal(bundleKey, messageKey, messageArgs) {


### PR DESCRIPTION
-added a property to use text-overflow ellipsis within a Message-component
![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/9dd758b5-ce7f-4db7-9832-3d7b7707aecf)
