### PR TITLE
Add coordinates to GFI popup

### DIFF
--- a/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
+++ b/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
@@ -165,7 +165,7 @@ Oskari.clazz.define(
             var me = this,
                 contentDiv = me._renderContentData(id, contentData),
                 sanitizedTitle = Oskari.util.sanitize(title),
-                popupContentHtml = me._renderPopupContent(id, sanitizedTitle, contentDiv, additionalTools,lonlat, options.showCoordinates),
+                popupContentHtml = me._renderPopupContent(id, sanitizedTitle, contentDiv, additionalTools, lonlat, options.showCoordinates),
                 popupElement = me._popupWrapper.clone(),
                 lonlatArray = [lonlat.lon, lonlat.lat],
                 colourScheme = options.colourScheme,
@@ -377,11 +377,10 @@ Oskari.clazz.define(
 
             headerWrapper.append(popupHeaderTitle);
 
-            // do we show coordinates?
+            // render coordinates to gfi header 
             if (showCoordinates) {
                 let mapModule = this.getMapModule();
                 let loc = Oskari.getLocalization('coordinatetool');
-
                 let crs = mapModule.getProjection();
 
                 let coordinateWrapper = jQuery('<div class="coordinateWrapper"></div>');
@@ -408,15 +407,9 @@ Oskari.clazz.define(
                     lonlatString = loc.display.compass.n + ': ' + lat + ' ' + loc.display.compass.e + ': ' + lon;
                 }
 
-                let srsDiv = jQuery('<div></div>');
-                let lonlatDiv = jQuery('<div></div>');
-
                 let crsText = loc.display.crs[crs] || crs;
-
-                srsDiv.append(crsText);
-                lonlatDiv.append(lonlatString);
-
-                coordinateWrapper.append(srsDiv);
+                let crsDiv = jQuery('<div>' + crsText + '</div>');
+                coordinateWrapper.append(crsDiv);
                 coordinateWrapper.append(lonlatString);
                 headerWrapper.append(coordinateWrapper);
             }

--- a/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
+++ b/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
@@ -377,7 +377,7 @@ Oskari.clazz.define(
 
             headerWrapper.append(popupHeaderTitle);
 
-            // render coordinates to gfi header 
+            // render coordinates to gfi header
             if (showCoordinates) {
                 let mapModule = this.getMapModule();
                 let loc = Oskari.getLocalization('coordinatetool');

--- a/bundles/mapping/infobox/resources/scss/infobox.ol.scss
+++ b/bundles/mapping/infobox/resources/scss/infobox.ol.scss
@@ -127,20 +127,39 @@ div.popupHeader {
     margin: 0px;
     @include border-radius(6px 6px 0px 0px);
     display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    width: 390px;
+    float: left;
+    height: auto;
+  
+    div.popupHeaderTitle {
+    display: flex;
     flex-direction: row;
     justify-content: space-between;
     width: 390px;
     float: left;
     height: 40px;
+    padding-left: 15px;
+
 
     div {
         vertical-align: top;
-        padding-left: 15px;
         padding-right: 0;
         padding-top: 10px;
         word-break: break-word;
     }
-
+  }
+    div.coordinateWrapper {
+      font-size: 12px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      width: 390px;
+      float: left;
+      padding-left: 15px;
+      padding-bottom: 5px;
+  }
 }
 
 div.popupContent {

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
@@ -573,7 +573,8 @@ Oskari.clazz.define(
             var options = {
                 hidePrevious: params.hidePrevious === undefined ? true : params.hidePrevious,
                 colourScheme: params.colourScheme,
-                font: params.font
+                font: params.font,
+                showCoordinates: this._config.showCoordinates
             };
             if (reqBuilder) {
                 var request = reqBuilder(


### PR DESCRIPTION
Show coordinate projection and the coordinates of a clicked point on map in GFI popup.

Requires _showCoordinates: true_ to be added to mapfull GetInfoPlugin cofig.