### PR TITLE
Historic ortophotos timeseries mobile tweak

### DIFF
--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesHeader.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesHeader.jsx
@@ -48,7 +48,7 @@ export const TimeSeriesHeader = ({ toggleMode, title, mode = 'year', loading = f
     const switchButtonMessage = <Message messageKey={switchButtonMessageKey} />;
     const modeIcon = mode === 'year' ? <LoginOutlined /> : <LogoutOutlined />;
     return (
-        <Header className="timeseries-range-drag-handle" textcolor={textColor} hovercolor={hoverColor}>
+        <Header className="timeseries-range-drag-handle" textColor={textColor} hovercolor={hoverColor}>
             {getHeaderContent(title, loading, error, value)}
             <div className="header-mid-spacer"></div>
             <Tooltip title={getTooltipContent(mode, modeIcon)}>

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesHeader.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesHeader.jsx
@@ -42,13 +42,13 @@ const getTooltipContent = (mode, modeIcon) => {
     );
 }
 
-export const TimeSeriesHeader = ({ toggleMode, title, mode = 'year', loading = false, error = false, value}) => {
+export const TimeSeriesHeader = ({ toggleMode, title, mode = 'year', loading = false, error = false, value, theme}) => {
     const helpMessage = <Message messageKey="rangeControl.helpMessage" />;
     const switchButtonMessageKey = mode === 'year' ? 'rangeControl.switchToRange' : 'rangeControl.switchToYear';
     const switchButtonMessage = <Message messageKey={switchButtonMessageKey} />;
     const modeIcon = mode === 'year' ? <LoginOutlined /> : <LogoutOutlined />;
     return (
-        <Header className="timeseries-range-drag-handle">
+        <Header className="timeseries-range-drag-handle" theme={theme}>
             {getHeaderContent(title, loading, error, value)}
             <div className="header-mid-spacer"></div>
             <Tooltip title={getTooltipContent(mode, modeIcon)}>
@@ -70,5 +70,7 @@ TimeSeriesHeader.propTypes = {
     title: PropTypes.string.isRequired,
     mode: PropTypes.oneOf(['year', 'range']),
     loading: PropTypes.bool,
-    error: PropTypes.bool
+    error: PropTypes.bool,
+    value: PropTypes.any,
+    theme: PropTypes.object
 };

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesHeader.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesHeader.jsx
@@ -42,22 +42,22 @@ const getTooltipContent = (mode, modeIcon) => {
     );
 }
 
-export const TimeSeriesHeader = ({ toggleMode, title, mode = 'year', loading = false, error = false, value, theme}) => {
+export const TimeSeriesHeader = ({ toggleMode, title, mode = 'year', loading = false, error = false, value, textColor, hoverColor }) => {
     const helpMessage = <Message messageKey="rangeControl.helpMessage" />;
     const switchButtonMessageKey = mode === 'year' ? 'rangeControl.switchToRange' : 'rangeControl.switchToYear';
     const switchButtonMessage = <Message messageKey={switchButtonMessageKey} />;
     const modeIcon = mode === 'year' ? <LoginOutlined /> : <LogoutOutlined />;
     return (
-        <Header className="timeseries-range-drag-handle" theme={theme}>
+        <Header className="timeseries-range-drag-handle" textColor={textColor} hoverColor={hoverColor}>
             {getHeaderContent(title, loading, error, value)}
             <div className="header-mid-spacer"></div>
             <Tooltip title={getTooltipContent(mode, modeIcon)}>
-                <IconButton type="text" size="large" theme={theme}>
+                <IconButton type="text" size="large" textColor={textColor} hoverColor={hoverColor}>
                     <QuestionCircleOutlined />
                 </IconButton>
             </Tooltip>
             <Tooltip title={switchButtonMessage}>
-                <IconButton type="text" size="large" onClick={() => toggleMode()} theme={theme}>
+                <IconButton type="text" size="large" onClick={() => toggleMode()} textColor={textColor} hoverColor={hoverColor}>
                     {modeIcon}
                 </IconButton>
             </Tooltip>
@@ -72,5 +72,6 @@ TimeSeriesHeader.propTypes = {
     loading: PropTypes.bool,
     error: PropTypes.bool,
     value: PropTypes.any,
-    theme: PropTypes.object
+    textColor: PropTypes.string,
+    hoverColor: PropTypes.string
 };

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesHeader.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesHeader.jsx
@@ -52,12 +52,12 @@ export const TimeSeriesHeader = ({ toggleMode, title, mode = 'year', loading = f
             {getHeaderContent(title, loading, error, value)}
             <div className="header-mid-spacer"></div>
             <Tooltip title={getTooltipContent(mode, modeIcon)}>
-                <IconButton type="text" size="large">
+                <IconButton type="text" size="large" theme={theme}>
                     <QuestionCircleOutlined />
                 </IconButton>
             </Tooltip>
             <Tooltip title={switchButtonMessage}>
-                <IconButton type="text" size="large" onClick={() => toggleMode()}>
+                <IconButton type="text" size="large" onClick={() => toggleMode()} theme={theme}>
                     {modeIcon}
                 </IconButton>
             </Tooltip>

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesHeader.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesHeader.jsx
@@ -48,16 +48,16 @@ export const TimeSeriesHeader = ({ toggleMode, title, mode = 'year', loading = f
     const switchButtonMessage = <Message messageKey={switchButtonMessageKey} />;
     const modeIcon = mode === 'year' ? <LoginOutlined /> : <LogoutOutlined />;
     return (
-        <Header className="timeseries-range-drag-handle" textColor={textColor} hoverColor={hoverColor}>
+        <Header className="timeseries-range-drag-handle" textcolor={textColor} hovercolor={hoverColor}>
             {getHeaderContent(title, loading, error, value)}
             <div className="header-mid-spacer"></div>
             <Tooltip title={getTooltipContent(mode, modeIcon)}>
-                <IconButton type="text" size="large" textColor={textColor} hoverColor={hoverColor}>
+                <IconButton type="text" size="large" $textColor={textColor} $hoverColor={hoverColor}>
                     <QuestionCircleOutlined />
                 </IconButton>
             </Tooltip>
             <Tooltip title={switchButtonMessage}>
-                <IconButton type="text" size="large" onClick={() => toggleMode()} textColor={textColor} hoverColor={hoverColor}>
+                <IconButton type="text" size="large" onClick={() => toggleMode()} $textColor={textColor} $hoverColor={hoverColor}>
                     {modeIcon}
                 </IconButton>
             </Tooltip>

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
@@ -5,8 +5,10 @@ import { Background } from './styled';
 import { TimeSeriesHeader } from './TimeSeriesHeader';
 import { TimeSeriesRange } from './TimeSeriesRange';
 import { TimeSeriesYear } from './TimeSeriesYear';
+import { ThemeConsumer } from 'oskari-ui/util';
 
-export const TimeSeriesRangeControl = ({
+export const TimeSeriesRangeControl = ThemeConsumer(({
+    theme,
     controller,
     title,
     start,
@@ -28,6 +30,7 @@ export const TimeSeriesRangeControl = ({
     return (
         <Background isMobile={isMobile}>
             <TimeSeriesHeader
+                theme={theme}
                 toggleMode={() => toggleMode()}
                 title={title}
                 mode={mode}
@@ -57,7 +60,7 @@ export const TimeSeriesRangeControl = ({
             )}
         </Background>
     );
-};
+});
 
 TimeSeriesRangeControl.propTypes = {
     controller: PropTypes.instanceOf(Controller).isRequired,

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
@@ -1,11 +1,11 @@
-import { Controller } from 'oskari-ui/util';
+import { Controller, ThemeConsumer } from 'oskari-ui/util';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Background } from './styled';
 import { TimeSeriesHeader } from './TimeSeriesHeader';
 import { TimeSeriesRange } from './TimeSeriesRange';
 import { TimeSeriesYear } from './TimeSeriesYear';
-import { ThemeConsumer } from 'oskari-ui/util';
+import { getNavigationTheme } from 'oskari-ui/theme/ThemeHelper';
 
 export const TimeSeriesRangeControl = ThemeConsumer(({
     theme,
@@ -27,10 +27,16 @@ export const TimeSeriesRangeControl = ThemeConsumer(({
             controller.updateValue(value[1], 'year');
         }
     };
+    const navigationTheme = getNavigationTheme(theme);
+    const textColor = navigationTheme.getTextColor();
+    const hoverColor = navigationTheme.getButtonHoverColor();
+    const backgroundColor = navigationTheme.getNavigationBackgroundColor();
+
     return (
-        <Background theme={theme} isMobile={isMobile}>
+        <Background textColor={textColor} backgroundColor={backgroundColor} isMobile={isMobile}>
             <TimeSeriesHeader
-                theme={theme}
+                textColor={textColor}
+                hoverColor={hoverColor}
                 toggleMode={() => toggleMode()}
                 title={title}
                 mode={mode}

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesRangeControl.jsx
@@ -28,7 +28,7 @@ export const TimeSeriesRangeControl = ThemeConsumer(({
         }
     };
     return (
-        <Background isMobile={isMobile}>
+        <Background theme={theme} isMobile={isMobile}>
             <TimeSeriesHeader
                 theme={theme}
                 toggleMode={() => toggleMode()}

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesYear.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesYear.jsx
@@ -5,6 +5,15 @@ import React from 'react';
 import { Col, ColFixed, Row } from './styled';
 import { YearRangeSlider } from './YearRangeSlider';
 import { ThemeConsumer } from 'oskari-ui/util';
+
+const ForwardIcon = () => {
+    return <StepForwardOutlined style={{ fontSize: '125%' }}/>;
+};
+
+const BackwardIcon = () => {
+    return <StepBackwardOutlined style={{ fontSize: '125%' }}/>;
+};
+
 export const TimeSeriesYear = ThemeConsumer(({ onChange, start, end, value, dataYears, isMobile, theme }) => {
     const currentYearIntValue = parseInt(value);
     // when current value is after last data layer
@@ -49,7 +58,7 @@ export const TimeSeriesYear = ThemeConsumer(({ onChange, start, end, value, data
                     disabled={prevDataYear === null}
                     onClick={() => onChange(prevDataYear)}
                 >
-                    <StepBackwardOutlined />
+                    <BackwardIcon />
                 </Button>
             </Col>
             <Col>
@@ -62,7 +71,7 @@ export const TimeSeriesYear = ThemeConsumer(({ onChange, start, end, value, data
                     disabled={nextDataYear === null}
                     onClick={() => onChange(nextDataYear)}
                 >
-                    <StepForwardOutlined />
+                    <ForwardIcon/>
                 </Button>
             </Col>
         </Row>;
@@ -77,7 +86,7 @@ export const TimeSeriesYear = ThemeConsumer(({ onChange, start, end, value, data
                     disabled={prevDataYear === null}
                     onClick={() => onChange(prevDataYear)}
                 >
-                    <StepBackwardOutlined />
+                    <BackwardIcon />
                 </Button>
             </Col>
             <ColFixed>
@@ -99,7 +108,7 @@ export const TimeSeriesYear = ThemeConsumer(({ onChange, start, end, value, data
                     disabled={nextDataYear === null}
                     onClick={() => onChange(nextDataYear)}
                 >
-                    <StepForwardOutlined />
+                    <ForwardIcon/>
                 </Button>
             </Col>
         </Row>

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesYear.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesYear.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { Col, ColFixed, Row } from './styled';
 import { YearRangeSlider } from './YearRangeSlider';
 import { ThemeConsumer } from 'oskari-ui/util';
+import { getNavigationTheme } from 'oskari-ui/theme/ThemeHelper';
 
 const ForwardIcon = () => {
     return <StepForwardOutlined style={{ fontSize: '125%' }}/>;
@@ -34,6 +35,10 @@ export const TimeSeriesYear = ThemeConsumer(({ onChange, start, end, value, data
         }
     }
 
+    const navigationTheme = getNavigationTheme(theme);
+    const textColor = navigationTheme.getTextColor();
+    const hoverColor = navigationTheme.getButtonHoverColor();
+    const backgroundColor = navigationTheme.getNavigationBackgroundColor();
     if (isMobile) {
         const currentYearDisabled = !dataYears?.includes(currentYearIntValue);
         // need to clone this, otherwise the "current year" will remain even if we switch to a valid year without panning the map
@@ -51,7 +56,7 @@ export const TimeSeriesYear = ThemeConsumer(({ onChange, start, end, value, data
             });
 
         return <Row>
-            <Col>
+            <Col textColor={textColor} hoverColor={hoverColor} backgroundColor={backgroundColor}>
                 <Button
                     type="primary"
                     shape="circle"
@@ -61,10 +66,10 @@ export const TimeSeriesYear = ThemeConsumer(({ onChange, start, end, value, data
                     <BackwardIcon />
                 </Button>
             </Col>
-            <Col>
+            <Col textColor={textColor} hoverColor={hoverColor} backgroundColor={backgroundColor}>
                 <Select value={currentYearIntValue} onChange={(value) => onChange(parseInt(value))}>{options}</Select>
             </Col>
-            <Col theme={theme}>
+            <Col textColor={textColor} hoverColor={hoverColor} backgroundColor={backgroundColor}>
                 <Button
                     type="primary"
                     shape="circle"
@@ -79,7 +84,7 @@ export const TimeSeriesYear = ThemeConsumer(({ onChange, start, end, value, data
 
     return (
         <Row>
-            <Col theme={theme}>
+            <Col textColor={textColor} hoverColor={hoverColor} backgroundColor={backgroundColor}>
                 <Button
                     type="primary"
                     shape="circle"
@@ -101,7 +106,7 @@ export const TimeSeriesYear = ThemeConsumer(({ onChange, start, end, value, data
                     onChange={(val) => onChange(val)}
                 />
             </ColFixed>
-            <Col theme={theme}>
+            <Col textColor={textColor} hoverColor={hoverColor} backgroundColor={backgroundColor}>
                 <Button
                     type="primary"
                     shape="circle"

--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesYear.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesYear.jsx
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Col, ColFixed, Row } from './styled';
 import { YearRangeSlider } from './YearRangeSlider';
-
-export const TimeSeriesYear = ({ onChange, start, end, value, dataYears, isMobile }) => {
+import { ThemeConsumer } from 'oskari-ui/util';
+export const TimeSeriesYear = ThemeConsumer(({ onChange, start, end, value, dataYears, isMobile, theme }) => {
     const currentYearIntValue = parseInt(value);
     // when current value is after last data layer
     let prevDataYear = dataYears[dataYears.length - 1] || null;
@@ -55,7 +55,7 @@ export const TimeSeriesYear = ({ onChange, start, end, value, dataYears, isMobil
             <Col>
                 <Select value={currentYearIntValue} onChange={(value) => onChange(parseInt(value))}>{options}</Select>
             </Col>
-            <Col>
+            <Col theme={theme}>
                 <Button
                     type="primary"
                     shape="circle"
@@ -70,7 +70,7 @@ export const TimeSeriesYear = ({ onChange, start, end, value, dataYears, isMobil
 
     return (
         <Row>
-            <Col>
+            <Col theme={theme}>
                 <Button
                     type="primary"
                     shape="circle"
@@ -92,7 +92,7 @@ export const TimeSeriesYear = ({ onChange, start, end, value, dataYears, isMobil
                     onChange={(val) => onChange(val)}
                 />
             </ColFixed>
-            <Col>
+            <Col theme={theme}>
                 <Button
                     type="primary"
                     shape="circle"
@@ -104,7 +104,7 @@ export const TimeSeriesYear = ({ onChange, start, end, value, dataYears, isMobil
             </Col>
         </Row>
     );
-};
+});
 
 TimeSeriesYear.propTypes = {
     onChange: PropTypes.func.isRequired,

--- a/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
@@ -6,11 +6,11 @@ const backgroundColor = '#3c3c3c';
 const borderColor = '#3c3c3c';
 const noDataColor = '#FF0000';
 
-export const Background = styled.div(({ isMobile }) => ({
-    minHeight: isMobile ? '120px !important' : '90px !imoprtant',
-    width: isMobile ? '260px !important' : '720px !important',
-    color: '#ffffff',
-    backgroundColor: backgroundColor
+export const Background = styled.div(({ isMobile, theme }) => ({
+    'minHeight': isMobile ? '120px !important' : '90px !imoprtant',
+    'width': isMobile ? '260px !important' : '720px !important',
+    'color': theme ? theme?.map?.navigation?.color?.text : '#ffffff',
+    'background-color': theme ? theme?.color?.icon : backgroundColor
 }));
 
 export const Header = styled.h3`

--- a/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
@@ -19,7 +19,7 @@ export const Header = styled.h3`
     cursor: move;
     display: flex;
     align-items: center;
-    color: ${props => props?.theme ? props?.theme?.color?.accent : '#ffffff'};
+    color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.text : '#ffffff'};
     .header-mid-spacer {
         flex: 1;
     }
@@ -27,12 +27,12 @@ export const Header = styled.h3`
 
 export const IconButton = styled(Button)`
     padding: 10px;
-    color: ${primaryColor};
+    color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.text : primaryColor};
 
     &:hover,
     &:focus,
     &:active {
-        color: ${primaryColor};
+        color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.accent : primaryColor};
     }
 
     .anticon {

--- a/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
@@ -27,12 +27,12 @@ export const Header = styled.h3`
 
 export const IconButton = styled(Button)`
     padding: 10px;
-    color: ${props => props?.textColor ? props?.textColor : primaryColor};
+    color: ${props => props?.$textColor ? props?.$textColor : primaryColor};
 
     &:hover,
     &:focus,
     &:active {
-        color: ${props => props?.hoverColor ? props?.hoverColor : primaryColor};
+        color: ${props => props?.$hovercolor ? props?.$hovercolor : primaryColor};
         background: transparent;
     }
 

--- a/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
@@ -33,6 +33,7 @@ export const IconButton = styled(Button)`
     &:focus,
     &:active {
         color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.accent : primaryColor};
+        background: transparent;
     }
 
     .anticon {
@@ -61,6 +62,7 @@ export const Col = styled.div`
         background-color: ${props => props?.theme ? props?.theme?.color?.icon : primaryColor};
         border-width: 2px;
         border-color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.text : primaryColor};
+        color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.text : primaryColor};
 
         &:hover,
         &:focus,

--- a/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
@@ -59,12 +59,14 @@ export const Col = styled.div`
 
     button {
         background-color: ${props => props?.theme ? props?.theme?.color?.icon : primaryColor};
+        border-width: 2px;
         border-color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.text : primaryColor};
 
         &:hover,
         &:focus,
         &:active {
             background-color: ${props => props?.theme ? props?.theme?.color?.icon : primaryColor};
+            border-width: 2px;
             border-color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.accent : primaryColor};
             color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.accent : primaryColor};
         }

--- a/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
@@ -58,14 +58,15 @@ export const Col = styled.div`
     position: relative;
 
     button {
-        background-color: ${primaryColor};
-        border-color: ${primaryColor};
+        background-color: ${props => props?.theme ? props?.theme?.color?.icon : primaryColor};
+        border-color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.text : primaryColor};
 
         &:hover,
         &:focus,
         &:active {
-            background-color: ${primaryColor};
-            border-color: ${primaryColor};
+            background-color: ${props => props?.theme ? props?.theme?.color?.icon : primaryColor};
+            border-color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.accent : primaryColor};
+            color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.accent : primaryColor};
         }
     }
 `;

--- a/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
@@ -19,7 +19,7 @@ export const Header = styled.h3`
     cursor: move;
     display: flex;
     align-items: center;
-    color: #ffffff;
+    color: ${props => props?.theme ? props?.theme?.color?.accent : '#ffffff'};
     .header-mid-spacer {
         flex: 1;
     }

--- a/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
@@ -2,15 +2,15 @@ import { Button, NumberInput } from 'oskari-ui';
 import styled from 'styled-components';
 
 const primaryColor = '#ecb900';
-const backgroundColor = '#3c3c3c';
+const bgColor = '#3c3c3c';
 const borderColor = '#3c3c3c';
 const noDataColor = '#FF0000';
 
-export const Background = styled.div(({ isMobile, theme }) => ({
-    'minHeight': isMobile ? '120px !important' : '90px !imoprtant',
+export const Background = styled.div(({ isMobile, textColor, backgroundColor }) => ({
+    'minHeight': isMobile ? '120px !important' : '90px !important',
     'width': isMobile ? '260px !important' : '720px !important',
-    'color': theme ? theme?.map?.navigation?.color?.text : '#ffffff',
-    'background-color': theme ? theme?.color?.icon : backgroundColor
+    'color': textColor || '#ffffff',
+    'background-color': backgroundColor || bgColor
 }));
 
 export const Header = styled.h3`
@@ -19,7 +19,7 @@ export const Header = styled.h3`
     cursor: move;
     display: flex;
     align-items: center;
-    color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.text : '#ffffff'};
+    color: ${props => props?.textColor ? props?.textColor : '#ffffff'};
     .header-mid-spacer {
         flex: 1;
     }
@@ -27,12 +27,12 @@ export const Header = styled.h3`
 
 export const IconButton = styled(Button)`
     padding: 10px;
-    color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.text : primaryColor};
+    color: ${props => props?.textColor ? props?.textColor : primaryColor};
 
     &:hover,
     &:focus,
     &:active {
-        color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.accent : primaryColor};
+        color: ${props => props?.hoverColor ? props?.hoverColor : primaryColor};
         background: transparent;
     }
 
@@ -59,18 +59,18 @@ export const Col = styled.div`
     position: relative;
 
     button {
-        background-color: ${props => props?.theme ? props?.theme?.color?.icon : primaryColor};
+        background-color: ${props => props?.backgroundColor ? props?.backgroundColor : primaryColor};
         border-width: 2px;
-        border-color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.text : primaryColor};
-        color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.text : primaryColor};
+        border-color: ${props => props?.textColor ? props?.textColor : primaryColor};
+        color: ${props => props?.textColor ? props?.textColor : primaryColor};
 
         &:hover,
         &:focus,
         &:active {
-            background-color: ${props => props?.theme ? props?.theme?.color?.icon : primaryColor};
+            background-color: ${props => props?.backgroundColor ? props?.backgroundColor : primaryColor};
             border-width: 2px;
-            border-color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.accent : primaryColor};
-            color: ${props => props?.theme ? props?.theme?.map?.navigation?.color?.accent : primaryColor};
+            border-color: ${props => props?.hoverColor ? props?.hoverColor : primaryColor};
+            color: ${props => props?.hoverColor ? props?.hoverColor : primaryColor};
         }
     }
 `;

--- a/bundles/framework/timeseries/view/TimeSeriesRangeControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeSeriesRangeControlPlugin.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { LocaleProvider } from 'oskari-ui/util';
+import { LocaleProvider, ThemeProvider } from 'oskari-ui/util';
 import { TimeSeriesRangeControl } from './TimeSeriesRange/TimeSeriesRangeControl';
 import { TimeSeriesRangeControlHandler } from './TimeSeriesRange/TimeSeriesRangeControlHandler';
 
@@ -73,11 +73,13 @@ class TimeSeriesRangeControlPlugin extends BasicMapModulePlugin {
         }
         ReactDOM.render(
             <LocaleProvider value={{ bundleKey: 'timeseries' }}>
-                <TimeSeriesRangeControl
-                    {...this.stateHandler.getState()}
-                    controller={this.stateHandler.getController()}
-                    isMobile={this._isMobile}
-                />
+                <ThemeProvider>
+                    <TimeSeriesRangeControl
+                        {...this.stateHandler.getState()}
+                        controller={this.stateHandler.getController()}
+                        isMobile={this._isMobile}
+                    />
+                </ThemeProvider>
             </LocaleProvider>,
             mountElement
         );

--- a/bundles/framework/timeseries/view/TimeSeriesRangeControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeSeriesRangeControlPlugin.js
@@ -19,6 +19,8 @@ class TimeSeriesRangeControlPlugin extends BasicMapModulePlugin {
         this._element = null;
         this._isMobile = Oskari.util.isMobile();
         this._sandbox = Oskari.getSandbox();
+        this.mapModule = this._sandbox.findRegisteredModuleInstance('MainMapModule');
+
         this._delegate = delegate;
 
         this.stateHandler = new TimeSeriesRangeControlHandler(delegate, () => this.updateUI());
@@ -73,7 +75,7 @@ class TimeSeriesRangeControlPlugin extends BasicMapModulePlugin {
         }
         ReactDOM.render(
             <LocaleProvider value={{ bundleKey: 'timeseries' }}>
-                <ThemeProvider>
+                <ThemeProvider value={this.mapModule.getMapTheme()}>
                     <TimeSeriesRangeControl
                         {...this.stateHandler.getState()}
                         controller={this.stateHandler.getController()}

--- a/src/react/theme/ThemeHelper.js
+++ b/src/react/theme/ThemeHelper.js
@@ -39,7 +39,8 @@ export const getNavigationTheme = (theme) => {
         // like 0.5 for calc() usage
         getButtonRoundnessFactor: () => borderRadius / 100,
         getEffect: () => theme.navigation?.effect,
-        getButtonOpacity: () => theme.navigation?.opacity || 1
+        getButtonOpacity: () => theme.navigation?.opacity || 1,
+        getNavigationBackgroundColor: () => theme.navigation?.color?.bg || theme.navigation?.color?.primary || DEFAULT_COLORS.NAV_BG
     };
     return funcs;
 };

--- a/src/react/theme/globalStyles.js
+++ b/src/react/theme/globalStyles.js
@@ -7,7 +7,7 @@ document.head.appendChild(GLOBAL_STYLE);
 
 export const setGlobalStyle = (theme = {}) => {
     // default to dark gray
-    const navColor = theme.navigation?.color?.primary || DEFAULT_COLORS.NAV_BG;
+    const navColor = theme.navigation?.color?.bg || theme.navigation?.color?.primary || DEFAULT_COLORS.NAV_BG;
     const headerTheme = getHeaderTheme(theme);
     const navigationDimensions = getNavigationDimensions();
     // inject Theme support for jQuery-based UI-elements (navigation, flyout, popup)


### PR DESCRIPTION
Added a new variable to the navigation theme for bg color. This needs to be added to the theme of the app using the historical ortophotos timeseries. For instance in paikkis ->

Oskari.app.getTheming().setTheme({
    "color": {
        "icon": "#3c3c3c",
        "accent": "#ffd400",
        "primary": "#fdf8d9",
        "text": "#3c3c3c"
    },
    "map": {
        "color": {
            "header": {
                "bg": "#fdf8d9",
                "icon": "#3c3c3c",
                "text": "#3c3c3c"
            },
            "accent": "#ffd400"
        },
        "navigation": {
            "color": {
                "text": "#FFFFFF",
                "accent": "#ffd400",
                "primary": "#141414",
                "bg": "#3c3c3c"
            },
            "roundness": 100,
            "opacity": 0.8
        },
        "font": "arial"
    }
});

Paikkis without setting the new variable (using the buttons' default background):
![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/85423d4f-cb34-4492-b090-2df0cb8ab0fb)

With the variable set to something lighter: 
![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/d11ee539-c763-439e-9286-6f39d984ac8c)

...and with ASDI theme and no navigation bg set the result is still readable
![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/5d937d98-02cf-41db-ad7b-f236d99b3a51)
