### PR TITLE
Note about callback removal on statsgrid cache

### DIFF
--- a/bundles/statistics/statsgrid/service/Cache.js
+++ b/bundles/statistics/statsgrid/service/Cache.js
@@ -62,6 +62,8 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.Cache',
                 this.put(key, response);
             }
             const queueKey = 'queue_' + key;
+            // FIXME: this doesn't make sense anymore.
+            // Previously it was used to call functions registered on addToQueue(), but the callback are no longer used so this is kind of a weird function
             this.put(queueKey, null);
         },
         /**


### PR DESCRIPTION
We should probably add Promise resolve/reject functions as params to `addToQueue()` and use them on `respondToQueue()` for this to make more sense. But lets return to this when it becomes an issue.