### PR TITLE
refactor visible columns handling

### DIFF
--- a/bundles/framework/featuredata/plugin/FeatureDataPluginHandler.js
+++ b/bundles/framework/featuredata/plugin/FeatureDataPluginHandler.js
@@ -237,21 +237,19 @@ class FeatureDataPluginUIHandler extends StateHandler {
     }
 
     createVisibleColumnsSettings (newActiveLayerId, features) {
-        if (!features || !features.length) {
-            return {
-                allColumns: [],
-                visibleColumns: [],
-                activeLayerPropertyLabels: null,
-                activeLayerPropertyTypes: null
-            };
-        }
         const { activeLayerId, visibleColumnsSettings } = this.getState();
         const activeLayerChanged = activeLayerId && newActiveLayerId && activeLayerId !== newActiveLayerId;
-        const allColumns = Object.keys(features[0].properties).filter(key => !FEATUREDATA_DEFAULT_HIDDEN_FIELDS.includes(key));
-        const newVisibleColumns = activeLayerChanged ? [].concat(allColumns) : visibleColumnsSettings?.visibleColumns ? visibleColumnsSettings.visibleColumns : [].concat(allColumns);
+
+        if (!activeLayerChanged && visibleColumnsSettings) {
+            return visibleColumnsSettings;
+        }
+
         const activeLayer = this.mapModule.getSandbox().findMapLayerFromSelectedMapLayers(newActiveLayerId) || null;
+        const activeLayerProperties = activeLayer?.getProperties() || null;
+        const allColumns = activeLayerProperties?.map((property) => property.name);
         const activeLayerPropertyLabels = activeLayer?.getPropertyLabels() || null;
         const activeLayerPropertyTypes = activeLayer?.getPropertyTypes() || null;
+        const newVisibleColumns = activeLayerChanged ? [].concat(allColumns) : visibleColumnsSettings?.visibleColumns ? visibleColumnsSettings.visibleColumns : [].concat(allColumns);
 
         return {
             allColumns,

--- a/bundles/framework/featuredata/view/FeatureDataContainer.jsx
+++ b/bundles/framework/featuredata/view/FeatureDataContainer.jsx
@@ -55,7 +55,7 @@ const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, 
     if (!features || !features.length) {
         return <Message bundleKey={FEATUREDATA_BUNDLE_ID} messageKey={'layer.outOfContentArea'}/>;
     };
-    const columnSettings = createColumnSettingsFromFeatures(features, selectedFeatureIds, showSelectedFirst, sorting, visibleColumnsSettings);
+    const columnSettings = createColumnSettings(selectedFeatureIds, showSelectedFirst, sorting, visibleColumnsSettings);
     const dataSource = createDatasourceFromFeatures(features);
     const featureTable = <FeatureDataTable>
         <SelectionsContainer>
@@ -97,9 +97,9 @@ const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, 
     return featureTable;
 };
 
-const createColumnSettingsFromFeatures = (features, selectedFeatureIds, showSelectedFirst, sorting, visibleColumnsSettings) => {
-    const { visibleColumns, activeLayerPropertyLabels } = visibleColumnsSettings;
-    return Object.keys(features[0].properties)
+const createColumnSettings = (selectedFeatureIds, showSelectedFirst, sorting, visibleColumnsSettings) => {
+    const { allColumns, visibleColumns, activeLayerPropertyLabels } = visibleColumnsSettings;
+    return allColumns
         .filter(key => !FEATUREDATA_DEFAULT_HIDDEN_FIELDS.includes(key) && visibleColumns.includes(key))
         .map(key => {
             return {


### PR DESCRIPTION
user layer.getProperties() to determine which columns should be displayed in the grid in the first place -> remove those fields that have been hidden by the admin if there are any.