### PR TITLE
Statsgrid state fixes

### DIFF
--- a/bundles/statistics/statsgrid/components/SeriesControl.js
+++ b/bundles/statistics/statsgrid/components/SeriesControl.js
@@ -117,8 +117,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SeriesControl', function (contr
         if (!this._isValidIndex(requestedIndex)) {
             return;
         }
-        this._renderHandle(requestedIndex);
-        this._updateValueDisplay(requestedIndex);
+        this._updateSeriesIndex(requestedIndex);
         this._setSelectedValue(requestedIndex);
     },
     _next: function () {

--- a/bundles/statistics/statsgrid/components/classification/editclassification/SizeSlider.jsx
+++ b/bundles/statistics/statsgrid/components/classification/editclassification/SizeSlider.jsx
@@ -51,7 +51,7 @@ export const SizeSlider = ({
     disabled
 }) => {
     const { count, min, max } = values;
-    const [range, setRange] = useState([min, max]);
+    const [internalRange, setRange] = useState([min, max]);
     const minRange = count * SLIDER_PROPS.step;
     const onChange = (range) => {
         if (range[1] - range[0] < minRange) {
@@ -59,14 +59,14 @@ export const SizeSlider = ({
         }
         setRange(range);
     };
-    const onAfterChange = () => {
+    const onAfterChange = (range) => {
         controller.updateClassification({ min: range[0], max: range[1] });
     };
     return (
         <div>
             <Message messageKey="classify.labels.pointSize"/>
             <StyledSlider
-                value = {range}
+                value = {internalRange}
                 disabled = {disabled}
                 onChange={onChange}
                 onAfterChange={onAfterChange}

--- a/bundles/statistics/statsgrid/helper/ClassificationHelper.js
+++ b/bundles/statistics/statsgrid/helper/ClassificationHelper.js
@@ -56,9 +56,12 @@ export const getClassification = (data, metadata = {}, lastSelected = {}) => {
         classification.fractionDigits = metadata.decimalCount;
     }
     if (typeof metadata.base === 'number') {
-        // if there is a base value the data is divided at base value
-        classification.base = metadata.base;
-        classification.type = 'div';
+        // doesn't make sense to use divided classification if data isn't divided
+        if (data.min < metadata.base && data.max > metadata.base) {
+            // if there is a base value the data is divided at base value
+            classification.base = metadata.base;
+            classification.type = 'div';
+        }
     }
     validateClassification(classification, data);
     return classification;

--- a/bundles/statistics/statsgrid/helper/ClassificationHelper.js
+++ b/bundles/statistics/statsgrid/helper/ClassificationHelper.js
@@ -105,49 +105,15 @@ export const getClassifiedData = (indicator, groupStats) => {
         return { error: 'noEnough' };
     }
     const dataByRegions = getDataByRegions(indicator);
-    const values = seriesValues || dataByRegions.map(d => d.value);
+    const values = seriesValues || dataByRegions.map(d => d.value).filter(val => typeof val !== 'undefined');
     const isDivided = opts.type === 'div';
     const { format } = Oskari.getNumberFormatter(opts.fractionDigits);
-    var stats = new geostats(values);
+
+    const stats = new geostats(values);
     stats.silent = true;
     stats.setPrecision();
-    let bounds;
-    const setBounds = (stats) => {
-        if (opts.method === 'jenks') {
-            bounds = stats.getClassJenks(opts.count);
-        } else if (opts.method === 'quantile') {
-            bounds = stats.getQuantile(opts.count);
-        } else if (opts.method === 'equal') {
-            bounds = stats.getEqInterval(opts.count);
-        } else if (opts.method === 'manual') {
-            bounds = getBoundsFallback(opts.manualBounds, opts.count, stats.min(), stats.max());
-            stats.setBounds(bounds);
-        }
-    };
-    // TODO: remove
-    if (groupStats) {
-        groupStats.silent = true;
-        const groupOpts = groupStats.classificationOptions || {};
-        const calculateBounds =
-            groupOpts.method !== opts.method ||
-            groupOpts.count !== opts.count ||
-            (opts.method === 'manual' && !Oskari.util.arraysEqual(groupStats.bounds, opts.manualBounds));
 
-        if (calculateBounds) {
-            setBounds(groupStats);
-            groupOpts.method = opts.method;
-            groupOpts.count = opts.count;
-            groupStats.classificationOptions = groupOpts;
-        } else {
-            bounds = groupStats.bounds;
-        }
-        // Set bounds manually.
-        stats.setBounds(groupStats.bounds);
-    } else if (isDivided) {
-        bounds = getDividedBounds(stats, opts);
-    } else {
-        setBounds(stats);
-    }
+    const bounds = isDivided ? getDividedBounds(stats, opts) : getBounds(stats, opts);
     if (bounds.some(bound => isNaN(bound))) {
         console.warn('Failed to create bounds');
         return { error: 'noEnough' };
@@ -204,6 +170,24 @@ export const getClassifiedData = (indicator, groupStats) => {
         bounds,
         stats: statistics
     };
+};
+
+const getBounds = (stats, opts) => {
+    if (opts.method === 'jenks') {
+        return stats.getClassJenks(opts.count);
+    }
+    if (opts.method === 'quantile') {
+        return stats.getQuantile(opts.count);
+    }
+    if (opts.method === 'equal') {
+        return stats.getEqInterval(opts.count);
+    }
+    if (opts.method === 'manual') {
+        const bounds = getBoundsFallback(opts.manualBounds, opts.count, stats.min(), stats.max());
+        stats.setBounds(bounds);
+        return bounds;
+    }
+    return [];
 };
 
 const getPixelsForClassification = (classification, index) => {

--- a/bundles/statistics/statsgrid/helper/ColorHelper.js
+++ b/bundles/statistics/statsgrid/helper/ColorHelper.js
@@ -49,7 +49,18 @@ const _getDividedChoropleth = (classification, baseIndex) => {
     const overBase = count - baseIndex - neutral;
 
     const colorCount = Math.max(underBase, overBase) * 2 + neutral;
-    const colorset = [...getColorset(colorCount, color)];
+    let colorset = [];
+    try {
+        colorset = [...getColorset(colorCount, color)];
+    } catch(e) {
+        // If values are divided unequally, high count doesn't have required amount of colors
+        // validateClassification and getOptions should handle this properly but it requires some refactoring
+        // For now avoid error and let user update classification
+        const max = Math.max(underBase, overBase);
+        const cause = `${max} groups are ${overBase > underBase ? 'over' : 'under'} base value`;
+        console.warn(`Failed to get divided colors. Count ${count} requires ${colorCount} colors because ${cause}.`);
+        return [];
+    }
     if (reverseColors) {
         colorset.reverse();
     }

--- a/bundles/statistics/statsgrid/helper/ColorHelper.js
+++ b/bundles/statistics/statsgrid/helper/ColorHelper.js
@@ -33,7 +33,11 @@ export const getColorsForClassification = (classification) => {
 
 export const getDividedColors = (classification, bounds) => {
     const { mapStyle, base = 0 } = classification;
-    const baseIndex = bounds.findIndex(bound => bound >= base);
+    let baseIndex = bounds.findIndex(bound => bound >= base);
+    if (baseIndex === -1) {
+        // all bounds are under base value, use last index
+        baseIndex = bounds.length -1;
+    }
 
     if (mapStyle === 'points') {
         return _getDividedPoints(classification, baseIndex);

--- a/bundles/statistics/statsgrid/helper/StatisticsHelper.js
+++ b/bundles/statistics/statsgrid/helper/StatisticsHelper.js
@@ -98,7 +98,12 @@ export const populateSeriesData = (data, regions, regionset, fractionDigits) => 
         if (error) {
             return;
         }
-        dataByRegions.forEach(d => seriesValues.push(d.value));
+        dataByRegions.forEach(d => {
+            if (typeof d.value === 'undefined') {
+                return;
+            }
+            seriesValues.push(d.value)
+        });
         seriesMax = seriesMax > max ? seriesMax : max;
         seriesMin = seriesMin < min ? seriesMin : min;
         if (allInts === false) {


### PR DESCRIPTION
- fix series step buttons
- fix size slider classification update
- filter undefined values before passing values to stats.js
- ugly fix for divided colors (validation, getOptions,.. should be refactored to auto select and disable options)
- some indicators have all values under or over base value => doesn't make sense to use divided points/colors

- remove series stats bounds handling. seriesValues is used instead of precalculated  groupStats.