### PR TITLE
Initial attempt to make getRegions() caching work with async

### DIFF
--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -5,6 +5,16 @@ import { populateIndicatorOptions } from './SearchIndicatorOptionsHelper';
 import { getIndicatorMetadata } from './IndicatorHelper';
 import { getDatasources, getUnsupportedDatasourceIds } from '../helper/ConfigHelper';
 
+const getValueAsArray = (selection) => {
+    if (selection === null || typeof selection === 'undefined') {
+        return [];
+    }
+    if (Array.isArray(selection)) {
+        return selection;
+    }
+    return [selection];
+};
+
 class SearchController extends StateHandler {
     constructor (instance, service, stateHandler) {
         super();
@@ -434,8 +444,9 @@ class SearchController extends StateHandler {
      * @param {Object} commonSearchValues User's selected values from the search form
      */
     async handleMultipleIndicatorsSearch (commonSearchValues) {
-        const indicators = Array.isArray(commonSearchValues.indicator) ? commonSearchValues.indicator : [commonSearchValues.indicator];
+        const indicators = getValueAsArray(commonSearchValues.indicator);
         if (indicators.length === 0) {
+            // nothing selected
             return;
         }
         const refinedSearchValues = [];

--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -435,7 +435,7 @@ class SearchController extends StateHandler {
      */
     async handleMultipleIndicatorsSearch (commonSearchValues) {
         const indicators = Array.isArray(commonSearchValues.indicator) ? commonSearchValues.indicator : [commonSearchValues.indicator];
-        if (!commonSearchValues.indicator || indicators.length === 0) {
+        if (indicators.length === 0) {
             return;
         }
         const refinedSearchValues = [];

--- a/bundles/statistics/statsgrid/view/search/SearchFlyout.jsx
+++ b/bundles/statistics/statsgrid/view/search/SearchFlyout.jsx
@@ -44,7 +44,7 @@ const IndicatorField = styled('div')`
 const ClickableArea = ({ children }) => <div>{children}</div>;
 
 const SearchFlyout = ({ state, controller }) => {
-    const datasources =  getDatasources();
+    const datasources = getDatasources();
     const regionsets = getRegionsets();
     if (!datasources.length || !regionsets.length) {
         // Nothing to show -> show generic "data missing" message


### PR DESCRIPTION
To make await work _when adding multiple indicators at once_ we NEED TO always return a promise instead of undefined. This version still limits making the same requests to server for regions multiple times, but wraps the "call already made but waiting for answer" to a promise that we can resolve _when_ the cache has the value. It's a bit messy but checking it in so we can start improving the other parts as this fixes issues when adding multiple indicators at once.