### PR TITLE
add layerswipe to created link

### DIFF
--- a/bundles/mapping/layerswipe/instance.js
+++ b/bundles/mapping/layerswipe/instance.js
@@ -290,6 +290,9 @@ Oskari.clazz.define(
         eventHandlers: {
             'Toolbar.ToolSelectedEvent': function (event) {
                 if (event.getToolId() !== 'LayerSwipe' && event.getToolId() !== 'link' && event.getToolId() !== 'save_view') {
+                    // This bundle generates state for both link and saving views, but only if it's active.
+                    // If we deactivate when link or save view tools are clicked the state is not stored as expected.
+                    // So we need to keep the swipe tool active when these tools are clicked.
                     this.setActive(false);
                 }
             },

--- a/bundles/mapping/layerswipe/instance.js
+++ b/bundles/mapping/layerswipe/instance.js
@@ -62,6 +62,7 @@ Oskari.clazz.define(
                 };
                 sandbox.request(this, addToolButtonBuilder('LayerSwipe', 'basictools', buttonConf));
             }
+
             if (this.isActive()) {
                 // when starting we need to force setup even when state is "already active"
                 // we need to set state.active to false and then init the functionality by setting it back to true
@@ -113,6 +114,13 @@ Oskari.clazz.define(
         },
         getState: function () {
             return this.state || {};
+        },
+        getStateParameters: function () {
+            const { active } = this.getState();
+            if (active) {
+                return 'swipe=true';
+            }
+            return '';
         },
         updateSwipeLayer: function () {
             this.unregisterEventListeners();
@@ -281,7 +289,7 @@ Oskari.clazz.define(
 
         eventHandlers: {
             'Toolbar.ToolSelectedEvent': function (event) {
-                if (event.getToolId() !== 'LayerSwipe') {
+                if (event.getToolId() !== 'LayerSwipe' && event.getToolId() !== 'link' && event.getToolId() !== 'save_view') {
                     this.setActive(false);
                 }
             },


### PR DESCRIPTION
Add swipe to url when creating a link with link tool. Also, do not deactivate layerswipe-tool when either link-tool or save map view are clicked in toolbar.

When the tool is activated via a alink it doesn't currently get activated in the toolbar becaus of some default logic for selecting the hand tool. This is "a bit" confusing but we need to think how this _should_ work in case there were multiple tools activated via the link.

This pr replaces https://github.com/oskariorg/oskari-frontend/pull/2544, which can be closed after this one has been merged. 