### PR TITLE
Hide statsgrid panel in publisher when statistical data is not shown on map

### DIFF
--- a/bundles/statistics/statsgrid/publisher/AbstractStatsPluginTool.js
+++ b/bundles/statistics/statsgrid/publisher/AbstractStatsPluginTool.js
@@ -76,7 +76,7 @@ export class AbstractStatsPluginTool extends AbstractPublisherTool {
         if (this._isStatsActive()) {
             return true;
         }
-        return Oskari.util.keyExists(data, 'configuration.statsgrid.state');
+        return !!data?.configuration?.statsgrid?.state;
     }
 
     getStatsgridConf (initialData) {


### PR DESCRIPTION
The state is present but with value null when statsgrid is not active with the new impl.