### PR TITLE
Keep classification open as workaround to fix it being duplicated

### DIFF
--- a/bundles/statistics/statsgrid/handler/ViewHandler.js
+++ b/bundles/statistics/statsgrid/handler/ViewHandler.js
@@ -148,12 +148,17 @@ class UIHandler extends StateHandler {
 
     addMapButton (id) {
         const mapButtons = [...this.getState().mapButtons, id];
+        /*
         if (id === CLASSIFICATION && this.controls[id]) {
             // classification is by default open while the other windows are not
             // close it if we add the button for classification
+            // FIXME: this makes classification duplicate itself when toggled with the other buttons.
+            // lets keep it open and recalculate the activeMapButtons so it's activated since its open by default
             this.close(id);
         }
-        this.updateState({ mapButtons });
+        */
+        const activeMapButtons = mapButtons.filter(id => this.controls[id]);
+        this.updateState({ mapButtons, activeMapButtons });
     }
 
     removeMapButton (id) {
@@ -233,6 +238,7 @@ class UIHandler extends StateHandler {
         this.controls[id] = controls;
         this.notifyExtensions(id, true);
     }
+
     _createSeriesControls () {
         if (!this.seriesControlPlugin) {
             this.seriesControlPlugin = createSeriesControlPlugin(this.instance.getSandbox(), this.stateHandler);

--- a/bundles/statistics/statsgrid/publisher/ClassificationTool.js
+++ b/bundles/statistics/statsgrid/publisher/ClassificationTool.js
@@ -25,7 +25,7 @@ class ClassificationTool extends AbstractStatsPluginTool {
         if (!handler) {
             return;
         }
-        handler.getController().updateClassificationState('editEnabled', enabled);
+        handler.updateClassificationState('editEnabled', enabled);
     }
 
     stop () {
@@ -33,7 +33,7 @@ class ClassificationTool extends AbstractStatsPluginTool {
         if (!handler) {
             return;
         }
-        handler.getController().updateClassificationState('editEnabled', true);
+        handler.updateClassificationState('editEnabled', true);
     }
 
     // TODO: is this main tool (always included)??
@@ -41,8 +41,7 @@ class ClassificationTool extends AbstractStatsPluginTool {
         if (!this._isStatsActive()) {
             return null;
         }
-        const stats = this.getStatsgridBundle();
-        const { location } = stats?.togglePlugin?.getConfig() || {};
+        const { location } = this.getPlugin().getConfig() || {};
         return {
             configuration: {
                 statsgrid: {
@@ -52,7 +51,7 @@ class ClassificationTool extends AbstractStatsPluginTool {
                             classes: 'bottom right'
                         }
                     },
-                    state: this.__sandbox.getStatefulComponents().statsgrid.getState()
+                    state: this.getSandbox().getStatefulComponents().statsgrid.getState()
                 }
             }
         };

--- a/bundles/statistics/statsgrid/publisher/OpacityTool.js
+++ b/bundles/statistics/statsgrid/publisher/OpacityTool.js
@@ -21,7 +21,7 @@ class OpacityTool extends AbstractStatsPluginTool {
         if (!handler) {
             return;
         }
-        handler.getController().updateClassificationState('transparent', enabled);
+        handler.updateClassificationState('transparent', enabled);
     }
 
     stop () {
@@ -29,7 +29,7 @@ class OpacityTool extends AbstractStatsPluginTool {
         if (!handler) {
             return;
         }
-        handler.getController().updateClassificationState('transparent');
+        handler.updateClassificationState('transparent');
     }
 };
 


### PR DESCRIPTION
Previously tried to remove it from screen when the button to toggle it is added. This caused problems with the classification UI being duplicated when toggling it WHEN there are other buttons on the togglePlugin. By itself it worked ok even when closed while adding the button.