### PR TITLE
Async layers get features timing fix

### DIFF
--- a/bundles/framework/featuredata2/view/FeatureDataHandler.js
+++ b/bundles/framework/featuredata2/view/FeatureDataHandler.js
@@ -141,22 +141,21 @@ class ViewHandler extends StateHandler {
             return;
         }
         const selectedFeatures = this._getSelectedFeatureIds(layerId);
-        const layerState = this.getLayerState(layerId);
-        this.updateState({ layerId, selectedFeatures, ...layerState });
+        this.updateState({ layerId, selectedFeatures, ...this.getLayerState({ layerId }) });
     }
 
     setIsActive (isActive) {
         if (isActive === this.getState().isActive) {
             return;
         }
-        const layerState = isActive ? this.getLayerState() : {};
-        this.updateState({ isActive, ...layerState });
+        this.updateState({ isActive, ...this.getLayerState({ isActive }) });
     }
 
-    getLayerState (layerId = this.getState().layerId) {
+    getLayerState (state = {}) {
+        const { layerId, isActive } = { ...this.getState(), ...state };
         const layer = Oskari.getSandbox().findMapLayerFromSelectedMapLayers(layerId);
-        const features = this._getCurrentFeatureProperties(layerId);
-        const inScale = !!layer && layer.isInScale();
+        const features = isActive ? this._getCurrentFeatureProperties(layerId) : [];
+        const inScale = isActive ? !!layer && layer.isInScale() : false;
         return {
             inScale,
             features

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -965,9 +965,14 @@ Oskari.clazz.define(
          */
         getVectorFeatures (geojson = {}, opts = {}) {
             const layerPlugins = this.getLayerPlugins();
+            const bbox = this.getSandbox().getMap().getBbox();
+            if (!bbox) {
+                this.log.info('Tried to get vector features before map is ready');
+                return {};
+            }
             // Detect if requested geojson is not on the current viewport
             if (geojson && geojson.geometry) {
-                const { left, bottom, right, top } = this.getSandbox().getMap().getBbox();
+                const { left, bottom, right, top } = bbox;
                 const extent = [left, bottom, right, top];
                 const features = filterFeaturesByExtent([geojson], extent);
                 if (!features.length) {


### PR DESCRIPTION
Mapfull syncs map state by MapMoveRequest 
https://github.com/oskariorg/oskari-frontend/blob/2.13.0/bundles/framework/mapfull/instance.js#L261
https://github.com/oskariorg/oskari-frontend/blob/2.13.0/src/sandbox/sandbox-map-methods.js#L48

Sandbox map bbox is set after map move (moovend -> notifyMoveEnd ->updateDomain)

Looks like in some cases setting map location takes so long that FeatureData2 tries to get features before bbox is set (mapfull state has vector layer).

As layers are added to map async them aren't available (selected/on map) when FeatureData2 is initialized. 
https://github.com/oskariorg/oskari-frontend/blob/2.13.0/bundles/framework/featuredata2/view/FeatureDataHandler.js#L21
Async layers triggers MapLayerAddEvent => _addLayer => setActiveLayer => getLayerState tries to get features

Changed get actual layer state only when FeatureData2 is active (flyout is shown) => doesn't trigger getFeatures on startup
Also added safety check for AbstractMapModule (skip getFeatures without bbox)
