### PR TITLE
Notification mobile layout

### DIFF
--- a/bundles/framework/announcements/instance.js
+++ b/bundles/framework/announcements/instance.js
@@ -133,7 +133,7 @@ Oskari.clazz.define('Oskari.framework.bundle.announcements.AnnouncementsBundleIn
             return handler.apply(this, [event]);
         },
         eventHandlers: {
-            MapSizeChangedEvent: function(event) {
+            MapSizeChangedEvent: function (event) {
                 this.renderBanner(this.handler.getState());
             }
         }

--- a/bundles/framework/announcements/instance.js
+++ b/bundles/framework/announcements/instance.js
@@ -22,7 +22,6 @@ Oskari.clazz.define('Oskari.framework.bundle.announcements.AnnouncementsBundleIn
         this.bannerControls = null;
         this.descriptionPopupControls = null;
     }, {
-
         afterStart: function () {
             const me = this;
             if (me.started) {
@@ -124,6 +123,19 @@ Oskari.clazz.define('Oskari.framework.bundle.announcements.AnnouncementsBundleIn
          * implements BundleInstance protocol update method - does nothing atm
          */
         stop: function () {
+        },
+        onEvent: function (event) {
+            const handler = this.eventHandlers[event.getName()];
+            if (!handler) {
+                return;
+            }
+
+            return handler.apply(this, [event]);
+        },
+        eventHandlers: {
+            MapSizeChangedEvent: function(event) {
+                this.renderBanner(this.handler.getState());
+            }
         }
     }, {
         extend: ['Oskari.userinterface.extension.DefaultExtension']

--- a/bundles/framework/announcements/view/AnnouncementsBanner.jsx
+++ b/bundles/framework/announcements/view/AnnouncementsBanner.jsx
@@ -74,27 +74,40 @@ const getContent = (state, controller, renderDescriptionPopup) => {
             </PopupLink>
         );
     }
+
+    const notificationContent = <>
+        <InfoContainer>
+            <InfoIcon/>
+            <Column>
+                <StyledTitle>{title}</StyledTitle>
+                <span>
+                    {description}
+                    <Margin/>
+                </span>
+            </Column>
+        </InfoContainer>
+        <Margin/>
+        <Column style={{ whiteSpace: 'nowrap' }}>
+            <StyledCheckbox checked={state.dontShowAgain.includes(announcement.id)} onChange={setShowAgain}>
+                <Message messageKey='dontShow' bundleKey={BUNDLE_KEY} />
+            </StyledCheckbox>
+            <Pagination simple hideOnSinglePage current={currentBanner} total={count} defaultPageSize={1} onChange={onPageChange}/>
+        </Column>
+    </>;
+
+    const isMobile = Oskari.util.isMobile();
     return (
         <ThemeProvider>
-            <Row>
-                <InfoContainer>
-                    <InfoIcon/>
-                    <Column>
-                        <StyledTitle>{title}</StyledTitle>
-                        <span>
-                            {description}
-                            <Margin/>
-                        </span>
-                    </Column>
-                </InfoContainer>
-                <Margin/>
-                <Column style={{ whiteSpace: 'nowrap' }}>
-                    <StyledCheckbox checked={state.dontShowAgain.includes(announcement.id)} onChange={setShowAgain}>
-                        <Message messageKey='dontShow' bundleKey={BUNDLE_KEY} />
-                    </StyledCheckbox>
-                    <Pagination simple hideOnSinglePage current={currentBanner} total={count} defaultPageSize={1} onChange={onPageChange}/>
+            { isMobile &&
+                <Column>
+                    { notificationContent }
                 </Column>
-            </Row>
+            }
+            { !isMobile &&
+                <Row>
+                    { notificationContent }
+                </Row>
+            }
         </ThemeProvider>
     );
 };


### PR DESCRIPTION
-column layout in mobile mode and as-it-was in desktop
-detect size change and move between the two
-text coloring based on theme (light text when background is dark) will follow on another pr

![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/b04874e5-001f-4ecf-a886-86b96bbbcfae)

