### PR TITLE
Statsgrid user dataset link

### DIFF
--- a/bundles/statistics/statsgrid/handler/IndicatorFormHandler.js
+++ b/bundles/statistics/statsgrid/handler/IndicatorFormHandler.js
@@ -276,7 +276,7 @@ class IndicatorFormController extends StateHandler {
 
     selectIndicator (dataset) {
         const selections = { [SELECTOR]: dataset[SELECTOR] };
-        const indicator = {...this.getSelectedIndicator(), selections };
+        const indicator = { ...this.getSelectedIndicator(), selections };
         indicator.hash = getHashForIndicator(indicator);
         this.instance.getStateHandler()?.getController().selectSavedIndicator(indicator, dataset.regionset);
     }

--- a/bundles/statistics/statsgrid/handler/IndicatorFormHandler.js
+++ b/bundles/statistics/statsgrid/handler/IndicatorFormHandler.js
@@ -276,6 +276,12 @@ class IndicatorFormController extends StateHandler {
         this.instance.getSearchHandler()?.onCacheUpdate({ datasourceId, indicator });
     }
 
+    selectIndicator (dataset) {
+        const selections = { [SELECTOR]: dataset[SELECTOR] };
+        const indicator = {...this.getSelectedIndicator(), selections };
+        indicator.hash = getHashForIndicator(indicator);
+        this.instance.getStateHandler()?.getController().selectSavedIndicator(indicator, dataset.regionset);
+    }
     selectSavedIndicator (indicator, regionset) {
         this.instance.getStateHandler()?.getController().selectSavedIndicator(indicator, regionset);
     }
@@ -356,10 +362,10 @@ const wrapped = controllerMixin(IndicatorFormController, [
     'showClipboardPopup',
     'saveForm',
     'importFromClipboard',
-    'setClipboardValue',
     'editDataset',
     'showIndicatorPopup',
-    'deleteDataset'
+    'deleteDataset',
+    'selectIndicator'
 ]);
 
 export { wrapped as IndicatorFormHandler };

--- a/bundles/statistics/statsgrid/view/Form/IndicatorDatasets.jsx
+++ b/bundles/statistics/statsgrid/view/Form/IndicatorDatasets.jsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import { Message } from 'oskari-ui';
 import { Table } from 'oskari-ui/components/Table';
-import { ButtonContainer, IconButton } from 'oskari-ui/components/buttons';
+import { IconButton } from 'oskari-ui/components/buttons';
 import styled from 'styled-components';
 
 const StyledTable = styled(Table)`
     max-height: 475px;
     overflow-y: auto;
+`;
+const ButtonContainer = styled.div`
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: flex-end;
+    button {
+        margin-left: 5px;
+    }
 `;
 
 export const IndicatorDatasets = ({ state, controller }) => {
@@ -17,9 +25,11 @@ export const IndicatorDatasets = ({ state, controller }) => {
             width: 250,
             title: <Message messageKey='userIndicators.modify.title' />,
             render: (title, item) => {
-                const regionset = state.regionsetOptions.find(r => r.id === item.regionset);
+                const regionset = state.regionsetOptions.find(r => r.id === item.regionset) || {};
                 return (
-                    <span><Message messageKey='parameters.year' /> {item.year} - {regionset.name}</span>
+                    <a onClick={() => controller.selectIndicator(item)}>
+                        <Message messageKey='parameters.year' /> {item.year} - {regionset.name}
+                    </a>
                 );
             }
         },


### PR DESCRIPTION
- create clickable dataset name to add/select indicator
- ButtonContainer is meant to use for Flyout/Popup buttons => copied style without margins
- don't wrap removed `setClipboardValue`