### PR TITLE
try plugin impl first to avoid accidentally falling to flyout impl

### DIFF
--- a/bundles/framework/announcements/instance.js
+++ b/bundles/framework/announcements/instance.js
@@ -34,18 +34,19 @@ Oskari.clazz.define('Oskari.framework.bundle.announcements.AnnouncementsBundleIn
             }
             me.service = Oskari.clazz.create('Oskari.framework.announcements.service.AnnouncementsService', me.sandbox);
             me.sandbox.registerService(me.service);
-            const flyout = me.plugins['Oskari.userinterface.Flyout'];
-            // It looks like plugin (embedded map) handles announcements differently so render popups only if flyout is present
-            if (flyout) {
-                this.handler = new AnnouncementsHandler(this.service);
-                this.handler.addStateListener(state => this.stateChanged(state));
-                flyout.initHandler(this.handler);
-            }
             if (me.conf && me.conf.plugin) {
                 const mapModule = me.sandbox.findRegisteredModuleInstance('MainMapModule');
                 const plugin = Oskari.clazz.create('Oskari.framework.announcements.plugin.AnnouncementsPlugin', me.conf.plugin.config);
                 mapModule.registerPlugin(plugin);
                 mapModule.startPlugin(plugin);
+            } else {
+                const flyout = me.plugins['Oskari.userinterface.Flyout'];
+                // It looks like plugin (embedded map) handles announcements differently so render popups only if flyout is present
+                if (flyout) {
+                    this.handler = new AnnouncementsHandler(this.service);
+                    this.handler.addStateListener(state => this.stateChanged(state));
+                    flyout.initHandler(this.handler);
+                }
             }
 
             // RPC function to get announcements


### PR DESCRIPTION
Flyout plugin got added under the hood to announcements plugin by a side effect when xy-tool is present. No we're not falling back to the flyout impl unless absolutely necessary.

these two now can co-exist in embedded map
![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/c0ce2f78-c5ac-4017-aab2-d3df796351f7)

regular map works like before;   
![image](https://github.com/oskariorg/oskari-frontend/assets/131667037/0356d389-46d7-40de-8076-9794820b7866)
