### PR TITLE
Fix timeseries year order.

### DIFF
--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -182,7 +182,7 @@ class SearchController extends StateHandler {
                             selected,
                             selectors[keyWithTime].values[selectors[keyWithTime].values.length - 1].id
                         ];
-                        selected = [...selectValues].sort((a, b) => (b - a));
+                        selected = [...selectValues].sort((a, b) => (a - b));
                     }
                 }
                 this.updateState({
@@ -394,7 +394,8 @@ class SearchController extends StateHandler {
                             searchTimeseries: false
                         });
                     } else {
-                        selected = [selected, selectors[key].values[selectors[key].values.length - 1].id];
+                        const series = [selected, selectors[key].values[selectors[key].values.length - 1].id];
+                        selected = [...series].sort((a, b) => (a - b));
                     }
                 }
             } else {

--- a/bundles/statistics/statsgrid/view/search/IndicatorParams.jsx
+++ b/bundles/statistics/statsgrid/view/search/IndicatorParams.jsx
@@ -42,16 +42,16 @@ export const IndicatorParams = ({ state, controller }) => {
                                     <b><Message messageKey='parameters.from' /></b>
                                     <StyledSelect
                                         options={timeOptions}
-                                        value={state.indicatorParams?.selected[param][1]}
-                                        onChange={(value) => controller.setParamSelection(param, value, 1)}
+                                        value={state.indicatorParams?.selected[param][0]}
+                                        onChange={(value) => controller.setParamSelection(param, value, 0)}
                                     />
                                 </Field>
                                 <Field>
                                     <b><Message messageKey='parameters.to' /></b>
                                     <StyledSelect
                                         options={timeOptions}
-                                        value={state.indicatorParams?.selected[param][0]}
-                                        onChange={(value) => controller.setParamSelection(param, value, 0)}
+                                        value={state.indicatorParams?.selected[param][1]}
+                                        onChange={(value) => controller.setParamSelection(param, value, 1)}
                                     />
                                 </Field>
                             </TimeseriesField>


### PR DESCRIPTION
Fixes statsgrid search timeseries year order when timeseries selection is already active before selecting indicators.