### PR TITLE
statsgrid: Fix transparency and editing classification settings for embedded maps

### DIFF
--- a/bundles/statistics/statsgrid/components/classification/Classification.jsx
+++ b/bundles/statistics/statsgrid/components/classification/Classification.jsx
@@ -49,7 +49,7 @@ export const Classification = ({
     pluginState
 }) => {
     const [isEdit, setEdit] = useState(false);
-    const { layer, classification: {transparent, editEnabled} } = pluginState;
+    const { layer, classification: { transparent, editEnabled } } = pluginState;
     const { activeIndicator, indicators } = state;
     const current = indicators.find(ind => ind.hash === activeIndicator);
     if (!current) {

--- a/bundles/statistics/statsgrid/handler/ViewHandler.js
+++ b/bundles/statistics/statsgrid/handler/ViewHandler.js
@@ -55,8 +55,12 @@ class UIHandler extends StateHandler {
     setEmbeddedTools (conf) {
         const mapButtons = embeddedTools.filter(tool => conf[tool]);
         const activeMapButtons = embeddedTools.filter(id => this.controls[id]);
-        // TODO: state.classification confista (classificationDefaults) jotta julkaistun kartan tila saadaan alustettua
-        this.updateState({ mapButtons, activeMapButtons });
+        const classification = {
+            ...this.getState().classification,
+            editEnabled: !!conf?.allowClassification,
+            transparent: !!conf?.transparent
+        };
+        this.updateState({ mapButtons, activeMapButtons, classification });
     }
 
     setIndicatorFormHandler (formHandler) {


### PR DESCRIPTION
So the thematic maps legend uses the transparency (and enabling editing for the classification)  setting from config:
![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/fa4e4f48-cf82-446c-ab25-02ab9a7500e2)
