### PR TITLE
Antd v5 migration layerlist

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
@@ -5,7 +5,7 @@ import { Controller, LocaleConsumer } from 'oskari-ui/util';
 import { LayerCollapsePanel } from './LayerCollapsePanel';
 import { Alert } from '../Alert';
 import styled from 'styled-components';
-
+import { PanelToolContainer } from './PanelToolContainer';
 const StyledCollapse = styled(Collapse)`
     border-radius: 0 !important;
     & > div {
@@ -14,33 +14,59 @@ const StyledCollapse = styled(Collapse)`
             padding-bottom: 2px;
         }
     }
+
+    > .ant-collapse-content > .ant-collapse-content-box {
+        padding: 0px;
+        & > .ant-list {
+            width: 100%;
+        }
+    }
+    & > div:first-child {
+        min-height: 22px;
+    }
+    & > .ant-collapse-header {
+        flex-direction: row;
+        flex-wrap: wrap !important;
+    }
 `;
 
 const LayerCollapse = ({ groups, openGroupTitles, selectedLayerIds, opts, controller }) => {
-
     if (!Array.isArray(groups) || groups.length === 0) {
         return <Alert showIcon type='info' message={<Message messageKey='errors.noResults' />} />;
     }
+
+    const groupItems = groups.map(group => {
+        const allLayersOnMap = true;
+        return {
+            key: group.getId(),
+            label: group.getTitle(),
+            className: `t_group gid_${group.getId()}`,
+            // data-attr doesn't seem to work for the panel in AntD-version 4.8.5
+//            data-gid={group.getId()}
+            extra: <PanelToolContainer
+                group={group}
+                opts={opts}
+                layerCount={group.getLayerCount()}
+                controller={controller}
+                allLayersOnMap={allLayersOnMap} />,
+            children: <LayerCollapsePanel key={group.getId()}
+                trimmed
+                selectedLayerIds={selectedLayerIds}
+                group={group}
+                openGroupTitles={openGroupTitles}
+                opts={opts}
+                controller={controller}
+            />
+
+        };
+    });
+
     return (
         <StyledCollapse
             bordered activeKey={openGroupTitles}
             onChange={keys => controller.updateOpenGroupTitles(keys)}
-        >
-            {
-                groups.map(group => {
-                    return (
-                        <LayerCollapsePanel key={group.getId()}
-                            trimmed
-                            selectedLayerIds={selectedLayerIds}
-                            group={group}
-                            openGroupTitles={openGroupTitles}
-                            opts={opts}
-                            controller={controller}
-                        />
-                    );
-                })
-            }
-        </StyledCollapse>
+            items={groupItems}
+        />
     );
 };
 

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
@@ -15,34 +15,46 @@ const StyledCollapse = styled(Collapse)`
         }
     }
 
-    > .ant-collapse-content > .ant-collapse-content-box {
+    .ant-collapse-content > .ant-collapse-content-box {
         padding: 0px;
         & > .ant-list {
             width: 100%;
         }
     }
-    & > div:first-child {
-        min-height: 22px;
-    }
-    & > .ant-collapse-header {
+
+    .ant-collapse-header {
         flex-direction: row;
         flex-wrap: wrap !important;
     }
 `;
+
+const getLayerRowModels = (layers = [], selectedLayerIds = [], controller, opts) => {
+    return layers.map(oskariLayer => {
+        return {
+            id: oskariLayer.getId(),
+            model: oskariLayer,
+            selected: selectedLayerIds.includes(oskariLayer.getId()),
+            controller,
+            opts
+        };
+    });
+};
 
 const LayerCollapse = ({ groups, openGroupTitles, selectedLayerIds, opts, controller }) => {
     if (!Array.isArray(groups) || groups.length === 0) {
         return <Alert showIcon type='info' message={<Message messageKey='errors.noResults' />} />;
     }
 
+    // TODO: openGroupTitles we should probably check and do something with the info
+
     const groupItems = groups.map(group => {
-        const allLayersOnMap = true;
+        const layerRows = getLayerRowModels(group.getLayers(), selectedLayerIds, controller, opts);
+        // set group switch active if all layers in group are selected
+        const allLayersOnMap = layerRows.length > 0 && layerRows.every(layer => selectedLayerIds.includes(layer.id));
         return {
             key: group.getId(),
             label: group.getTitle(),
             className: `t_group gid_${group.getId()}`,
-            // data-attr doesn't seem to work for the panel in AntD-version 4.8.5
-//            data-gid={group.getId()}
             extra: <PanelToolContainer
                 group={group}
                 opts={opts}
@@ -54,10 +66,10 @@ const LayerCollapse = ({ groups, openGroupTitles, selectedLayerIds, opts, contro
                 selectedLayerIds={selectedLayerIds}
                 group={group}
                 openGroupTitles={openGroupTitles}
+                layerRows={layerRows}
                 opts={opts}
                 controller={controller}
             />
-
         };
     });
 

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
@@ -45,16 +45,16 @@ const LayerCollapse = ({ groups, openGroupTitles, selectedLayerIds, opts, contro
         return <Alert showIcon type='info' message={<Message messageKey='errors.noResults' />} />;
     }
 
-    // TODO: openGroupTitles we should probably check and do something with the info
-
     const groupItems = groups.map(group => {
         const layerRows = getLayerRowModels(group.getLayers(), selectedLayerIds, controller, opts);
         // set group switch active if all layers in group are selected
         const allLayersOnMap = layerRows.length > 0 && layerRows.every(layer => selectedLayerIds.includes(layer.id));
+        const hasChildren = layerRows.length > 0 || group.getGroups().length > 0;
         return {
             key: group.getId(),
             label: group.getTitle(),
             className: `t_group gid_${group.getId()}`,
+            collapsible: hasChildren ? 'header' : 'disabled',
             extra: <PanelToolContainer
                 group={group}
                 opts={opts}
@@ -75,7 +75,8 @@ const LayerCollapse = ({ groups, openGroupTitles, selectedLayerIds, opts, contro
 
     return (
         <StyledCollapse
-            bordered activeKey={openGroupTitles}
+            bordered
+            activeKey={openGroupTitles}
             onChange={keys => controller.updateOpenGroupTitles(keys)}
             items={groupItems}
         />

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
@@ -28,7 +28,7 @@ const StyledCollapse = styled(Collapse)`
     }
 `;
 
-const getLayerRowModels = (layers = [], selectedLayerIds = [], controller, opts) => {
+export const getLayerRowModels = (layers = [], selectedLayerIds = [], controller, opts) => {
     return layers.map(oskariLayer => {
         return {
             id: oskariLayer.getId(),

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
@@ -98,30 +98,25 @@ const StyledCollapsePanel = styled('div')`
     }
 `;
 
-const getLayerRowModels = (layers = [], selectedLayerIds = [], controller, opts) => {
-    return layers.map(oskariLayer => {
-        return {
-            id: oskariLayer.getId(),
-            model: oskariLayer,
-            selected: selectedLayerIds.includes(oskariLayer.getId()),
-            controller,
-            opts
-        };
-    });
-};
-
 const LayerCollapsePanel = (props) => {
-    const { group, selectedLayerIds, openGroupTitles, opts, controller, ...propsNeededForPanel } = props;
-    const layerRows = getLayerRowModels(group.getLayers(), selectedLayerIds, controller, opts);
-    // set group switch active if all layers in group are selected
-    const allLayersOnMap = layerRows.length > 0 && layerRows.every(layer => selectedLayerIds.includes(layer.id));
+    const { group, selectedLayerIds, layerRows, openGroupTitles, opts, controller, ...propsNeededForPanel } = props;
+    // const layerRows = getLayerRowModels(group.getLayers(), selectedLayerIds, controller, opts);
     // Note! Not rendering layerlist/subgroups when the panel is closed is a trade-off for performance
     //   between render as whole vs render when the panel is opened.
-    const isPanelOpen = propsNeededForPanel.isActive;
+    const isPanelOpen = true; // propsNeededForPanel.isActive;
     // after AntD version 4.9.0 we could disable panels without children:
     // const hasChildren = layerRows.length > 0 || group.getGroups().length > 0;
-    return <div>lorem_ipsum_placeholder_content</div>;
 
+    // return <><div>lorem_ipsum_placeholder_content </div>{group.getGroups()?.length}</>;
+
+    return (
+        <ErrorBoundary hide={true} debug={{ group, selectedLayerIds }}>
+            { isPanelOpen && <StyledCollapsePanel>
+                <LayerList layers={layerRows} />
+            </StyledCollapsePanel>
+            }
+        </ErrorBoundary>
+    );
     /*
     return (
         <ErrorBoundary hide={true} debug={{group, selectedLayerIds}}>
@@ -157,13 +152,13 @@ const LayerCollapsePanel = (props) => {
     */
 };
 
-
 LayerCollapsePanel.propTypes = {
     group: PropTypes.any.isRequired,
     selectedLayerIds: PropTypes.array.isRequired,
     openGroupTitles: PropTypes.array.isRequired,
     opts: PropTypes.object,
-    controller: PropTypes.instanceOf(Controller).isRequired
+    controller: PropTypes.instanceOf(Controller).isRequired,
+    layerRows: PropTypes.array
 };
 /*
 const comparisonFn = (prevProps, nextProps) => {

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
@@ -53,11 +53,15 @@ const LayerCollapsePanel = (props) => {
     // const layerRows = getLayerRowModels(group.getLayers(), selectedLayerIds, controller, opts);
     // Note! Not rendering layerlist/subgroups when the panel is closed is a trade-off for performance
     //   between render as whole vs render when the panel is opened.
-    const isPanelOpen = true; // propsNeededForPanel.isActive;
+
+    // After upgrade to antd 5.x this has become obsolete but keeping this line here commented,
+    // as a reminder to know where to start looking if there are performance issues.
+    //
+    // const isPanelOpen = propsNeededForPanel.isActive;
 
     return (
         <ErrorBoundary hide={true} debug={{ group, selectedLayerIds }}>
-            { isPanelOpen && <StyledCollapsePanel>
+            <StyledCollapsePanel>
                 <SubGroupList
                     subgroups={group.getGroups()}
                     selectedLayerIds={selectedLayerIds}
@@ -67,7 +71,6 @@ const LayerCollapsePanel = (props) => {
                     { ...propsNeededForPanel } />
                 <LayerList layers={layerRows} />
             </StyledCollapsePanel>
-            }
         </ErrorBoundary>
     );
 };

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
@@ -10,66 +10,6 @@ import { LAYER_GROUP_TOGGLE_LIMIT } from '../../../../constants';
 import styled from 'styled-components';
 import { InfoIcon } from 'oskari-ui/components/icons';
 
-/* ----- Group tools ------------- */
-const StyledCollapsePanelTools = styled.div`
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-`;
-
-// Memoed based on layerCount, allLayersOnMap and group.unfilteredLayerCount
-const PanelToolContainer = React.memo(({group, layerCount, allLayersOnMap, opts = {}, controller}) => {
-    const toggleLayersOnMap = (addLayers) => {
-        if (addLayers) {
-            controller.addGroupLayersToMap(group);
-        } else {
-            controller.removeGroupLayersFromMap(group);
-        }
-    };
-    // the switch adds ALL the layers in the group to the map so it's misleading if we show it when some layers are not shown in the list
-    // TODO: show switch for filtered layers BUT only add the layers that match the filter when toggled
-    const filtered = typeof group.unfilteredLayerCount !== 'undefined' && layerCount !== group.unfilteredLayerCount;
-    const toggleLimitExceeded = opts[LAYER_GROUP_TOGGLE_LIMIT] > 0 && layerCount > opts[LAYER_GROUP_TOGGLE_LIMIT];
-    const showAllLayersToggle = opts[LAYER_GROUP_TOGGLE_LIMIT] !== 0 && !toggleLimitExceeded && !filtered;
-    return (
-        <StyledCollapsePanelTools>
-            {group.description && (
-                <InfoIcon
-                    space={false}
-                    title={group.description}
-                    size={20}
-                    style={{ marginRight: '5px', marginTop: '3px' }}
-                />
-            )}
-            <LayerCountBadge
-                layerCount={layerCount}
-                unfilteredLayerCount={group.unfilteredLayerCount} />
-            { showAllLayersToggle && <AllLayersSwitch
-                checked={allLayersOnMap}
-                layerCount={layerCount}
-                onToggle={toggleLayersOnMap} />
-            }
-            <GroupToolRow group={group} />
-        </StyledCollapsePanelTools>
-    );
-}, (prevProps, nextProps) => {
-    if (prevProps.group.name !== nextProps.group.name) {
-        return false;
-    }
-    if (prevProps.group.description !== nextProps.group.description) {
-        return false;
-    }
-    const propsToCheck = ['allLayersOnMap', 'layerCount'];
-    const changed = propsToCheck.some(prop => prevProps[prop] !== nextProps[prop]);
-    if (changed) {
-        return false;
-    }
-    const unfilteredTypeChange = typeof prevProps.group.unfilteredLayerCount !== typeof nextProps.group.unfilteredLayerCount;
-    const unfilteredCountChange = prevProps.group.unfilteredLayerCount !== nextProps.group.unfilteredLayerCount;
-    return !unfilteredTypeChange || !unfilteredCountChange;
-});
-/* ----- /Group tools ------------- */
-
 /* ----- Layer list ------ */
 // Without this wrapper used here the "even" prop would be passed to "ListItem" that would generate an error
 // After we update to styled-components version 5.1 we could use "transient" props instead:
@@ -115,42 +55,46 @@ const SubGroupList = ({ subgroups = [], selectedLayerIds, openGroupTitles, opts,
         return null;
     }
 
-    return subgroups.map(group => {
-        return (
-            <StyledSubCollapse key={group.getId()}
+    const items = subgroups.map(group => {
+        const subItems = [{
+            key: group.getId(),
+            label: 'does_not_have_a_label_and_probably_shouldnt_be_a_collapse_anyway',
+            children: <LayerCollapsePanel
+                key={group.getId()}
+                group={group}
+                selectedLayerIds={selectedLayerIds}
+                openGroupTitles={openGroupTitles}
+                controller={controller}
+                opts={opts}
+                propsNeededForPanel={propsNeededForPanel}
+            />
+
+        }];
+        return {
+            key: group.getId(),
+            label: 'does_not_have_a_label_and_probably_shouldnt_be_a_collapse_anyway',
+            children: <StyledSubCollapse key={group.getId()}
                 activeKey={openGroupTitles}
-                onChange={keys => controller.updateOpenGroupTitles(keys)}>
-                <LayerCollapsePanel
-                    key={group.getId()}
-                    group={group}
-                    selectedLayerIds={selectedLayerIds}
-                    openGroupTitles={openGroupTitles}
-                    controller={controller}
-                    opts={opts}
-                    propsNeededForPanel={propsNeededForPanel}
-                />
-            </StyledSubCollapse>
-        );
+                onChange={keys => controller.updateOpenGroupTitles(keys)}
+                items={subItems}/>
+        }
     });
+
+    return (
+        <StyledSubCollapse key={'luffliff'}
+            activeKey={openGroupTitles}
+            onChange={keys => controller.updateOpenGroupTitles(keys)}
+            items={items}/>
+    );
 };
 /* ----- /Subgroup list ------ */
 
 /*  ----- Main component for LayerCollapsePanel ------ */
-// ant-collapse-content-box will have the layer list and subgroup layer list. 
+// ant-collapse-content-box will have the layer list and subgroup layer list.
 //  Without padding 0 the subgroups will be padded twice
-const StyledCollapsePanel = styled(CollapsePanel)`
-    > .ant-collapse-content > .ant-collapse-content-box {
-        padding: 0px;
-        & > .ant-list {
-            width: 100%;
-        }
-    }
+const StyledCollapsePanel = styled('div')`
     & > div:first-child {
         min-height: 22px;
-    }
-    & > .ant-collapse-header {
-        flex-direction: row;
-        flex-wrap: wrap !important;
     }
 `;
 
@@ -176,6 +120,9 @@ const LayerCollapsePanel = (props) => {
     const isPanelOpen = propsNeededForPanel.isActive;
     // after AntD version 4.9.0 we could disable panels without children:
     // const hasChildren = layerRows.length > 0 || group.getGroups().length > 0;
+    return <div>lorem_ipsum_placeholder_content</div>;
+
+    /*
     return (
         <ErrorBoundary hide={true} debug={{group, selectedLayerIds}}>
             <StyledCollapsePanel {...propsNeededForPanel}
@@ -207,6 +154,7 @@ const LayerCollapsePanel = (props) => {
             </StyledCollapsePanel>
         </ErrorBoundary>
     );
+    */
 };
 
 

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
@@ -39,7 +39,6 @@ LayerList.propTypes = {
 };
 /* ----- /Layer list ------ */
 
-
 /*  ----- Main component for LayerCollapsePanel ------ */
 // ant-collapse-content-box will have the layer list and subgroup layer list.
 //  Without padding 0 the subgroups will be padded twice
@@ -55,14 +54,7 @@ const LayerCollapsePanel = (props) => {
     // Note! Not rendering layerlist/subgroups when the panel is closed is a trade-off for performance
     //   between render as whole vs render when the panel is opened.
     const isPanelOpen = true; // propsNeededForPanel.isActive;
-    // after AntD version 4.9.0 we could disable panels without children:
-    // const hasChildren = layerRows.length > 0 || group.getGroups().length > 0;
 
-    // return <><div>lorem_ipsum_placeholder_content </div>{group.getGroups()?.length}</>;
-
-    if (!layerRows) {
-        console.log('pööp');
-    }
     return (
         <ErrorBoundary hide={true} debug={{ group, selectedLayerIds }}>
             { isPanelOpen && <StyledCollapsePanel>
@@ -78,39 +70,6 @@ const LayerCollapsePanel = (props) => {
             }
         </ErrorBoundary>
     );
-    /*
-    return (
-        <ErrorBoundary hide={true} debug={{group, selectedLayerIds}}>
-            <StyledCollapsePanel {...propsNeededForPanel}
-                // collapsible={hasChildren ? 'header' : 'disabled'}
-                // TODO: remove gid_[id] once data-attributes work for AntD Collapse.Panels
-                className={`t_group gid_${group.getId()}`}
-                // data-attr doesn't seem to work for the panel in AntD-version 4.8.5
-                data-gid={group.getId()}
-                header={group.getTitle()}
-                extra={
-                    <PanelToolContainer
-                        group={group}
-                        opts={opts}
-                        layerCount={group.getLayerCount()}
-                        controller={controller}
-                        allLayersOnMap={allLayersOnMap} />
-                }>
-                    { isPanelOpen && <React.Fragment>
-                        <SubGroupList
-                            subgroups={group.getGroups()}
-                            selectedLayerIds={selectedLayerIds}
-                            opts={opts}
-                            openGroupTitles={openGroupTitles}
-                            controller={controller}
-                            { ...propsNeededForPanel } />
-                        <LayerList
-                            layers={layerRows} />
-                    </React.Fragment>}
-            </StyledCollapsePanel>
-        </ErrorBoundary>
-    );
-    */
 };
 
 LayerCollapsePanel.propTypes = {
@@ -121,51 +80,4 @@ LayerCollapsePanel.propTypes = {
     controller: PropTypes.instanceOf(Controller).isRequired,
     layerRows: PropTypes.array
 };
-/*
-const comparisonFn = (prevProps, nextProps) => {
-    // expandIcon is something the parent component adds as a context
-    const ignored = ['expandIcon'];
-    const arrayChildCheck = ['selectedLayerIds'];
-    let useMemoized = true;
-
-    if (prevProps.group.getTitle() !== nextProps.group.getTitle()) {
-        // re-render if name changes
-        return false;
-    }
-    // check if layers have changed
-    const prevLayers = prevProps.group.getLayers().map(lyr => lyr.getId());
-    const nextLayers = nextProps.group.getLayers().map(lyr => lyr.getId());
-
-    if (!Oskari.util.arraysEqual(prevLayers, nextLayers)) {
-        return false;
-    }
-    // TODO: check if layer names have changed?
-    // check if group contains selected layers/layers that have been removed from selected layers
-    const prevLayersOnSelected = prevLayers.some(id => selectedLayerIds.includes(id));
-    const nextLayersOnSelected = nextLayers.some(id => selectedLayerIds.includes(id));
-    if (prevLayersOnSelected !== nextLayersOnSelected) {
-        return false;
-    }
-
-    Object.getOwnPropertyNames(nextProps).forEach(name => {
-        if (ignored.includes(name)) {
-            return;
-        }
-        // TODO: check if layerids <> selectedlayerids change?
-        if (arrayChildCheck.includes(name)) {
-            if (!Oskari.util.arraysEqual(nextProps[name], prevProps[name])) {
-                useMemoized = false;
-            }
-            return;
-        }
-        if (nextProps[name] !== prevProps[name]) {
-            useMemoized = false;
-        }
-    });
-    return useMemoized;
-};
-/*
-const memoized = React.memo(LayerCollapsePanel, comparisonFn);
-export { memoized as LayerCollapsePanel };
-*/
 export { LayerCollapsePanel };

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapsePanel.jsx
@@ -1,14 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Collapse, CollapsePanel, List, ListItem } from 'oskari-ui';
+import { List, ListItem } from 'oskari-ui';
 import { Controller, ErrorBoundary } from 'oskari-ui/util';
 import { Layer } from './Layer/';
-import { LayerCountBadge } from './LayerCountBadge';
-import { AllLayersSwitch } from './AllLayersSwitch';
-import { GroupToolRow } from './GroupToolRow';
-import { LAYER_GROUP_TOGGLE_LIMIT } from '../../../../constants';
+import { SubGroupList } from './SubGroupList';
 import styled from 'styled-components';
-import { InfoIcon } from 'oskari-ui/components/icons';
 
 /* ----- Layer list ------ */
 // Without this wrapper used here the "even" prop would be passed to "ListItem" that would generate an error
@@ -29,7 +25,7 @@ const renderLayer = (itemProps, index) => {
 };
 
 const LayerList = ({ layers }) => {
-    if (!layers.length) {
+    if (!layers?.length) {
         // no layers
         // return <div>No data</div>;
         return null;
@@ -43,51 +39,6 @@ LayerList.propTypes = {
 };
 /* ----- /Layer list ------ */
 
-/* ----- Subgroup list ------ */
-const StyledSubCollapse = styled(Collapse)`
-    border: none;
-    border-top: 1px solid #d9d9d9;
-    padding-left: 15px !important;
-`;
-const SubGroupList = ({ subgroups = [], selectedLayerIds, openGroupTitles, opts, controller, propsNeededForPanel }) => {
-    if (!subgroups.length) {
-        // no subgroups
-        return null;
-    }
-
-    const items = subgroups.map(group => {
-        const subItems = [{
-            key: group.getId(),
-            label: 'does_not_have_a_label_and_probably_shouldnt_be_a_collapse_anyway',
-            children: <LayerCollapsePanel
-                key={group.getId()}
-                group={group}
-                selectedLayerIds={selectedLayerIds}
-                openGroupTitles={openGroupTitles}
-                controller={controller}
-                opts={opts}
-                propsNeededForPanel={propsNeededForPanel}
-            />
-
-        }];
-        return {
-            key: group.getId(),
-            label: 'does_not_have_a_label_and_probably_shouldnt_be_a_collapse_anyway',
-            children: <StyledSubCollapse key={group.getId()}
-                activeKey={openGroupTitles}
-                onChange={keys => controller.updateOpenGroupTitles(keys)}
-                items={subItems}/>
-        }
-    });
-
-    return (
-        <StyledSubCollapse key={'luffliff'}
-            activeKey={openGroupTitles}
-            onChange={keys => controller.updateOpenGroupTitles(keys)}
-            items={items}/>
-    );
-};
-/* ----- /Subgroup list ------ */
 
 /*  ----- Main component for LayerCollapsePanel ------ */
 // ant-collapse-content-box will have the layer list and subgroup layer list.
@@ -109,9 +60,19 @@ const LayerCollapsePanel = (props) => {
 
     // return <><div>lorem_ipsum_placeholder_content </div>{group.getGroups()?.length}</>;
 
+    if (!layerRows) {
+        console.log('pööp');
+    }
     return (
         <ErrorBoundary hide={true} debug={{ group, selectedLayerIds }}>
             { isPanelOpen && <StyledCollapsePanel>
+                <SubGroupList
+                    subgroups={group.getGroups()}
+                    selectedLayerIds={selectedLayerIds}
+                    opts={opts}
+                    openGroupTitles={openGroupTitles}
+                    controller={controller}
+                    { ...propsNeededForPanel } />
                 <LayerList layers={layerRows} />
             </StyledCollapsePanel>
             }

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/PanelToolContainer.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/PanelToolContainer.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import styled from 'styled-components';
+import { PropTypes } from 'prop-types';
+import { LAYER_GROUP_TOGGLE_LIMIT } from '../../../../constants';
+import { LayerCountBadge } from './LayerCountBadge';
+import { AllLayersSwitch } from './AllLayersSwitch';
+import { InfoIcon } from 'oskari-ui/components/icons';
+import { GroupToolRow } from './GroupToolRow';
+
+/* ----- Group tools ------------- */
+const StyledCollapsePanelTools = styled.div`
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+`;
+
+// Memoed based on layerCount, allLayersOnMap and group.unfilteredLayerCount
+export const PanelToolContainer = React.memo(function PanelToolContainer ({ group, layerCount, allLayersOnMap, opts = {}, controller }) {
+    const toggleLayersOnMap = (addLayers) => {
+        if (addLayers) {
+            controller.addGroupLayersToMap(group);
+        } else {
+            controller.removeGroupLayersFromMap(group);
+        }
+    };
+    // the switch adds ALL the layers in the group to the map so it's misleading if we show it when some layers are not shown in the list
+    // TODO: show switch for filtered layers BUT only add the layers that match the filter when toggled
+    const filtered = typeof group.unfilteredLayerCount !== 'undefined' && layerCount !== group.unfilteredLayerCount;
+    const toggleLimitExceeded = opts[LAYER_GROUP_TOGGLE_LIMIT] > 0 && layerCount > opts[LAYER_GROUP_TOGGLE_LIMIT];
+    const showAllLayersToggle = opts[LAYER_GROUP_TOGGLE_LIMIT] !== 0 && !toggleLimitExceeded && !filtered;
+    return (
+        <StyledCollapsePanelTools>
+            {group.description && (
+                <InfoIcon
+                    space={false}
+                    title={group.description}
+                    size={20}
+                    style={{ marginRight: '5px', marginTop: '3px' }}
+                />
+            )}
+            <LayerCountBadge
+                layerCount={layerCount}
+                unfilteredLayerCount={group.unfilteredLayerCount} />
+            { showAllLayersToggle && <AllLayersSwitch
+                checked={allLayersOnMap}
+                layerCount={layerCount}
+                onToggle={toggleLayersOnMap} />
+            }
+            <GroupToolRow group={group} />
+        </StyledCollapsePanelTools>
+    );
+}, (prevProps, nextProps) => {
+    if (prevProps.group.name !== nextProps.group.name) {
+        return false;
+    }
+    if (prevProps.group.description !== nextProps.group.description) {
+        return false;
+    }
+    const propsToCheck = ['allLayersOnMap', 'layerCount'];
+    const changed = propsToCheck.some(prop => prevProps[prop] !== nextProps[prop]);
+    if (changed) {
+        return false;
+    }
+    const unfilteredTypeChange = typeof prevProps.group.unfilteredLayerCount !== typeof nextProps.group.unfilteredLayerCount;
+    const unfilteredCountChange = prevProps.group.unfilteredLayerCount !== nextProps.group.unfilteredLayerCount;
+    return !unfilteredTypeChange || !unfilteredCountChange;
+});
+
+PanelToolContainer.propTypes = {
+    group: PropTypes.any,
+    layerCount: PropTypes.any,
+    allLayersOnMap: PropTypes.bool,
+    opts: PropTypes.any,
+    controller: PropTypes.object
+};
+/* ----- /Group tools ------------- */

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/SubGroupList.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/SubGroupList.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Collapse } from 'oskari-ui';
+import { LayerCollapsePanel } from './LayerCollapsePanel';
+import styled from 'styled-components';
+import { Controller } from 'oskari-ui/util';
+import { getLayerRowModels } from './LayerCollapse';
+
+const StyledSubCollapse = styled(Collapse)`
+    border: none;
+    border-top: 1px solid #d9d9d9;
+    padding-left: 15px !important;
+`;
+export const SubGroupList = ({ subgroups = [], selectedLayerIds, openGroupTitles, opts, controller, propsNeededForPanel }) => {
+    if (!subgroups?.length) {
+        // no subgroups
+        return null;
+    }
+    const items = subgroups.map(group => {
+        return {
+            key: group.getId(),
+            label: group.getTitle(),
+            children: <LayerCollapsePanel
+                key={group.getId()}
+                group={group}
+                selectedLayerIds={selectedLayerIds}
+                openGroupTitles={openGroupTitles}
+                controller={controller}
+                opts={opts}
+                {... propsNeededForPanel}
+                layerRows={getLayerRowModels(group.getLayers(), selectedLayerIds, controller, opts)}
+            />
+        };
+    });
+    return <StyledSubCollapse
+        activeKey={openGroupTitles}
+        onChange={keys => controller.updateOpenGroupTitles(keys)}
+        items={items}
+    />;
+};
+
+SubGroupList.propTypes = {
+    subgroups: PropTypes.any.isRequired,
+    selectedLayerIds: PropTypes.array.isRequired,
+    openGroupTitles: PropTypes.array.isRequired,
+    opts: PropTypes.object,
+    controller: PropTypes.instanceOf(Controller).isRequired,
+    layerRows: PropTypes.array,
+    propsNeededForPanel: PropTypes.any
+};


### PR DESCRIPTION
layerlist collapses to use items instead of children & refactor the code a bit