### PR TITLE
Add delay to notifying statelisteners for React StateHandler

### DIFF
--- a/src/react/util/state/StateHandler.js
+++ b/src/react/util/state/StateHandler.js
@@ -8,12 +8,14 @@ export class StateHandler {
         this.state = {};
         this.stashedState = null;
     }
+
     /**
      * @returns {object} Current state
      */
     getState () {
         return this.state;
     }
+
     /**
      * @param {Object} state A new state replacing the previous one.
      */
@@ -21,6 +23,7 @@ export class StateHandler {
         this.state = state;
         this.notify();
     }
+
     /**
      * @param {Object} props Extends and overrides keys in state.
      */
@@ -31,6 +34,7 @@ export class StateHandler {
         };
         this.notify();
     }
+
     /**
      * Stashes current state so it can be returned to later on.
      */
@@ -41,6 +45,7 @@ export class StateHandler {
         }
         this.stashedState = { ...this.state };
     }
+
     /**
      * To check if we have a state in stash.
      * @return {boolean} True, if we have state in stash.
@@ -48,6 +53,7 @@ export class StateHandler {
     hasStashedState () {
         return !!this.stashedState;
     }
+
     /**
      * Retain previously stashed state. Clears the stash.
      */
@@ -57,6 +63,7 @@ export class StateHandler {
         }
         this.stashedState = null;
     }
+
     /**
      * Register a listener function. Listeners will be called every time the state changes.
      * @param {function} consumer The consumer function.
@@ -64,11 +71,19 @@ export class StateHandler {
     addStateListener (consumer) {
         this.stateListeners.push(consumer);
     }
+
     /**
-     * Handles calling registerd listeners.
+     * Handles calling registered listeners.
      * @private
      */
     notify () {
-        this.stateListeners.forEach(consumer => consumer(this.getState()));
+        if (this.timeout) {
+            clearTimeout(this.timeout);
+        }
+        // This allows multiple small state updates to be run one after another before re-rendering is triggered
+        this.timeout = setTimeout(() => {
+            this.stateListeners.forEach(consumer => consumer(this.getState()));
+            this.timeout = null;
+        }, 10);
     }
 }


### PR DESCRIPTION
This allows multiple small state updates to be run before triggering statelisteners/re-render.

Fixes the issue with statsgrid being started for editing when more than one tool is enabled for editing. Without this opening the statsgrid for publisher results in JS error:
```
RangeError: Maximum call stack size exceeded
    at _objectSpread (StateHandler.js:5:23)
    at HandlerWithController.updateState (StateHandler.js:28:1)
    at HandlerWithController.notifyExtensions (ViewHandler.js:393:14)
    at HandlerWithController.close (ViewHandler.js:369:12)
    at HandlerWithController.onViewChange (ViewHandler.js:166:14)
```

However since this is a base class for all React state handlers in Oskari this might have unexpected side-effects.