### PR TITLE
Timeseries control header icon hover color fix

### DIFF
--- a/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesHeader.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/TimeSeriesHeader.jsx
@@ -48,16 +48,16 @@ export const TimeSeriesHeader = ({ toggleMode, title, mode = 'year', loading = f
     const switchButtonMessage = <Message messageKey={switchButtonMessageKey} />;
     const modeIcon = mode === 'year' ? <LoginOutlined /> : <LogoutOutlined />;
     return (
-        <Header className="timeseries-range-drag-handle" textColor={textColor} hovercolor={hoverColor}>
+        <Header className="timeseries-range-drag-handle" textColor={textColor} hoverColor={hoverColor}>
             {getHeaderContent(title, loading, error, value)}
             <div className="header-mid-spacer"></div>
             <Tooltip title={getTooltipContent(mode, modeIcon)}>
-                <IconButton type="text" size="large" $textColor={textColor} $hoverColor={hoverColor}>
+                <IconButton type="text" size="large" textColor={textColor} hoverColor={hoverColor}>
                     <QuestionCircleOutlined />
                 </IconButton>
             </Tooltip>
             <Tooltip title={switchButtonMessage}>
-                <IconButton type="text" size="large" onClick={() => toggleMode()} $textColor={textColor} $hoverColor={hoverColor}>
+                <IconButton type="text" size="large" onClick={() => toggleMode()} textColor={textColor} hoverColor={hoverColor}>
                     {modeIcon}
                 </IconButton>
             </Tooltip>

--- a/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/styled.jsx
@@ -27,12 +27,12 @@ export const Header = styled.h3`
 
 export const IconButton = styled(Button)`
     padding: 10px;
-    color: ${props => props?.$textColor ? props?.$textColor : primaryColor};
+    color: ${props => props?.textColor ? props?.textColor : primaryColor};
 
     &:hover,
     &:focus,
     &:active {
-        color: ${props => props?.$hovercolor ? props?.$hovercolor : primaryColor};
+        color: ${props => props?.hoverColor ? props?.hoverColor : primaryColor};
         background: transparent;
     }
 


### PR DESCRIPTION
Header had `$hoverColor` and styled `$hovercolor` => default value was used instead color from theme

Changed to use same naming (camelCase without $)