### PR TITLE
Statsgrid cache update

### DIFF
--- a/bundles/statistics/statsgrid/handler/IndicatorFormHandler.js
+++ b/bundles/statistics/statsgrid/handler/IndicatorFormHandler.js
@@ -147,8 +147,7 @@ class IndicatorFormController extends StateHandler {
             Messaging.error(this.loc('errors.myIndicatorRegionselect'));
             return;
         }
-        const indicator = this.getSelectedIndicator();
-        this.showDataTable(indicator, datasetRegionset);
+        this.showDataTable();
     }
 
     updateFormData (value, regionId) {
@@ -170,7 +169,9 @@ class IndicatorFormController extends StateHandler {
         });
     }
 
-    async showDataTable (indicator, regionsetId) {
+    async showDataTable () {
+        const indicator = this.getSelectedIndicator();
+        const regionsetId = this.getState().datasetRegionset;
         this.updateState({
             loading: true
         });
@@ -198,6 +199,7 @@ class IndicatorFormController extends StateHandler {
             this.updateState({
                 loading: false,
                 selectedDataset: data,
+                datasetRegionset: regionsetId,
                 formData: {
                     regions: formRegions,
                     labels
@@ -223,7 +225,7 @@ class IndicatorFormController extends StateHandler {
         this.updateState({
             loading: true
         });
-        const { formData, datasetRegionset } = this.getState();
+        const { formData, datasetRegionset, datasetYear } = this.getState();
         const indicator = this.getSelectedIndicator(true);
         if (typeof indicator.name !== 'string' || indicator.name.trim().length === 0) {
             Messaging.warn(this.loc('errors.myIndicatorNameInput'));
@@ -245,24 +247,31 @@ class IndicatorFormController extends StateHandler {
         try {
             indicator.id = await saveIndicator(indicator);
             indicator.hash = getHashForIndicator(indicator);
-            this.log.info('Saved indicator', data, 'Indicator: ' + indicator.id);
+            this.log.info('Saved indicator', indicator);
             if (Object.keys(data).length) {
                 await saveIndicatorData(indicator, data, datasetRegionset);
-                this.log.info('Saved data form values', data, 'Indicator: ' + indicator.id);
+                const indicatorInfo = `Indicator: ${indicator.id}, selection: ${datasetYear}, regionset: ${datasetRegionset}.`;
+                this.log.info('Saved data form values', data, indicatorInfo);
                 // add indicator only when data is saved
                 this.selectSavedIndicator(indicator, datasetRegionset);
             }
             Messaging.success(this.loc('userIndicators.dialog.successMsg'));
             this.cancelForm();
             this.preparePopupData(indicator);
+            this.notifyCacheUpdate(indicator);
         } catch (error) {
             Messaging.error(this.loc('errors.indicatorSave'));
             this.cancelForm();
         }
     }
 
+    notifyCacheUpdate (indicator) {
+        const { datasourceId } = this.getState();
+        this.instance.getSearchHandler()?.onCacheUpdate({ datasourceId, indicator});
+    }
+
     selectSavedIndicator (indicator, regionset) {
-        this.instance.getStateHandler()?.getController().selectIndicator(indicator, regionset);
+        this.instance.getStateHandler()?.getController().selectSavedIndicator(indicator, regionset);
     }
 
     importFromClipboard (data) {
@@ -304,9 +313,10 @@ class IndicatorFormController extends StateHandler {
         });
     }
     editDataset (item = {}) {
-        const selections = { [SELECTOR]: item[SELECTOR] };
-        const indicator = { ...this.getSelectedIndicator(), selections };
-        this.showDataTable(indicator, item.regionset);
+        const datasetYear = item[SELECTOR];
+        const datasetRegionset = item.regionset;
+        this.updateState({ datasetYear, datasetRegionset });
+        this.showDataTable();
     }
 
     async deleteDataset (item = {}) {
@@ -324,6 +334,7 @@ class IndicatorFormController extends StateHandler {
             Messaging.error(this.loc('errors.datasetDelete'));
         }
         this.preparePopupData(indicator);
+        this.notifyCacheUpdate(indicator);
     }
 }
 
@@ -333,7 +344,6 @@ const wrapped = controllerMixin(IndicatorFormController, [
     'setindicatorSource',
     'setDatasetYear',
     'setDatasetRegionset',
-    'showDataTable',
     'addStatisticalData',
     'updateFormData',
     'cancelForm',

--- a/bundles/statistics/statsgrid/handler/IndicatorFormHandler.js
+++ b/bundles/statistics/statsgrid/handler/IndicatorFormHandler.js
@@ -267,7 +267,7 @@ class IndicatorFormController extends StateHandler {
 
     notifyCacheUpdate (indicator) {
         const { datasourceId } = this.getState();
-        this.instance.getSearchHandler()?.onCacheUpdate({ datasourceId, indicator});
+        this.instance.getSearchHandler()?.onCacheUpdate({ datasourceId, indicator });
     }
 
     selectSavedIndicator (indicator, regionset) {

--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -58,8 +58,8 @@ class SearchController extends StateHandler {
         this.setSelectedIndicators(indicators);
     }
 
-    onCacheUpdate({ datasourceId, indicatorId }) {
-        const { selectedDatasource,  selectedIndicators } = this.getState();
+    onCacheUpdate ({ datasourceId, indicatorId }) {
+        const { selectedDatasource, selectedIndicators } = this.getState();
         if (datasourceId && selectedDatasource === datasourceId) {
             this.fetchindicatorOptions();
         }

--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -58,6 +58,16 @@ class SearchController extends StateHandler {
         this.setSelectedIndicators(indicators);
     }
 
+    onCacheUpdate({ datasourceId, indicatorId }) {
+        const { selectedDatasource,  selectedIndicators } = this.getState();
+        if (datasourceId && selectedDatasource === datasourceId) {
+            this.fetchindicatorOptions();
+        }
+        if (indicatorId && selectedIndicators.includes(indicatorId)) {
+            this.fetchIndicatorParams();
+        }
+    }
+
     async fetchindicatorOptions () {
         const { selectedDatasource, isUserDatasource } = this.getState();
         if (!selectedDatasource) {

--- a/bundles/statistics/statsgrid/handler/StatisticsHandler.js
+++ b/bundles/statistics/statsgrid/handler/StatisticsHandler.js
@@ -214,7 +214,11 @@ class StatisticsController extends StateHandlerBase {
         }
     }
 
-    async selectIndicator (indicator, regionset) {
+    async selectSavedIndicator (indicator, regionset) {
+        if (this.isIndicatorSelected(indicator, true)) {
+            // remove indicator first to get updated indicator and data
+            this.removeIndicator(indicator);
+        }
         await this.addIndicator(indicator, regionset);
         this.setActiveIndicator(indicator.hash);
     }
@@ -288,7 +292,7 @@ const wrapped = controllerMixin(StatisticsController, [
     'setActiveRegionset',
     'setActiveRegion',
     'addIndicator',
-    'selectIndicator',
+    'selectSavedIndicator',
     'resetState',
     'updateIndicator',
     'updateClassification',

--- a/bundles/statistics/statsgrid/helper/ClassificationHelper.js
+++ b/bundles/statistics/statsgrid/helper/ClassificationHelper.js
@@ -77,7 +77,15 @@ export const validateClassification = (classification, data = {}) => {
     }
     // geostats fails with jenks if there isn't at least one more unique values than count
     if (classification.method === 'jenks' && data.uniqueCount <= classification.count) {
-        classification.count = data.uniqueCount - 1;
+        const newCount = data.uniqueCount - 1;
+        const { min } = LIMITS.count;
+        if (newCount >= min) {
+            classification.count = newCount;
+        } else {
+            // cannot use 'jenks', change method
+            classification.method = 'equal';
+            classification.count = min;
+        }
     }
     // Discontinuos mode is problematic for series data,
     // because each class has to get at least one hit -> set distinct mode.


### PR DESCRIPTION
- notify search handler to update state if updated datasource an/or indicator is selected. Now handler triggers notify but maybe it should be in cache. Cache has to use some event to notify update as it is stored to helper for now.
- change edit dataset to update state and showDataTable use state. 
- remove saved indicator from selected if was already selected to refresh indicator values and data
- hash is used to get data cache key but every call doesn't have hash because id, ds, selections, regionset are needed for backend call => get hash if missing in geDataCacheKey
- don't use jenks if unique value count <3