### PR TITLE
Statsgrid fixes

### DIFF
--- a/bundles/statistics/statsgrid/handler/IndicatorFormHandler.js
+++ b/bundles/statistics/statsgrid/handler/IndicatorFormHandler.js
@@ -26,6 +26,12 @@ class IndicatorFormController extends StateHandler {
         this.reset();
         await this.preparePopupData({ ds, id });
         this.instance.getViewHandler().show('indicatorForm');
+        if (!id && !Oskari.user().isLoggedIn()) {
+            Messaging.warn({
+                duration: 10,
+                content: this.loc('userIndicators.notLoggedInWarning')
+            });
+        }
     }
 
     showClipboardPopup () {

--- a/bundles/statistics/statsgrid/handler/IndicatorHelper.js
+++ b/bundles/statistics/statsgrid/handler/IndicatorHelper.js
@@ -1,4 +1,4 @@
-import { getHash, getHashForIndicator, getDataProviderKey, populateData, populateSeriesData } from '../helper/StatisticsHelper';
+import { getHash, getDataProviderKey, populateData, populateSeriesData } from '../helper/StatisticsHelper';
 import { updateIndicatorListInCache, removeIndicatorFromCache } from './SearchIndicatorOptionsHelper';
 import { getRegionsAsync } from '../helper/RegionsHelper';
 

--- a/bundles/statistics/statsgrid/handler/IndicatorHelper.js
+++ b/bundles/statistics/statsgrid/handler/IndicatorHelper.js
@@ -8,7 +8,8 @@ const indicatorMetadataStore = {};
 const indicatorDataStore = {};
 const getMetaCacheKey = (datasourceId, indicatorId) => 'ds_' + datasourceId + '_ind_' + indicatorId;
 const getDataCacheKey = (indicator, regionsetId) => {
-    const hash = indicator.hash || getHashForIndicator(indicator);
+    // Don't use series for hash because every time is stored separately
+    const hash = getHash(indicator.ds, indicator.id, indicator.selections);
     return 'hash_' + hash + '_rs_' + regionsetId;
 };
 

--- a/bundles/statistics/statsgrid/handler/ViewHandler.js
+++ b/bundles/statistics/statsgrid/handler/ViewHandler.js
@@ -11,11 +11,12 @@ import { showHistogramPopup } from '../components/manualClassification/Histogram
 export const FLYOUTS = ['search', 'grid', 'diagram']; // to toggle tile
 
 const CLASSIFICATION = 'classification';
+const SERIES = 'series';
 const classificationDefaults = {
     editEnabled: true,
     transparent: false
 };
-const embeddedTools = [...FLYOUTS, CLASSIFICATION];
+const embeddedTools = [...FLYOUTS, CLASSIFICATION, SERIES];
 
 class UIHandler extends StateHandler {
     constructor (instance, stateHandler, searchHandler) {
@@ -86,6 +87,7 @@ class UIHandler extends StateHandler {
 
         // automaticly shown/closed views
         const hasClassificationButton = viewState.mapButtons.includes(CLASSIFICATION);
+        const hasSeriesButton = viewState.mapButtons.includes(SERIES);
         if (isActive) {
             if (classification) {
                 classification.update(state, viewState);
@@ -97,13 +99,14 @@ class UIHandler extends StateHandler {
             if (state.isSeriesActive) {
                 if (series) {
                     series.update(state);
-                } else {
-                    this.show('series');
+                } else if (!hasSeriesButton) {
+                    // series is always visible except when there is a button to show it
+                    this.show(SERIES);
                 }
             }
         } else {
             this.close(CLASSIFICATION);
-            this.close('series');
+            this.close(SERIES);
         }
         // create toggle plugin only when needed
         if (viewState.mapButtons.length > 0 && !this.togglePlugin) {

--- a/bundles/statistics/statsgrid/helper/ClassificationHelper.js
+++ b/bundles/statistics/statsgrid/helper/ClassificationHelper.js
@@ -109,11 +109,11 @@ export const getGroupStats = (dataBySelection) => {
  */
 export const getClassifiedData = (indicator, groupStats) => {
     const { classification: opts, data: { seriesValues } } = indicator;
-    if (seriesValues && seriesValues.length < 3) {
-        return { error: 'noEnough' };
-    }
     const dataByRegions = getDataByRegions(indicator);
     const values = seriesValues || dataByRegions.map(d => d.value).filter(val => typeof val !== 'undefined');
+    if (!values.length || seriesValues.length < 3) {
+        return { error: 'noEnough' };
+    }
     const isDivided = opts.type === 'div';
     const { format } = Oskari.getNumberFormatter(opts.fractionDigits);
 


### PR DESCRIPTION
- Fix timeseries data cache key. If all indicator params is passed to gethash every selection gets same hash from series param. So every selection (year) got same region values (first from backend and others from cache). Force to get new hash always for data cache key and don't pass series.
- SearchHandler checks that indicator has data before adding it but it doesn't check that it has at least one region has value. There is some WIP changes for SearchHandler => for now check that stats.js gets at least one value
- Same handling for series plugin than classification has => fixes visibility toggle for embedded maps
- Warn guest user when adding own indicator