### PR TITLE
Statsgrid table sort fix

### DIFF
--- a/bundles/statistics/statsgrid/view/Table/Sorter.jsx
+++ b/bundles/statistics/statsgrid/view/Table/Sorter.jsx
@@ -13,16 +13,19 @@ const Icon = styled('div')`
     margin-left: 5px;
 `;
 
-export const Sorter = ({ sortOrder, changeSortOrder }) => {
-    let icon = <CaretDownFilled />;
-    if (sortOrder === 'ascend') {
+export const Sorter = ({ sortOrder, changeSortOrder, column }) => {
+    const isActive = sortOrder.column === column;
+    const order =  isActive ? sortOrder.order : null;
+    let icon = null;
+    if ( order === 'ascend') {
         icon = <CaretUpFilled />;
+    } else if (order === 'descend') {
+        icon = <CaretDownFilled />;
     }
+    const tooltip = order === 'ascend' ? 'statsgrid.orderByDescending' : 'statsgrid.orderByAscending';
     return (
-        <Tooltip
-            title={sortOrder === 'ascend' ? <Message messageKey='statsgrid.orderByDescending' /> : <Message messageKey='statsgrid.orderByAscending' />}
-        >
-            <Content onClick={changeSortOrder}>
+        <Tooltip title={<Message messageKey={tooltip} />}>
+            <Content onClick={() => changeSortOrder(column)}>
                 <Message messageKey='statsgrid.orderBy' /><Icon>{icon}</Icon>
             </Content>
         </Tooltip>


### PR DESCRIPTION
fix table sorting. As we are using own sorter for indicator data to get undefined values last, there is no need for storing null sorters
Previously:
![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/7048bb6b-7d5c-41b8-bd2a-a9106721629d)
Also it didn't store values. It set all but selected sorters to null as them was passed to antd table.

Could also to store values like {name: order, [hash]: order, active:[column]}


Changes:
- default to region name ascend sort (previously didn't have any sorting by default)
- render carrot only if column is active (previously no visual indication which column sorter was used)
=> not sure how this should be shown (jQuery has carrot always and active column name is underlined, first click changes to use columns sorter and following toggles)