### PR TITLE
fix copy/paste error

### DIFF
--- a/bundles/framework/featuredata/plugin/FeatureDataPluginHandler.js
+++ b/bundles/framework/featuredata/plugin/FeatureDataPluginHandler.js
@@ -231,7 +231,7 @@ class FeatureDataPluginUIHandler extends StateHandler {
 
     openExportDataPopup () {
         if (this.exportDataPopupController) {
-            this.closeSelectByPropertiesPopupPopup();
+            this.closeExportDataPopup();
             return;
         }
         this.exportDataPopupController = showExportDataPopup(this.getState(), this.getController());


### PR DESCRIPTION
The original code was meant to shut down the popup on the second click but there was a misfortunate copy/paste-bug. Fixed that and the button works like a toggle now. 