### PR TITLE
fix featuredata d & d - handle in publisher

### DIFF
--- a/bundles/mapping/mapmodule/MapModuleTextButton.jsx
+++ b/bundles/mapping/mapmodule/MapModuleTextButton.jsx
@@ -81,16 +81,18 @@ export const MapModuleTextButton = ({ visible, onClick, icon, children, active, 
         return null;
     };
 
-    return <ThemedButton
-        icon={icon || null}
-        onClick={onClick}
-        active={active}
-        position={position}
-        loading={loading}
-        {...rest}
-    >
-        {children}
-    </ThemedButton>;
+    return <div>
+        <ThemedButton
+            icon={icon || null}
+            onClick={onClick}
+            active={active}
+            position={position}
+            loading={loading}
+            {...rest}
+        >
+            {children}
+        </ThemedButton>
+    </div>;
 };
 
 MapModuleTextButton.propTypes = {

--- a/bundles/mapping/mapmodule/MapModuleTextButton.jsx
+++ b/bundles/mapping/mapmodule/MapModuleTextButton.jsx
@@ -76,12 +76,16 @@ const ThemedButton = ThemeConsumer(({ theme = {}, active, ...rest }) => {
     );
 });
 
+// We need an additional wrapper around the button for the publisher to be able to handle dragging properly.
+const PublisherDraggableWrapper = styled('div')`
+`;
+
 export const MapModuleTextButton = ({ visible, onClick, icon, children, active, position, loading, ...rest }) => {
     if (!visible) {
         return null;
     };
 
-    return <div>
+    return <PublisherDraggableWrapper>
         <ThemedButton
             icon={icon || null}
             onClick={onClick}
@@ -92,7 +96,7 @@ export const MapModuleTextButton = ({ visible, onClick, icon, children, active, 
         >
             {children}
         </ThemedButton>
-    </div>;
+    </PublisherDraggableWrapper>;
 };
 
 MapModuleTextButton.propTypes = {


### PR DESCRIPTION
add a wrapping div to MapModuleTextButton so publisher can add the dragging handle properly

![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/3ff17c91-b9e6-47d0-af96-c95e81575c13)
