### PR TITLE
add pagination to featuredata grid for performance

### DIFF
--- a/bundles/framework/featuredata/view/FeatureDataContainer.jsx
+++ b/bundles/framework/featuredata/view/FeatureDataContainer.jsx
@@ -11,6 +11,7 @@ import { ExportButton } from './ExportData';
 
 export const FEATUREDATA_BUNDLE_ID = 'FeatureData';
 export const FEATUREDATA_WFS_STATUS = { loading: 'loading', error: 'error' };
+export const DEFAULT_PAGE_SIZE = 100;
 
 const theme = getHeaderTheme(Oskari.app.getTheming().getTheme());
 
@@ -79,7 +80,7 @@ const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, 
             columns={ columnSettings }
             size={ 'large '}
             dataSource={ dataSource }
-            pagination={false}
+            pagination={{ defaultPageSize: DEFAULT_PAGE_SIZE, hideOnSinglePage: true, simple: true }}
             onChange={(pagination, filters, sorter, extra) => {
                 controller.updateSorting(sorter);
             }}


### PR DESCRIPTION
Added pagination and used a default page size of 100, so grids with featurecount under the threshold will behave as before.

![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/61ffa38d-316a-48b2-bceb-44c68b6863a3)
