### PR TITLE
fool tooltip into being displayed correctly

### DIFF
--- a/src/react/components/LabeledInput.jsx
+++ b/src/react/components/LabeledInput.jsx
@@ -11,7 +11,9 @@ const Component = styled.div`
 `;
 const Textarea = styled(Input.TextArea)`
     font-family: inherit;
-`
+    // We need this to get the tooltip to calculate it's position correctly
+    display: block;
+`;
 
 export const LabeledInput = ({
     label,


### PR DESCRIPTION
fool tooltip to it's correct place above a textarea

![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/bf9b2442-c67c-4a68-b6f3-2cc764c7af6d)
