### PR TITLE
Parallel async StateHandler

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerListHandler.test.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerListHandler.test.js
@@ -38,6 +38,6 @@ describe('LayerListHandler', () => {
         jest.runAllTimers();
         // Setting an invalid group key won't change the state.
         expect(handler.getState().grouping.selected).toBe(existingGrouping);
-        expect(mockFn).toHaveBeenCalledTimes(2);
+        expect(mockFn).toHaveBeenCalledTimes(3);
     });
 });

--- a/bundles/statistics/statsgrid/handler/IndicatorFormHandler.js
+++ b/bundles/statistics/statsgrid/handler/IndicatorFormHandler.js
@@ -1,4 +1,4 @@
-import { AsyncStateHandler, controllerMixin, Messaging } from 'oskari-ui/util';
+import { StateHandler, controllerMixin, Messaging } from 'oskari-ui/util';
 
 import { getHashForIndicator } from '../helper/StatisticsHelper';
 import { getIndicatorMetadata, getIndicatorData, saveIndicator, saveIndicatorData, deleteIndicator } from './IndicatorHelper';
@@ -7,7 +7,7 @@ import { getRegionsAsync } from '../helper/RegionsHelper';
 
 const SELECTOR = 'year';
 
-class IndicatorFormController extends AsyncStateHandler {
+class IndicatorFormController extends StateHandler {
     constructor (instance) {
         super();
         this.instance = instance;
@@ -68,6 +68,7 @@ class IndicatorFormController extends AsyncStateHandler {
             formData: {}
         };
     }
+
     reset () {
         this.updateState(this.getInitState());
     }
@@ -280,6 +281,7 @@ class IndicatorFormController extends AsyncStateHandler {
         indicator.hash = getHashForIndicator(indicator);
         this.instance.getStateHandler()?.getController().selectSavedIndicator(indicator, dataset.regionset);
     }
+
     selectSavedIndicator (indicator, regionset) {
         this.instance.getStateHandler()?.getController().selectSavedIndicator(indicator, regionset);
     }
@@ -322,6 +324,7 @@ class IndicatorFormController extends AsyncStateHandler {
             }
         });
     }
+
     editDataset (item = {}) {
         const datasetYear = item[SELECTOR];
         const datasetRegionset = item.regionset;

--- a/bundles/statistics/statsgrid/handler/IndicatorFormHandler.js
+++ b/bundles/statistics/statsgrid/handler/IndicatorFormHandler.js
@@ -1,4 +1,4 @@
-import { StateHandler, controllerMixin, Messaging } from 'oskari-ui/util';
+import { AsyncStateHandler, controllerMixin, Messaging } from 'oskari-ui/util';
 
 import { getHashForIndicator } from '../helper/StatisticsHelper';
 import { getIndicatorMetadata, getIndicatorData, saveIndicator, saveIndicatorData, deleteIndicator } from './IndicatorHelper';
@@ -7,7 +7,7 @@ import { getRegionsAsync } from '../helper/RegionsHelper';
 
 const SELECTOR = 'year';
 
-class IndicatorFormController extends StateHandler {
+class IndicatorFormController extends AsyncStateHandler {
     constructor (instance) {
         super();
         this.instance = instance;

--- a/bundles/statistics/statsgrid/handler/MyIndicatorsHandler.js
+++ b/bundles/statistics/statsgrid/handler/MyIndicatorsHandler.js
@@ -1,8 +1,8 @@
-import { StateHandler, controllerMixin, Messaging } from 'oskari-ui/util';
+import { AsyncStateHandler, controllerMixin, Messaging } from 'oskari-ui/util';
 import { populateIndicatorOptions } from './SearchIndicatorOptionsHelper';
 import { deleteIndicator } from './IndicatorHelper';
 
-class IndicatorsHandler extends StateHandler {
+class IndicatorsHandler extends AsyncStateHandler {
     constructor (instance, formHandler, userDsId) {
         super();
         this.instance = instance;

--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -1,4 +1,4 @@
-import { StateHandler, controllerMixin, Messaging } from 'oskari-ui/util';
+import { AsyncStateHandler, controllerMixin, Messaging } from 'oskari-ui/util';
 import { showMedataPopup } from '../components/description/MetadataPopup';
 import { getHashForIndicator } from '../helper/StatisticsHelper';
 import { populateIndicatorOptions } from './SearchIndicatorOptionsHelper';
@@ -15,7 +15,7 @@ const getValueAsArray = (selection) => {
     return [selection];
 };
 
-class SearchController extends StateHandler {
+class SearchController extends AsyncStateHandler {
     constructor (instance, stateHandler) {
         super();
         this.instance = instance;

--- a/bundles/statistics/statsgrid/handler/StatisticsHandler.js
+++ b/bundles/statistics/statsgrid/handler/StatisticsHandler.js
@@ -1,11 +1,11 @@
 import { getHashForIndicator, getUILabels, getUpdatedLabels, formatData } from '../helper/StatisticsHelper';
-import { StateHandler as StateHandlerBase, controllerMixin } from 'oskari-ui/util';
+import { AsyncStateHandler, controllerMixin } from 'oskari-ui/util';
 import { getClassification, getClassifiedData, validateClassification } from '../helper/ClassificationHelper';
 import { getDataForIndicator, getIndicatorMetadata } from './IndicatorHelper';
 import { LAYER_ID } from '../constants';
 import { getRegionsets } from '../helper/ConfigHelper';
 
-class StatisticsController extends StateHandlerBase {
+class StatisticsController extends AsyncStateHandler {
     constructor (instance) {
         super();
         this.instance = instance;

--- a/src/react/util/index.js
+++ b/src/react/util/index.js
@@ -2,7 +2,7 @@
  * Oskari UI util module contains helpers for modern Oskari UI development.
  * @module oskari-ui/util
  */
-export { StateHandler, Controller, controllerMixin } from './state';
+export { AsyncStateHandler, StateHandler, Controller, controllerMixin } from './state';
 export { Timeout, Messaging, handleBinder } from './extras';
 export { GenericContext, withContext, LocaleProvider, LocaleConsumer, ThemeProvider, ThemeConsumer } from './contexts';
 export { ErrorBoundary } from './ErrorBoundary';

--- a/src/react/util/state/AsyncStateHandler.js
+++ b/src/react/util/state/AsyncStateHandler.js
@@ -1,0 +1,18 @@
+import { StateHandler } from './StateHandler';
+
+export class AsyncStateHandler extends StateHandler {
+    /**
+     * Handles calling registered listeners.
+     * @private
+     */
+    notify () {
+        if (this.timeout) {
+            clearTimeout(this.timeout);
+        }
+        // This allows multiple small state updates to be run one after another before re-rendering is triggered
+        this.timeout = setTimeout(() => {
+            super.notify();
+            this.timeout = null;
+        }, 10);
+    }
+}

--- a/src/react/util/state/AsyncStateHandler.js
+++ b/src/react/util/state/AsyncStateHandler.js
@@ -2,7 +2,16 @@ import { StateHandler } from './StateHandler';
 
 export class AsyncStateHandler extends StateHandler {
     /**
-     * Handles calling registered listeners.
+     * Handles calling registered listeners (https://github.com/oskariorg/oskari-frontend/pull/2626).
+     * Overrides notifying of state changes by making it asynchronous which helps when there are multiple state changes one after another. This skips rendering between updateState()-"spamming".
+     *
+     * Compared to non-async StateHandler:
+     * - Fixes an issue where multiple updateState() calls in short succession may result in JS error "RangeError: Maximum call stack size exceeded"
+     * - Any input fields that are managed through async state handling have their carets moving to the end of the value after each change:
+     *    - https://github.com/facebook/react/issues/5386
+     *    - https://dev.to/kwirke/solving-caret-jumping-in-react-inputs-36ic
+     *   This is annoying for user who is trying to modify the field value by adding/removing characters in the middle of the value.
+     *   The caret jumping can be "fixed"/worked around by duplicating the input value state handling like this: https://github.com/oskariorg/oskari-frontend/pull/2625/commits/15adc82944678ebe4f9be282c75ba7bc8f07d3a0
      * @private
      */
     notify () {

--- a/src/react/util/state/StateHandler.js
+++ b/src/react/util/state/StateHandler.js
@@ -77,13 +77,6 @@ export class StateHandler {
      * @private
      */
     notify () {
-        if (this.timeout) {
-            clearTimeout(this.timeout);
-        }
-        // This allows multiple small state updates to be run one after another before re-rendering is triggered
-        this.timeout = setTimeout(() => {
-            this.stateListeners.forEach(consumer => consumer(this.getState()));
-            this.timeout = null;
-        }, 10);
+        this.stateListeners.forEach(consumer => consumer(this.getState()));
     }
 }

--- a/src/react/util/state/index.js
+++ b/src/react/util/state/index.js
@@ -1,3 +1,4 @@
 export { controllerMixin } from './mixins';
 export { Controller } from './Controller';
 export { StateHandler } from './StateHandler';
+export { AsyncStateHandler } from './AsyncStateHandler';


### PR DESCRIPTION
To restore cursor behavior on input fields for most of the UI (instead of #2625) and allow statsgrid to use an async one instead to prevent the issue described in #2595.