### PR TITLE
Featuredata compressed layout

### DIFF
--- a/bundles/framework/featuredata/plugin/FeatureDataPluginHandler.js
+++ b/bundles/framework/featuredata/plugin/FeatureDataPluginHandler.js
@@ -33,6 +33,7 @@ class FeatureDataPluginUIHandler extends StateHandler {
             flyoutOpen: false,
             activeLayerFeatures: null,
             showSelectedFirst: false,
+            showCompressed: true,
             loadingStatus: {},
             visibleColumnsSettings: {
                 allColumns: [],
@@ -89,6 +90,11 @@ class FeatureDataPluginUIHandler extends StateHandler {
             newState.sorting = this.determineSortingColumn(activeLayerId, activeLayerFeatures);
         }
         this.updateState(newState);
+    }
+
+    toggleShowCompressed () {
+        const { showCompressed } = this.getState();
+        this.updateState({ showCompressed: !showCompressed });
     }
 
     updateStateAfterMapEvent () {
@@ -522,6 +528,7 @@ const wrapped = controllerMixin(FeatureDataPluginUIHandler, [
     'closeFlyout',
     'setActiveTab',
     'toggleShowSelectedFirst',
+    'toggleShowCompressed',
     'updateStateAfterMapEvent',
     'updateSelectedFeatures',
     'updateSorting',

--- a/bundles/framework/featuredata/resources/locale/en.js
+++ b/bundles/framework/featuredata/resources/locale/en.js
@@ -63,7 +63,7 @@ Oskari.registerLocalization(
                 }
             },
             "showSelectedFirst": "Show selected first",
-            "toggleCompressedView": "Compressed view",
+            "toggleCompressedView": "Condensed view",
             "selectionTools": {
                 "title": "Select Features",
                 "instructions": " ",

--- a/bundles/framework/featuredata/resources/locale/en.js
+++ b/bundles/framework/featuredata/resources/locale/en.js
@@ -63,6 +63,7 @@ Oskari.registerLocalization(
                 }
             },
             "showSelectedFirst": "Show selected first",
+            "toggleCompressedView": "Compressed view",
             "selectionTools": {
                 "title": "Select Features",
                 "instructions": " ",

--- a/bundles/framework/featuredata/resources/locale/fi.js
+++ b/bundles/framework/featuredata/resources/locale/fi.js
@@ -63,7 +63,7 @@ Oskari.registerLocalization(
                 }
             },
             "showSelectedFirst": "Näytä valitut ensin",
-            "toggleCompressedView": "Näkymätiiviste",
+            "toggleCompressedView": "Tiivis näkymä",
             "selectionTools": {
                 "title": "Valitse kohteita",
                 "instructions": " ",

--- a/bundles/framework/featuredata/resources/locale/fi.js
+++ b/bundles/framework/featuredata/resources/locale/fi.js
@@ -63,6 +63,7 @@ Oskari.registerLocalization(
                 }
             },
             "showSelectedFirst": "Näytä valitut ensin",
+            "toggleCompressedView": "Näkymätiiviste",
             "selectionTools": {
                 "title": "Valitse kohteita",
                 "instructions": " ",

--- a/bundles/framework/featuredata/resources/locale/fi.js
+++ b/bundles/framework/featuredata/resources/locale/fi.js
@@ -63,7 +63,7 @@ Oskari.registerLocalization(
                 }
             },
             "showSelectedFirst": "Näytä valitut ensin",
-            "toggleCompressedView": "Tiivis näkymä",
+            "toggleCompressedView": "Tiivistetty näkymä",
             "selectionTools": {
                 "title": "Valitse kohteita",
                 "instructions": " ",

--- a/bundles/framework/featuredata/resources/locale/sv.js
+++ b/bundles/framework/featuredata/resources/locale/sv.js
@@ -63,7 +63,7 @@ Oskari.registerLocalization(
                 }
             },
             "showSelectedFirst": "Visa de valda först",
-            "toggleCompressedView": "SV: Compressed view",
+            "toggleCompressedView": "Förtätad vy",
             "selectionTools": {
                 "title": "Markera objekt på kartan",
                 "instructions": " ",

--- a/bundles/framework/featuredata/resources/locale/sv.js
+++ b/bundles/framework/featuredata/resources/locale/sv.js
@@ -63,6 +63,7 @@ Oskari.registerLocalization(
                 }
             },
             "showSelectedFirst": "Visa de valda först",
+            "toggleCompressedView": "SV: Compressed view",
             "selectionTools": {
                 "title": "Markera objekt på kartan",
                 "instructions": " ",

--- a/bundles/framework/featuredata/view/CompressedView.jsx
+++ b/bundles/framework/featuredata/view/CompressedView.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Switch } from 'oskari-ui/components/Switch';
+import { FEATUREDATA_BUNDLE_ID } from './FeatureDataContainer';
+import { Message } from 'oskari-ui';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const CompressedViewContainer = styled('div')`
+`;
+export const CompressedView = (props) => {
+    return <CompressedViewContainer>
+        <Switch
+            label={<Message bundleKey={FEATUREDATA_BUNDLE_ID} messageKey='toggleCompressedView'/>}
+            checked={ props.showCompressed }
+            defaultChecked = { true }
+            onChange={ () => { props.toggleShowCompressed(); } }/>
+    </CompressedViewContainer>;
+};
+CompressedView.propTypes = {
+    showCompressed: PropTypes.bool,
+    toggleShowCompressed: PropTypes.func
+};

--- a/bundles/framework/featuredata/view/CompressedView.jsx
+++ b/bundles/framework/featuredata/view/CompressedView.jsx
@@ -10,6 +10,7 @@ const CompressedViewContainer = styled('div')`
 export const CompressedView = (props) => {
     return <CompressedViewContainer>
         <Switch
+            size={'small'}
             label={<Message bundleKey={FEATUREDATA_BUNDLE_ID} messageKey='toggleCompressedView'/>}
             checked={ props.showCompressed }
             defaultChecked = { true }

--- a/bundles/framework/featuredata/view/FeatureDataContainer.jsx
+++ b/bundles/framework/featuredata/view/FeatureDataContainer.jsx
@@ -36,13 +36,33 @@ const StyledTable = styled(Table)`
         display: none;
     }
 
-    .table-cell-compressed-view {
+    td.table-cell-compressed-view {
         white-space: nowrap;
         word-break: break-word;
         overflow: hidden;
         text-overflow: ellipsis;
         min-width: 3em;
         max-width: 8em;
+    }
+
+    th.table-cell-compressed-view {
+        white-space: nowrap;
+        word-break: break-word;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        min-width: 3em;
+        max-width: 8em;
+
+        span.ant-table-column-title {
+            max-width: 75%;
+            white-space: nowrap;
+            word-break: break-word;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        span.ant-table-column-sorter {
+            max-width: 25%;
+        }
     }
 
     overflow-y: auto;

--- a/bundles/framework/featuredata/view/FeatureDataContainer.jsx
+++ b/bundles/framework/featuredata/view/FeatureDataContainer.jsx
@@ -8,6 +8,7 @@ import { ShowSelectedItemsFirst } from './ShowSelectedItemsFirst';
 import { TabTitle } from './TabStatusIndicator';
 import { FilterVisibleColumns } from './FilterVisibleColumns';
 import { ExportButton } from './ExportData';
+import { CompressedView } from './CompressedView';
 
 export const FEATUREDATA_BUNDLE_ID = 'FeatureData';
 export const FEATUREDATA_WFS_STATUS = { loading: 'loading', error: 'error' };
@@ -51,7 +52,7 @@ const SelectionRow = styled('div')`
     flex-direction: row;
     padding-bottom: 1em;
 `;
-const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, sorting, visibleColumnsSettings, showExportButton, controller) => {
+const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, showCompressed, sorting, visibleColumnsSettings, showExportButton, controller) => {
     if (!features || !features.length) {
         return <Message bundleKey={FEATUREDATA_BUNDLE_ID} messageKey={'layer.outOfContentArea'}/>;
     };
@@ -66,6 +67,7 @@ const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, 
                 </SelectionRow>
                 <SelectionRow>
                     <ShowSelectedItemsFirst showSelectedFirst={showSelectedFirst} toggleShowSelectedFirst={controller.toggleShowSelectedFirst}/>
+                    <CompressedView showCompressed={showCompressed} toggleShowCompressed={controller.toggleShowCompressed}/>
                 </SelectionRow>
             </>}
 
@@ -73,6 +75,7 @@ const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, 
                 <SelectionRow>
                     <ShowSelectedItemsFirst showSelectedFirst={showSelectedFirst} toggleShowSelectedFirst={controller.toggleShowSelectedFirst}/>
                     <FilterVisibleColumns {...visibleColumnsSettings} updateVisibleColumns={controller.updateVisibleColumns}/>
+                    <CompressedView showCompressed={showCompressed} toggleShowCompressed={controller.toggleShowCompressed}/>
                 </SelectionRow>
             }
         </SelectionsContainer>
@@ -136,7 +139,7 @@ const createDatasourceFromFeatures = (features) => {
     });
 };
 
-const createLayerTabs = (layerId, layers, features, selectedFeatureIds, showSelectedFirst, sorting, loadingStatus, visibleColumnsSettings, controller) => {
+const createLayerTabs = (layerId, layers, features, selectedFeatureIds, showSelectedFirst, showCompressed, sorting, loadingStatus, visibleColumnsSettings, controller) => {
     const tabs = layers?.map(layer => {
         const status = loadingStatus[layer.getId()];
         const showExportButton = layer.hasPermission('download');
@@ -148,7 +151,7 @@ const createLayerTabs = (layerId, layers, features, selectedFeatureIds, showSele
                 openSelectByPropertiesPopup={controller.openSelectByPropertiesPopup}
             />,
             children: layer.getId() === layerId
-                ? createFeaturedataGrid(features, selectedFeatureIds, showSelectedFirst, sorting, visibleColumnsSettings, showExportButton, controller)
+                ? createFeaturedataGrid(features, selectedFeatureIds, showSelectedFirst, showCompressed, sorting, visibleColumnsSettings, showExportButton, controller)
                 : null
         };
     }) || [];
@@ -164,8 +167,26 @@ const ContainerDiv = styled('div')`
     }
 `;
 export const FeatureDataContainer = ({ state, controller }) => {
-    const { layers, activeLayerId, activeLayerFeatures, selectedFeatureIds, showSelectedFirst, loadingStatus, visibleColumnsSettings, sorting } = state;
-    const tabs = createLayerTabs(activeLayerId, layers, activeLayerFeatures, selectedFeatureIds, showSelectedFirst, sorting, loadingStatus, visibleColumnsSettings, controller);
+    const { layers,
+        activeLayerId,
+        activeLayerFeatures,
+        selectedFeatureIds,
+        showSelectedFirst,
+        showCompressed,
+        loadingStatus,
+        visibleColumnsSettings,
+        sorting } = state;
+    const tabs = createLayerTabs(
+        activeLayerId,
+        layers,
+        activeLayerFeatures,
+        selectedFeatureIds,
+        showSelectedFirst,
+        showCompressed,
+        sorting,
+        loadingStatus,
+        visibleColumnsSettings,
+        controller);
     return (
         <ContainerDiv isMobile={Oskari.util.isMobile()}>
             <Tabs

--- a/bundles/framework/featuredata/view/FeatureDataContainer.jsx
+++ b/bundles/framework/featuredata/view/FeatureDataContainer.jsx
@@ -81,6 +81,12 @@ const SelectionRow = styled('div')`
     flex-direction: row;
     padding-bottom: 1em;
 `;
+
+const SelectionRowGroup = styled('div')`
+    display: flex;
+    flex-direction: row;
+`;
+
 const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, showCompressed, sorting, visibleColumnsSettings, showExportButton, controller) => {
     if (!features || !features.length) {
         return <Message bundleKey={FEATUREDATA_BUNDLE_ID} messageKey={'layer.outOfContentArea'}/>;
@@ -102,11 +108,13 @@ const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, 
 
             { !showExportButton && <>
                 <SelectionRow>
-                    <ShowSelectedItemsFirst showSelectedFirst={showSelectedFirst} toggleShowSelectedFirst={controller.toggleShowSelectedFirst}/>
+                    <SelectionRowGroup>
+                        <ShowSelectedItemsFirst showSelectedFirst={showSelectedFirst} toggleShowSelectedFirst={controller.toggleShowSelectedFirst}/>
+                        <CompressedView showCompressed={showCompressed} toggleShowCompressed={controller.toggleShowCompressed}/>
+                    </SelectionRowGroup>
                     <FilterVisibleColumns {...visibleColumnsSettings} updateVisibleColumns={controller.updateVisibleColumns}/>
                 </SelectionRow>
                 <SelectionRow>
-                    <CompressedView showCompressed={showCompressed} toggleShowCompressed={controller.toggleShowCompressed}/>
                 </SelectionRow>
             </>}
         </SelectionsContainer>

--- a/bundles/framework/featuredata/view/FeatureDataContainer.jsx
+++ b/bundles/framework/featuredata/view/FeatureDataContainer.jsx
@@ -36,6 +36,15 @@ const StyledTable = styled(Table)`
         display: none;
     }
 
+    .table-cell-compressed-view {
+        white-space: nowrap;
+        word-break: break-word;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        min-width: 3em;
+        max-width: 8em;
+    }
+
     overflow-y: auto;
     flex: 1 1 auto;
 `;
@@ -56,7 +65,7 @@ const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, 
     if (!features || !features.length) {
         return <Message bundleKey={FEATUREDATA_BUNDLE_ID} messageKey={'layer.outOfContentArea'}/>;
     };
-    const columnSettings = createColumnSettings(selectedFeatureIds, showSelectedFirst, sorting, visibleColumnsSettings);
+    const columnSettings = createColumnSettings(selectedFeatureIds, showSelectedFirst, showCompressed, sorting, visibleColumnsSettings);
     const dataSource = createDatasourceFromFeatures(features);
     const featureTable = <FeatureDataTable>
         <SelectionsContainer>
@@ -71,17 +80,19 @@ const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, 
                 </SelectionRow>
             </>}
 
-            { !showExportButton &&
+            { !showExportButton && <>
                 <SelectionRow>
                     <ShowSelectedItemsFirst showSelectedFirst={showSelectedFirst} toggleShowSelectedFirst={controller.toggleShowSelectedFirst}/>
                     <FilterVisibleColumns {...visibleColumnsSettings} updateVisibleColumns={controller.updateVisibleColumns}/>
+                </SelectionRow>
+                <SelectionRow>
                     <CompressedView showCompressed={showCompressed} toggleShowCompressed={controller.toggleShowCompressed}/>
                 </SelectionRow>
-            }
+            </>}
         </SelectionsContainer>
         <StyledTable
             columns={ columnSettings }
-            size={ 'large '}
+            size={ 'small'}
             dataSource={ dataSource }
             pagination={{ defaultPageSize: DEFAULT_PAGE_SIZE, hideOnSinglePage: true, simple: true }}
             onChange={(pagination, filters, sorter, extra) => {
@@ -100,13 +111,14 @@ const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, 
     return featureTable;
 };
 
-const createColumnSettings = (selectedFeatureIds, showSelectedFirst, sorting, visibleColumnsSettings) => {
+const createColumnSettings = (selectedFeatureIds, showSelectedFirst, showCompressed, sorting, visibleColumnsSettings) => {
     const { allColumns, visibleColumns, activeLayerPropertyLabels } = visibleColumnsSettings;
     return allColumns
         .filter(key => visibleColumns.includes(key))
         .map(key => {
             return {
                 align: 'left',
+                className: showCompressed ? 'table-cell-compressed-view' : '',
                 title: activeLayerPropertyLabels && activeLayerPropertyLabels[key] ? activeLayerPropertyLabels[key] : key,
                 key,
                 dataIndex: key,

--- a/bundles/framework/featuredata/view/ShowSelectedItemsFirst.jsx
+++ b/bundles/framework/featuredata/view/ShowSelectedItemsFirst.jsx
@@ -1,17 +1,21 @@
 import React from 'react';
-import { Checkbox } from 'oskari-ui/components/Checkbox';
+import { Switch } from 'oskari-ui/components/Switch';
 import { Message } from 'oskari-ui';
 import { FEATUREDATA_BUNDLE_ID } from './FeatureDataContainer';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 const SelectedItemsFirstContainer = styled('div')`
+    padding: 0 1em 0 0;
 `;
 export const ShowSelectedItemsFirst = (props) => {
     return <SelectedItemsFirstContainer>
-        <Checkbox checked={ props.showSelectedFirst } onChange={ () => { props.toggleShowSelectedFirst(); } }>
-            <Message bundleKey={FEATUREDATA_BUNDLE_ID} messageKey='showSelectedFirst'/>
-        </Checkbox>
+        <Switch
+            size={'small'}
+            label={<Message bundleKey={FEATUREDATA_BUNDLE_ID} messageKey='showSelectedFirst'/>}
+            checked={ props.showSelectedFirst }
+            defaultChecked = { false }
+            onChange={ () => { props.toggleShowSelectedFirst(); } }/>
     </SelectedItemsFirstContainer>;
 };
 ShowSelectedItemsFirst.propTypes = {


### PR DESCRIPTION
-add a toggle for compressed view when there's long content in table. 
-for unified look and feel the "show selected first" checkbox is now a toggle as well.
-label for the new toggle is a working title
-still need to figure out how to add a title to the antd table cells with overflowing content

compressed: 
![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/c5194c19-4980-4fcf-9e69-0086cc43ce2a)

like before
![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/6b4c117a-a0d2-4959-91d2-df91a845feaf)
