### PR TITLE
Time series styling fixes/theme support

### DIFF
--- a/bundles/framework/timeseries/instance.js
+++ b/bundles/framework/timeseries/instance.js
@@ -35,17 +35,17 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesToolBundleI
          * implements BundleInstance protocol start methdod
          */
         start: function () {
-            var me = this;
+            const me = this;
             if (me.started) {
                 return;
             }
             me.started = true;
 
-            var sandboxName = (me.conf ? me.conf.sandbox : null) || 'sandbox';
-            var sandbox = me._sandbox = Oskari.getSandbox(sandboxName);
+            const sandboxName = (me.conf ? me.conf.sandbox : null) || 'sandbox';
+            const sandbox = me._sandbox = Oskari.getSandbox(sandboxName);
 
             if (me.conf && me.conf.plugins) {
-                var plugin = me.conf.plugins.find(function (plugin) {
+                const plugin = me.conf.plugins.find(function (plugin) {
                     return plugin.id === 'Oskari.mapframework.bundle.timeseries.TimeseriesControlPlugin';
                 });
                 if (plugin) {
@@ -63,7 +63,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesToolBundleI
             });
             me._registerForLayerFiltering();
             Oskari.on('app.start', function () {
-                var active = me._timeseriesService.getActiveTimeseries();
+                const active = me._timeseriesService.getActiveTimeseries();
                 if (active) {
                     me._updateControl(active);
                 }
@@ -80,9 +80,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesToolBundleI
          * @private
          */
         _registerForLayerFiltering: function () {
-            var layerlistService = Oskari.getSandbox().getService('Oskari.mapframework.service.LayerlistService');
+            const layerlistService = Oskari.getSandbox().getService('Oskari.mapframework.service.LayerlistService');
             if (layerlistService) {
-                var loc = Oskari.getMsg.bind(null, 'timeseries');
+                const loc = Oskari.getMsg.bind(null, 'timeseries');
                 layerlistService.registerLayerlistFilterButton(
                     loc('layerFilter.timeseries'),
                     loc('layerFilter.tooltip'),
@@ -192,7 +192,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesToolBundleI
             if (!this._controlPlugin) {
                 return;
             }
-            var mapModule = this._sandbox.findRegisteredModuleInstance('MainMapModule');
+            const mapModule = this._sandbox.findRegisteredModuleInstance('MainMapModule');
             mapModule.stopPlugin(this._controlPlugin);
             mapModule.unregisterPlugin(this._controlPlugin);
             this._controlPlugin = null;

--- a/bundles/framework/timeseries/resources/css/timeseriesplayback.css
+++ b/bundles/framework/timeseries/resources/css/timeseriesplayback.css
@@ -6,13 +6,6 @@
   stroke-width: 3px;
   stroke: #E4E6E7;
 }
-.timeline-svg g.subset-axis line, g.subset-axis path {
-  stroke: #333;
-}
-.timeline-svg g.subset-axis text, g.full-axis text {
-  fill: #333;
-  stroke: none;
-}
 .timeline-svg g.tick text.bold {
   font-weight: 600;
 }

--- a/bundles/framework/timeseries/resources/css/timeseriesplayback.css
+++ b/bundles/framework/timeseries/resources/css/timeseriesplayback.css
@@ -1,34 +1,10 @@
 /* override these to theme component */
-.timeseriescontrolplugin {
-  background-color: rgba(255, 255, 255, 1);
-}
-
-.timeseries-handle {
-  width: 15px;
-  height: 100px;
-  cursor: grab;
-}
-
 .timeline-svg g.full-axis .tick line {
   visibility: hidden;
 }
 .timeline-svg g.full-axis .domain {
   stroke-width: 3px;
   stroke: #E4E6E7;
-}
-.timeline-svg g.full-axis-controls circle {
-  stroke: #E4E6E7;
-  stroke-width: 2px;
-  fill: #5C6160;
-}
-.timeline-svg g.full-axis-controls line {
-  stroke: #FAD500;
-  stroke-width: 3px;
-}
-.timeline-svg g.drag-handle circle{
-  fill: #FAD500;
-  stroke: #4E4E4E;
-  stroke-width: 2px;
 }
 .timeline-svg g.subset-axis line, g.subset-axis path {
   stroke: #333;
@@ -44,11 +20,6 @@
   color: #333;
 }
 /* end theming */
-
-.timeseriescontrolplugin {
-  white-space: nowrap;
-  z-index: 15002!important;
-}
 
 .timeseries-aux{
   display: inline-block;

--- a/bundles/framework/timeseries/resources/css/timeseriesplayback.css
+++ b/bundles/framework/timeseries/resources/css/timeseriesplayback.css
@@ -9,9 +9,6 @@
 .timeline-svg g.tick text.bold {
   font-weight: 600;
 }
-.timeseries-menus label.oskari-select {
-  color: #333;
-}
 /* end theming */
 
 .timeseries-aux{

--- a/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
@@ -16,7 +16,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
      */
     function (delegate, conf) {
         conf = conf || {};
-        var me = this;
+        const me = this;
         me._clazz = 'Oskari.mapframework.bundle.timeseries.TimeseriesControlPlugin';
         me._defaultLocation = conf.location || 'top left';
         me._index = 90;
@@ -42,7 +42,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
         me._setFrameInterval(me._uiState.frameInterval); // sets throttle for animation, too
         me._throttleNewTime = Oskari.util.throttle(me._requestNewTime.bind(me), 500);
         this._uiState.times = delegate.getTimes();
-        var range = delegate.getSubsetRange();
+        const range = delegate.getSubsetRange();
         this._uiState.rangeStart = range[0];
         this._uiState.rangeEnd = range[1];
         this._uiState.currentTime = delegate.getCurrentTime();
@@ -117,11 +117,11 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
          */
         _filterSkipOptions: function (times) {
             times = times.map(function (t) { return dayjs(t); }); // optimization: parse time strings once
-            var shortestInterval = Number.MAX_VALUE;
-            for (var i = 0; i < times.length - 1; i++) {
-                var current = times[i];
-                var next = times[i + 1];
-                var difference = next.diff(current);
+            let shortestInterval = Number.MAX_VALUE;
+            for (let i = 0; i < times.length - 1; i++) {
+                const current = times[i];
+                const next = times[i + 1];
+                const difference = next.diff(current);
                 if (difference < shortestInterval) {
                     shortestInterval = difference;
                 }
@@ -144,8 +144,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
          * @private
          */
         _requestNewTime: function () {
-            var me = this;
-            var nextTime = null;
+            const me = this;
+            let nextTime = null;
             if (me._uiState.isAnimating) {
                 nextTime = this._getNextTime(this._uiState.currentTime);
             }
@@ -176,7 +176,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
             if (this._waitingForFrame) {
                 return;
             }
-            var nextTime = this._getNextTime(this._uiState.currentTime);
+            const nextTime = this._getNextTime(this._uiState.currentTime);
             if (!nextTime) {
                 this._setAnimationState(false);
                 return;
@@ -193,15 +193,15 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
          * @return {String} time, ISO-string
          */
         _getNextTime: function (fromTime) {
-            var targetTime = dayjs(fromTime);
-            var index;
+            let targetTime = dayjs(fromTime);
+            let index;
             if (this._uiState.stepInterval) {
                 targetTime = targetTime.add(1, this._uiState.stepInterval);
                 index = d3.bisectLeft(this._uiState.times, targetTime.toISOString());
             } else {
                 index = d3.bisectRight(this._uiState.times, targetTime.toISOString());
             }
-            var endIndex = Math.max(d3.bisect(this._uiState.times, this._uiState.rangeEnd) - 1, 0);
+            const endIndex = Math.max(d3.bisect(this._uiState.times, this._uiState.rangeEnd) - 1, 0);
             if (targetTime.toISOString() > this._uiState.rangeEnd) {
                 return null;
             } else if (index > endIndex) {
@@ -214,18 +214,18 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
          * @private
          */
         _createControlElement: function () {
-            var me = this,
-                el = jQuery(
-                    '<div class="mapplugin timeseriescontrolplugin">' +
-                    '<div class="timeseries-timelines"><svg class="timeline-svg">' +
-                    '<g class="full-axis"></g>' +
-                    '<g class="full-axis-controls"><line x1="0" y1="' + me.__fullAxisYPos + '" x2="0" y2="' + me.__fullAxisYPos + '" /><circle cx="0" cy="' + me.__fullAxisYPos + '" r="8"/><circle cx="0" cy="' + me.__fullAxisYPos + '" r="8"/></g>' +
-                    '<g class="full-axis-brush"></g>' +
-                    '<g class="subset-axis"></g>' +
-                    '<g class="subset-bg"><rect x="-10" y="-10" width="10" height="10"/></g>' +
-                    '<g class="drag-handle" cursor="ew-resize"><rect x="-15" y="-15" width="30" height="30" fill-opacity="0"/><circle cx="0" cy="0" r="8"/></g>' +
-                    '</svg></div>' +
-                    '</div>');
+            const me = this;
+            const el = jQuery(
+                '<div class="mapplugin timeseriescontrolplugin">' +
+                '<div class="timeseries-timelines"><svg class="timeline-svg">' +
+                '<g class="full-axis"></g>' +
+                '<g class="full-axis-controls"><line x1="0" y1="' + me.__fullAxisYPos + '" x2="0" y2="' + me.__fullAxisYPos + '" /><circle cx="0" cy="' + me.__fullAxisYPos + '" r="8"/><circle cx="0" cy="' + me.__fullAxisYPos + '" r="8"/></g>' +
+                '<g class="full-axis-brush"></g>' +
+                '<g class="subset-axis"></g>' +
+                '<g class="subset-bg"><rect x="-10" y="-10" width="10" height="10"/></g>' +
+                '<g class="drag-handle" cursor="ew-resize"><rect x="-15" y="-15" width="30" height="30" fill-opacity="0"/><circle cx="0" cy="0" r="8"/></g>' +
+                '</svg></div>' +
+                '</div>');
             return el;
         },
         /**
@@ -235,9 +235,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
          * @return {String} time, ISO-string
          */
         _getClosestTime: function (time) {
-            var index1 = Math.max(d3.bisectRight(this._uiState.times, time) - 1, 0);
-            var index2 = index1 + 1;
-            var index;
+            const index1 = Math.max(d3.bisectRight(this._uiState.times, time) - 1, 0);
+            const index2 = index1 + 1;
+            let index;
             if (index1 < this._uiState.times.length - 1 && Math.abs(dayjs(this._uiState.times[index1]).diff(time)) > Math.abs(dayjs(this._uiState.times[index2]).diff(time))) {
                 index = index2;
             } else {
@@ -252,8 +252,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
          * @return {Number} index, rangeStart index or rangeEnd index if given index was outside the range.
          */
         _getRangeCheckedIndex: function (index) {
-            var rangeStartIndex = Math.max(d3.bisectLeft(this._uiState.times, this._uiState.rangeStart), 0);
-            var rangeEndIndex = Math.max(d3.bisect(this._uiState.times, this._uiState.rangeEnd) - 1, 0);
+            const rangeStartIndex = Math.max(d3.bisectLeft(this._uiState.times, this._uiState.rangeStart), 0);
+            const rangeEndIndex = Math.max(d3.bisect(this._uiState.times, this._uiState.rangeEnd) - 1, 0);
             if (index < rangeStartIndex) {
                 return rangeStartIndex;
             } else if (index > rangeEndIndex) {
@@ -270,8 +270,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
             if (this.isAnimating) {
                 return;
             }
-            var index = d3.bisectLeft(this._uiState.times, this._uiState.currentTime);
-            var newTime = this._uiState.times[index + delta];
+            const index = d3.bisectLeft(this._uiState.times, this._uiState.currentTime);
+            const newTime = this._uiState.times[index + delta];
             if (newTime && newTime >= this._uiState.rangeStart && newTime <= this._uiState.rangeEnd) {
                 this._uiState.currentTime = newTime;
                 this._throttleNewTime();
@@ -304,8 +304,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
             }
             this.setElement(this._createControlElement());
             this.addToPluginContainer(this.getElement());
-            var aux = '<div class="timeseries-aux"></div>';
-            var times = this._uiState.times;
+            const aux = '<div class="timeseries-aux"></div>';
+            const times = this._uiState.times;
             if (isMobile) {
                 this._timelineWidth = 260;
                 this._setRange(times[0], times[times.length - 1]);
@@ -323,7 +323,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
             this._updateTimeDisplay();
         },
         _makeDraggable: function () {
-            this._element.prepend('<div class="timeseries-handle oskari-flyoutheading"></div>');
+            this._element.prepend('<div class="timeseries-handle"></div>');
             this._element.draggable({
                 scroll: false,
                 handle: '.timeseries-handle'
@@ -336,7 +336,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
          * @param {Boolean} suppressUpdate true if no timelines update should be done
          */
         _setWidth: function (mapWidth, suppressUpdate) {
-            var targetWidth = Math.min(mapWidth - this._widthMargin, 860) - 260;
+            const targetWidth = Math.min(mapWidth - this._widthMargin, 860) - 260;
             if (!this._inMobileMode && this._timelineWidth !== targetWidth) {
                 this._timelineWidth = targetWidth;
                 if (!suppressUpdate) {
@@ -354,17 +354,17 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
             if (!this._inMobileMode) {
                 if (typeof topMargin === 'string') {
                     if (topMargin.indexOf('%') !== -1) {
-                        var mapHeight = this.getSandbox().getMap().getHeight() || 200;
-                        var percetageFromTop = topMargin.substr(0, topMargin.length - 1);
+                        const mapHeight = this.getSandbox().getMap().getHeight() || 200;
+                        const percetageFromTop = topMargin.substring(0, topMargin.length - 1);
                         if (!isNaN(percetageFromTop)) {
-                            var margin = mapHeight / 100 * percetageFromTop;
+                            const margin = mapHeight / 100 * percetageFromTop;
                             this._element.css('margin-top', margin + 'px');
                         }
                     } else {
                         this._element.css('margin-top', topMargin);
                     }
                 } else if (typeof topMargin === 'number') {
-                    this._element.css('margin-top', margin + 'px');
+                    this._element.css('margin-top', topMargin + 'px');
                 }
             }
         },
@@ -376,7 +376,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
          * @return {Object[]} key, value that has been localized
          */
         _generateSelectOptions: function (prefix, options) {
-            var me = this;
+            const me = this;
             return options.map(function (e) {
                 return {
                     title: me.loc(prefix + e.key),
@@ -389,10 +389,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
          * @private
          */
         _initMenus: function () {
-            var me = this;
-            var template = jQuery('<div class="timeseries-menus"><div class="timeseries-menus-half"></div><div class="timeseries-menus-half"></div></div>');
+            const me = this;
+            const template = jQuery('<div class="timeseries-menus"><div class="timeseries-menus-half"></div><div class="timeseries-menus-half"></div></div>');
 
-            var speedMenu = Oskari.clazz.create('Oskari.userinterface.component.Select');
+            const speedMenu = Oskari.clazz.create('Oskari.userinterface.component.Select');
             speedMenu.setOptions(this._generateSelectOptions('animationSpeed.', this.__speedOptions));
             speedMenu.setTitle(this.loc('label.animationSpeed'));
             speedMenu.setValue(this._uiState.frameInterval);
@@ -402,7 +402,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
             });
             template.find('.timeseries-menus-half').first().append(speedMenu.getElement());
 
-            var skipMenu = Oskari.clazz.create('Oskari.userinterface.component.Select');
+            const skipMenu = Oskari.clazz.create('Oskari.userinterface.component.Select');
             skipMenu.setOptions(this._generateSelectOptions('skip.', this._validSkipOptions));
             skipMenu.setTitle(this.loc('label.skipAhead'));
             skipMenu.setValue(this._uiState.stepInterval);
@@ -418,12 +418,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
          * @private
          */
         _initStepper: function () {
-            var me = this;
-            var template = jQuery(
+            const me = this;
+            const template = jQuery(
                 '<div class="timeseries-stepper">' +
                 '<div class="timeseries-back"></div><div class="timeseries-playpause"></div><div class="timeseries-forward"></div><div class="timeseries-datetime"></div>' +
                 '</div>');
-            var dateTime = template.find('.timeseries-datetime');
+            const dateTime = template.find('.timeseries-datetime');
             me._updateTimeDisplay = function () {
                 const date = new Date(me._uiState.currentTime);
                 const diff = date.getTimezoneOffset() * 60000;
@@ -434,9 +434,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
                     me._setAnimationState(false);
                     return;
                 }
-                var times = me._uiState.times;
-                var curIndex = Math.max(d3.bisectLeft(times, me._uiState.currentTime), 0);
-                var endIndex = Math.max(d3.bisect(times, me._uiState.rangeEnd) - 1, 0);
+                const times = me._uiState.times;
+                const curIndex = Math.max(d3.bisectLeft(times, me._uiState.currentTime), 0);
+                const endIndex = Math.max(d3.bisect(times, me._uiState.rangeEnd) - 1, 0);
                 if (curIndex >= endIndex) {
                     me._restartAnimation();
                 } else {
@@ -520,26 +520,26 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
          * @param  {Boolean} isMobile is in mobile mode?
          */
         _updateTimelines: function (isMobile) {
-            var me = this;
-            var margin = { left: 15, right: 15 };
-            var tickFormatter = me._getTickFormatter();
-            var tickCount = me._timelineWidth / 60;
-            var svg = d3.select(this._element.find('.timeline-svg').get(0));
+            const me = this;
+            const margin = { left: 15, right: 15 };
+            const tickFormatter = me._getTickFormatter();
+            const tickCount = me._timelineWidth / 60;
+            const svg = d3.select(this._element.find('.timeline-svg').get(0));
             svg
                 .attr('viewBox', isMobile ? '0 50 ' + this._timelineWidth + ' 50' : null)
                 .attr('width', this._timelineWidth)
                 .attr('height', isMobile ? 50 : 100);
 
-            var times = this._uiState.times;
-            var scaleFull = d3.scaleTime()
+            const times = this._uiState.times;
+            const scaleFull = d3.scaleTime()
                 .domain([new Date(times[0]), new Date(times[times.length - 1])])
                 .range([margin.left, this._timelineWidth - margin.right]);
 
-            var scaleSubset = d3.scaleTime()
+            const scaleSubset = d3.scaleTime()
                 .domain([new Date(this._uiState.rangeStart), new Date(this._uiState.rangeEnd)])
                 .range([margin.left, this._timelineWidth - margin.right]);
 
-            var axisFull = d3.axisTop(scaleFull)
+            const axisFull = d3.axisTop(scaleFull)
                 .ticks(tickCount)
                 .tickPadding(7)
                 .tickFormat(tickFormatter);
@@ -547,7 +547,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
                 .attr('transform', 'translate(0,' + me.__fullAxisYPos + ')')
                 .call(axisFull);
 
-            var axisSubset = d3.axisTop(scaleSubset)
+            const axisSubset = d3.axisTop(scaleSubset)
                 .ticks(tickCount)
                 .tickPadding(7)
                 .tickFormat(tickFormatter);
@@ -555,18 +555,18 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
                 .attr('transform', 'translate(0,80)')
                 .call(axisSubset);
 
-            var handle = svg.select('g.drag-handle')
+            const handle = svg.select('g.drag-handle')
                 .attr('transform', 'translate(' + scaleSubset(new Date(this._uiState.currentTime)) + ',80)')
                 .on('.drag', null); // remove old event handlers
 
             function renderHandle () {
-                var newX = scaleSubset(new Date(me._uiState.currentTime));
+                const newX = scaleSubset(new Date(me._uiState.currentTime));
                 handle.attr('transform', 'translate(' + newX + ',80)');
             }
             me._renderHandle = renderHandle;
 
             function timeFromMouse (newX) {
-                var scaleRange = scaleSubset.range();
+                const scaleRange = scaleSubset.range();
                 if (newX > scaleRange[1]) {
                     newX = scaleRange[1];
                 }
@@ -577,7 +577,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
             }
 
             function updateFullAxisControls () {
-                var range = scaleSubset.domain().map(scaleFull);
+                const range = scaleSubset.domain().map(scaleFull);
                 svg.selectAll('.full-axis-controls circle').each(function (d, i) {
                     d3.select(this).attr('cx', range[i]);
                 });
@@ -594,23 +594,23 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
                 .attr('height', 50)
                 .on('click', null) // remove old event handlers
                 .on('click', function (e) {
-                    var newX = d3.pointer(e)[0];
+                    const newX = d3.pointer(e)[0];
                     timeFromMouse(newX);
                 });
 
-            var dragBehavior = d3.drag()
+            const dragBehavior = d3.drag()
                 .subject(function (e) {
                     return { x: scaleSubset(new Date(me._uiState.currentTime)), y: e.y };
                 })
                 .on('drag', function (e) {
-                    var newX = e.x;
+                    const newX = e.x;
                     timeFromMouse(newX);
                 });
 
             handle.call(dragBehavior);
 
             if (!isMobile) {
-                var brush = d3.brushX()
+                const brush = d3.brushX()
                     .extent([[margin.left, 0], [this._timelineWidth - margin.right, 50]])
                     .handleSize(40)
                     .on('.brush', null) // remove old event handlers
@@ -627,12 +627,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
             }
 
             function brushed (e) {
-                var selection = e.selection;
-                var inverted = selection.map(function (e) { return scaleFull.invert(e).toISOString(); });
+                const selection = e.selection;
+                const inverted = selection.map(function (e) { return scaleFull.invert(e).toISOString(); });
                 scaleSubset.domain(inverted.map(function (t) { return new Date(me._getClosestTime(t)); }));
                 svg.select('.subset-axis').call(axisSubset);
 
-                var changedTime = me._uiState.currentTime;
+                let changedTime = me._uiState.currentTime;
                 if (inverted[0] > me._uiState.currentTime) {
                     changedTime = inverted[0];
                 }
@@ -672,7 +672,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
          */
         _createEventHandlers: function () {
             return {
-                MapSizeChangedEvent: function (evt) {
+                'MapSizeChangedEvent': function (evt) {
                     this._setWidth(evt.getWidth());
                 },
                 'Toolbar.ToolSelectedEvent': function (evt) {
@@ -694,6 +694,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
             }
         }
     }, {
-        'extend': ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],
-        'protocol': ['Oskari.mapframework.module.Module', 'Oskari.mapframework.ui.module.common.mapmodule.Plugin']
+        extend: ['Oskari.mapping.mapmodule.plugin.BasicMapModulePlugin'],
+        protocol: ['Oskari.mapframework.module.Module', 'Oskari.mapframework.ui.module.common.mapmodule.Plugin']
     });

--- a/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
@@ -242,7 +242,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
             const themeObj = this.getMapModule().getMapTheme();
             const theme = getNavigationTheme(themeObj);
             const buttonColor = theme.getButtonColor();
-            // const textColor = theme.getTextColor();
+            const textColor = theme.getTextColor();
             const accentColor = theme.getButtonHoverColor();
             styleEl.innerHTML = `
             .mapplugin.timeseriescontrolplugin {
@@ -274,6 +274,13 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
                 fill: ${accentColor};
                 stroke: ${buttonColor};
                 stroke-width: 2px;
+            }
+            .timeline-svg g.subset-axis line, g.subset-axis path {
+                stroke: ${textColor};
+            }
+            .timeline-svg g.subset-axis text, g.full-axis text {
+                fill: ${textColor};
+                stroke: none;
             }
             `;
         },

--- a/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
@@ -249,6 +249,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
                 white-space: nowrap;
                 background-color: ${theme.getNavigationBackgroundColor()};
                 flex-direction: row;
+                color: ${textColor};
             }
             @media (max-width: 600px) {
                 .mapplugin.timeseriescontrolplugin {

--- a/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
+++ b/bundles/framework/timeseries/view/TimeseriesControlPlugin.js
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
+import { getNavigationTheme } from 'oskari-ui/theme';
 import * as d3 from 'd3';
 dayjs.extend(customParseFormat);
 
@@ -215,6 +216,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
          */
         _createControlElement: function () {
             const me = this;
+            this._createThematicStyling();
             const el = jQuery(
                 '<div class="mapplugin timeseriescontrolplugin">' +
                 '<div class="timeseries-timelines"><svg class="timeline-svg">' +
@@ -227,6 +229,53 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesControlPlug
                 '</svg></div>' +
                 '</div>');
             return el;
+        },
+        _createThematicStyling: function () {
+            const styleId = 'timeseries_style';
+            let styleEl = document.getElementById(styleId);
+            if (!styleEl) {
+                styleEl = document.createElement('style');
+                styleEl.setAttribute('id', styleId);
+                document.head.appendChild(styleEl);
+            }
+
+            const themeObj = this.getMapModule().getMapTheme();
+            const theme = getNavigationTheme(themeObj);
+            const buttonColor = theme.getButtonColor();
+            // const textColor = theme.getTextColor();
+            const accentColor = theme.getButtonHoverColor();
+            styleEl.innerHTML = `
+            .mapplugin.timeseriescontrolplugin {
+                white-space: nowrap;
+                background-color: ${theme.getNavigationBackgroundColor()};
+                flex-direction: row;
+            }
+            @media (max-width: 600px) {
+                .mapplugin.timeseriescontrolplugin {
+                    flex-direction: column;
+                }
+            }
+            .mapplugin.timeseriescontrolplugin .timeseries-handle {
+                background-color: ${accentColor};
+                width: 15px;
+                height: 100px;
+                cursor: grab;
+            }
+            .mapplugin.timeseriescontrolplugin .timeline-svg g.full-axis-controls circle {
+                stroke: ${accentColor};
+                fill: ${buttonColor};
+                stroke-width: 2px;
+            }
+            .mapplugin.timeseriescontrolplugin .timeline-svg g.full-axis-controls line {
+                stroke: ${accentColor};
+                stroke-width: 3px;
+            }
+            .timeline-svg g.drag-handle circle{
+                fill: ${accentColor};
+                stroke: ${buttonColor};
+                stroke-width: 2px;
+            }
+            `;
         },
         /**
          * @method _getClosestTime Get closest time instant in timeseries relative to param

--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -105,14 +105,7 @@ a:focus {
   color: #ff9100;
 }
 
-/* Selection colours */
-::selection {
-  background: #ffd400;
-}
-
-::-moz-selection {
-  background: #ffd400;
-}
+/* Selection colours (main ones in src\react\theme\globalStyles.js) */
 
 img::selection {
   background: transparent;

--- a/src/react/theme/ThemeHelper.js
+++ b/src/react/theme/ThemeHelper.js
@@ -53,9 +53,9 @@ export const getTextColor = (bgColor) => {
 };
 
 export const getFontClass = (theme) => {
-    let fontClassSuffix = theme.font || DEFAULT_FONT;
+    const fontClassSuffix = theme.font || DEFAULT_FONT;
     return 'oskari-theme-font-' + fontClassSuffix;
-}
+};
 
 /* ------------------------------------------------------------------------------ */
 // Note! Copy-pasted from bundles/mapping/mapmodule/oskariStyle!
@@ -66,7 +66,7 @@ export const getFontClass = (theme) => {
  * @param {String} effect Oskari style constant (auto, darken, lighten with specifiers minor, normal, major)
  * @return {String} Affected color or undefined if effect or color is missing
  */
- export const getColorEffect = (color, effect) => {
+export const getColorEffect = (color, effect) => {
     if (!effect || !color || effect === EFFECT.NONE) {
         return;
     }

--- a/src/react/theme/globalStyles.js
+++ b/src/react/theme/globalStyles.js
@@ -62,5 +62,9 @@ export const setGlobalStyle = (theme = {}) => {
                 width: 0;
             }
         }
+        ::selection {
+            background-color: ${headerTheme.getBgColor()};
+            color:  ${headerTheme.getTextColor()};
+        }
     `;
 };

--- a/src/theming.js
+++ b/src/theming.js
@@ -1,4 +1,4 @@
-import { setGlobalStyle } from './react/theme'
+import { setGlobalStyle } from './react/theme';
 
 const DEFAULT_THEME = {
     color: {
@@ -14,27 +14,26 @@ let currentTheme = {
 let listeners = [];
 
 export const THEMING = {
-    getTheme() {
+    getTheme () {
         return cloneDeep(currentTheme);
     },
-    setTheme(newTheme = {}) {
+    setTheme (newTheme = {}) {
         // start with new object so we bust any memoized value for listeners and get a good value for reset as well
         currentTheme = merge({}, DEFAULT_THEME, newTheme);
         setGlobalStyle(currentTheme);
         listeners.forEach(l => l(currentTheme));
     },
     /**
-     * 
      * @param {Function} listener function to call with new theme object if theme changes
      * @returns function to call for removing the listener (for cleanup)
      */
-    addListener(listener) {
+    addListener (listener) {
         if (typeof listener === 'function') {
             listeners.push(listener);
         }
         return () => {
             listeners = [...listeners.filter(fn => fn !== listener)];
-        }
+        };
     }
 };
 
@@ -46,7 +45,7 @@ const cloneDeep = (original) => {
     const theClone = Array.isArray(original) ? [] : {};
     for (const key in original) {
         const value = original[key];
-        theClone[key] = (typeof value === "object") ? cloneDeep(value) : value;
+        theClone[key] = (typeof value === 'object') ? cloneDeep(value) : value;
     }
     return theClone;
 };


### PR DESCRIPTION
A bunch of formatting changes in the first commit but the next ones are the ones that matter. The timeseries plugin used the oskari-flyoutheading class creatively for styling purposes, but something changed on the current develop branch that it no longer works as expected.

**Currently on develop branch:**
![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/d420ec3d-2eba-47d0-acd9-29779ced2a6f)

**in version 2.11.1:**
![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/bcba547e-3e93-49d0-8734-d114fd59d06f)

This fixes it by moving some of the styling from css to js in preparation of React rewrite and in doing so added theme support for the player.

**After this PR:**
Light theme:
![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/a5606bd2-66b4-4a98-aae8-9d502c72af69)

Darker theme:
![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/3a618cd5-8a43-4065-be6c-c3779d5e6c6b)

Also took a crack at fixing the mobile mode that's broken even on the 2.11.1 release
**Currently in 2.11.1 version;**
![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/9ef3edfb-c974-4ecc-b8ca-2b46214a232a)

**After this PR:**
![image](https://github.com/oskariorg/oskari-frontend/assets/2210335/aae5841c-42fc-4a21-8e81-120f69ff31db)

While it still breaks when the screen size changes (and even when the user opens the main navigation on mobile mode) it's still better than it was. We'll have to keep working on this in the future.

Note! Should have done another PR, but moved the text-selection color to theme as well from resources/portal.css so we can use theming for that as well.