### PR TITLE
Statsgrid state histogram

### DIFF
--- a/bundles/statistics/statsgrid/components/manualClassification/edgeLines.js
+++ b/bundles/statistics/statsgrid/components/manualClassification/edgeLines.js
@@ -1,32 +1,34 @@
 import * as d3 from 'd3';
-
+const TICKS = 4;
 /**
  * Draws right/left edges (min/max bounds values) of chart
  * @param {Object} svg node into which to render
  * @param {Object[]} handlesData values of bounds handles
  * @param {Function} xScale d3 scale function
- * @param {Number} histoHeight height of histogram area in px
+ * @param {Object} opts
  */
-export function edgeLines (svg, handlesData, xScale, yScale, histoHeight) {
-    const formatter = Oskari.getNumberFormatter(2);
-
+export function edgeLines (svg, handlesData, xScale, yScale, opts) {
+    const { histoHeight, fractionDigits = 1, highestBar, margin} = opts;
+    const formatter = Oskari.getNumberFormatter(fractionDigits);
+    // For small datasets integer ticks might show same values => decrease
+    const ticks = highestBar > TICKS ? TICKS : highestBar;
     const left = handlesData[0].value;
     const right = handlesData[handlesData.length - 1].value;
     const bounds = svg.selectAll('.edge')
         .data([left, right]);
 
     const yAxis = d3.axisLeft(yScale)
-        .ticks(4);
+        .ticks(ticks, 'd');
     svg.append('g')
         .classed('edge', true)
-        .attr('transform', `translate(${xScale(left)} 0)`)
+        .attr('transform', `translate(${xScale(left)} ${margin})`)
         .call(yAxis);
 
     const boundsEnter = bounds
         .enter()
         .append('g')
         .classed('edge', true)
-        .attr('transform', (d) => `translate(${xScale(d)} 0)`);
+        .attr('transform', (d) => `translate(${xScale(d)} ${margin})`);
 
     boundsEnter
         .append('path')

--- a/bundles/statistics/statsgrid/components/manualClassification/editor.js
+++ b/bundles/statistics/statsgrid/components/manualClassification/editor.js
@@ -6,7 +6,7 @@ import { updateDragHandles } from './updateDragHandles';
 import * as d3 from 'd3';
 
 const width = 500;
-const height = 303;
+const height = 310;
 const margin = 12;
 const histoHeight = 200;
 
@@ -23,7 +23,6 @@ export function manualClassificationEditor (el, manualBounds, indicatorData, col
         .append('svg')
         .attr('width', width)
         .attr('height', height);
-
     const histoClip = svg.append('defs').append('clipPath').attr('id', 'histoClip');
     const guide = svg.append('g');
     const histoGroup = svg.append('g').attr('clip-path', 'url(#histoClip)');
@@ -32,9 +31,9 @@ export function manualClassificationEditor (el, manualBounds, indicatorData, col
 
     const histogramGenerator = d3.histogram().thresholds(50);
     const histoData = histogramGenerator(indicatorData);
-
+    const highestBar = d3.max(histoData, (d) => d.length);
     const y = d3.scaleLinear()
-        .domain([0, d3.max(histoData, (d) => d.length)])
+        .domain([0, highestBar])
         .range([histoHeight, 0]);
 
     const x = d3.scaleLinear()
@@ -42,8 +41,9 @@ export function manualClassificationEditor (el, manualBounds, indicatorData, col
         .clamp(true)
         .range([margin * 2, width - margin]); // double left margin to get more space for tick labels
 
+    const opts = { histoHeight, height, margin, highestBar, fractionDigits };
     // HISTOGRAM CLIP PATH
-    histogram(histoClip, histoData, x, y, height);
+    histogram(histoClip, histoData, x, y, opts);
 
     const handlesData = manualBounds.map((d, i) => ({ value: d, id: i }));
 
@@ -76,7 +76,7 @@ export function manualClassificationEditor (el, manualBounds, indicatorData, col
         .on('end', notify);
 
     // BOUNDS EDGES
-    edgeLines(boundsLines, handlesData, x, y, histoHeight);
+    edgeLines(boundsLines, handlesData, x, y, opts);
 
     // VALUE INPUT INIT & INTERACTION
 
@@ -115,8 +115,8 @@ export function manualClassificationEditor (el, manualBounds, indicatorData, col
         });
 
     function update (skipInput) {
-        updateBandBlocks(histoGroup, handlesData, x, colorSet, histoHeight);
-        updateDragHandles(dragHandles, handlesData, x, dragBehavior, isSelected, isBase, histoHeight);
+        updateBandBlocks(histoGroup, handlesData, x, colorSet, opts);
+        updateDragHandles(dragHandles, handlesData, x, dragBehavior, isSelected, isBase, opts);
 
         if (skipInput) {
             return;
@@ -128,7 +128,7 @@ export function manualClassificationEditor (el, manualBounds, indicatorData, col
         valueInput.property('value', fixed).classed('fail', false);
 
         // VALUE INPUT GUIDE BOX
-        inputGuide(guide, x, 50, histoHeight + 50, x(value));
+        inputGuide(guide, x, 50, height, x(value));
     }
     update();
 }

--- a/bundles/statistics/statsgrid/components/manualClassification/histogram.js
+++ b/bundles/statistics/statsgrid/components/manualClassification/histogram.js
@@ -4,15 +4,16 @@
  * @param {Object[]} histoData histogram layout data https://github.com/d3/d3-array/blob/master/README.md#_histogram
  * @param {Function} xScale d3 scale function
  * @param {Function} yScale d3 scale function
- * @param {Number} chartHeight in px
+ * @param {Object} opts
  */
-export function histogram (svg, histoData, xScale, yScale, chartHeight) {
+export function histogram (svg, histoData, xScale, yScale, opts) {
+    const { height, margin } = opts;
     histoData.forEach((d) => {
         svg.append('rect')
             .attr('x', xScale(d.x0))
-            .attr('y', yScale(d.length))
+            .attr('y', yScale(d.length) + margin)
             .attr('width', xScale(d.x1) - xScale(d.x0))
-            .attr('height', chartHeight)
+            .attr('height', height)
             .attr('shape-rendering', 'crispEdges');
     });
 }

--- a/bundles/statistics/statsgrid/components/manualClassification/inputGuide.js
+++ b/bundles/statistics/statsgrid/components/manualClassification/inputGuide.js
@@ -4,10 +4,11 @@ const arrowSize = 8;
  * @param {Object} svg node into which to render
  * @param {Function} xScale d3 scale function
  * @param {Number} height box height
- * @param {Number} yZero loacation of box to edge
+ * @param {Number} svgHeight
  * @param {Number} cursorLocation pixel location in x direction where to draw triangle
  */
-export function inputGuide (svg, xScale, height, yZero, cursorLocation) {
+export function inputGuide (svg, xScale, height, svgHeight, cursorLocation) {
+    const yZero = svgHeight - height;
     const guide = svg.selectAll('.guide')
         .data([cursorLocation]);
 

--- a/bundles/statistics/statsgrid/components/manualClassification/updateBandBlocks.js
+++ b/bundles/statistics/statsgrid/components/manualClassification/updateBandBlocks.js
@@ -4,9 +4,10 @@
  * @param {Object[]} handlesData values of bounds handles
  * @param {Function} xScale d3 scale function
  * @param {String[]} colorSet classification colors, hex without #
- * @param {Number} histoHeight height of histogram area in px
+ * @param {Object} opts
  */
-export function updateBandBlocks (svg, handlesData, xScale, colorSet, histoHeight) {
+export function updateBandBlocks (svg, handlesData, xScale, colorSet, opts) {
+    const { histoHeight, margin } = opts;
     const blockData = handlesData
         .sort((a, b) => {
             return a.value - b.value;
@@ -25,7 +26,7 @@ export function updateBandBlocks (svg, handlesData, xScale, colorSet, histoHeigh
     blocks.enter()
         .append('rect')
         .attr('class', 'block')
-        .attr('y', 0)
+        .attr('y', margin)
         .attr('height', histoHeight)
         .attr('fill', (d, i) => colorSet[i])
         .merge(blocks)

--- a/bundles/statistics/statsgrid/components/manualClassification/updateDragHandles.js
+++ b/bundles/statistics/statsgrid/components/manualClassification/updateDragHandles.js
@@ -5,9 +5,11 @@
  * @param {Function} xScale d3 scale function
  * @param {Function} dragBehavior d3 drag behavior
  * @param {Function} isSelected for checking if handleData is selected
- * @param {Number} histoHeight height of histogram area in px
+ * @param {Object} opts
  */
-export function updateDragHandles (svg, handlesData, xScale, dragBehavior, isSelected, isBase, histoHeight) {
+export function updateDragHandles (svg, handlesData, xScale, dragBehavior, isSelected, isBase, opts) {
+    const { histoHeight, margin } = opts;
+    const y = histoHeight + 40;
     const handles = svg.selectAll('.handle')
         .data(handlesData.slice(1, -1), (d) => d.id);
 
@@ -19,11 +21,11 @@ export function updateDragHandles (svg, handlesData, xScale, dragBehavior, isSel
     handlesEnter
         .append('path')
         .classed('handle-line', true)
-        .attr('d', `M0 0 v${histoHeight + 25}`);
+        .attr('d', `M0 ${margin} v${y - margin}`);
 
     handlesEnter
         .append('circle')
-        .attr('cy', histoHeight + 25);
+        .attr('cy', y);
 
     const mergedHandles = handlesEnter
         .merge(handles);

--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -3,7 +3,7 @@ import { showMedataPopup } from '../components/description/MetadataPopup';
 import { getHashForIndicator } from '../helper/StatisticsHelper';
 import { populateIndicatorOptions } from './SearchIndicatorOptionsHelper';
 import { getIndicatorMetadata } from './IndicatorHelper';
-import { getDatasources, getUnsupportedDatasourceIds } from '../helper/ConfigHelper';
+import { getDatasources, getUnsupportedDatasourceIds, getRegionsets } from '../helper/ConfigHelper';
 
 const getValueAsArray = (selection) => {
     if (selection === null || typeof selection === 'undefined') {
@@ -81,7 +81,10 @@ class SearchController extends StateHandler {
                         Messaging.error(this.loc('errors.indicatorListIsEmpty'));
                     }
                 },
-                error => Messaging.error(this.loc(error)));
+                error => {
+                    Messaging.error(this.loc(error));
+                    this.updateState({loading: false});
+                })
         } catch (error) {
             Messaging.error(this.loc('errors.indicatorListError'));
             this.updateState({
@@ -358,7 +361,8 @@ class SearchController extends StateHandler {
         Object.keys(selectors).forEach(key => {
             let selected;
             if (selectors[key].time) {
-                selected = selectors[key].values[0].id;
+                // time has multi-select => use array
+                selected = [selectors[key].values[0].id];
                 if (this.getState().searchTimeseries) {
                     if (selectors[key].values?.length <= 1) {
                         Messaging.error(this.loc('errors.cannotDisplayAsSeries'));
@@ -376,7 +380,9 @@ class SearchController extends StateHandler {
 
             selections[key] = selected;
         });
-        selections.regionsets = regionsets[0];
+        // metadata regionsets doesn't have same order than all regionsets
+        // select first allowed value from all regionsets
+        selections.regionsets = getRegionsets().find(rs => regionsets.includes(rs.id))?.id;
         return selections;
     }
 

--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -357,13 +357,14 @@ class SearchController extends StateHandler {
     }
 
     initParamSelections (selectors, regionsets) {
+        const { regionsetFilter, searchTimeseries } = this.getState();
         const selections = {};
         Object.keys(selectors).forEach(key => {
             let selected;
             if (selectors[key].time) {
                 // time has multi-select => use array
                 selected = [selectors[key].values[0].id];
-                if (this.getState().searchTimeseries) {
+                if (searchTimeseries) {
                     if (selectors[key].values?.length <= 1) {
                         Messaging.error(this.loc('errors.cannotDisplayAsSeries'));
                         this.updateState({
@@ -382,7 +383,8 @@ class SearchController extends StateHandler {
         });
         // metadata regionsets doesn't have same order than all regionsets
         // select first allowed value from all regionsets
-        selections.regionsets = getRegionsets().find(rs => regionsets.includes(rs.id))?.id;
+        const allowedIds = regionsetFilter.length ? regionsets.filter(id => regionsetFilter.includes(id)) : regionsets;
+        selections.regionsets = getRegionsets().find(rs => allowedIds.includes(rs.id))?.id;
         return selections;
     }
 

--- a/bundles/statistics/statsgrid/handler/StatisticsHandler.js
+++ b/bundles/statistics/statsgrid/handler/StatisticsHandler.js
@@ -273,13 +273,14 @@ class StatisticsController extends StateHandlerBase {
         const labels = getUILabels(indicator, meta);
         // format data here because data is populated before classification (fractionDigits) created
         formatData(data, classification);
-
+        const allowedRegionsets = Array.isArray(meta.regionsets) ? meta.regionsets : [];
         return {
             ...indicator,
             data,
             classification,
             labels,
-            classifiedData
+            classifiedData,
+            allowedRegionsets
         };
     }
 

--- a/bundles/statistics/statsgrid/resources/scss/manualClassification.scss
+++ b/bundles/statistics/statsgrid/resources/scss/manualClassification.scss
@@ -28,7 +28,7 @@
     }
     div.input-area {
         position: absolute;
-        bottom: 13px;
+        bottom: 12px;
         left: 0;
         right: 0;
         text-align: center;

--- a/bundles/statistics/statsgrid/view/Table/TableFlyout.jsx
+++ b/bundles/statistics/statsgrid/view/Table/TableFlyout.jsx
@@ -44,13 +44,21 @@ const IndicatorHeader = styled('div')`
     height: 100%;
 `;
 const StyledRemoveButton = styled(IconButton)`
-    margin-left: 10px;
+    margin-right: 10px;
+    height: 20px;
 `;
 const HeaderCell = styled('div')`
     display: flex;
     flex-direction: column;
     justify-content: space-between;
     height: 100%;
+`;
+const HeaderTools = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin-top: 10px;
+    height: 20px;
 `;
 
 const TableFlyout = ({ state, controller }) => {
@@ -122,10 +130,11 @@ const TableFlyout = ({ state, controller }) => {
                             />
                         )}
                     </RegionHeader>
-                    <Sorter
-                        sortOrder={sortOrder['name']}
-                        changeSortOrder={() => changeSortOrder('name')}
-                    />
+                    <HeaderTools>
+                        <Sorter
+                            sortOrder={sortOrder['name']}
+                            changeSortOrder={() => changeSortOrder('name')} />
+                    </HeaderTools>
                 </HeaderCell>
             );
         }
@@ -148,21 +157,17 @@ const TableFlyout = ({ state, controller }) => {
             title: () => {
                 return (
                     <HeaderCell>
-                        <IndicatorHeader
-                            onClick={(e) => {
-                                controller.setActiveIndicator(hash);
-                            }}
-                        >
+                        <IndicatorHeader onClick={() => controller.setActiveIndicator(hash)}>
                             <IndicatorName indicator={indicator} />
+                        </IndicatorHeader>
+                        <HeaderTools>
+                            <Sorter
+                                sortOrder={sortOrder[hash]}
+                                changeSortOrder={() => changeSortOrder(hash)}/>
                             <StyledRemoveButton
                                 type='delete'
-                                onClick={() => controller.removeIndicator(indicator)}
-                            />
-                        </IndicatorHeader>
-                        <Sorter
-                            sortOrder={sortOrder[hash]}
-                            changeSortOrder={() => changeSortOrder(hash)}
-                        />
+                                onClick={() => controller.removeIndicator(indicator)}/>
+                        </HeaderTools>
                     </HeaderCell>
                 );
             }

--- a/bundles/statistics/statsgrid/view/Table/TableFlyout.jsx
+++ b/bundles/statistics/statsgrid/view/Table/TableFlyout.jsx
@@ -62,7 +62,7 @@ const HeaderTools = styled.div`
 `;
 
 const TableFlyout = ({ state, controller }) => {
-    const { indicators, activeIndicator, regionset, loading, regions } = state;
+    const { indicators, activeIndicator, regionset, regions } = state;
     let initialSort = {
         regionName: null
     };
@@ -100,7 +100,15 @@ const TableFlyout = ({ state, controller }) => {
         return data;
     });
     const columnSettings = [];
-
+    const regionsetIds = [];
+    indicators.forEach(ind => {
+        const sets = ind.allowedRegionsets || [];
+        sets.forEach(id => {
+            if (!regionsetIds.includes(id)) {
+                regionsetIds.push(id);
+            }
+        });
+    });
     columnSettings.push({
         dataIndex: 'name',
         align: 'left',
@@ -124,7 +132,9 @@ const TableFlyout = ({ state, controller }) => {
                         ) : (
                             <Select
                                 filterOption={false}
-                                options={getRegionsets().map(rs => ({ value: rs.id, label: rs.name }))}
+                                options={getRegionsets()
+                                    .filter(rs => regionsetIds.includes(rs.id))
+                                    .map(rs => ({ value: rs.id, label: rs.name }))}
                                 value={regionset}
                                 onChange={(value) => controller.setActiveRegionset(value)}
                             />

--- a/bundles/statistics/statsgrid/view/search/IndicatorCollapse.jsx
+++ b/bundles/statistics/statsgrid/view/search/IndicatorCollapse.jsx
@@ -1,13 +1,19 @@
 import React from 'react';
 import { Message, Collapse, CollapsePanel } from 'oskari-ui';
+import { DeleteButton } from 'oskari-ui/components/buttons';
 import { IndicatorRow } from './IndicatorRow';
 import styled from 'styled-components';
 
 const StyledCollapse = styled(Collapse)`
     margin-top: 20px;
 `;
+const RemoveAll = styled(DeleteButton)`
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 10px;
+`;
 
-export const IndicatorCollapse = ({ indicators = [], removeIndicator, showMetadata }) => {
+export const IndicatorCollapse = ({ indicators = [], removeIndicator, removeAll, showMetadata }) => {
     return (
         <StyledCollapse>
             <CollapsePanel
@@ -18,6 +24,12 @@ export const IndicatorCollapse = ({ indicators = [], removeIndicator, showMetada
                     indicators.map((indicator) => (
                         <IndicatorRow key={indicator.hash} indicator={indicator} removeIndicator={removeIndicator} showMetadata={showMetadata}/>
                     ))
+                }
+                { indicators.length > 1 &&
+                    <RemoveAll type='button'
+                        tooltip={<Message messageKey='indicatorList.removeAll' />}
+                        title={<Message messageKey='indicatorList.removeAll' />}
+                        onConfirm={() => removeAll()}/>
                 }
             </CollapsePanel>
         </StyledCollapse>

--- a/bundles/statistics/statsgrid/view/search/IndicatorParams.jsx
+++ b/bundles/statistics/statsgrid/view/search/IndicatorParams.jsx
@@ -39,10 +39,18 @@ const TimeSeriesParams = ({fieldName, timeOptions, selectedValues, controller}) 
     </TimeseriesField>
 );
 
-export const IndicatorParams = ({ params, allRegionsets = [], searchTimeseries, controller }) => {
+export const IndicatorParams = ({ params, allRegionsets = [], searchTimeseries, regionsetFilter, controller }) => {
     const paramKeys = Object.keys(params.selectors);
     const indicatorRegionsets = params.regionset || [];
-    const regionsetOptions = allRegionsets.filter(rs => indicatorRegionsets.includes(rs.id));
+    const regionsetOptions = allRegionsets
+        .filter(rs => indicatorRegionsets.includes(rs.id))
+        .map(rs => {
+            const opt = { value: rs.id, label: rs.name };
+            if (regionsetFilter.length && !regionsetFilter.includes(rs.id)) {
+                opt.disabled = true;
+            }
+            return opt;
+        });
 
     return (
         <div>
@@ -74,7 +82,7 @@ export const IndicatorParams = ({ params, allRegionsets = [], searchTimeseries, 
                 <Field>
                     <b><Message messageKey='parameters.regionset' /></b>
                     <StyledSelect
-                        options={regionsetOptions.map(rs => ({ value: rs.id, label: rs.name }))}
+                        options={regionsetOptions}
                         value={params.selected.regionsets}
                         onChange={(value) => controller.setParamSelection('regionsets', value)}
                     />

--- a/bundles/statistics/statsgrid/view/search/IndicatorParams.jsx
+++ b/bundles/statistics/statsgrid/view/search/IndicatorParams.jsx
@@ -65,6 +65,7 @@ export const IndicatorParams = ({ params, allRegionsets = [], searchTimeseries, 
                             options={selector?.values?.map(value => ({ value: value.id, label: value.title }))}
                             value={params.selected[param]}
                             onChange={(value) => controller.setParamSelection(param, value)}
+                            mode={selector?.time === true ? 'multiple' : ''}
                         />
                     </Field>
                 );

--- a/bundles/statistics/statsgrid/view/search/SearchFlyout.jsx
+++ b/bundles/statistics/statsgrid/view/search/SearchFlyout.jsx
@@ -129,6 +129,7 @@ const SearchFlyout = ({ state, controller }) => {
                 <IndicatorParams
                     allRegionsets={regionsets}
                     params={state.indicatorParams}
+                    regionsetFilter={state.regionsetFilter}
                     searchTimeseries={state.searchTimeseries}
                     controller={controller}
                 />

--- a/bundles/statistics/statsgrid/view/search/SearchFlyout.jsx
+++ b/bundles/statistics/statsgrid/view/search/SearchFlyout.jsx
@@ -163,6 +163,7 @@ export const showSearchFlyout = (state, indicators = [], searchController, state
                 <SearchFlyout state={state} controller={searchController} />
                 <IndicatorCollapse indicators={indicators}
                     removeIndicator={stateController.removeIndicator}
+                    removeAll={stateController.resetState}
                     showMetadata={searchController.openMetadataPopup}/>
             </Content>
         </LocaleProvider>,
@@ -179,6 +180,7 @@ export const showSearchFlyout = (state, indicators = [], searchController, state
                     <SearchFlyout state={state} controller={searchController} />
                     <IndicatorCollapse indicators={indicators}
                         removeIndicator={stateController.removeIndicator}
+                        removeAll={stateController.resetState}
                         showMetadata={searchController.openMetadataPopup}/>
                 </Content>
             </LocaleProvider>


### PR DESCRIPTION
- Handle regionset filter properly (auto select first and disable options)
- Histogram: Add top margin, use integers for ticks and use same formatting than other components (was fixed to 2 decimals)
- SearchFlyout: add remove all button and use multi select for time param
- Table: move delete icon to header tools
- Filter regionset options (table)

![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/9e64a3d5-71d4-4047-bae8-7c9aac316280)

![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/b865c09c-e5c5-454b-b370-d8a288b43cb6)

![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/b104489e-6ea5-49fe-9b8f-1fd52fdf428f)
