### PR TITLE
Antd v5 migration zindex fixes

### DIFF
--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -532,3 +532,7 @@ This seems to only happen on the Firefox browser
 .ant-dropdown {
   z-index: 30050 !important;
 }
+
+.ant-popover {
+  z-index: 30030 !important;
+}

--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -540,3 +540,7 @@ This seems to only happen on the Firefox browser
 .ant-picker-dropdown {
   z-index: 30050 !important;
 }
+
+.ant-message, .ant-notification {
+  z-index: 30010 !important;
+}

--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -536,3 +536,7 @@ This seems to only happen on the Firefox browser
 .ant-popover {
   z-index: 30030 !important;
 }
+
+.ant-picker-dropdown {
+  z-index: 30050 !important;
+}

--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -523,7 +523,12 @@ This seems to only happen on the Firefox browser
 
 /*
   Fixes antd v5 dropdown menus opening under flyouts
+  z-index values copied from the old .less implementation
 */
 .ant-select-dropdown {
-  z-index: 99998 !important;
+  z-index: 30050 !important;
+}
+
+.ant-dropdown {
+  z-index: 30050 !important;
 }


### PR DESCRIPTION
-popover, color picker, daterange picker and notifications & messages now appear on top of other things