### PR TITLE
Notification text color

### DIFF
--- a/bundles/framework/announcements/view/AnnouncementsBanner.jsx
+++ b/bundles/framework/announcements/view/AnnouncementsBanner.jsx
@@ -27,6 +27,8 @@ const PopupLink = styled('div')`
     div {
         text-decoration: underline
     }
+
+    margin: 0.5em 0;
 `;
 
 const InfoIcon = styled(InfoCircleOutlined)`
@@ -92,7 +94,6 @@ const ThemedNotificationContent = ThemeConsumer(({ theme, state, link, content, 
     const announcement = bannerAnnouncements[currentBanner - 1];
     const count = bannerAnnouncements.length;
     const { title } = Oskari.getLocalized(announcement.locale);
-    theme.color.primary = '#01A0E3';
     const textColor = getTextColor(theme?.color?.primary);
 
     return <>

--- a/bundles/framework/announcements/view/AnnouncementsBanner.jsx
+++ b/bundles/framework/announcements/view/AnnouncementsBanner.jsx
@@ -95,7 +95,7 @@ const ThemedNotificationContent = ThemeConsumer(({ theme, state, link, content, 
     const count = bannerAnnouncements.length;
     const { title } = Oskari.getLocalized(announcement.locale);
     const textColor = getTextColor(theme?.color?.primary);
-
+    const linkColor = Oskari.util.isDarkColor(theme?.color?.primary) ? textColor : DEFAULT_POPUP_LINK_COLOR;
     const pagingSection = <>
         <StyledCheckbox checked={state.dontShowAgain.includes(announcement.id)} onChange={setShowAgain}>
             <TextColorWrapper textColor={textColor}>
@@ -110,7 +110,7 @@ const ThemedNotificationContent = ThemeConsumer(({ theme, state, link, content, 
             <Column>
                 <StyledTitle textColor={textColor}>{title}</StyledTitle>
                 <span>
-                    {getDescription(link, content, announcement, renderDescriptionPopup, textColor)}
+                    {getDescription(link, content, announcement, renderDescriptionPopup, linkColor)}
                     <Margin/>
                 </span>
             </Column>

--- a/bundles/framework/announcements/view/AnnouncementsBanner.jsx
+++ b/bundles/framework/announcements/view/AnnouncementsBanner.jsx
@@ -1,22 +1,35 @@
 import React, { Fragment } from 'react';
 import { showBanner } from 'oskari-ui/components/window';
-import { Checkbox, Message, Pagination, Link } from 'oskari-ui';
+import { Checkbox, Message, Pagination } from 'oskari-ui';
 import { BUNDLE_KEY } from '../constants';
 import styled from 'styled-components';
 import { InfoCircleOutlined, SelectOutlined } from '@ant-design/icons';
-import { ThemeProvider } from 'oskari-ui/util';
+import { ThemeConsumer } from 'oskari-ui/util';
+import { getTextColor } from 'oskari-ui/theme';
 
+const DEFAULT_GREY_TEXT = '#3c3c3c';
+const DEFAULT_POPUP_LINK_COLOR = '#0091ff';
 const LinkIcon = styled(SelectOutlined)`
     margin-left: 6px;
 `;
 
-const PopupLink = styled('span')`
-    color: #0091ff;
+const TextColorWrapper = styled('span')`
+    color: ${props => props.textColor ? props.textColor : DEFAULT_POPUP_LINK_COLOR};
+`;
+
+const PopupLink = styled('div')`
+    color: ${props => props.textColor ? props.textColor : DEFAULT_POPUP_LINK_COLOR};
     cursor: pointer;
+    a {
+        color: ${props => props.textColor ? props.textColor : DEFAULT_POPUP_LINK_COLOR};
+    }
+
+    div {
+        text-decoration: underline
+    }
 `;
 
 const InfoIcon = styled(InfoCircleOutlined)`
-    color: #3c3c3c;
     font-size: 24px;
     margin-right: 10px;
 `;
@@ -24,64 +37,71 @@ const InfoIcon = styled(InfoCircleOutlined)`
 const StyledCheckbox = styled(Checkbox)`
     margin-left: 10px;
     margin-bottom: 10px;
+
 `;
+
 const StyledTitle = styled.span`
     font-weight: bold;
-    color: #3c3c3c;
+    color: ${props => props.textColor ? props.textColor : DEFAULT_GREY_TEXT};
 `;
+
 const Column = styled.div`
     display: flex;
     flex-direction: column;
 `;
+
 const InfoContainer = styled.div`
     display: flex;
     flex-direction: row;
+    color: ${props => props.textColor ? props.textColor : DEFAULT_GREY_TEXT};
 `;
+
 const Row = styled.div`
     display: flex;
     flex-direction: row;
     justify-content: space-between;
     width: 100%;
 `;
+
 const Margin = styled.div`
     margin-right: auto;
 `;
 
-const getContent = (state, controller, renderDescriptionPopup) => {
-    const { bannerAnnouncements, currentBanner = 1 } = state;
-    const announcement = bannerAnnouncements[currentBanner - 1];
-
-    if (!announcement) return null;
-
-    const { title, link, content } = Oskari.getLocalized(announcement.locale);
-    const count = bannerAnnouncements.length;
-    const setShowAgain = (e) => controller.setShowAgain(announcement.id, e.target.checked);
-    const onPageChange = (page) => controller.onBannerChange(page);
-
-    let description = <span/>;
-
-    if (link) {
-        description = (
-            <Link url={link}>
-                <Message messageKey={'externalLink'} bundleKey={BUNDLE_KEY} />
-            </Link>
-        );
-    } else if (content) {
-        description = (
-            <PopupLink onClick={() => renderDescriptionPopup(announcement)}>
-                <Message messageKey={'externalLink'} bundleKey={BUNDLE_KEY} />
-                <LinkIcon/>
-            </PopupLink>
-        );
+const StyledPagination = styled(Pagination)`
+    ul {
+        color: ${props => props.textColor ? props.textColor : DEFAULT_GREY_TEXT};
+    }
+    .ant-pagination-simple-pager {
+        color: ${props => props.textColor ? props.textColor : DEFAULT_GREY_TEXT};
+    }
+    .ant-pagination-simple-pager > input {
+        color: #000000;
     }
 
-    const notificationContent = <>
-        <InfoContainer>
+    .ant-pagination-next :not(.ant-pagination-disabled) > .ant-pagination-item-link {
+        color: ${props => props.textColor ? props.textColor : DEFAULT_GREY_TEXT};
+    }
+
+    .ant-pagination-prev :not(.ant-pagination-disabled) > .ant-pagination-item-link {
+        color: ${props => props.textColor ? props.textColor : DEFAULT_GREY_TEXT};
+    }
+`;
+
+const ThemedNotificationContent = ThemeConsumer(({ theme, state, link, content, renderDescriptionPopup, setShowAgain, onPageChange }) => {
+    const { bannerAnnouncements, currentBanner = 1 } = state;
+    const announcement = bannerAnnouncements[currentBanner - 1];
+    const count = bannerAnnouncements.length;
+    const { title } = Oskari.getLocalized(announcement.locale);
+    theme.color.primary = '#01A0E3';
+    const textColor = getTextColor(theme?.color?.primary);
+
+    return <>
+        <InfoContainer textColor={textColor}>
             <InfoIcon/>
             <Column>
-                <StyledTitle>{title}</StyledTitle>
+                <StyledTitle textColor={textColor}>{title}</StyledTitle>
                 <span>
-                    {description}
+                    {getDescription(link, content, announcement, renderDescriptionPopup, textColor)}
                     <Margin/>
                 </span>
             </Column>
@@ -89,15 +109,61 @@ const getContent = (state, controller, renderDescriptionPopup) => {
         <Margin/>
         <Column style={{ whiteSpace: 'nowrap' }}>
             <StyledCheckbox checked={state.dontShowAgain.includes(announcement.id)} onChange={setShowAgain}>
-                <Message messageKey='dontShow' bundleKey={BUNDLE_KEY} />
+                <TextColorWrapper textColor={textColor}>
+                    <Message messageKey='dontShow' bundleKey={BUNDLE_KEY} />
+                </TextColorWrapper>
             </StyledCheckbox>
-            <Pagination simple hideOnSinglePage current={currentBanner} total={count} defaultPageSize={1} onChange={onPageChange}/>
+            <StyledPagination textColor={textColor} simple hideOnSinglePage current={currentBanner} total={count} defaultPageSize={1} onChange={onPageChange}/>
         </Column>
     </>;
+});
+
+const getDescription = (link, content, announcement, renderDescriptionPopup, textColor) => {
+    let description = <span/>;
+
+    if (link) {
+        description = (
+            <PopupLink textColor={textColor}>
+                <a href={link} target='_blank' rel='noreferrer noopener'>
+                    <Message messageKey={'externalLink'} bundleKey={BUNDLE_KEY} />
+                </a>
+                <LinkIcon/>
+            </PopupLink>
+        );
+    } else if (content) {
+        description = (
+            <PopupLink textColor={textColor} onClick={() => renderDescriptionPopup(announcement)}>
+                <Message messageKey={'externalLink'} bundleKey={BUNDLE_KEY} />
+                <LinkIcon/>
+            </PopupLink>
+        );
+    }
+
+    return description;
+};
+
+const getContent = (state, controller, renderDescriptionPopup) => {
+    const { bannerAnnouncements, currentBanner = 1 } = state;
+    const announcement = bannerAnnouncements[currentBanner - 1];
+
+    if (!announcement) return null;
+
+    const { link, content } = Oskari.getLocalized(announcement.locale);
+    const setShowAgain = (e) => controller.setShowAgain(announcement.id, e.target.checked);
+    const onPageChange = (page) => controller.onBannerChange(page);
 
     const isMobile = Oskari.util.isMobile();
+
+    const notificationContent = <ThemedNotificationContent
+        state={state}
+        link={link}
+        content={content}
+        renderDescriptionPopup={renderDescriptionPopup}
+        setShowAgain={setShowAgain}
+        onPageChange={onPageChange}/>;
+
     return (
-        <ThemeProvider>
+        <>
             { isMobile &&
                 <Column>
                     { notificationContent }
@@ -108,7 +174,7 @@ const getContent = (state, controller, renderDescriptionPopup) => {
                     { notificationContent }
                 </Row>
             }
-        </ThemeProvider>
+        </>
     );
 };
 

--- a/bundles/framework/announcements/view/AnnouncementsBanner.jsx
+++ b/bundles/framework/announcements/view/AnnouncementsBanner.jsx
@@ -89,13 +89,21 @@ const StyledPagination = styled(Pagination)`
     }
 `;
 
-const ThemedNotificationContent = ThemeConsumer(({ theme, state, link, content, renderDescriptionPopup, setShowAgain, onPageChange }) => {
+const ThemedNotificationContent = ThemeConsumer(({ theme, state, link, content, renderDescriptionPopup, setShowAgain, onPageChange, isMobile }) => {
     const { bannerAnnouncements, currentBanner = 1 } = state;
     const announcement = bannerAnnouncements[currentBanner - 1];
     const count = bannerAnnouncements.length;
     const { title } = Oskari.getLocalized(announcement.locale);
     const textColor = getTextColor(theme?.color?.primary);
 
+    const pagingSection = <>
+        <StyledCheckbox checked={state.dontShowAgain.includes(announcement.id)} onChange={setShowAgain}>
+            <TextColorWrapper textColor={textColor}>
+                <Message messageKey='dontShow' bundleKey={BUNDLE_KEY} />
+            </TextColorWrapper>
+        </StyledCheckbox>
+        <StyledPagination textColor={textColor} simple hideOnSinglePage current={currentBanner} total={count} defaultPageSize={1} onChange={onPageChange}/>
+    </>;
     return <>
         <InfoContainer textColor={textColor}>
             <InfoIcon/>
@@ -108,14 +116,8 @@ const ThemedNotificationContent = ThemeConsumer(({ theme, state, link, content, 
             </Column>
         </InfoContainer>
         <Margin/>
-        <Column style={{ whiteSpace: 'nowrap' }}>
-            <StyledCheckbox checked={state.dontShowAgain.includes(announcement.id)} onChange={setShowAgain}>
-                <TextColorWrapper textColor={textColor}>
-                    <Message messageKey='dontShow' bundleKey={BUNDLE_KEY} />
-                </TextColorWrapper>
-            </StyledCheckbox>
-            <StyledPagination textColor={textColor} simple hideOnSinglePage current={currentBanner} total={count} defaultPageSize={1} onChange={onPageChange}/>
-        </Column>
+        { isMobile && <Row>{pagingSection}</Row> }
+        { !isMobile && <Column style={{ whiteSpace: 'nowrap' }}>{pagingSection}</Column> }
     </>;
 });
 
@@ -156,6 +158,7 @@ const getContent = (state, controller, renderDescriptionPopup) => {
     const isMobile = Oskari.util.isMobile();
 
     const notificationContent = <ThemedNotificationContent
+        isMobile={isMobile}
         state={state}
         link={link}
         content={content}


### PR DESCRIPTION
-white text when notification background is considered dark
-white link color too
-added some link margin
-"do not show again"-checkbox and paging side by side in mobile mode
-known issue: we might wanna refactor the existing Link-component so that it would better enable custom styling/coloring. But we might wanna do that in a controlled fashion and actually spec which attributes we might want to be able to control so for the time being I just went with yet-another-custom a-tag.

![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/4deb3354-75ab-4f4d-b5ce-2ac9af5fb17e)

![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/bd46ea31-f61f-4ee8-91a5-2450d8cde0e5)
