### PR TITLE
Recognize series as button for embedded maps

### DIFF
--- a/bundles/statistics/statsgrid/handler/ViewHandler.js
+++ b/bundles/statistics/statsgrid/handler/ViewHandler.js
@@ -15,7 +15,7 @@ const classificationDefaults = {
     editEnabled: true,
     transparent: false
 };
-const embeddedTools = [...FLYOUTS, CLASSIFICATION];
+const embeddedTools = [...FLYOUTS, CLASSIFICATION, 'series'];
 
 class UIHandler extends StateHandler {
     constructor (instance, stateHandler, searchHandler) {


### PR DESCRIPTION
This allows the button for time series control to be shown on the embedded map if selected on the publisher functionality.

![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/f3a91265-28be-4e46-9604-8653bbc23cc9)

However the button only resets the location of the plugin at this point instead of toggling it on/off screen.