### PR TITLE
Admin LayerEditor hover style sv localization

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -98,7 +98,13 @@ Oskari.registerLocalization(
                 "overridden": "Replaced file identifier"
             },
             "jsonTab": {
-                "info": "These tools enable advanced configuration, use with caution."
+                "info": "These tools enable advanced configuration, use with caution.",
+                "fields": {
+                    "attributes": "Attributes",
+                    "capabilities": "Capabilities parsed for layer",
+                    "options": "Options",
+                    "params": "Params"
+                }
             },
             "capabilities": {
                 "parsed": "Capabilities parsed for layer",
@@ -116,12 +122,6 @@ Oskari.registerLocalization(
                     "additionalLegend": "The map layer has been given a legend that overrides the default legend provided by the service. The overriding legend was linked to a style that is no longer available. Please update the layer legend. The problematic style is marked with a ( ! ).",
                     "globalWithStyles": "The layer has more than one style available in the service. However, the layer has been defined with a single default legend. Consider removing the current default legend to be able to use the style based legends."
                 }
-            },
-            "jsonFields": {
-                "attributes": "Attributes",
-                "capabilities": "Capabilities parsed for layer",
-                "options": "Options",
-                "params": "Params"
             },
             "attributes": {
                 "label": "Attributes",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -98,7 +98,13 @@ Oskari.registerLocalization(
                 "overridden": "Korvaava tiedostotunniste"
             },
             "jsonTab": {
-                "info": "Nämä työkalut mahdollistavat lisäkonfiguraation, käytä harkiten."
+                "info": "Nämä työkalut mahdollistavat lisäkonfiguraation, käytä harkiten.",
+                "fields": {
+                    "attributes": "Attribuutit",
+                    "capabilities": "Tasolle parsitut Capabilities-tiedot",
+                    "options": "Valinnat (options)",
+                    "params": "Parametrit"
+                }
             },
             "capabilities": {
                 "parsed": "Tasolle parsitut Capabilities-tiedot",
@@ -116,12 +122,6 @@ Oskari.registerLocalization(
                     "additionalLegend": "Tasolle on tallennettu erikseen rajapintapalvelun oman karttaselitteen yliajava karttaselite, jolle ei löydy tyyliä. Päivitä karttaselitteen tiedot. Poistuneen/ei-toimivan karttaselitteen nimessä on ( ! )-merkki.",
                     "globalWithStyles": "Tasolle on määritetty vain yksi yleinen oletuskarttaselite, vaikka sillä olisi rajapintapalvelusta useita tyylejä käytettävissä. Poista oletuskarttaselite ja määritä mahdolliset tyylikohtaiset karttaselitteet."
                 }
-            },
-            "jsonFields": {
-                "attributes": "Attribuutit",
-                "capabilities": "Tasolle parsitut Capabilities-tiedot",
-                "options": "Options",
-                "params": "Parametrit"
             },
             "attributes": {
                 "label": "Attribuutit",

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -212,15 +212,15 @@ Oskari.registerLocalization(
                     }
                 },
                 "hover": {
-                    "title": "Objektsmarkering och verktygstips",
-                    "tooltip": "Verktygstipsrader visas för objekt",
+                    "title": "Framhävning av objekt och verktygstips",
+                    "tooltip": "Verktygstipsrader, som visas för objekt",
                     "useStyle": "Använd stildefinitioner",
                     "inherit": "Ärv stildefinitioner",
                     "effect": "Använd effekten",
-                    "fromProperty": "Använd egenskap som etikett",
+                    "fromProperty": "Använd egenskapen som etikett",
                     "labelTooltip": {
-                        "key": "Etiketten visas som den är",
-                        "keyProperty": "Etikettinnehåll tas emot från egenskap"
+                        "key": "Etiketten visas i sin ursprungliga form",
+                        "keyProperty": "Etikettinnehållet tas från den valda egenskapen"
                     }
                 }
             },

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -210,6 +210,18 @@ Oskari.registerLocalization(
                         "json": "Stildefinitioner JSON-syntaxen är ogiltig.",
                         "optionalStyles": "Stilen har inte ett giltigt filter."
                     }
+                },
+                "hover": {
+                    "title": "Objektsmarkering och verktygstips",
+                    "tooltip": "Verktygstipsrader visas för objekt",
+                    "useStyle": "Använd stildefinitioner",
+                    "inherit": "Ärv stildefinitioner",
+                    "effect": "Använd effekten",
+                    "fromProperty": "Använd egenskap som etikett",
+                    "labelTooltip": {
+                        "key": "Etiketten visas som den är",
+                        "keyProperty": "Etikettinnehåll tas emot från egenskap"
+                    }
                 }
             },
             "layerStatus": {

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -98,7 +98,13 @@ Oskari.registerLocalization(
                 "overridden": "Filtagg för metadatans"
             },
             "jsonTab": {
-                "info": "Dessa verktyg möjliggör avancerad konfiguration, använd med försiktighet."
+                "info": "Dessa verktyg möjliggör avancerad konfiguration, använd med försiktighet.",
+                "fields": {
+                    "attributes": "Attribut",
+                    "capabilities": "Utvald information från kartlagrets capabilities",
+                    "options": "Alternativen (options)",
+                    "params": "Parametrar"
+                }
             },
             "capabilities": {
                 "parsed": "Utvald information från kartlagrets capabilities",

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/JsonTabPane/JsonTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/JsonTabPane/JsonTabPane.jsx
@@ -104,7 +104,7 @@ const ParsedCollapse = ({ json = {}, jsonKey, controller }) => {
     };
     return (
         <Collapse>
-            <CollapsePanel header={<Message messageKey={`jsonFields.${jsonKey}`}/>}
+            <CollapsePanel header={<Message messageKey={`jsonTab.fields.${jsonKey}`}/>}
                 extra={<PanelExtra setEdit={setEdit} skipEdit={!controller} />}>
                 { edit && <EditBlock edit={edit} onUpdate={onUpdate}/> }
                 <TextAreaInput value={prettier} autoSize={textAreaSize} />


### PR DESCRIPTION
Add sv localization for hover style and json tab.
Move `jsonFields` localization under `jsonTab`