### PR TITLE
Fix CSS problem when removing the last plugin in container

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -2073,8 +2073,6 @@ Oskari.clazz.define(
                 // no position given, add to end
                 content.append(element);
             }
-            // Make sure container is visible
-            container.css('display', '');
         },
 
         /**
@@ -2084,16 +2082,10 @@ Oskari.clazz.define(
          * @param {Boolean} detachOnly true to detach and preserve event handlers, false to remove element
          */
         removeMapControlPlugin: function (element, detachOnly) {
-            var container = element.parents('.mapplugins');
-            var content = element.parents('.mappluginsContent');
-            // TODO take this into use in all UI plugins so we can hide unused containers...
             if (detachOnly) {
                 element.detach();
             } else {
                 element.remove();
-            }
-            if (!this.isInLayerToolsEditMode() && content.children().length === 0) {
-                container.css('display', 'none');
             }
         },
 


### PR DESCRIPTION
The plugin containers now uses display: flex so changing between display: none and '' breaks the UI when exiting publisher on certain cases (mostly when something is added to the bottom right plugin container and then removed from it):

Original layout:
![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/85c3db61-b68f-475c-8791-e43e16232a93)

After exiting publisher with the "right" circumstances:
![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/809e7e74-374d-49fd-8599-d951a41ed049)
