### PR TITLE
Statsgrid set active regionset fix

### DIFF
--- a/bundles/statistics/statsgrid/handler/StatisticsHandler.js
+++ b/bundles/statistics/statsgrid/handler/StatisticsHandler.js
@@ -100,15 +100,11 @@ class StatisticsController extends StateHandlerBase {
         const updated = [];
         // async/await doesn't work with map()
         for (let i = 0; i < indicators.length; i++) {
-            const indicator = indicators[i];
-            const data = await getDataForIndicator(indicator, regionset);
-            validateClassification(indicator.classification, data);
-            const classifiedData = getClassifiedData(indicator);
-            updated.push({
-                ...indicator,
-                data,
-                classifiedData
-            });
+            const indicator = {...indicators[i]};
+            indicator.data = await getDataForIndicator(indicator, regionset);
+            validateClassification(indicator.classification, indicator.data);
+            indicator.classifiedData = getClassifiedData(indicator);
+            updated.push(indicator);
         };
         return updated;
     }
@@ -226,8 +222,8 @@ class StatisticsController extends StateHandlerBase {
     async addIndicator (indicator, regionset) {
         if (this.isIndicatorSelected(indicator, true)) {
             // already selected
-            if (regionset === this.getState().regionset) {
-                this.setActiveRegionset(regionset);
+            if (regionset !== this.getState().regionset) {
+                await this.setActiveRegionset(regionset);
             }
             return true;
         }


### PR DESCRIPTION
Classified data was calculated from previous outdated data. Added missing ! to comparison and await to handle regionset change properly from search flyout.