### PR TITLE
Don't add React-based publisher tools to panel if they are not displayed

### DIFF
--- a/bundles/framework/publisher2/handler/ToolPanelHandler.js
+++ b/bundles/framework/publisher2/handler/ToolPanelHandler.js
@@ -16,13 +16,15 @@ class UIHandler extends StateHandler {
             const tool = this.toolsToInit.shift();
             try {
                 tool.init(data);
-                this._addToolToState(tool);
+                if (tool.isDisplayed(data)) {
+                    this._addToolToState(tool);
+                }
             } catch (err) {
                 Oskari.log('ToolPanelHandler').error('Error initializing publisher tool:', tool);
             }
         }
         const { tools } = this.getState();
-        return tools.some(tool => tool.publisherTool.isDisplayed(data));
+        return tools.length > 0;
     }
 
     _addToolToState (tool) {


### PR DESCRIPTION
As the React-component listing the tools won't check that if tool should be displayed -> just don't add it to publisher panel state. This might lead to an issue where tool should become visible during publisher usage, but since isDiplayed() requires the initial payload as param to check if it should be displayed and we don't have that when rendering the tools list -> just check it when initializing the publisher.

Fixes the issue where statsgrid control for timeseries toggle would be shown even when there is no timeseries to show. This was because the panel was previously happy if any of the tools were going to be shown and the isDisplayed() was NOT checked per tool while rendering the list.