### PR TITLE
StatsGrid filter duplicate indicators 

### DIFF
--- a/bundles/statistics/statsgrid/handler/SearchIndicatorOptionsHelper.js
+++ b/bundles/statistics/statsgrid/handler/SearchIndicatorOptionsHelper.js
@@ -100,7 +100,7 @@ export const populateIndicatorOptions = async (datasourceId, successCallback, er
             indicatorListPerDatasource[cacheKey] = response;
         }
         // always signal complete when we are done with retries, even if server returned !complete
-        successCallback({...response, complete: true });
+        successCallback({ ...response, complete: true });
     } catch (error) {
         if (typeof errorCallback === 'function') {
             errorCallback('errors.indicatorListError');
@@ -118,7 +118,7 @@ export const populateIndicatorOptions = async (datasourceId, successCallback, er
 */
 const filterDuplicates = (indicators = []) => {
     const ids = new Set();
-    return indicators.filter(({id}) => ids.has(id) ? false : ids.add(id));
+    return indicators.filter(({ id }) => ids.has(id) ? false : ids.add(id));
 };
 
 const RETRY_LIMIT = 5;

--- a/bundles/statistics/statsgrid/handler/SearchIndicatorOptionsHelper.js
+++ b/bundles/statistics/statsgrid/handler/SearchIndicatorOptionsHelper.js
@@ -94,17 +94,13 @@ export const populateIndicatorOptions = async (datasourceId, successCallback, er
 
     try {
         const response = await populateIndicatorListFromServer(datasourceId, successCallback);
-        const value = {
-            // always signal complete when we are done with retries, even if server returned !complete
-            complete: true,
-            indicators: response.indicators || []
-        };
         if (response.complete) {
             // cache result if complete
             // this allows the server to continue processing and return updated list when available
-            indicatorListPerDatasource[cacheKey] = value;
+            indicatorListPerDatasource[cacheKey] = response;
         }
-        successCallback(value);
+        // always signal complete when we are done with retries, even if server returned !complete
+        successCallback({...response, complete: true });
     } catch (error) {
         if (typeof errorCallback === 'function') {
             errorCallback('errors.indicatorListError');
@@ -120,6 +116,10 @@ export const populateIndicatorOptions = async (datasourceId, successCallback, er
 /*
 ------------------ INTERNAL HELPERS ------------------------
 */
+const filterDuplicates = (indicators = []) => {
+    const ids = new Set();
+    return indicators.filter(({id}) => ids.has(id) ? false : ids.add(id));
+};
 
 const RETRY_LIMIT = 5;
 const populateIndicatorListFromServer = async (datasourceId, successCallback, retryCount = RETRY_LIMIT, previousResult = {}) => {
@@ -168,7 +168,11 @@ const getIndicatorListFromServer = async (datasourceId) => {
         if (!response.ok) {
             throw new Error(response.statusText);
         }
-        return await response.json();
+        const { indicators, ...rest } = await response.json();
+        return {
+            ...rest,
+            indicators: filterDuplicates(indicators)
+        };
     } catch (error) {
         throw new Error('errors.indicatorListIsEmpty');
     }


### PR DESCRIPTION
First tried to filter cached/returned indicators but partial indicators are passed via success callback. So moved filtering to backed response.

Fixes issue where indicator select is broken when backend returns duplicate indicators