### PR TITLE
Statsgrid search fixes

### DIFF
--- a/bundles/statistics/statsgrid/components/SeriesControl.js
+++ b/bundles/statistics/statsgrid/components/SeriesControl.js
@@ -50,6 +50,15 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SeriesControl', function (contr
     updateState: function (state) {
         this._uiState = { ...this._uiState, ...state };
     },
+    resetState: function () {
+        this._uiState = {
+            values: [],
+            animating: false,
+            interval: 2000,
+            index: 0,
+            hash: null
+        };
+    },
     /**
      * @method _generateSelectOptions Generate localized options for <select> dropdowns
      * @private

--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -341,7 +341,7 @@ class SearchController extends StateHandler {
             });
 
             if (result.regionsets.length === 0) {
-                Messaging.error('errors.regionsetsIsEmpty');
+                Messaging.error(this.loc('errors.regionsetsIsEmpty'));
             }
 
             const data = {
@@ -425,9 +425,9 @@ class SearchController extends StateHandler {
             }
         };
 
-        const keyWithTime = Object.keys(this.getState().indicatorParams.selected).find((key) => this.getState().indicatorParams.selectors[key].time);
+        const keyWithTime = Object.keys(this.getState().indicatorParams.selected).find((key) => this.getState().indicatorParams.selectors[key]?.time);
 
-        if (this.getState().searchTimeseries) {
+        if (keyWithTime && this.getState().searchTimeseries) {
             data.selections[keyWithTime] = this.getState().indicatorParams.selected[keyWithTime][0];
             const values = this.getState().indicatorParams.selectors[keyWithTime].values.filter(val => val.id >= this.getState().indicatorParams.selected[keyWithTime][0] && val.id <= this.getState().indicatorParams.selected[keyWithTime][1]).reverse();
             data.series = {

--- a/bundles/statistics/statsgrid/plugin/SeriesControlPlugin.js
+++ b/bundles/statistics/statsgrid/plugin/SeriesControlPlugin.js
@@ -55,6 +55,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.SeriesControlPlugin',
                 this.removeFromPluginContainer(this.getElement());
                 this.element = null;
             }
+            this._seriesControl.resetState();
         },
         _buildUI: function () {
             this._isMobileVisible = true;

--- a/bundles/statistics/statsgrid/view/search/IndicatorParams.jsx
+++ b/bundles/statistics/statsgrid/view/search/IndicatorParams.jsx
@@ -6,37 +6,42 @@ const Field = styled('div')`
     display: flex;
     flex-direction: column;
     margin-bottom: 10px;
-    width: 50%;
-    margin-right: 10px;
+    width: 180px;
 `;
-const TimeseriesField = styled('div')`
+const Timeseries = styled.div`
     display: flex;
     flex-direction: row;
-    width: 50%;
+    margin-bottom: 10px;
+`;
+const TimeseriesField = styled.div`
+    display: flex;
+    flex-direction: column;
+    width: 100px;
+    margin-right: 10px;
 `;
 const StyledSelect = styled(Select)`
     width: 100%;
 `;
 
 const TimeSeriesParams = ({fieldName, timeOptions, selectedValues, controller}) => (
-    <TimeseriesField>
-        <Field>
+    <Timeseries>
+        <TimeseriesField>
             <b><Message messageKey='parameters.from' /></b>
             <StyledSelect
                 options={timeOptions}
                 value={selectedValues[0]}
                 onChange={(value) => controller.setParamSelection(fieldName, value, 0)}
             />
-        </Field>
-        <Field>
+        </TimeseriesField>
+        <TimeseriesField>
             <b><Message messageKey='parameters.to' /></b>
             <StyledSelect
                 options={timeOptions}
                 value={selectedValues[1]}
                 onChange={(value) => controller.setParamSelection(fieldName, value, 1)}
             />
-        </Field>
-    </TimeseriesField>
+        </TimeseriesField>
+    </Timeseries>
 );
 
 export const IndicatorParams = ({ params, allRegionsets = [], searchTimeseries, regionsetFilter, controller }) => {

--- a/bundles/statistics/statsgrid/view/search/SearchFlyout.jsx
+++ b/bundles/statistics/statsgrid/view/search/SearchFlyout.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Checkbox, Select, Message, Spin, Button } from 'oskari-ui';
+import { Checkbox, Select, Message, Spin } from 'oskari-ui';
 import { showFlyout } from 'oskari-ui/components/window';
-import { ButtonContainer, PrimaryButton, SecondaryButton } from 'oskari-ui/components/buttons';
+import { ButtonContainer, PrimaryButton, SecondaryButton, IconButton } from 'oskari-ui/components/buttons';
 import styled from 'styled-components';
 import { LocaleProvider } from 'oskari-ui/util';
 import { IndicatorParams } from './IndicatorParams';
@@ -30,15 +30,20 @@ const Row = styled('div')`
     width: 100%;
     align-items: end;
 `;
-const AddIndicatorBtn = styled(Button)`
-    max-width: 40%;
+const UserIndicatorButton = styled(IconButton)`
+    margin-left: 10px;
 `;
 const IndicatorField = styled('div')`
     display: flex;
     flex-direction: column;
     width: 100%;
-    margin-right: 10px;
 `;
+
+const UserIndicator = ({isSingle, onClick}) => {
+    const type = isSingle ? 'edit' : 'add';
+    const title = isSingle ? 'userIndicators.modify.edit' : 'userIndicators.buttonTitle';
+    return <UserIndicatorButton bordered type={type} title={<Message messageKey={title} />} onClick={onClick} />
+};
 
 // For preventing checkbox clickable area from stretching to 100% of content width
 const ClickableArea = ({ children }) => <div>{children}</div>;
@@ -104,14 +109,7 @@ const SearchFlyout = ({ state, controller }) => {
                             onChange={(value) => controller.setSelectedIndicators(value)}
                         />
                     </IndicatorField>
-                    {state.isUserDatasource && (
-                        <AddIndicatorBtn
-                            onClick={() => controller.showIndicatorForm()}
-                        >
-                            { !singleIndicatorSelected && (<Message messageKey='userIndicators.buttonTitle' />) }
-                            { singleIndicatorSelected && (<Message messageKey='userIndicators.modify.edit' />) }
-                        </AddIndicatorBtn>
-                    )}
+                    {state.isUserDatasource && <UserIndicator onClick={controller.showIndicatorForm} isSingle={singleIndicatorSelected} /> }
                 </Row>
             </Field>
             {state.selectedIndicators && state.selectedIndicators.length > 0 && (


### PR DESCRIPTION
- use IconButton for user indicator add/edit
- use fixed widths for indicator param selects
- move margin from indicator select (right) to user indicator button (left)
- reset series control state when plugin is closed -> fixes issue where control is toggled and content isn't shown correctly. On close content was removed. Show doesn't update values as indicator (hash) isn't changed (checks hash to optimize rendering)
- if indicator doesn't have time selector, adding indicator caused error. Regionset is stored to selected and selectors doesn't have regionset.
- fix missing regionsets error message

![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/bb176bc4-d84b-4ddc-bc28-6c0f6d69d671)

![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/43e90c1a-bf67-4e76-8d95-807a8eaff0f9)

![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/ef768e2f-f7fe-4f48-9add-78e21ff4454e)

