### PR TITLE
replace actionlinks with a dropdown

### DIFF
--- a/bundles/catalogue/metadatasearch/view/resultlist/MetadataSearchResultListContainer.jsx
+++ b/bundles/catalogue/metadatasearch/view/resultlist/MetadataSearchResultListContainer.jsx
@@ -3,13 +3,35 @@ import { METADATA_BUNDLE_LOCALIZATION_ID } from '../../instance';
 import { PropTypes } from 'prop-types';
 import { ActionLinkContainer, FlexRight, FlexRow } from './MetadataSearchResultListStyledComponents';
 import { MetadataSearchResultList } from './MetadataSearchResultList';
+import { Select } from 'oskari-ui';
+import styled from 'styled-components';
 
 const SEARCH_RESULT_FILTER_TYPES = {
+    all: null,
     datasets: ['dataset', 'series'],
     services: ['service']
 };
 
+const StyledSelect = styled(Select)`
+    min-width: 15em;
+`;
+
+const SearchResultTitle = styled('div')`
+    margin: auto 1em auto 0;
+`;
+
 export const MetadataSearchResultListContainer = (props) => {
+    const options = [{
+        label: Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'searchResults.showSearch'),
+        value: 'all'
+    }, {
+        label: Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'searchResults.showDatasets'),
+        value: 'datasets'
+    }, {
+        label: Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'searchResults.showServices'),
+        value: 'services'
+    }];
+
     const { searchResults,
         toggleSearch,
         toggleSearchResultsFilter,
@@ -20,27 +42,15 @@ export const MetadataSearchResultListContainer = (props) => {
         selectedLayers,
         toggleLayerVisibility } = props;
 
-    const searchResultsFiltered = searchResultsFilter ? searchResults.filter((item) => searchResultsFilter.includes(item.natureofthetarget)) : searchResults;
+    const searchResultsFiltered = searchResultsFilter && searchResultsFilter.length ? searchResults.filter((item) => searchResultsFilter.includes(item.natureofthetarget)) : searchResults;
     const hasSearchResults = !!(searchResults && searchResults.length);
     return <>
         <FlexRow>
-            <div>{Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'searchResults.resultTitle')}</div>
+            <SearchResultTitle>{Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'searchResults.resultTitle')}</SearchResultTitle>
             <FlexRight>
-                { searchResultsFilter &&
-                    <ActionLinkContainer>
-                        <a onClick={() => toggleSearchResultsFilter(null)}>{Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'searchResults.showSearch')}</a>
-                    </ActionLinkContainer>
-                }
-                {
-                    hasSearchResults && !searchResultsFilter &&
-                        <>
-                            <ActionLinkContainer>
-                                <a onClick={() => toggleSearchResultsFilter(SEARCH_RESULT_FILTER_TYPES.datasets)}>{Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'searchResults.showDatasets')}</a>
-                            </ActionLinkContainer>
-                            <ActionLinkContainer>
-                                <a onClick={() => toggleSearchResultsFilter(SEARCH_RESULT_FILTER_TYPES.services)}>{Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'searchResults.showServices')}</a>
-                            </ActionLinkContainer>
-                        </>
+                { hasSearchResults && <ActionLinkContainer>
+                    <StyledSelect options={options} onChange={(value) => toggleSearchResultsFilter(SEARCH_RESULT_FILTER_TYPES[value])} defaultValue={'all'}/>
+                </ActionLinkContainer>
                 }
                 <ActionLinkContainer>
                     <a onClick={toggleSearch}>{Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'searchResults.modifySearch')}</a>


### PR DESCRIPTION
Replace the action links in search results with a single dropdown doing the job. 

![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/4727692f-1b78-433a-9f51-3213689b470b)
