### PR TITLE
swipe all ol layers attached to topmost oskarilayer (clustering)

### DIFF
--- a/bundles/mapping/layerswipe/instance.js
+++ b/bundles/mapping/layerswipe/instance.js
@@ -125,6 +125,11 @@ Oskari.clazz.define(
         updateSwipeLayer: function () {
             this.unregisterEventListeners();
             const topLayer = this.getTopmostLayer();
+
+            // no top layer === no layers -> deactivate tool
+            if (!topLayer) {
+                this.setActive(false);
+            }
             this.olLayers = topLayer?.ol || null;
             if (this?.olLayers === null) {
                 return;

--- a/bundles/mapping/layerswipe/instance.js
+++ b/bundles/mapping/layerswipe/instance.js
@@ -14,7 +14,7 @@ Oskari.clazz.define(
         this.splitterWidth = 5;
         this.cropSize = null;
         this.mapModule = null;
-        this.layer = null; // ol layer
+        this.olLayers = null; // ol layers (always an array of ol layers bound to a given oskarilayer, e.g. clustering uses two layers)
         this.oskariLayerId = null;
         this.popupService = null;
         this.popup = null;
@@ -79,7 +79,7 @@ Oskari.clazz.define(
             }
             if (active) {
                 this.updateSwipeLayer();
-                if (this.layer === null) {
+                if (this.olLayers === null) {
                     return;
                 }
                 this.showSplitter();
@@ -125,8 +125,8 @@ Oskari.clazz.define(
         updateSwipeLayer: function () {
             this.unregisterEventListeners();
             const topLayer = this.getTopmostLayer();
-            this.layer = topLayer?.ol || null;
-            if (this?.layer === null) {
+            this.olLayers = topLayer?.ol || null;
+            if (this?.olLayers === null) {
                 return;
             }
             if (topLayer.layerId !== null) {
@@ -136,7 +136,7 @@ Oskari.clazz.define(
             if (this.alertTimer) {
                 clearTimeout(this.alertTimer);
             }
-            if (this.layer === null) {
+            if (this?.olLayers === null) {
                 // When switching the background map, multiple events including
                 // remove, add and re-arrange will be triggered in order. The remove
                 // layer event causes the NO_RASTER alert to be shown when the
@@ -207,42 +207,45 @@ Oskari.clazz.define(
             }
             const olLayers = this.mapModule.getOLMapLayers(layerId);
             return {
-                ol: olLayers.length !== 0 ? olLayers[0] : null,
+                ol: olLayers.length !== 0 ? olLayers : null,
                 layerId
             };
         },
 
         registerEventListeners: function () {
-            if (this.layer === null) {
+            if (this.olLayers === null) {
                 return;
             }
-            const prerenderKey = this.layer.on('prerender', (event) => {
-                const ctx = event.context;
-                if (!this.isActive()) {
-                    ctx.restore();
-                    return;
-                }
 
-                const mapSize = this.mapModule.getMap().getSize();
-                const tl = getRenderPixel(event, [0, 0]);
-                const tr = getRenderPixel(event, [this.cropSize, 0]);
-                const bl = getRenderPixel(event, [0, mapSize[1]]);
-                const br = getRenderPixel(event, [this.cropSize, mapSize[1]]);
+            this.olLayers.forEach((olLayer) => {
+                const prerenderKey = olLayer.on('prerender', (event) => {
+                    const ctx = event.context;
+                    if (!this.isActive()) {
+                        ctx.restore();
+                        return;
+                    }
 
-                ctx.save();
-                ctx.beginPath();
-                ctx.moveTo(tl[0], tl[1]);
-                ctx.lineTo(bl[0], bl[1]);
-                ctx.lineTo(br[0], br[1]);
-                ctx.lineTo(tr[0], tr[1]);
-                ctx.closePath();
-                ctx.clip();
+                    const mapSize = this.mapModule.getMap().getSize();
+                    const tl = getRenderPixel(event, [0, 0]);
+                    const tr = getRenderPixel(event, [this.cropSize, 0]);
+                    const bl = getRenderPixel(event, [0, mapSize[1]]);
+                    const br = getRenderPixel(event, [this.cropSize, mapSize[1]]);
+
+                    ctx.save();
+                    ctx.beginPath();
+                    ctx.moveTo(tl[0], tl[1]);
+                    ctx.lineTo(bl[0], bl[1]);
+                    ctx.lineTo(br[0], br[1]);
+                    ctx.lineTo(tr[0], tr[1]);
+                    ctx.closePath();
+                    ctx.clip();
+                });
+                this.eventListenerKeys.push(prerenderKey);
+                const postrenderKey = olLayer.on('postrender', (event) => {
+                    event.context.restore();
+                });
+                this.eventListenerKeys.push(postrenderKey);
             });
-            this.eventListenerKeys.push(prerenderKey);
-            const postrenderKey = this.layer.on('postrender', (event) => {
-                event.context.restore();
-            });
-            this.eventListenerKeys.push(postrenderKey);
         },
 
         unregisterEventListeners: function () {


### PR DESCRIPTION
When there are multiple ol layers attached to the topmost oskari layer - swipe them all. Fixes the non-swiping issue of clustered layers. (see attached image, hiding both the cluster and an individual marker that physically reside on different ol layers)

Also deactivate the tool when there are no map layers on.

![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/1713e0d9-7ddb-418e-92a9-12a70bbc6eba)

