### PR TITLE
Statsgrid state series

### DIFF
--- a/bundles/statistics/statsgrid/components/SeriesControl.js
+++ b/bundles/statistics/statsgrid/components/SeriesControl.js
@@ -313,7 +313,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SeriesControl', function (contr
         const { values, id } = indicator.series;
         const value = indicator.selections[id];
         const index = values.indexOf(value);
-        this.updateState({ values, index });
+        this.updateState({ values, index, hash: indicator.hash });
         this._updateLineSegments();
         this._updateSeriesIndex(index);
         this._setAnimationState(false);

--- a/bundles/statistics/statsgrid/components/SeriesControl.js
+++ b/bundles/statistics/statsgrid/components/SeriesControl.js
@@ -133,13 +133,18 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SeriesControl', function (contr
         }
         this._setSelectedValue(next);
     },
-    _setSelectedValue: function (index) {
-        const { animating, values } = this.getState();
+    _setSelectedValue: function (index, delayed) {
+        const { animating, values, interval } = this.getState();
         const value = values[index];
         this.controller.setSeriesValue(value);
         if (animating) {
             this._updateSeriesIndex(index);
-            this._throttleAnimation();
+            if (delayed === true) {
+                // Wait frameInterval before starting the animation
+                setTimeout(this._throttleAnimation, interval);
+            } else {
+                this._throttleAnimation();
+            }
         }
     },
     _isValidIndex: function (index) {
@@ -170,12 +175,10 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SeriesControl', function (contr
         if (!animating) {
             return;
         }
-        const { values, index, interval } = this.getState();
+        const { values, index } = this.getState();
         if (index >= values.length -1) {
             // Step to the beginning, if the series is on the last value
-            this._setSelectedValue(this.values[0]);
-            // Wait frameInterval before starting the animation
-            setTimeout(this._throttleAnimation, interval);
+            this._setSelectedValue(0, true);
         } else {
             this._throttleAnimation();
         }

--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -749,17 +749,17 @@ class SearchController extends StateHandler {
         }
     }
 
-    addIndicators (searchValues) {
+    async addIndicators (searchValues) {
         let latestHash = null;
-        searchValues.forEach(values => {
+        for (let i = 0; i < searchValues.length; i++) {
             // TODO: search values indicator => id, datasource => ds
-            const { datasource: ds, indicator: id, regionset, ...rest } = values;
+            const { datasource: ds, indicator: id, regionset, ...rest } = searchValues[i];
             const indicator = { id, ds, ...rest };
             indicator.hash = getHashForIndicator(indicator);
-            if (this.stateHandler.addIndicator(indicator, regionset)) {
+            if (await this.stateHandler.addIndicator(indicator, regionset)) {
                 latestHash = indicator.hash;
             }
-        });
+        };
         if (latestHash) {
             // Search added some new indicators, let's set the last one as the active indicator.
             this.stateHandler.setActiveIndicator(latestHash);

--- a/bundles/statistics/statsgrid/handler/ViewHandler.js
+++ b/bundles/statistics/statsgrid/handler/ViewHandler.js
@@ -72,7 +72,7 @@ class UIHandler extends StateHandler {
 
     onViewChange (viewState) {
         const state = this.stateHandler.getState();
-        const { classification } = this.controls;
+        const { classification, series } = this.controls;
 
         const hasIndicators = state.indicators.length > 0;
         const { onMap, visible } = viewState.layer;
@@ -86,16 +86,15 @@ class UIHandler extends StateHandler {
                 this.show('classification');
             }
             if (state.isSeriesActive) {
-                if (!this.seriesControlPlugin) {
-                    this.seriesControlPlugin = createSeriesControlPlugin(this.instance.getSandbox(), this.stateHandler);
+                if (series) {
+                    series.update(state);
+                } else {
+                    this.show('series');
                 }
-                this.seriesControlPlugin.refresh();
             }
         } else {
             this.close('classification');
-            if (this.seriesControlPlugin) {
-                this.seriesControlPlugin.stopPlugin();
-            }
+            this.close('series');
         }
         // create toggle plugin only when needed
         if (viewState.mapButtons.length > 0 && !this.togglePlugin) {
@@ -124,6 +123,9 @@ class UIHandler extends StateHandler {
                 control.update(state);
             }
         });
+        if (state.isSeriesActive && !this.controls.series) {
+            this.show('series');
+        }
     }
 
     onSearchChange (state) {
@@ -203,12 +205,32 @@ class UIHandler extends StateHandler {
             controls = showIndicatorForm(this.formHandler.getState(), this.formHandler.getController(), onCloseWrapper);
         } else if (id === 'clipboard' && this.formHandler) {
             controls = showClipboardPopup(this.formHandler.getState(), this.formHandler.getController(), onClose);
+        } else if (id === 'series') {
+            controls = this._createSeriesControls();
         } else {
             this.log.warn(`Tried to show view with id: ${id}`);
             return;
         }
         this.controls[id] = controls;
         this.notifyExtensions(id, true);
+    }
+    _createSeriesControls () {
+        if (!this.seriesControlPlugin) {
+            this.seriesControlPlugin = createSeriesControlPlugin(this.instance.getSandbox(), this.stateHandler);
+        } else if (!this.seriesControlPlugin.getElement()) {
+            this.seriesControlPlugin.redrawUI();
+        }
+        this.seriesControlPlugin.refresh();
+
+        const close = () => this.seriesControlPlugin.stopPlugin();
+        const update = state => {
+            if (state.isSeriesActive) {
+                this.seriesControlPlugin.refresh(state);
+            } else {
+                this.close('series');
+            }
+        };
+        return { update, close };
     }
 
     close (id) {

--- a/bundles/statistics/statsgrid/plugin/SeriesControlPlugin.js
+++ b/bundles/statistics/statsgrid/plugin/SeriesControlPlugin.js
@@ -28,14 +28,13 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SeriesControlPlugin',
             this.element ? this.teardownUI() : this._buildUI();
             return !!this.element;
         },
-        refresh: function (indicator) {
+        refresh: function (state) {
             if (!this.element) {
                 return;
             }
-            if (!indicator) {
-                const { activeIndicator, indicators } = this.stateHandler.getState();
-                indicator = indicators.find(ind => ind.hash === activeIndicator);
-            }
+            const { activeIndicator, indicators } = state || this.stateHandler.getState();
+            const indicator = indicators.find(ind => ind.hash === activeIndicator);
+
             this._seriesControl.updateValues(indicator);
         },
         /**


### PR DESCRIPTION
- Fix step to beginning
- Add async + await to searh handler add indicators => select active after all indicators are added
- update series visibility on state change (interested on active indicator change + isSeriesActive) => updateValues checks if hash is changed before updating anything => should be ok to listen state changed
  => fixes issue where active indicator is changed between series and normal indicator and series plugin didn't toggle visibility
