### PR TITLE
align checkbox to the top even when label is on multiple rows

### DIFF
--- a/src/react/components/Checkbox.jsx
+++ b/src/react/components/Checkbox.jsx
@@ -7,6 +7,10 @@ const StyledCheckbox = styled(AntCheckbox)`
     + .ant-checkbox-wrapper {
         margin-left: 0;
     }
+
+    .ant-checkbox {
+        margin-bottom: auto;
+    }
 `;
 
 export const Checkbox = (props) => (


### PR DESCRIPTION
Align checkbox to the top of the label container even with a label on multiple rows
![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/e2e0b6da-173a-460b-be44-858c77771f35)
