### PR TITLE
poll for (new) announcements automatically

### DIFF
--- a/bundles/framework/announcements/view/AnnouncementsHandler.js
+++ b/bundles/framework/announcements/view/AnnouncementsHandler.js
@@ -82,15 +82,7 @@ class ViewHandler extends StateHandler {
 
     onPopupClose () {
         const { popupAnnouncements } = this.getState();
-        let { alreadyShown } = this.getState();
-        if (!alreadyShown) {
-            alreadyShown = [];
-        }
-
-        if (popupAnnouncements) {
-            alreadyShown = alreadyShown.concat(popupAnnouncements.map(ann => ann.id));
-        }
-
+        const alreadyShown = this.getAlreadyShown(popupAnnouncements);
         this.updateState({
             popupAnnouncements: [],
             alreadyShown: [...new Set(alreadyShown)]
@@ -99,19 +91,24 @@ class ViewHandler extends StateHandler {
 
     onBannerClose () {
         const { bannerAnnouncements } = this.getState();
+        const alreadyShown = this.getAlreadyShown(bannerAnnouncements);
+        this.updateState({
+            bannerAnnouncements: [],
+            alreadyShown: [...new Set(alreadyShown)]
+        });
+    }
+
+    getAlreadyShown (announcements) {
         let { alreadyShown } = this.getState();
         if (!alreadyShown) {
             alreadyShown = [];
         }
 
-        if (bannerAnnouncements) {
-            alreadyShown = alreadyShown.concat(bannerAnnouncements.map(ann => ann.id));
+        if (announcements) {
+            alreadyShown = alreadyShown.concat(announcements.map(ann => ann.id));
         }
 
-        this.updateState({
-            bannerAnnouncements: [],
-            alreadyShown: [...new Set(alreadyShown)]
-        });
+        return alreadyShown;
     }
 
     onBannerChange (currentBanner) {


### PR DESCRIPTION
-implement polling for announcements automatically.

6 announcements exist at startup
![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/7c545b94-5515-4927-9266-ffd37cff0da5)

after the ones shown on startup are hidden by closing the banner (or popup) a new announcement was added to db and after the polling interval has passed the new notification is shown automatically: 
![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/b5a2da41-1141-4190-af3a-a43fda831e54)
