### PR TITLE
remove reference to panning tools from guided tour - localisation (en…

### DIFF
--- a/bundles/mapping/mapmodule/resources/locale/en.js
+++ b/bundles/mapping/mapmodule/resources/locale/en.js
@@ -145,7 +145,7 @@ Oskari.registerLocalization(
         "guidedTour": {
             "help1": {
                 "title": "Pan Map View",
-                "message": "You can pan the map view in several ways. <br/><br/>  Select a hand tool and drag the map view with a mouse.<br/><br/>  Use arrow keys on your keyboard. <br/><br/>  Click arrows in the panning tool. You can find it in the upper right corner."
+                "message": "You can pan the map view in several ways. <br/><br/>  Select a hand tool and drag the map view with a mouse.<br/><br/>  Use arrow keys on your keyboard."
             },
             "help2": {
                 "title": "Zoom In and Out Map View",

--- a/bundles/mapping/mapmodule/resources/locale/fi.js
+++ b/bundles/mapping/mapmodule/resources/locale/fi.js
@@ -144,7 +144,7 @@ Oskari.registerLocalization(
         "guidedTour": {
             "help1": {
                 "title": "Kartan liikuttaminen",
-                "message": "Kartan liikuttaminen onnistuu kolmella eri tavalla. <br/> Raahaa karttaa hiirellä, kun käsi-työkalu on valittuna. <br/> Liikuta karttaa näppäimistön nuolinäppäimillä. <br/> Klikkaa nuolia oikeassa yläkulmassa olevassa panorointityökalussa."
+                "message": "Kartan liikuttaminen onnistuu kahdella eri tavalla. <br/> Raahaa karttaa hiirellä, kun käsi-työkalu on valittuna. <br/> Liikuta karttaa näppäimistön nuolinäppäimillä."
             },
             "help2": {
                 "title": "Lähentäminen ja loitontaminen",


### PR DESCRIPTION
Removed the sentence referring to panning tools from guided tour (fi, en). Other localisations seem to be outdated anyway (as far as I can tell, even the swedish one)