### PR TITLE
add fallback for getting the visible columns from feature properties

### DIFF
--- a/bundles/framework/featuredata/plugin/FeatureDataPluginHandler.js
+++ b/bundles/framework/featuredata/plugin/FeatureDataPluginHandler.js
@@ -255,6 +255,15 @@ class FeatureDataPluginUIHandler extends StateHandler {
         const activeLayer = this.mapModule.getSandbox().findMapLayerFromSelectedMapLayers(newActiveLayerId) || null;
         const activeLayerProperties = activeLayer?.getProperties() || null;
         let allColumns = activeLayerProperties?.map((property) => property.name);
+
+        // for some reason no properties for layer -> resort to features as last fallback.
+        if (!allColumns?.length) {
+            const features = this.getFeaturesByLayerId(newActiveLayerId);
+            if (features?.length) {
+                allColumns = Object.keys(features[0]?.properties) || [];
+            }
+        }
+
         const activeLayerPropertyLabels = activeLayer?.getPropertyLabels() || null;
         const activeLayerPropertyTypes = activeLayer?.getPropertyTypes() || null;
         const newVisibleColumns = activeLayerChanged ? [].concat(allColumns) : visibleColumnsSettings?.visibleColumns ? visibleColumnsSettings.visibleColumns : [].concat(allColumns);


### PR DESCRIPTION
For some reason for some layers layer.properties is an empty array and in that case we gotta resort to getting the columns from feature.properties 