### PR TITLE
Statsgrid series sort

### DIFF
--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -306,7 +306,7 @@ class SearchController extends StateHandler {
                         }
                         combinedValues[selectorName].values = addMissingElements(combinedValues[selectorName].values, value.selectors[selectorName].values, 'id');
                         if (value.selectors[selectorName].time) {
-                            combinedValues[selectorName].values.sort((a,b) => b.id - a.id);
+                            combinedValues[selectorName].values.sort((a, b) => b.id - a.id);
                         }
                     });
                 });
@@ -352,7 +352,7 @@ class SearchController extends StateHandler {
                     combinedValues[selector.id].values.push(valObject);
                 });
                 if (selector.time) {
-                    combinedValues[selector.id].values.sort((a,b) => b.id - a.id);
+                    combinedValues[selector.id].values.sort((a, b) => b.id - a.id);
                 }
             });
 

--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -305,6 +305,9 @@ class SearchController extends StateHandler {
                             };
                         }
                         combinedValues[selectorName].values = addMissingElements(combinedValues[selectorName].values, value.selectors[selectorName].values, 'id');
+                        if (value.selectors[selectorName].time) {
+                            combinedValues[selectorName].values.sort((a,b) => b.id - a.id);
+                        }
                     });
                 });
                 if (index === indicators.length - 1) resolve();
@@ -348,6 +351,9 @@ class SearchController extends StateHandler {
                     };
                     combinedValues[selector.id].values.push(valObject);
                 });
+                if (selector.time) {
+                    combinedValues[selector.id].values.sort((a,b) => b.id - a.id);
+                }
             });
 
             if (result.regionsets.length === 0) {

--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -58,12 +58,12 @@ class SearchController extends StateHandler {
         this.setSelectedIndicators(indicators);
     }
 
-    onCacheUpdate ({ datasourceId, indicatorId }) {
+    onCacheUpdate ({ datasourceId, indicator }) {
         const { selectedDatasource, selectedIndicators } = this.getState();
         if (datasourceId && selectedDatasource === datasourceId) {
             this.fetchindicatorOptions();
         }
-        if (indicatorId && selectedIndicators.includes(indicatorId)) {
+        if (indicator && selectedIndicators.includes(indicator.id)) {
             this.fetchIndicatorParams();
         }
     }

--- a/bundles/statistics/statsgrid/handler/StatisticsHandler.js
+++ b/bundles/statistics/statsgrid/handler/StatisticsHandler.js
@@ -224,11 +224,12 @@ class StatisticsController extends StateHandlerBase {
     }
 
     async addIndicator (indicator, regionset) {
+        // update existing indicators to changed regionset
+        if (regionset !== this.getState().regionset) {
+            await this.setActiveRegionset(regionset);
+        }
         if (this.isIndicatorSelected(indicator, true)) {
             // already selected
-            if (regionset !== this.getState().regionset) {
-                await this.setActiveRegionset(regionset);
-            }
             return true;
         }
         try {
@@ -241,14 +242,14 @@ class StatisticsController extends StateHandlerBase {
             const indicatorToAdd = await this.getIndicatorToAdd(indicator, regionset);
             this.instance.addDataProviderInfo(indicatorToAdd);
             this.updateState({
-                regionset,
+                loading: false,
                 indicators: [...this.getState().indicators, indicatorToAdd]
             });
         } catch (error) {
+            this.updateState({ loading: false });
             this.log.warn(error.message);
             return false;
         }
-        this.updateState({ loading: false });
         return true;
     }
 


### PR DESCRIPTION
Fixes:
- sort time params. for some reason backend doesn't return time selector values for user indicators in same order than for others. However combined selectors has still to be sorted. Sorting selectors (not series values) param Select shows values in same order. Also doesn't have to think about Guest user's cache.
- update existing indicators to use changed regionset always. Previously changed only if indicator was already selected. New indicator with new regionset => existing indicators had outdated data => change active indicator shows data for wrong regionset
- fix fetch indicator params on cache update

![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/084b8afc-1226-4e03-88ac-40d139230c7d)
![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/4e0cb80b-1a67-44e1-be69-c53ee62ce18f)
![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/4fffa9a7-97cf-419a-8b4c-ad72a5d52415)
