### PR TITLE
Statsgrid colors fix

### DIFF
--- a/bundles/statistics/statsgrid/constants.js
+++ b/bundles/statistics/statsgrid/constants.js
@@ -456,8 +456,8 @@ export const COLOR_SETS = [{
     'name': 'Pastel1',
     'type': 'qual',
     'colors': [
-        'bb4ae,ccebc5',
-        'bb4ae,b3cde3,ccebc5',
+        'fbb4ae,ccebc5',
+        'fbb4ae,b3cde3,ccebc5',
         'fbb4ae,b3cde3,ccebc5,decbe4',
         'fbb4ae,b3cde3,ccebc5,decbe4,fed9a6',
         'fbb4ae,b3cde3,ccebc5,decbe4,fed9a6,ffffcc',

--- a/bundles/statistics/statsgrid2016/service/constants.js
+++ b/bundles/statistics/statsgrid2016/service/constants.js
@@ -452,8 +452,8 @@ export const COLOR_SETS = [{
     'name': 'Pastel1',
     'type': 'qual',
     'colors': [
-        'bb4ae,ccebc5',
-        'bb4ae,b3cde3,ccebc5',
+        'fbb4ae,ccebc5',
+        'fbb4ae,b3cde3,ccebc5',
         'fbb4ae,b3cde3,ccebc5,decbe4',
         'fbb4ae,b3cde3,ccebc5,decbe4,fed9a6',
         'fbb4ae,b3cde3,ccebc5,decbe4,fed9a6,ffffcc',


### PR DESCRIPTION
- fix invalid colors
- checked that every other colorsets have valid colors (every color length === 6)

Not sure where (AddFeaturesToMapRequestHandler, OpenLayers) shit hit the fan because map/layer behaved so weirdly. More than one feature got hover style, every feature got fill style even one request had invalid fill color... However everything looked good in request params except one had invalid fill color.

![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/9d763633-d8bc-4f2a-9441-620893ee493c)
![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/24a85e12-45f0-4b5e-8ca3-fb387cb9f202)
