### PR TITLE
Fine tune statsgrid async state to fix editing embedded map

### DIFF
--- a/bundles/statistics/statsgrid/handler/ViewHandler.js
+++ b/bundles/statistics/statsgrid/handler/ViewHandler.js
@@ -1,4 +1,4 @@
-import { StateHandler, controllerMixin, Messaging } from 'oskari-ui/util';
+import { AsyncStateHandler, controllerMixin, Messaging } from 'oskari-ui/util';
 import { getContainerOptions, createSeriesControlPlugin, createTogglePlugin, stopTogglePlugin } from '../helper/ViewHelper';
 import { showTableFlyout } from '../view/Table/TableFlyout';
 import { showSearchFlyout } from '../view/search/SearchFlyout';
@@ -18,7 +18,7 @@ const classificationDefaults = {
 };
 const embeddedTools = [...FLYOUTS, CLASSIFICATION, SERIES];
 
-class UIHandler extends StateHandler {
+class UIHandler extends AsyncStateHandler {
     constructor (instance, stateHandler, searchHandler) {
         super();
         this.instance = instance;


### PR DESCRIPTION
Currently editing embedded maps results in js max stack error. This should fix it