### PR TITLE
Add initial one day duration for new announcements

### DIFF
--- a/bundles/admin/admin-announcements/view/AnnouncementsForm.jsx
+++ b/bundles/admin/admin-announcements/view/AnnouncementsForm.jsx
@@ -82,7 +82,7 @@ const validateLocale = (state, defaultLang) => {
 const initState = announcement => {
     const { beginDate, endDate, options, locale, ...rest } = announcement;
     const begin = beginDate ? dayjs(beginDate) : dayjs().startOf('hour');
-    const end = endDate ? dayjs(endDate) : dayjs().startOf('hour');
+    const end = endDate ? dayjs(endDate) : dayjs().add(1, 'day').startOf('hour');
     return {
         ...rest,
         date: [begin, end],


### PR DESCRIPTION
Previously the end date was the same as start date. Now admins might not need to edit the end date if it's a shorted duration announcement