### PR TITLE
Transform statsgrid publisher tools to react

### DIFF
--- a/bundles/framework/publisher2/handler/ToolPanelHandler.js
+++ b/bundles/framework/publisher2/handler/ToolPanelHandler.js
@@ -3,7 +3,7 @@ import { StateHandler, controllerMixin } from 'oskari-ui/util';
 class UIHandler extends StateHandler {
     constructor (tools, consumer) {
         super();
-        this.toolsToInit = tools || [];
+        this.toolsToInit = tools ? [...tools] : [];
         this.setState({
             tools: []
         });

--- a/bundles/framework/publisher2/view/PanelReactTools.js
+++ b/bundles/framework/publisher2/view/PanelReactTools.js
@@ -1,0 +1,103 @@
+import React from 'react';
+import { LocaleProvider } from 'oskari-ui/util';
+import ReactDOM from 'react-dom';
+import { ToolPanelHandler } from '../handler/ToolPanelHandler';
+import { PublisherToolsList } from './form/PublisherToolsList';
+
+/**
+ * @class Oskari.mapframework.bundle.publisher.view.PanelAdditionalTools
+ *
+ */
+Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelReactTools',
+
+    /**
+     * @method create called automatically on construction
+     * @static
+     */
+    function (tools, groupId) {
+        this.groupId = groupId;
+        this.tools = tools || [];
+        this.tools = [...this.tools].sort((a, b) => a.index - b.index);
+        this.panel = null;
+        this.handler = null;
+    }, {
+        /**
+         * @method init
+         * Creates the Oskari.userinterface.component.AccordionPanel where the UI is rendered
+         */
+        init: function (data) {
+            this.handler = new ToolPanelHandler(this.tools, () => this._updateUI());
+            return this.handler.init(data);
+        },
+        getName: function () {
+            return `Oskari.mapframework.bundle.publisher2.view.PanelReactTools.${this.groupId}`;
+        },
+        /**
+         * Returns the UI panel and populates it with the data that we want to show the user.
+         *
+         * @method getPanel
+         * @return {Oskari.userinterface.component.AccordionPanel}
+         */
+        getPanel: function () {
+            if (!this.panel) {
+                this.panel = Oskari.clazz.create(
+                    'Oskari.userinterface.component.AccordionPanel'
+                );
+                this.panel.setTitle(Oskari.getMsg('Publisher2', `BasicView.${this.groupId}.label`));
+                this._updateUI();
+            }
+            return this.panel;
+        },
+
+        /**
+         * @method getValues
+         * @return {Object}
+         */
+        getValues: function () {
+            // just return empty -> tools and their plugins' configs get returned by the layout panel, which has all the tools
+            return null;
+        },
+        /**
+         * Returns any errors found in validation (currently doesn't check anything) or an empty
+         * array if valid. Error object format is defined in Oskari.userinterface.component.FormInput
+         * validate() function.
+         *
+         * @method validate
+         * @return {Object[]}
+         */
+        validate: function () {
+            return [];
+        },
+
+        /**
+         * Populates the map layers panel in publisher
+         *
+         * @method _updateUI
+         * @private
+         */
+        _updateUI: function () {
+            if (!this.panel) {
+                return;
+            }
+            const contentPanel = this.panel.getContainer();
+
+            ReactDOM.render(
+                <LocaleProvider value={{ bundleKey: 'Publisher2' }}>
+                    <PublisherToolsList
+                        state={this.handler.getState()}
+                        controller={this.handler.getController()}
+                    />
+                </LocaleProvider>,
+                contentPanel[0]
+            );
+        },
+        /**
+        * Stop panel.
+        * @method stop
+        * @public
+        **/
+        stop: function () {
+            this.handler.stop();
+        }
+    }
+);

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -4,6 +4,7 @@ import { mergeValues } from '../util/util';
 import { Messaging, ThemeProvider } from 'oskari-ui/util';
 import { Header } from 'oskari-ui';
 import styled from 'styled-components';
+import './PanelReactTools';
 
 const StyledHeader = styled(Header)`
     padding: 15px 15px 10px 10px;
@@ -26,7 +27,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
      *
      */
     function (instance, localization, data) {
-        var me = this;
+        const me = this;
         me.data = data;
         me.panels = [];
         me.instance = instance;
@@ -107,10 +108,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
             const rpcTools = publisherTools.groups.rpc;
             const layerTools = publisherTools.groups.layers;
             const additionalTools = publisherTools.groups.additional;
+            const statsgridTools = publisherTools.groups.data;
             // clear rpc/layers groups from others for looping/group so they are not listed twice
             delete publisherTools.groups.rpc;
             delete publisherTools.groups.layers;
             delete publisherTools.groups.additional;
+            delete publisherTools.groups.data;
 
             const mapLayersPanel = this._createMapLayersPanel(layerTools);
             mapLayersPanel.getPanel().addClass('t_layers');
@@ -132,6 +135,19 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PublisherSidebar
                     accordion.addPanel(panel);
                 }
             });
+            if (statsgridTools) {
+                const groupId = 'data';
+                const toolPanel = Oskari.clazz.create('Oskari.mapframework.bundle.publisher2.view.PanelReactTools', statsgridTools, groupId);
+                const hasToolsToShow = toolPanel.init(this.data);
+                console.log('hasToolsToShow', hasToolsToShow);
+                this.panels.push(toolPanel);
+                if (hasToolsToShow) {
+                    const panel = toolPanel.getPanel();
+                    panel.addClass('t_tools');
+                    panel.addClass('t_' + groupId);
+                    accordion.addPanel(panel);
+                }
+            }
 
             // add additional tools panel if there are tools for it
             if (additionalTools) {

--- a/bundles/statistics/statsgrid/helper/StatisticsHelper.js
+++ b/bundles/statistics/statsgrid/helper/StatisticsHelper.js
@@ -133,7 +133,7 @@ export const formatData = (data, classification) => {
 };
 
 export const getUILabels = (ind, metadata) => {
-    const selectionValues = Oskari.getMsg('StatsGrid' ,'panels.newSearch.selectionValues');
+    const selectionValues = Oskari.getMsg('StatsGrid', 'panels.newSearch.selectionValues');
     const { selections, series } = ind;
     const getError = () => ({
         error: true,

--- a/bundles/statistics/statsgrid/publisher/AbstractStatsPluginTool.js
+++ b/bundles/statistics/statsgrid/publisher/AbstractStatsPluginTool.js
@@ -7,7 +7,7 @@ export class AbstractStatsPluginTool extends AbstractPublisherTool {
     getTool () {
         const id = this._getToolId();
         return {
-            id: this.pluginId || defaultPlugin,
+            id: this.pluginId || (defaultPlugin + '.' + id),
             title: this.getTitle(),
             config: {
                 [id]: true
@@ -20,6 +20,10 @@ export class AbstractStatsPluginTool extends AbstractPublisherTool {
         // TODO: move localizations:
         // Oskari.getMsg('StatsGrid', 'tool.label' + title)
         return Oskari.getMsg('Publisher2', 'BasicView.data.' + this.title);
+    }
+
+    getComponent () {
+        return {};
     }
 
     init (data) {
@@ -72,7 +76,7 @@ export class AbstractStatsPluginTool extends AbstractPublisherTool {
         if (this._isStatsActive()) {
             return true;
         }
-        return Oskari.util.keyExists(data, 'configuration.statsgrid.conf');
+        return Oskari.util.keyExists(data, 'configuration.statsgrid.state');
     }
 
     getStatsgridConf (initialData) {

--- a/bundles/statistics/statsgrid/publisher/ClassificationTool.js
+++ b/bundles/statistics/statsgrid/publisher/ClassificationTool.js
@@ -15,6 +15,12 @@ class ClassificationTool extends AbstractStatsPluginTool {
     }
 
     setEnabled (enabled) {
+        if (enabled === this.isEnabled()) {
+            return;
+        }
+
+        // Stop checks if we are already disabled so toggle the value after
+        this.state.enabled = enabled;
         const handler = this.getViewHandler();
         if (!handler) {
             return;

--- a/bundles/statistics/statsgrid/publisher/OpacityTool.js
+++ b/bundles/statistics/statsgrid/publisher/OpacityTool.js
@@ -11,6 +11,12 @@ class OpacityTool extends AbstractStatsPluginTool {
     }
 
     setEnabled (enabled) {
+        if (enabled === this.isEnabled()) {
+            return;
+        }
+
+        // Stop checks if we are already disabled so toggle the value after
+        this.state.enabled = enabled;
         const handler = this.getViewHandler();
         if (!handler) {
             return;


### PR DESCRIPTION
We should use the same ReactToolsPanel for AdditionalTools, but lets migrate it later.