### PR TITLE
Minor changes for Analysis react

### DIFF
--- a/bundles/mapping/mapuserdatalayer/domain/UserDataLayer.js
+++ b/bundles/mapping/mapuserdatalayer/domain/UserDataLayer.js
@@ -22,7 +22,7 @@ export class UserDataLayer extends WFSLayer {
         return this._locale;
     }
 
-    setLocale (locale) {
+    setLocale (locale = {}) {
         this._locale = locale;
     }
 

--- a/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/ReqEventHandler.js
+++ b/bundles/mapping/mapwfs2/plugin/WfsVectorLayerPlugin/ReqEventHandler.js
@@ -66,16 +66,12 @@ export class ReqEventHandler {
                 if (['Polygon', 'MultiPolygon'].indexOf(filterFeature.geometry.type) >= 0 && typeof filterFeature.properties.area !== 'number') {
                     return;
                 }
-                var targetLayers;
-                if (plugin.WFSLayerService.getAnalysisWFSLayerId()) {
-                    targetLayers = [plugin.WFSLayerService.getAnalysisWFSLayerId()];
+                let targetLayers;
+                if (event.selectFromAllLayers()) {
+                    targetLayers = plugin.getAllLayerIds();
                 } else {
-                    if (event.selectFromAllLayers()) {
-                        targetLayers = plugin.getAllLayerIds();
-                    } else {
-                        const layerId = plugin.WFSLayerService.getTopWFSLayer();
-                        targetLayers = layerId ? [layerId] : [];
-                    }
+                    const layerId = plugin.WFSLayerService.getTopWFSLayer();
+                    targetLayers = layerId ? [layerId] : [];
                 }
                 const featuresResult = plugin.getFeatures({
                     geometry: filterFeature.geometry

--- a/bundles/mapping/mapwfs2/service/WFSLayerService.js
+++ b/bundles/mapping/mapwfs2/service/WFSLayerService.js
@@ -21,7 +21,6 @@ Oskari.clazz.define(
         me.selectedWFSLayerIds = [];
         me.selectFromAllLayers = false;
         me.selectionToolsActive = null;
-        me.analysisWFSLayerId = null;
 
         for (let p in me.eventHandlers) {
             if (me.eventHandlers.hasOwnProperty(p)) {
@@ -126,11 +125,5 @@ Oskari.clazz.define(
                 }
             }
             return topWFSLayer;
-        },
-        getAnalysisWFSLayerId: function () {
-            return this.analysisWFSLayerId;
-        },
-        setAnalysisWFSLayerId: function (layerId) {
-            this.analysisWFSLayerId = layerId;
         }
     });

--- a/src/react/components/icons/Info.jsx
+++ b/src/react/components/icons/Info.jsx
@@ -25,13 +25,13 @@ const StyledInfoIcon = styled(QuestionCircleOutlined)`
  * @param {Object} style Additional styles
  * @returns 
  */
-export const Info = ThemeConsumer(({ theme = {}, children, title, size = 16, style, space = true }) => {
+export const Info = ThemeConsumer(({ theme = {}, children, title, size = 16, style, space = true, placement = 'top' }) => {
     const helper = getNavigationTheme(theme);
     const hover = helper.getButtonHoverColor();
     const bgColor = Oskari.util.hexToRgb(hover);
 
     return (
-        <Tooltip title={title || children}>
+        <Tooltip title={title || children} placement={placement}>
             <StyledInfoIcon
                 className='t_icon t_info'
                 $space={space}

--- a/src/react/components/window/SidePanel.jsx
+++ b/src/react/components/window/SidePanel.jsx
@@ -12,7 +12,7 @@ const StyledPanel = styled('div')`
     top: 0;
     /* sidebar has 3, we want to open it on top of this */
     z-index: 2;
-    width: 252px;
+    width: ${props => props.width || 252}px;
     display: flex;
     flex-direction: column;
     font-family: ${props => props.font};
@@ -31,9 +31,9 @@ const StyledHeader = styled(Header)`
     padding: 15px 15px 10px 10px;
 `;
 
-export const SidePanel = ThemeConsumer(({ title, onClose, children, theme = {} }) => {
+export const SidePanel = ThemeConsumer(({ title, onClose, children, theme = {}, options }) => {
     return (
-        <StyledPanel className={`t_print_panel ${getFontClass(theme)}`}>
+        <StyledPanel className={`t_print_panel ${getFontClass(theme)}`} width={options.width}>
             <Content>
                 <StyledHeader
                     title={title}


### PR DESCRIPTION
- Remove analysisWFSLayerId as it isn't used anymore
- Allow SidePanel to have custom width (Analysis requires more space)
- Add placement prop for InfoIcon and default to `top`

https://github.com/oskariorg/oskari-frontend-contrib/pull/104

Fix:
- Analysis which isn't user's own (link, session expired, embedded) is added to mapfull conf layers. For some reason it uses another json formatter and it doesn't have locale. This fixes js error only. Backend will be fixed with another PR.

https://github.com/oskariorg/oskari-server/blob/master/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/MapfullHandler.java#L400