### PR TITLE
Statsgrid search form fix.

### DIFF
--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -218,6 +218,10 @@ class SearchController extends StateHandler {
                     disabledDatasources: ids
                 });
             }
+        } else {
+            this.updateState({
+                disabledDatasources: []
+            });
         }
     }
 


### PR DESCRIPTION
Enable datasources when regionset restriction is removed.