### PR TITLE
add nullcheck for layer (might be a timing issue here)

### DIFF
--- a/bundles/mapping/layerswipe/instance.js
+++ b/bundles/mapping/layerswipe/instance.js
@@ -125,7 +125,10 @@ Oskari.clazz.define(
         updateSwipeLayer: function () {
             this.unregisterEventListeners();
             const topLayer = this.getTopmostLayer();
-            this.layer = topLayer.ol;
+            this.layer = topLayer?.ol || null;
+            if (this?.layer === null) {
+                return;
+            }
             if (topLayer.layerId !== null) {
                 this.setSwipeStatus(topLayer.layerId, this.cropSize);
             }


### PR DESCRIPTION
UpdateSwipeLayer could be called before there are any layers added to map which resulted in error.