### PR TITLE
Fix indicator parameter names.

### DIFF
--- a/bundles/statistics/statsgrid/view/search/IndicatorParams.jsx
+++ b/bundles/statistics/statsgrid/view/search/IndicatorParams.jsx
@@ -60,7 +60,7 @@ export const IndicatorParams = ({ state, controller }) => {
                 }
                 return (
                     <Field key={param}>
-                        <b><Message messageKey={`parameters.${param}`} /></b>
+                        <b><Message messageKey={`parameters.${param}`} defaultMsg={param} /></b>
                         <StyledSelect
                             options={selector?.values?.map(value => ({ value: value.id, label: value.title }))}
                             value={state.indicatorParams?.selected[param]}


### PR DESCRIPTION
Display param name directly if no translation exists.