### PR TITLE
StateHandler expiring modal

### DIFF
--- a/bundles/framework/statehandler/SessionExpiringPopup.jsx
+++ b/bundles/framework/statehandler/SessionExpiringPopup.jsx
@@ -32,12 +32,11 @@ const MessagePopup = (props) => {
         newSeconds = newSeconds < 10 ? 0 + newSeconds : newSeconds;
 
         if (newSeconds < 1) {
-            const modalController = showSessionExpiredModal();
+            showSessionExpiredModal();
             closeCallback();
             clearTimeout(timer);
             if (Oskari.user().isLoggedIn()) {
                 setTimeout(() => {
-                    modalController.close();
                     cancelCallback();
                 }, MODAL_DELAY_MS);
             } else {

--- a/bundles/framework/statehandler/session-methods.js
+++ b/bundles/framework/statehandler/session-methods.js
@@ -14,7 +14,7 @@ Oskari.clazz.category(
 
             sandbox.setSessionExpiring((minutes - 1), function () {
                 const popupController = showSessionExpiringPopup(minutes, () => {
-                    document.querySelector("form[action='/logout']").submit();
+                    document.querySelector("form[action='/logout']")?.submit();
                     popupController.close();
                 }, () => {
                     // continue session

--- a/src/react/components/window/Modal.jsx
+++ b/src/react/components/window/Modal.jsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { Header } from 'oskari-ui/components/window/Header';
 const StyledModal = styled(AntModal)`
     .ant-modal-body {
-        padding: 0.5em 0;
+        padding: 0 0 0.5em 0;
     }
 `;
 


### PR DESCRIPTION
Don't close modal on logout. If logout form isn't found, modal gives instructions to user to refresh/login.

Remove top padding. Without bottom padding popup content margin doesn't affect (text content doesn't have bottom margin).

![image](https://github.com/oskariorg/oskari-frontend/assets/22147092/59a372d4-197f-439c-8e52-d3ebe009389f)
