### PR TITLE
Fix cloning of Statgrid classification UI on publisher

### DIFF
--- a/bundles/statistics/statsgrid/components/classification/Classification.jsx
+++ b/bundles/statistics/statsgrid/components/classification/Classification.jsx
@@ -121,7 +121,7 @@ export const showClassificationContainer = (state, viewState, controller, option
                         showHistogram={showHistogram}
                     />
                 </LocaleProvider>
-            )
+            );
         }
     };
 };

--- a/bundles/statistics/statsgrid/handler/ViewHandler.js
+++ b/bundles/statistics/statsgrid/handler/ViewHandler.js
@@ -1,5 +1,5 @@
 import { StateHandler, controllerMixin } from 'oskari-ui/util';
-import { getContainerOptions, createSeriesControlPlugin, createTogglePlugin } from '../helper/ViewHelper';
+import { getContainerOptions, createSeriesControlPlugin, createTogglePlugin, stopTogglePlugin } from '../helper/ViewHelper';
 import { showTableFlyout } from '../view/Table/TableFlyout';
 import { showSearchFlyout } from '../view/search/SearchFlyout';
 import { showDiagramFlyout } from '../view/Diagram/DiagramFlyout';
@@ -108,7 +108,13 @@ class UIHandler extends StateHandler {
             this.togglePlugin = createTogglePlugin(sandbox, this);
         }
         if (this.togglePlugin) {
-            this.togglePlugin.refresh(viewState);
+            if (viewState.mapButtons.length > 0) {
+                this.togglePlugin.refresh(viewState);
+            } else {
+                const sandbox = this.instance.getSandbox();
+                stopTogglePlugin(sandbox, this.togglePlugin);
+                this.togglePlugin = null;
+            }
         }
     }
 
@@ -150,7 +156,8 @@ class UIHandler extends StateHandler {
 
     removeMapButton (id) {
         const mapButtons = this.getState().mapButtons.filter(btn => btn !== id);
-        this.updateState({ mapButtons });
+        const activeMapButtons = mapButtons.filter(id => this.controls[id]);
+        this.updateState({ mapButtons, activeMapButtons });
     }
 
     updateLayer (key, value) {

--- a/bundles/statistics/statsgrid/helper/ViewHelper.js
+++ b/bundles/statistics/statsgrid/helper/ViewHelper.js
@@ -24,3 +24,9 @@ export const createTogglePlugin = (sandbox, viewHandler) => {
     mapModule.startPlugin(plugin);
     return plugin;
 };
+
+export const stopTogglePlugin = (sandbox, togglePlugin) => {
+    const mapModule = sandbox.findRegisteredModuleInstance('MainMapModule');
+    mapModule.unregisterPlugin(togglePlugin);
+    mapModule.stopPlugin(togglePlugin);
+};

--- a/bundles/statistics/statsgrid/plugin/ThematicControls.jsx
+++ b/bundles/statistics/statsgrid/plugin/ThematicControls.jsx
@@ -20,8 +20,8 @@ const ICONS = {
 export const ThematicControls = ({ mapButtons, active, toggle }) => {
     return (
         <Container>
-            {mapButtons.map((id, index) => (
-                <div key={index}>
+            {mapButtons.map(id => (
+                <div key={id}>
                     <MapModuleButton
                         onClick={() => toggle(id)}
                         icon={ICONS[id]}

--- a/bundles/statistics/statsgrid/publisher/AbstractStatsPluginTool.js
+++ b/bundles/statistics/statsgrid/publisher/AbstractStatsPluginTool.js
@@ -6,8 +6,6 @@ const defaultPlugin = 'Oskari.statistics.statsgrid.TogglePlugin';
 export class AbstractStatsPluginTool extends AbstractPublisherTool {
     getTool () {
         const id = this._getToolId();
-        // TODO: move localizations:
-        // Oskari.getMsg('StatsGrid', 'tool.label' + title)
         return {
             id: this.pluginId || defaultPlugin,
             title: this.getTitle(),
@@ -19,6 +17,8 @@ export class AbstractStatsPluginTool extends AbstractPublisherTool {
     }
 
     getTitle () {
+        // TODO: move localizations:
+        // Oskari.getMsg('StatsGrid', 'tool.label' + title)
         return Oskari.getMsg('Publisher2', 'BasicView.data.' + this.title);
     }
 

--- a/bundles/statistics/statsgrid/publisher/AbstractStatsPluginTool.js
+++ b/bundles/statistics/statsgrid/publisher/AbstractStatsPluginTool.js
@@ -1,31 +1,95 @@
-import { LAYER_ID } from "../constants";
+import { AbstractPublisherTool } from '../../../framework/publisher2/tools/AbstractPublisherTool';
+
+import { LAYER_ID } from '../constants';
 const defaultPlugin = 'Oskari.statistics.statsgrid.TogglePlugin';
 
-Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractStatsPluginTool', function () {
-}, {
-    /* override if needed */
-    init: function (data) {
-        const id = this.id;
-        const conf = this.getStatsgridConf(data);
-        this.setEnabled(conf[id] === true);
-    },
-    getValues: function () {
+export class AbstractStatsPluginTool extends AbstractPublisherTool {
+    getTool () {
         const id = this._getToolId();
-        return this.getConfiguration({ [id]: this.isEnabled() });
-    },
-    getTool: function () {
-        const id = this._getToolId();
-        const title = this.title;
+        // TODO: move localizations:
+        // Oskari.getMsg('StatsGrid', 'tool.label' + title)
         return {
             id: this.pluginId || defaultPlugin,
-            title,
+            title: this.getTitle(),
             config: {
                 [id]: true
             },
             hasNoPlugin: true
         };
-    },
-    _setEnabledImpl: function (enabled) {
+    }
+
+    getTitle () {
+        return Oskari.getMsg('Publisher2', 'BasicView.data.' + this.title);
+    }
+
+    init (data) {
+        const id = this.id;
+        const conf = this.getStatsgridConf(data);
+        this.setEnabled(conf[id] === true);
+    }
+
+    getStatsgridBundle () {
+        return Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid');
+    }
+
+    getViewHandler () {
+        const instance = this.getStatsgridBundle();
+        if (!instance) {
+            return;
+        }
+        return instance.getViewHandler();
+    }
+
+    _getToolId () {
+        return this.id || 'AbstractStatsPluginTool';
+    }
+
+    getPlugin () {
+        return this.getViewHandler()?.togglePlugin;
+    }
+
+    getStateHandler () {
+        const instance = this.getStatsgridBundle();
+        if (!instance) {
+            return;
+        }
+        return instance.getStateHandler();
+    }
+
+    /**
+    * @method @private _isStatsActive
+    * @return true when stats layer is on the map, false if removed
+    */
+    _isStatsActive () {
+        return Oskari.getSandbox().isLayerAlreadySelected(LAYER_ID);
+    }
+
+    /**
+     * @method isDisplayed Is displayed.
+     * @returns {Boolean} true, if stats layer is on the map or data contains statsdrid conf
+     */
+    isDisplayed (data) {
+        if (this._isStatsActive()) {
+            return true;
+        }
+        return Oskari.util.keyExists(data, 'configuration.statsgrid.conf');
+    }
+
+    getStatsgridConf (initialData) {
+        const conf = initialData?.configuration?.statsgrid?.conf || {};
+        // Setup the plugin location whenever any of the stats tools parse initial config.
+        // There will be "too many calls" to this but it's not too bad and
+        // we want the location always set or reset no matter which tool sets it
+        this.getPlugin()?.setLocation(conf.location?.classes);
+        return conf;
+    }
+
+    // override since we want to use the instance we currently have, not create a new one
+    setEnabled (enabled) {
+        const changed = super.setEnabled(enabled);
+        if (!changed) {
+            return;
+        }
         const handler = this.getViewHandler();
         if (!handler) {
             return;
@@ -35,70 +99,17 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractStatsPluginTool'
         } else {
             handler.getController().removeMapButton(this.id);
         }
-    },
-    _stopImpl: function () {
-        this._setEnabledImpl(false);
-        /*
-        const handler = this.getViewHandler();
-        if (!handler) {
-            return;
-        }
-        handler.getController().removeTool(this.id);
-        */
-    },
-    /* override if needed ends */
-    _getToolId: function () {
-        return this.id || 'AbstractStatsPluginTool';
-    },
+    }
 
-    getStatsgridConf: function (initialData) {
-        const conf = initialData?.configuration?.statsgrid?.conf || {};
-        // Setup the plugin location whenever any of the stats tools parse initial config.
-        // There will be "too many calls" to this but it's not too bad and
-        // we want the location always set or reset no matter which tool sets it
-        this.getStatsgridBundle()?.togglePlugin?.setLocation(conf.location?.classes);
-        return conf;
-    },
+    getValues () {
+        if (!this.isEnabled()) {
+            return null;
+        }
+        const id = this._getToolId();
+        return this.getConfiguration({ [id]: this.isEnabled() });
+    }
 
-    getStatsgridBundle: function () {
-        return Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid');
-    },
-    getViewHandler: function () {
-        const instance = this.getStatsgridBundle();
-        if (!instance) {
-            return;
-        }
-        return instance.getViewHandler();
-    },
-    getStateHandler: function () {
-        const instance = this.getStatsgridBundle();
-        if (!instance) {
-            return;
-        }
-        return instance.getStateHandler();
-    },
-    /**
-    * @method @private _isStatsActive
-    * @return true when stats layer is on the map, false if removed
-    */
-    _isStatsActive: function () {
-        return Oskari.getSandbox().isLayerAlreadySelected(LAYER_ID);
-    },
-    /**
-     * @method isDisplayed Is displayed.
-     * @returns {Boolean} true, if stats layer is on the map or data contains statsdrid conf
-     */
-    isDisplayed: function (data) {
-        if (this._isStatsActive()) {
-            return true;
-        }
-        return Oskari.util.keyExists(data, 'configuration.statsgrid.conf');
-    },
-    getPlugin: function () {
-        var stats = this.getStatsgridBundle();
-        return stats?.togglePlugin;
-    },
-    getConfiguration: function (conf = {}) {
+    getConfiguration (conf = {}) {
         // just to make sure if user removes the statslayer while in publisher
         // if there is no statslayer on map -> don't setup tools configuration
         // otherwise the embedded map will get statsgrid config which means that editing the embedded
@@ -114,6 +125,14 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractStatsPluginTool'
             }
         };
     }
-}, {
-    'extend': ['Oskari.mapframework.publisher.tool.AbstractPluginTool']
-});
+};
+
+/*
+// Attach protocol to make this discoverable by Oskari publisher
+Oskari.clazz.defineES('Oskari.mapframework.publisher.tool.AbstractStatsPluginTool',
+    AbstractStatsPluginTool,
+    {
+        protocol: ['Oskari.mapframework.publisher.Tool']
+    }
+);
+*/

--- a/bundles/statistics/statsgrid/publisher/AbstractStatsPluginTool.js
+++ b/bundles/statistics/statsgrid/publisher/AbstractStatsPluginTool.js
@@ -125,6 +125,14 @@ export class AbstractStatsPluginTool extends AbstractPublisherTool {
             }
         };
     }
+
+    stop () {
+        const handler = this.getViewHandler();
+        if (!handler) {
+            return;
+        }
+        handler.getController().removeMapButton(this.id);
+    }
 };
 
 /*

--- a/bundles/statistics/statsgrid/publisher/ClassificationToggleTool.js
+++ b/bundles/statistics/statsgrid/publisher/ClassificationToggleTool.js
@@ -1,10 +1,19 @@
-Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationToggleTool', function () {
-}, {
-    index: 1,
-    group: 'data',
-    id: 'classification',
-    title: 'allowHidingClassification',
-}, {
-    'extend': ['Oskari.mapframework.publisher.tool.AbstractStatsPluginTool'],
-    'protocol': ['Oskari.mapframework.publisher.Tool']
-});
+import { AbstractStatsPluginTool } from './AbstractStatsPluginTool';
+
+class ClassificationToggleTool extends AbstractStatsPluginTool {
+    constructor (...args) {
+        super(...args);
+        this.index = 1;
+        this.group = 'data';
+        this.id = 'classification';
+        this.title = 'allowHidingClassification';
+    }
+};
+
+// Attach protocol to make this discoverable by Oskari publisher
+Oskari.clazz.defineES('Oskari.mapframework.publisher.tool.ClassificationToggleTool',
+    ClassificationToggleTool,
+    {
+        protocol: ['Oskari.mapframework.publisher.Tool']
+    }
+);

--- a/bundles/statistics/statsgrid/publisher/ClassificationTool.js
+++ b/bundles/statistics/statsgrid/publisher/ClassificationTool.js
@@ -1,34 +1,41 @@
-Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationTool', function () {
-}, {
-    index: 1,
-    group: 'data',
-    id: 'allowClassification',
-    title: 'allowClassification',
+import { AbstractStatsPluginTool } from './AbstractStatsPluginTool';
 
-    init: function (data) {
+class ClassificationTool extends AbstractStatsPluginTool {
+    constructor (...args) {
+        super(...args);
+        this.index = 1;
+        this.group = 'data';
+        this.id = 'allowClassification';
+        this.title = 'allowClassification';
+    }
+
+    init (data) {
         const conf = this.getStatsgridConf(data);
         this.setEnabled(conf[this.id] !== false);
-    },
-    _setEnabledImpl: function (enabled) {
+    }
+
+    setEnabled (enabled) {
         const handler = this.getViewHandler();
         if (!handler) {
             return;
         }
         handler.getController().updateClassificationState('editEnabled', enabled);
-    },
-    _stopImpl: function () {
+    }
+
+    _stopImpl () {
         const handler = this.getViewHandler();
         if (!handler) {
             return;
         }
-        handler.getController().updateClassificationState('editEnabled');
-    },
+        handler.getController().updateClassificationState('editEnabled', true);
+    }
+
     // TODO: is this main tool (always included)??
-    getValues: function () {
+    getValues () {
         if (!this._isStatsActive()) {
             return null;
         }
-        var stats = this.getStatsgridBundle();
+        const stats = this.getStatsgridBundle();
         const { location } = stats?.togglePlugin?.getConfig() || {};
         return {
             configuration: {
@@ -44,7 +51,12 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationTool', fun
             }
         };
     }
-}, {
-    'extend': ['Oskari.mapframework.publisher.tool.AbstractStatsPluginTool'],
-    'protocol': ['Oskari.mapframework.publisher.Tool']
-});
+};
+
+// Attach protocol to make this discoverable by Oskari publisher
+Oskari.clazz.defineES('Oskari.mapframework.publisher.tool.ClassificationTool',
+    ClassificationTool,
+    {
+        protocol: ['Oskari.mapframework.publisher.Tool']
+    }
+);

--- a/bundles/statistics/statsgrid/publisher/ClassificationTool.js
+++ b/bundles/statistics/statsgrid/publisher/ClassificationTool.js
@@ -22,7 +22,7 @@ class ClassificationTool extends AbstractStatsPluginTool {
         handler.getController().updateClassificationState('editEnabled', enabled);
     }
 
-    _stopImpl () {
+    stop () {
         const handler = this.getViewHandler();
         if (!handler) {
             return;

--- a/bundles/statistics/statsgrid/publisher/DiagramTool.js
+++ b/bundles/statistics/statsgrid/publisher/DiagramTool.js
@@ -1,10 +1,19 @@
-Oskari.clazz.define('Oskari.mapframework.publisher.tool.DiagramTool', function () {
-}, {
-    index: 1,
-    group: 'data',
-    id: 'diagram',
-    title: 'displayDiagram'
-}, {
-    'extend': ['Oskari.mapframework.publisher.tool.AbstractStatsPluginTool'],
-    'protocol': ['Oskari.mapframework.publisher.Tool']
-});
+import { AbstractStatsPluginTool } from './AbstractStatsPluginTool';
+
+class DiagramTool extends AbstractStatsPluginTool {
+    constructor (...args) {
+        super(...args);
+        this.index = 1;
+        this.group = 'data';
+        this.id = 'diagram';
+        this.title = 'displayDiagram';
+    }
+};
+
+// Attach protocol to make this discoverable by Oskari publisher
+Oskari.clazz.defineES('Oskari.mapframework.publisher.tool.DiagramTool',
+    DiagramTool,
+    {
+        protocol: ['Oskari.mapframework.publisher.Tool']
+    }
+);

--- a/bundles/statistics/statsgrid/publisher/OpacityTool.js
+++ b/bundles/statistics/statsgrid/publisher/OpacityTool.js
@@ -1,27 +1,36 @@
-Oskari.clazz.define('Oskari.mapframework.publisher.tool.OpacityTool', function () {
-},
-{
-    index: 1,
-    group: 'data',
-    id: 'transparent',
-    title: 'transparent',
-    pluginId: 'Oskari.statistics.statsgrid.ClassificationPlugin',
+import { AbstractStatsPluginTool } from './AbstractStatsPluginTool';
 
-    _setEnabledImpl: function (enabled) {
+class OpacityTool extends AbstractStatsPluginTool {
+    constructor (...args) {
+        super(...args);
+        this.index = 1;
+        this.group = 'data';
+        this.id = 'transparent';
+        this.title = 'transparent';
+        this.pluginId = 'Oskari.statistics.statsgrid.ClassificationPlugin';
+    }
+
+    setEnabled (enabled) {
         const handler = this.getViewHandler();
         if (!handler) {
             return;
         }
         handler.getController().updateClassificationState('transparent', enabled);
-    },
-    _stopImpl: function () {
+    }
+
+    _stopImpl () {
         const handler = this.getViewHandler();
         if (!handler) {
             return;
         }
         handler.getController().updateClassificationState('transparent');
     }
-}, {
-    'extend': ['Oskari.mapframework.publisher.tool.AbstractStatsPluginTool'],
-    'protocol': ['Oskari.mapframework.publisher.Tool']
-});
+};
+
+// Attach protocol to make this discoverable by Oskari publisher
+Oskari.clazz.defineES('Oskari.mapframework.publisher.tool.OpacityTool',
+    OpacityTool,
+    {
+        protocol: ['Oskari.mapframework.publisher.Tool']
+    }
+);

--- a/bundles/statistics/statsgrid/publisher/OpacityTool.js
+++ b/bundles/statistics/statsgrid/publisher/OpacityTool.js
@@ -18,7 +18,7 @@ class OpacityTool extends AbstractStatsPluginTool {
         handler.getController().updateClassificationState('transparent', enabled);
     }
 
-    _stopImpl () {
+    stop () {
         const handler = this.getViewHandler();
         if (!handler) {
             return;

--- a/bundles/statistics/statsgrid/publisher/SeriesToggleTool.js
+++ b/bundles/statistics/statsgrid/publisher/SeriesToggleTool.js
@@ -1,11 +1,15 @@
-Oskari.clazz.define('Oskari.mapframework.publisher.tool.SeriesToggleTool', function () {
-}, {
-    index: 1,
-    group: 'data',
-    id: 'series',
-    title: 'allowHidingSeriesControl',
+import { AbstractStatsPluginTool } from './AbstractStatsPluginTool';
 
-    isDisplayed: function (data) {
+class SeriesToggleTool extends AbstractStatsPluginTool {
+    constructor (...args) {
+        super(...args);
+        this.index = 1;
+        this.group = 'data';
+        this.id = 'series';
+        this.title = 'allowHidingSeriesControl';
+    }
+
+    isDisplayed (data) {
         const stats = this.getStatsgridBundle();
         if (!stats) {
             return false;
@@ -13,7 +17,12 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.SeriesToggleTool', funct
         const { indicators } = this.getStateHandler().getState();
         return indicators.some(ind => ind.series);
     }
-}, {
-    'extend': ['Oskari.mapframework.publisher.tool.AbstractStatsPluginTool'],
-    'protocol': ['Oskari.mapframework.publisher.Tool']
-});
+};
+
+// Attach protocol to make this discoverable by Oskari publisher
+Oskari.clazz.defineES('Oskari.mapframework.publisher.tool.SeriesToggleTool',
+    SeriesToggleTool,
+    {
+        protocol: ['Oskari.mapframework.publisher.Tool']
+    }
+);

--- a/bundles/statistics/statsgrid/publisher/StatsTableTool.js
+++ b/bundles/statistics/statsgrid/publisher/StatsTableTool.js
@@ -1,10 +1,19 @@
-Oskari.clazz.define('Oskari.mapframework.publisher.tool.StatsTableTool', function () {
-}, {
-    index: 1,
-    group: 'data',
-    id: 'grid',
-    title: 'grid',
-}, {
-    'extend': ['Oskari.mapframework.publisher.tool.AbstractStatsPluginTool'],
-    'protocol': ['Oskari.mapframework.publisher.Tool']
-});
+import { AbstractStatsPluginTool } from './AbstractStatsPluginTool';
+
+class StatsTableTool extends AbstractStatsPluginTool {
+    constructor (...args) {
+        super(...args);
+        this.index = 1;
+        this.group = 'data';
+        this.id = 'grid';
+        this.title = 'grid';
+    }
+};
+
+// Attach protocol to make this discoverable by Oskari publisher
+Oskari.clazz.defineES('Oskari.mapframework.publisher.tool.StatsTableTool',
+    StatsTableTool,
+    {
+        protocol: ['Oskari.mapframework.publisher.Tool']
+    }
+);


### PR DESCRIPTION
Also rewrite publisher tools to use the ES baseclass.

TODO: Cloning still happens if we first add some other button than classification.