### PR TITLE
Handle unknown indicators.

### DIFF
--- a/bundles/statistics/statsgrid/components/classification/Header.jsx
+++ b/bundles/statistics/statsgrid/components/classification/Header.jsx
@@ -37,6 +37,7 @@ export const Header = ({ selected, indicators, isEdit, toggleEdit, onChange }) =
         <Component className='classification-header'>
             {!renderSelect && <Single>{title}</Single>}
             {renderSelect && (
+                // TODO: Use IndicatorName component here once data comes from same place as diagram/table etc.
                 <Select value={selected} onChange={onChange}>
                     {indicators.map(opt => <Option key={opt.hash} value={opt.hash}>{opt.title}</Option>)}
                 </Select>

--- a/bundles/statistics/statsgrid/view/Diagram/DiagramFlyout.jsx
+++ b/bundles/statistics/statsgrid/view/Diagram/DiagramFlyout.jsx
@@ -4,6 +4,7 @@ import { Select, Message, Spin } from 'oskari-ui';
 import { showFlyout } from 'oskari-ui/components/window';
 import styled from 'styled-components';
 import { LocaleProvider } from 'oskari-ui/util';
+import { IndicatorName } from '../IndicatorName';
 
 const BUNDLE_KEY = 'StatsGrid';
 
@@ -49,7 +50,7 @@ const DiagramFlyout = ({ state, controller }) => {
             <Selections>
                 <StyledSelect
                     filterOption={false}
-                    options={state.indicators?.map(indicator => ({ value: indicator.hash, label: indicator.labels?.full }))}
+                    options={state.indicators?.map(indicator => ({ value: indicator.hash, label: <IndicatorName indicator={indicator} /> }))}
                     onChange={(value) => controller.setActiveIndicator(value)}
                     value={state.activeIndicator}
                     placeholder={<Message messageKey='panels.newSearch.selectIndicatorPlaceholder' />}

--- a/bundles/statistics/statsgrid/view/IndicatorName.jsx
+++ b/bundles/statistics/statsgrid/view/IndicatorName.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Message, Tooltip, WarningIcon } from 'oskari-ui';
+import styled from 'styled-components';
+
+const StyledWarningIcon = styled(WarningIcon)`
+    margin-left: 10px;
+`;
+
+const getIndicatorText = (labels) => {
+    const { indicator, params, full } = labels;
+    let cutLength = 60;
+    let minLength = 20;
+    const dots = '... ';
+    if (indicator && full.length > cutLength) {
+        if (params) {
+            cutLength = cutLength - dots.length - params.length;
+            return indicator.substring(0, Math.max(minLength, cutLength)) + dots + params;
+        } else {
+            cutLength = cutLength - dots.length;
+            return indicator.substring(0, cutLength) + dots;
+        }
+    } else {
+        return full;
+    }
+};
+
+export const IndicatorName = ({ indicator }) => {
+    if (!indicator.labels?.full || indicator.labels?.full === '') {
+        return (
+                <span><Message messageKey='missing.indicator' /><StyledWarningIcon /></span>
+        );
+    }
+    return (
+        <Tooltip title={indicator.labels?.full}>
+            <span>{getIndicatorText(indicator.labels)}</span>
+        </Tooltip>
+    );
+};

--- a/bundles/statistics/statsgrid/view/Table/TableFlyout.jsx
+++ b/bundles/statistics/statsgrid/view/Table/TableFlyout.jsx
@@ -6,6 +6,7 @@ import { showFlyout } from 'oskari-ui/components/window';
 import styled from 'styled-components';
 import { LocaleProvider } from 'oskari-ui/util';
 import { Sorter } from './Sorter';
+import { IndicatorName } from '../IndicatorName';
 
 const BUNDLE_KEY = 'StatsGrid';
 
@@ -44,6 +45,7 @@ const IndicatorHeader = styled('div')`
     word-wrap: break-word;
     word-break: break-word;
     text-align: left;
+    height: 100%;
 `;
 const StyledRemoveButton = styled(IconButton)`
     margin-left: 10px;
@@ -140,7 +142,7 @@ const TableFlyout = ({ state, controller }) => {
                                 controller.setActiveIndicator(indicator.hash);
                             }}
                         >
-                            {indicator.labels?.full}
+                            <IndicatorName indicator={indicator} />
                             <StyledRemoveButton
                                 type='delete'
                                 onClick={() => controller.removeIndicator(indicator)}

--- a/bundles/statistics/statsgrid/view/search/IndicatorCollapse.jsx
+++ b/bundles/statistics/statsgrid/view/search/IndicatorCollapse.jsx
@@ -1,45 +1,11 @@
 import React from 'react';
-import { Message, Collapse, CollapsePanel, Tooltip } from 'oskari-ui';
-import { IconButton } from 'oskari-ui/components/buttons';
-import { InfoCircleOutlined } from '@ant-design/icons';
+import { Message, Collapse, CollapsePanel } from 'oskari-ui';
+import { IndicatorRow } from './IndicatorRow';
 import styled from 'styled-components';
 
 const StyledCollapse = styled(Collapse)`
     margin-top: 20px;
 `;
-const Row = styled('div')`
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    word-break: break-all;
-`;
-const Actions = styled('div')`
-    display: flex;
-    flex-direction: row;
-    margin-left: 10px;
-`;
-const RemoveButton = styled(IconButton)`
-    margin-right: 10px;
-`;
-
-const getIndicatorText = (labels) => {
-    const { indicator, params, full } = labels;
-    let cutLength = 60;
-    let minLength = 20;
-    const dots = '... ';
-    if (indicator && full.length > cutLength) {
-        if (params) {
-            cutLength = cutLength - dots.length - params.length;
-            return indicator.substring(0, Math.max(minLength, cutLength)) + dots + params;
-        } else {
-            cutLength = cutLength - dots.length;
-            return indicator.substring(0, cutLength) + dots;
-        }
-    } else {
-        return full;
-    }
-};
 
 export const IndicatorCollapse = ({ state, controller }) => {
     return (
@@ -50,25 +16,9 @@ export const IndicatorCollapse = ({ state, controller }) => {
                 {state.indicators?.length < 1 ? (
                     <Message messageKey='indicatorList.emptyMsg' />
                 ) : (
-                    state.indicators?.map(indicator => {
-                        return (
-                            <Row key={indicator.indicator}>
-                                <Tooltip title={indicator.labels?.full}>
-                                    <span>{getIndicatorText(indicator.labels)}</span>
-                                </Tooltip>
-                                <Actions>
-                                    <RemoveButton
-                                        type='delete'
-                                        onClick={() => controller.removeIndicator(indicator)}
-                                    />
-                                    <IconButton
-                                        icon={<InfoCircleOutlined />}
-                                        onClick={() => controller.openMetadataPopup(indicator)}
-                                    />
-                                </Actions>
-                            </Row>
-                        );
-                    })
+                    state.indicators?.map(indicator => (
+                        <IndicatorRow key={indicator.indicator} indicator={indicator} controller={controller} />
+                    ))
                 )}
             </CollapsePanel>
         </StyledCollapse>

--- a/bundles/statistics/statsgrid/view/search/IndicatorRow.jsx
+++ b/bundles/statistics/statsgrid/view/search/IndicatorRow.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Message, Tooltip, WarningIcon } from 'oskari-ui';
+import { IconButton } from 'oskari-ui/components/buttons';
+import { InfoCircleOutlined } from '@ant-design/icons';
+import styled from 'styled-components';
+
+const Row = styled('div')`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    word-break: break-all;
+`;
+const Actions = styled('div')`
+    display: flex;
+    flex-direction: row;
+    margin-left: 10px;
+`;
+const RemoveButton = styled(IconButton)`
+    margin-right: 10px;
+`;
+const StyledWarningIcon = styled(WarningIcon)`
+    margin-left: 10px;
+`;
+
+const getIndicatorText = (labels) => {
+    const { indicator, params, full } = labels;
+    let cutLength = 60;
+    let minLength = 20;
+    const dots = '... ';
+    if (indicator && full.length > cutLength) {
+        if (params) {
+            cutLength = cutLength - dots.length - params.length;
+            return indicator.substring(0, Math.max(minLength, cutLength)) + dots + params;
+        } else {
+            cutLength = cutLength - dots.length;
+            return indicator.substring(0, cutLength) + dots;
+        }
+    } else {
+        return full;
+    }
+};
+
+export const IndicatorRow = ({ indicator, controller }) => {
+    const actions = (
+        <Actions>
+            <RemoveButton
+                type='delete'
+                onClick={() => controller.removeIndicator(indicator)}
+            />
+            <IconButton
+                icon={<InfoCircleOutlined />}
+                onClick={() => controller.openMetadataPopup(indicator)}
+            />
+        </Actions>
+    );
+
+    if (!indicator.labels?.full || indicator.labels?.full === '') {
+        return (
+            <Row>
+                <span><Message messageKey='missing.indicator' /><StyledWarningIcon /></span>
+                {actions}
+            </Row>
+        );
+    }
+
+    return (
+        <Row>
+            <Tooltip title={indicator.labels?.full}>
+                <span>{getIndicatorText(indicator.labels)}</span>
+            </Tooltip>
+            {actions}
+        </Row>
+    );
+};

--- a/bundles/statistics/statsgrid/view/search/IndicatorRow.jsx
+++ b/bundles/statistics/statsgrid/view/search/IndicatorRow.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Message, Tooltip, WarningIcon } from 'oskari-ui';
 import { IconButton } from 'oskari-ui/components/buttons';
 import { InfoCircleOutlined } from '@ant-design/icons';
+import { IndicatorName } from '../IndicatorName';
 import styled from 'styled-components';
 
 const Row = styled('div')`
@@ -19,57 +19,21 @@ const Actions = styled('div')`
 const RemoveButton = styled(IconButton)`
     margin-right: 10px;
 `;
-const StyledWarningIcon = styled(WarningIcon)`
-    margin-left: 10px;
-`;
-
-const getIndicatorText = (labels) => {
-    const { indicator, params, full } = labels;
-    let cutLength = 60;
-    let minLength = 20;
-    const dots = '... ';
-    if (indicator && full.length > cutLength) {
-        if (params) {
-            cutLength = cutLength - dots.length - params.length;
-            return indicator.substring(0, Math.max(minLength, cutLength)) + dots + params;
-        } else {
-            cutLength = cutLength - dots.length;
-            return indicator.substring(0, cutLength) + dots;
-        }
-    } else {
-        return full;
-    }
-};
 
 export const IndicatorRow = ({ indicator, controller }) => {
-    const actions = (
-        <Actions>
-            <RemoveButton
-                type='delete'
-                onClick={() => controller.removeIndicator(indicator)}
-            />
-            <IconButton
-                icon={<InfoCircleOutlined />}
-                onClick={() => controller.openMetadataPopup(indicator)}
-            />
-        </Actions>
-    );
-
-    if (!indicator.labels?.full || indicator.labels?.full === '') {
-        return (
-            <Row>
-                <span><Message messageKey='missing.indicator' /><StyledWarningIcon /></span>
-                {actions}
-            </Row>
-        );
-    }
-
     return (
         <Row>
-            <Tooltip title={indicator.labels?.full}>
-                <span>{getIndicatorText(indicator.labels)}</span>
-            </Tooltip>
-            {actions}
+            <IndicatorName indicator={indicator} />
+            <Actions>
+                <RemoveButton
+                    type='delete'
+                    onClick={() => controller.removeIndicator(indicator)}
+                />
+                <IconButton
+                    icon={<InfoCircleOutlined />}
+                    onClick={() => controller.openMetadataPopup(indicator)}
+                />
+            </Actions>
         </Row>
     );
 };

--- a/bundles/statistics/statsgrid2016/resources/locale/en.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/en.js
@@ -179,7 +179,8 @@ Oskari.registerLocalization({
             'onlyPartialDataForIndicators': 'Service did not return all data for {indicators, plural, one {the indicator} other {indicators}}'
         },
         'missing': {
-            'regionsetName': 'Unknown'
+            'regionsetName': 'Unknown',
+            'indicator': 'Unknown indicator'
         },
         'datacharts': {
             'flyout': 'Searched data',

--- a/bundles/statistics/statsgrid2016/resources/locale/fi.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/fi.js
@@ -180,7 +180,8 @@ Oskari.registerLocalization({
             'onlyPartialDataForIndicators': 'Palvelusta ei saatu kaikkia tietoja {indicators, plural, one {indikaattorille} other {indikaattoreille}}'
         },
         'missing': {
-            'regionsetName': 'Tuntematon'
+            'regionsetName': 'Tuntematon',
+            'indicator': 'Tuntematon indikaattori'
         },
         'datacharts': {
             'flyout': 'Haettu aineisto',

--- a/bundles/statistics/statsgrid2016/resources/locale/sv.js
+++ b/bundles/statistics/statsgrid2016/resources/locale/sv.js
@@ -176,7 +176,8 @@ Oskari.registerLocalization({
             'onlyPartialDataForIndicators': 'Tjänsten returnerade inte alla data för {indicators, plural, one {indikatorn} other {indikatorer}}'
         },
         'missing': {
-            'regionsetName': 'Okänd'
+            'regionsetName': 'Okänd',
+            'indicator': 'Okänd indikator'
         },
         'datacharts': {
             'flyout': 'Sökta datamängden',


### PR DESCRIPTION
Show "unknown indicator" text and icon if indicator metadata is not found through API.