### PR TITLE
StatsGrid opacity fix

### DIFF
--- a/bundles/statistics/statsgrid/components/RegionsetViewer.js
+++ b/bundles/statistics/statsgrid/components/RegionsetViewer.js
@@ -81,7 +81,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
         const addFeaturesRequestParams = [];
         const handledRegions = [];
         const { groups } = classifiedData;
-        const { mapStyle, showValues } = classification;
+        const { mapStyle, showValues, transparency } = classification;
         groups.forEach(function (regiongroup, index) {
             const { color, sizePx, regionIds } = regiongroup;
             const optionalStyles = [];
@@ -139,6 +139,7 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
                 optionalStyles: optionalStyles,
                 layerId: LAYER_ID,
                 prio: REGION_PRIO + index,
+                opacity: typeof transparency !== 'undefined' ? transparency : 100,
                 animationDuration: 250
             };
             const borderRequestOptions = Object.assign({}, regionRequestOptions, {

--- a/bundles/statistics/statsgrid/components/classification/Classification.jsx
+++ b/bundles/statistics/statsgrid/components/classification/Classification.jsx
@@ -74,15 +74,13 @@ export const Classification = ({
                         values = {classification}
                         editEnabled = {editEnabled}
                         controller = {controller}
-                        showHistogram = {showHistogram}
-                        opacity = {layer.opacity}/>
+                        showHistogram = {showHistogram}/>
                 }
                 <LegendContainer className = "classification-legend">
                     <Legend
                         classifiedData = {classifiedData}
                         mapStyle = {classification.mapStyle}
-                        transparency = {layer.opacity}
-                    />
+                        transparency = {classification.transparency} />
                 </LegendContainer>
             </ContentWrapper>
         </Container>

--- a/bundles/statistics/statsgrid/components/classification/Legend.jsx
+++ b/bundles/statistics/statsgrid/components/classification/Legend.jsx
@@ -11,7 +11,7 @@ const Container = styled.div`
 `;
 
 export const Legend = ({
-    transparency,
+    transparency = 100,
     mapStyle,
     classifiedData
 }) => {
@@ -20,7 +20,7 @@ export const Legend = ({
         const errorKey = error === 'general' ? 'cannotCreateLegend' : error;
         return (<InactiveLegend error = {errorKey} />);
     }
-    const opacity = transparency / 100 || 1;
+    const opacity = transparency / 100;
     const { groups } = classifiedData;
     const maxSizePx = groups.map(g => g.sizePx).reduce((max, val) => max < val ? val : max);
     return (
@@ -38,7 +38,7 @@ export const Legend = ({
 };
 
 Legend.propTypes = {
-    transparency: PropTypes.number.isRequired,
+    transparency: PropTypes.number,
     mapStyle: PropTypes.string.isRequired,
     classifiedData: PropTypes.object.isRequired
 };

--- a/bundles/statistics/statsgrid/components/classification/editclassification/EditClassification.jsx
+++ b/bundles/statistics/statsgrid/components/classification/editclassification/EditClassification.jsx
@@ -51,13 +51,13 @@ export const EditClassification = ({
     controller,
     editEnabled,
     showHistogram,
-    values,
-    opacity
+    values
 }) => {
     const options = getEditOptions(values, data);
     const handleChange = (id, value) => controller.updateClassification({ [id]: value });
     const onOpacityChange = opacity => Oskari.getSandbox().postRequestByName('ChangeMapLayerOpacityRequest', [LAYER_ID, opacity]);
     const disabled = !editEnabled;
+    const opacity = typeof values.transparency !== 'undefined' ? values.transparency : 100;
     return (
         <Container className="t_classification-edit">
             <LabeledSelect
@@ -131,6 +131,5 @@ EditClassification.propTypes = {
     editEnabled: PropTypes.bool.isRequired,
     values: PropTypes.object.isRequired,
     showHistogram: PropTypes.func.isRequired,
-    controller: PropTypes.object.isRequired,
-    opacity: PropTypes.number.isRequired
+    controller: PropTypes.object.isRequired
 };

--- a/bundles/statistics/statsgrid/handler/StatisticsHandler.js
+++ b/bundles/statistics/statsgrid/handler/StatisticsHandler.js
@@ -113,6 +113,10 @@ class StatisticsController extends StateHandlerBase {
         this.updateState({ activeRegion });
     }
 
+    onLayerOpacityChange (transparency) {
+        this.updateClassification({transparency});
+    }
+
     updateClassification (updated) {
         const { activeIndicator: hash, indicators } = this.getState();
         const indicator = indicators.find(ind => ind.hash === hash);
@@ -201,12 +205,8 @@ class StatisticsController extends StateHandlerBase {
             };
             const isSeriesActive = active ? !!active.series : false;
             this.updateState({ activeIndicator, isSeriesActive, activeRegion, regionset, indicators: indicatorsToAdd, loading: false });
-            // backwards compatibility
-            if (active) {
-                const opacity = active.classification?.transparency || 100;
-                this.sandbox.postRequestByName('ChangeMapLayerOpacityRequest', [LAYER_ID, opacity]);
-            } else {
-                // reset active
+            // reset active
+            if (!active) {
                 this.setActiveIndicator();
             }
         } catch (error) {

--- a/bundles/statistics/statsgrid/handler/StatisticsHandler.js
+++ b/bundles/statistics/statsgrid/handler/StatisticsHandler.js
@@ -114,7 +114,7 @@ class StatisticsController extends StateHandlerBase {
     }
 
     onLayerOpacityChange (transparency) {
-        this.updateClassification({transparency});
+        this.updateClassification({ transparency });
     }
 
     updateClassification (updated) {

--- a/bundles/statistics/statsgrid/handler/ViewHandler.js
+++ b/bundles/statistics/statsgrid/handler/ViewHandler.js
@@ -29,7 +29,6 @@ class UIHandler extends StateHandler {
 
         this.setState({
             layer: {
-                opacity: 100, // store layer opacity to trigger update
                 visible: true,
                 onMap: false
             },

--- a/bundles/statistics/statsgrid/instance.js
+++ b/bundles/statistics/statsgrid/instance.js
@@ -215,7 +215,7 @@ Oskari.clazz.define(
                     return;
                 }
                 const opacity = evt.getMapLayer().getOpacity();
-                this.getViewHandler().updateLayer('opacity', opacity);
+                this.getStateHandler().onLayerOpacityChange(opacity);
             },
             'FeatureEvent': function (event) {
                 if (event.getParams().operation !== 'click' || !event.hasFeatures() || !this.stateHandler) {


### PR DESCRIPTION
Moved opacity back to classification.transparency. 

Layer is added from state by mapfull bundle but it's not available (statsgrid registers) on first call
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/framework/mapfull/instance.js#L316-L337
on app start opacity is updated internally and add is skipped because statsgrid is already added layer on map 
=> no event => other components doesn't update