### PR TITLE
refactor determining the sorting column

### DIFF
--- a/bundles/framework/featuredata/plugin/FeatureDataPluginHandler.js
+++ b/bundles/framework/featuredata/plugin/FeatureDataPluginHandler.js
@@ -79,15 +79,15 @@ class FeatureDataPluginUIHandler extends StateHandler {
             visibleColumnsSettings,
             selectByPropertiesFilter: {},
             selectByPropertiesFeatureTypes: this.createSelectByPropertiesFeatureTypes(visibleColumnsSettings),
-            sorting: this.determineSortingColumn(layerId, features)
+            sorting: this.determineSortingColumn(layerId)
         });
     }
 
     toggleShowSelectedFirst () {
-        const { activeLayerId, activeLayerFeatures, sorting } = this.getState();
+        const { activeLayerId, sorting } = this.getState();
         const newState = { showSelectedFirst: !this.getState().showSelectedFirst };
         if (newState.showSelectedFirst && !sorting?.order) {
-            newState.sorting = this.determineSortingColumn(activeLayerId, activeLayerFeatures);
+            newState.sorting = this.determineSortingColumn(activeLayerId);
         }
         this.updateState(newState);
     }
@@ -119,12 +119,14 @@ class FeatureDataPluginUIHandler extends StateHandler {
             visibleColumnsSettings = this.createVisibleColumnsSettings(newActiveLayerId);
         };
 
+        const sorting = this.determineSortingColumn(newActiveLayerId);
         return {
             activeLayerId: newActiveLayerId,
             layers: featureDataLayers,
             activeLayerFeatures,
             selectedFeatureIds,
-            visibleColumnsSettings
+            visibleColumnsSettings,
+            sorting
         };
     }
 
@@ -137,9 +139,9 @@ class FeatureDataPluginUIHandler extends StateHandler {
     updateSorting (sorting) {
         // if show selected first - is checked but sorting is cancelled we need to set default sorting to keep the selected items first.
         const newState = { sorting };
-        const { showSelectedFirst, activeLayerFeatures, activeLayerId } = this.getState();
+        const { showSelectedFirst, activeLayerId } = this.getState();
         if (showSelectedFirst && !sorting.order) {
-            newState.sorting = this.determineSortingColumn(activeLayerId, activeLayerFeatures);
+            newState.sorting = this.determineSortingColumn(activeLayerId);
         }
         this.updateState(newState);
     }
@@ -155,7 +157,7 @@ class FeatureDataPluginUIHandler extends StateHandler {
     }
 
     updateVisibleColumns (value) {
-        const { visibleColumnsSettings, activeLayerFeatures, activeLayerId, sorting } = this.getState();
+        const { visibleColumnsSettings, activeLayerId, sorting } = this.getState();
 
         // Always have to have at least one column selected - don't allow setting this empty.
         if (value && value.length) {
@@ -167,7 +169,7 @@ class FeatureDataPluginUIHandler extends StateHandler {
         };
 
         if (!value.includes(sorting?.columnKey)) {
-            newState.sorting = this.determineSortingColumn(activeLayerId, activeLayerFeatures);
+            newState.sorting = this.determineSortingColumn(activeLayerId);
         }
 
         this.updateState(newState);
@@ -194,7 +196,7 @@ class FeatureDataPluginUIHandler extends StateHandler {
             visibleColumnsSettings,
             selectByPropertiesFilter,
             selectByPropertiesFeatureTypes,
-            sorting: activeLayerFeatures ? this.determineSortingColumn(activeLayerId, activeLayerFeatures) : null
+            sorting: this.determineSortingColumn(activeLayerId)
         };
 
         if (!activeLayerFeatures) {
@@ -202,7 +204,6 @@ class FeatureDataPluginUIHandler extends StateHandler {
             // empty should mean there is no features on viewport to list
             const newActiveLayerFeatures = this.getFeaturesByLayerId(activeLayerId);
             newState.activeLayerFeatures = newActiveLayerFeatures;
-            newState.sorting = newActiveLayerFeatures && newActiveLayerFeatures.length ? this.determineSortingColumn(activeLayerId, newActiveLayerFeatures) : null;
             newState.selectedFeatureIds = newActiveLayerFeatures && newActiveLayerFeatures.length ? this.getSelectedFeatureIdsByLayerId(activeLayerId) : null;
             newState.visibleColumnsSettings = this.createVisibleColumnsSettings(activeLayerId);
             newState.selectByPropertiesFilter = {};
@@ -349,26 +350,24 @@ class FeatureDataPluginUIHandler extends StateHandler {
         return currentLayer ? currentLayer.getId() : null;
     }
 
-    determineSortingColumn (activeLayerId, features) {
-        if (!features || !features.length) {
-            return null;
-        }
-        // this might not be set to state yet, if this is the first time flyout is opened
-        // so we're creating this in that case
-        let { visibleColumnsSettings } = this.getState();
-        if (!visibleColumnsSettings) {
-            visibleColumnsSettings = this.createVisibleColumnsSettings(activeLayerId);
+    determineSortingColumn (newActiveLayerId) {
+        const { activeLayerId, visibleColumnsSettings, sorting } = this.getState();
+        const activeLayerChanged = newActiveLayerId !== activeLayerId;
+
+        // Same layer and the previous sorting field is still visible -> use the old
+        if (!activeLayerChanged && sorting?.columnKey && visibleColumnsSettings?.visibleColumns?.includes(sorting?.columnKey)) {
+            return sorting;
         }
 
-        // get the first property that isn't in the default hidden fields and use that as default.
-        const defaultSortingColumn = Object.keys(features[0]?.properties).find((key) => this.columnShouldBeVisible(key, visibleColumnsSettings));
-        const sortedInfo = { order: 'ascend', columnKey: defaultSortingColumn };
-        return sortedInfo;
+        // otherwise this needs to be recreated.
+        return this.resetSortingColumn(newActiveLayerId);
     }
 
-    columnShouldBeVisible (key, visibleColumnsSettings) {
-        const { visibleColumns } = visibleColumnsSettings;
-        return visibleColumns?.includes(key);
+    resetSortingColumn (newActiveLayerId) {
+        const newVisibleColumnsSettings = this.createVisibleColumnsSettings(newActiveLayerId);
+        const defaultSortingColumn = newVisibleColumnsSettings?.visibleColumns[0] || null;
+        const sortedInfo = { order: 'ascend', columnKey: defaultSortingColumn };
+        return sortedInfo;
     }
 
     sendExportDataForm (data) {


### PR DESCRIPTION
Should select the default sorting column in all the cases (changing the tab, removing visible columns, adding/removing layers) so the "show selected first" - functionality also works in all cases 