### PR TITLE
Admin permissions efficiency issues

### DIFF
--- a/bundles/admin/admin-permissions/handler/layerRightsHandler.js
+++ b/bundles/admin/admin-permissions/handler/layerRightsHandler.js
@@ -12,7 +12,7 @@ class UIHandler extends StateHandler {
             loading: false,
             changedIds: new Set(),
             pagination: {
-                pageSize: 50,
+                pageSize: 20,
                 page: 1,
                 filter: ''
             }

--- a/bundles/admin/admin-permissions/view/LayerRightsTable.jsx
+++ b/bundles/admin/admin-permissions/view/LayerRightsTable.jsx
@@ -41,16 +41,26 @@ const getPermissionNames = (nameToLabel) => {
     return [...names, ...additionalNames];
 };
 
+const VIEW_LAYER = 'VIEW_LAYER';
+const VIEW_PUBLISHED = 'VIEW_PUBLISHED';
+const PUBLISH = 'PUBLISH';
+const DOWNLOAD = 'DOWNLOAD';
+
+const DEFAULT_PERMISSIONS = [VIEW_LAYER, VIEW_PUBLISHED, PUBLISH, DOWNLOAD];
+const isDefaultPermissionType = (permissionName) => {
+    return DEFAULT_PERMISSIONS.includes(permissionName);
+};
+
 const getPermissionTableHeader = (permissionType, permissionName) => {
     const translation = <Message messageKey={`rights.${permissionType}`} defaultMsg={permissionName} bundleKey='admin-permissions' />;
     switch (permissionType) {
-        case 'VIEW_LAYER':
+        case VIEW_LAYER:
             return <Tooltip title={translation}><StyledIcon><UnorderedListOutlined /></StyledIcon></Tooltip>
-        case 'VIEW_PUBLISHED':
+        case VIEW_PUBLISHED:
             return <Tooltip title={translation}><StyledIcon><EyeOutlined /></StyledIcon></Tooltip>
-        case 'PUBLISH':
+        case PUBLISH:
             return <Tooltip title={translation}><StyledIcon><ImportOutlined /></StyledIcon></Tooltip>
-        case 'DOWNLOAD':
+        case DOWNLOAD:
             return <Tooltip title={translation}><StyledIcon><ExportOutlined /></StyledIcon></Tooltip>
         default:
             // permissions might have server side localization as "name" that defaults to id if not given
@@ -105,13 +115,15 @@ export const LayerRightsTable = ThemeConsumer(({ theme, controller, state }) => 
             }
         });
         permissionNames.forEach((permissionType, index) => {
+            const permissionName = state.permissions.names[permissionType];
             columnSettings.push({
                 align: 'left',
+                width: isDefaultPermissionType(permissionName) ? '5em' : '10em',
                 title: () => {
                     const allCurrentLayersHavePermission = allChecked(permissionType);
                     return (
                         <HeaderCell>
-                            {getPermissionTableHeader(permissionType, state.permissions.names[permissionType])}
+                            {getPermissionTableHeader(permissionType, permissionName)}
                             <CheckAllCheckbox
                                 checked={allCurrentLayersHavePermission}
                                 onChange={() => controller.setCheckAllForPermission(permissionType, !allCurrentLayersHavePermission)}


### PR DESCRIPTION
-changed default page size from 50 to 20. After trying #all tricks in the book that was absolutely the only thing that seemed to make any difference whatsoever in speeding up the antd table re-rendering.
-some tweaking to column widths (layer name a bit wider, thos containing just check boxes narrower)

![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/5ece9d1d-c199-44a8-803e-693467962356)
