### PR TITLE
Fix indicator list updating.

### DIFF
--- a/bundles/statistics/statsgrid/handler/MyIndicatorsHandler.js
+++ b/bundles/statistics/statsgrid/handler/MyIndicatorsHandler.js
@@ -1,4 +1,5 @@
 import { StateHandler, controllerMixin, Messaging } from 'oskari-ui/util';
+import { populateIndicatorOptions } from './SearchIndicatorOptionsHelper';
 
 class IndicatorsHandler extends StateHandler {
     constructor (sandbox, instance, formHandler) {
@@ -34,14 +35,19 @@ class IndicatorsHandler extends StateHandler {
             loading: true
         });
         try {
-            const response = await this.service.getIndicatorList(this.userDsId);
-            this.updateState({
-                loading: false,
-                data: response.indicators
-            });
+            populateIndicatorOptions(this.userDsId,
+                response => {
+                    const { indicators = [], complete = false } = response;
+                    this.updateState({
+                        loading: !complete,
+                        data: indicators
+                    });
+                },
+                error => Messaging.error(this.loc(error.message)));
         } catch (error) {
-            this.log.warn('Could not list own indicators in personal data tab');
+            Messaging.error(error.message);
             this.updateState({
+                data: [],
                 loading: false
             });
         }

--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -30,6 +30,7 @@ class SearchController extends StateHandler {
         this.metadataPopup = null;
         this.loc = Oskari.getMsg.bind(null, 'StatsGrid');
         this.addStateListener(() => this.updateFlyout());
+        this.eventHandlers = this.createEventHandlers();
     };
 
     getName () {
@@ -135,10 +136,6 @@ class SearchController extends StateHandler {
             // show notification about empty indicator list for non-myindicators datasource
             Messaging.error(this.loc('errors.indicatorListIsEmpty'));
         }
-        // Notify other componets that datasource has more indicators now.
-        // Probably not be needed with the React impl
-        const indicatorsUpdatedEvent = Oskari.eventBuilder('StatsGrid.DatasourceEvent');
-        this.sandbox.notifyAll(indicatorsUpdatedEvent(datasourceId));
     }
 
     validateIndicatorList (indicators = []) {
@@ -878,6 +875,25 @@ class SearchController extends StateHandler {
         } else {
             formHandler.showIndicatorPopup(this.getState().selectedDatasource);
         }
+    }
+
+    createEventHandlers () {
+        const handlers = {
+            'StatsGrid.DatasourceEvent': (event) => {
+                this.fetchindicatorOptions();
+            }
+        };
+        Object.getOwnPropertyNames(handlers).forEach(p => this.sandbox.registerForEventByName(this, p));
+        return handlers;
+    }
+
+    onEvent (e) {
+        var handler = this.eventHandlers[e.getName()];
+        if (!handler) {
+            return;
+        }
+
+        return handler.apply(this, [e]);
     }
 }
 


### PR DESCRIPTION
- Fixed personal data indicators tab not loading indicators.
- Update indicator options on statsgrid search when indicators are added/removed.