### PR TITLE
Add mentions of new/changed bundles in changelog

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 # Oskari API changelog
 
 This document describes changes to the public API from Oskari frontend perspective (requests, events, conf/state, services). RPC-developers can check if the request/event API has changed

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Oskari API changelog
 
 This document describes changes to the public API from Oskari frontend perspective (requests, events, conf/state, services). RPC-developers can check if the request/event API has changed
@@ -10,6 +11,18 @@ Some extra tags:
 - [breaking] tag indicates that the change is not backwards compatible
 
 ## 2.13.0
+
+### [add] Added `metadatasearch` bundle
+
+React-based drop-in replacement for jQuery-based `metadatacatalogue` for searching metadata. 
+
+### [add] Added `featuredata` bundle
+
+React-based drop-in replacement for jQuery-based `featuredata2` for feature data table.
+
+### [add] Added a parallel version for `statsgrid` bundle
+
+The new implementation is React-based and has the same bundle id so no db migration is required, but the frontend code is linked from the new path (https://github.com/oskariorg/sample-application/pull/33). This makes it easy to switch the implementation to test it out. One notable difference is that the new one doesn't send the events like the old did as it doesn't need them internally. However the events were not exposed in the RPC API so this should not be an issue for most applications. The bundle documentation still refers to the jQuery implementation with the events.
 
 ### [rem] Removed `personaldata` bundle
 


### PR DESCRIPTION
These are already mentioned in release notes, but since changelog is more about what if bundles/requests/events aka the API between bundles changes I think these should be mentioned here. We should figure out where to put these kinds of things so we don't need to repeat it everywhere and people know where to look for these kinds of changes.

Also we should figure out if we want to change the bundle id when it's a drop-in replacement or have the bundle.js in new path like with statsgrid.