### PR TITLE
avoid caret jump in async state update

### DIFF
--- a/src/react/components/TextInput.jsx
+++ b/src/react/components/TextInput.jsx
@@ -1,6 +1,19 @@
 import styled from 'styled-components';
 import { Input } from 'antd';
 import 'antd/es/input/style/index.js';
+import React, { useState } from 'react';
 
-export const TextInput = styled(Input)`
-`;
+
+const StyledWrapper = styled(Input)``;
+
+export const TextInput = React.forwardRef((props, ref) => {
+    const [val, setVal] = useState(props.value);
+    const handleChange = (evt) => {
+        // https://dev.to/kwirke/solving-caret-jumping-in-react-inputs-36ic
+        // first do the sync setvalue to avoid caret jumping.
+        setVal(evt.currentTarget.value);
+        // then do the (duplicate) state update which might / might not be async.
+        props.onChange(evt);
+    }
+    return <StyledWrapper {...props} value={val} onChange={handleChange}/>
+});


### PR DESCRIPTION
do a sync state update before calling the (possibly) async one to avoid the caret jumping to end of input.

This does appear a bit hacky and also there might be some pitfall if the value is to be manipulated somehow in the latter onchange.  🤔 