### PR TITLE
use parseint when determining if visual viewport size != client size

### DIFF
--- a/bundles/mapping/mapmodule/plugin/pinchzoomreset/PinchZoomResetPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/pinchzoomreset/PinchZoomResetPlugin.js
@@ -55,7 +55,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PinchZoomResetP
          * @return {Boolean} true if page is zoomed in
          */
         isZoomedIn: function () {
-            return window.innerWidth !== window.visualViewport.width || window.innerHeight !== window.visualViewport.height;
+            return parseInt(window.innerWidth) !== parseInt(window.visualViewport.width) || parseInt(window.innerHeight) !== parseInt(window.visualViewport.height);
         },
 
         /**


### PR DESCRIPTION
Added parseint for determining if visual viewport size is different from window (desktop emulator worked fine with integers, mobile uses floats). Will hide the zoom reset - tool on android.
