### PR TITLE
Statsgrid regionset restriction handling.

### DIFF
--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -200,7 +200,6 @@ class SearchController extends StateHandler {
     }
 
     setSelectedRegionsets (value) {
-        this.clearSearch();
         this.updateState({
             selectedRegionsets: value
         });
@@ -208,6 +207,9 @@ class SearchController extends StateHandler {
             const unsupportedDatasources = this.service.getUnsupportedDatasetsList(this.state.selectedRegionsets);
             if (unsupportedDatasources) {
                 const ids = unsupportedDatasources.map((iteration) => iteration.id);
+                if (ids.includes(this.state.selectedDatasource)) {
+                    this.clearSearch();
+                }
                 this.updateState({
                     disabledDatasources: ids
                 });


### PR DESCRIPTION
- Keep other form values if regionset selection is removed.
- Clear selected datasource/indicator if the user selects a regionset that doesn't support them.