### PR TITLE
Style effect support alpha

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VectorStyle/HoverModal.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VectorStyle/HoverModal.jsx
@@ -9,7 +9,7 @@ import { IconButton } from 'oskari-ui/components/buttons';
 import { Controller } from 'oskari-ui/util';
 import { getGeometryType } from '../../../LayerHelper';
 import { SUPPORTED_FORMATS } from 'oskari-ui/components/StyleEditor/constants';
-import { EFFECT } from '../../../../../../mapping/mapmodule/oskariStyle/constants.js';
+import { EFFECT } from '../../../../../../../src/constants';
 
 const Row = styled.div`
     display: flex;

--- a/bundles/mapping/mapmodule/oskariStyle/constants.js
+++ b/bundles/mapping/mapmodule/oskariStyle/constants.js
@@ -21,29 +21,6 @@ export const LINE_CAP = {
     ROUND: 'round'
 };
 
-const AUTO = 'auto';
-const DARKEN = 'darken';
-const LIGHTEN = 'lighten';
-const MINOR = 'minor';
-const NORMAL = 'normal';
-const MAJOR = 'major';
-
-export const EFFECT = {
-    NONE: 'none',
-    AUTO,
-    DARKEN,
-    LIGHTEN,
-    AUTO_MINOR: `${AUTO} ${MINOR}`,
-    AUTO_NORMAL: `${AUTO} ${NORMAL}`,
-    AUTO_MAJOR: `${AUTO} ${MAJOR}`,
-    DARKEN_MINOR: `${DARKEN} ${MINOR}`,
-    DARKEN_NORMAL: `${DARKEN} ${NORMAL}`,
-    DARKEN_MAJOR: `${DARKEN} ${MAJOR}`,
-    LIGHTEN_MINOR: `${LIGHTEN} ${MINOR}`,
-    LIGHTEN_NORMAL: `${LIGHTEN} ${NORMAL}`,
-    LIGHTEN_MAJOR: `${LIGHTEN} ${MAJOR}`
-};
-
 export const FILL_STYLE = {
     THIN_DIAGONAL: 0,
     THICK_DIAGONAL: 1,

--- a/bundles/mapping/mapmodule/oskariStyle/generator.ol.js
+++ b/bundles/mapping/mapmodule/oskariStyle/generator.ol.js
@@ -5,7 +5,7 @@ import olStyleCircle from 'ol/style/Circle';
 import olStyleIcon from 'ol/style/Icon';
 import olStyleText from 'ol/style/Text';
 
-import { LINE_DASH, LINE_JOIN, EFFECT, FILL_STYLE, STYLE_TYPE, PATTERN_STROKE } from './constants';
+import { LINE_DASH, LINE_JOIN, FILL_STYLE, STYLE_TYPE, PATTERN_STROKE } from './constants';
 import { filterOptionalStyle, getOptionalStyleFilter } from './filter';
 
 const log = Oskari.log('MapModule.util.style');
@@ -315,7 +315,7 @@ const getFillStyle = styleDef => {
     if (!color) {
         return new olStyleFill({ color: TRANSPARENT });
     }
-    color = getColorEffect(styleDef.effect, color) || color;
+    color = Oskari.util.getColorEffect(color, styleDef.effect);
 
     if (Oskari.util.keyExists(styleDef, 'fill.area.pattern')) {
         const pattern = getFillPattern(styleDef.fill.area.pattern, color);
@@ -411,7 +411,7 @@ const getStrokeStyle = styleDef => {
     if (width === 0) {
         return null;
     }
-    stroke.color = color ? getColorEffect(effect, color) || color : TRANSPARENT;
+    stroke.color = color ? Oskari.util.getColorEffect(color, effect) : TRANSPARENT;
     if (width) {
         stroke.width = width;
     }
@@ -467,7 +467,7 @@ const getImageStyle = (mapModule, styleDef, requestedStyle) => {
     const opacity = styleDef.image.opacity || 1;
     // Oskari marker
     if (!isNaN(styleDef.image.shape)) {
-        const effect = getColorEffect(styleDef.effect, styleDef.image.fill?.color);
+        const effect = Oskari.util.getColorEffect(styleDef.image.fill?.color, styleDef.effect);
         const imageDef = { ...styleDef.image };
         if (effect) {
             imageDef.fill = { color: effect };
@@ -500,7 +500,7 @@ const getImageStyle = (mapModule, styleDef, requestedStyle) => {
     styleDef.image.size = size;
 
     let fillColor = styleDef.image.fill ? styleDef.image.fill.color : undefined;
-    fillColor = getColorEffect(styleDef.effect, fillColor) || fillColor;
+    fillColor = Oskari.util.getColorEffect(fillColor, styleDef.effect);
 
     if (mapModule.isSvg(styleDef.image)) {
         styleDef.image.color = fillColor;
@@ -597,7 +597,7 @@ const getTextStyle = styleDef => {
     }
     if (fill && fill.color) {
         text.fill = new olStyleFill({
-            color: getColorEffect(styleDef.effect, fill.color) || fill.color
+            color: Oskari.util.getColorEffect(fill.color, styleDef.effect)
         });
     }
     if (stroke) {
@@ -611,34 +611,4 @@ const getTextStyle = styleDef => {
         }
     }
     return new olStyleText(text);
-};
-
-/**
- * @method getColorEffect
- * @param {String} effect Oskari style constant
- * @param {String} color Color to apply the effect on
- * @return {String} Affected color or undefined if effect or color is missing
- */
-const getColorEffect = (effect, color) => {
-    if (!effect || !color || effect === EFFECT.NONE) {
-        return;
-    }
-    const minor = 60;
-    const normal = 90;
-    const major = 120;
-    const getEffect = (delta, auto) => Oskari.util.alterBrightness(color, delta, auto);
-    switch (effect) {
-    case EFFECT.AUTO : return getEffect(normal, true);
-    case EFFECT.AUTO_MINOR : return getEffect(minor, true);
-    case EFFECT.AUTO_NORMAL : return getEffect(normal, true);
-    case EFFECT.AUTO_MAJOR : return getEffect(major, true);
-    case EFFECT.DARKEN : return getEffect(-normal);
-    case EFFECT.DARKEN_MINOR : return getEffect(-minor);
-    case EFFECT.DARKEN_NORMAL : return getEffect(-normal);
-    case EFFECT.DARKEN_MAJOR : return getEffect(-major);
-    case EFFECT.LIGHTEN : return getEffect(normal);
-    case EFFECT.LIGHTEN_MINOR : return getEffect(minor);
-    case EFFECT.LIGHTEN_NORMAL : return getEffect(normal);
-    case EFFECT.LIGHTEN_MAJOR : return getEffect(major);
-    }
 };

--- a/bundles/mapping/mapmodule/plugin/panbuttons/PanButton3D.jsx
+++ b/bundles/mapping/mapmodule/plugin/panbuttons/PanButton3D.jsx
@@ -3,7 +3,7 @@ import { CaretDownOutlined, CaretUpOutlined, CaretLeftOutlined, CaretRightOutlin
 import styled from 'styled-components';
 import { ReturnIcon } from 'oskari-ui/components/icons';
 import { MapModuleButton } from '../../MapModuleButton';
-import { getColorEffect, EFFECT } from 'oskari-ui/theme';
+import { EFFECT } from '../../../../../src/constants';
 
 const StyledButtonContainer = styled('div')`
     position: relative;
@@ -97,7 +97,7 @@ const ArrowButton = ({ children, onClick, colors, top = 'initial', right = 'init
 export const PanButton3D = ({ colors, resetClicked, panClicked, isMobile = false, showArrows = false }) => {
     const { bgColor, icon, hover, primary } = colors;
     let backgroundV = bgColor;
-    let backgroundH = `linear-gradient(180deg, ${primary} 0%, ${primary} 35%, ${getColorEffect(primary, EFFECT.LIGHTEN_MINOR)} 100%)`;
+    let backgroundH = `linear-gradient(180deg, ${primary} 0%, ${primary} 35%, ${Oskari.util.getColorEffect(primary, EFFECT.LIGHTEN_MINOR)} 100%)`;
     if (isMobile || !showArrows) {
         return (
             <MapModuleButton

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,30 @@
+const AUTO = 'auto';
+const DARKEN = 'darken';
+const LIGHTEN = 'lighten';
+const MINOR = 'minor';
+const NORMAL = 'normal';
+const MAJOR = 'major';
+
+export const DELTA = {
+    [MINOR]: 60,
+    [NORMAL]: 90,
+    [MAJOR]: 120
+};
+
+export const DEFAULT_DELTA = DELTA[NORMAL];
+
+export const EFFECT = {
+    NONE: 'none',
+    AUTO,
+    DARKEN,
+    LIGHTEN,
+    AUTO_MINOR: `${AUTO} ${MINOR}`,
+    AUTO_NORMAL: `${AUTO} ${NORMAL}`,
+    AUTO_MAJOR: `${AUTO} ${MAJOR}`,
+    DARKEN_MINOR: `${DARKEN} ${MINOR}`,
+    DARKEN_NORMAL: `${DARKEN} ${NORMAL}`,
+    DARKEN_MAJOR: `${DARKEN} ${MAJOR}`,
+    LIGHTEN_MINOR: `${LIGHTEN} ${MINOR}`,
+    LIGHTEN_NORMAL: `${LIGHTEN} ${NORMAL}`,
+    LIGHTEN_MAJOR: `${LIGHTEN} ${MAJOR}`
+};

--- a/src/react/components/buttons/IconButton.jsx
+++ b/src/react/components/buttons/IconButton.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Message, Confirm, Button, Tooltip } from 'oskari-ui';
 import { ThemeConsumer } from '../../util';
-import { getColorEffect, EFFECT } from '../../theme';
+import { EFFECT } from '../../../constants';
 import styled from 'styled-components';
 import { PlusOutlined, EditOutlined, QuestionCircleOutlined, DeleteOutlined, CheckOutlined, StopOutlined} from '@ant-design/icons';
 import { Forward } from '../icons/Forward'
@@ -124,7 +124,7 @@ const ThemeButton = ThemeConsumer(({
     if (!hover) {
         hover = COLORS.hover;
     } else if (Oskari.util.isDarkColor(hover)) {
-        hover = getColorEffect(hover, EFFECT.LIGHTEN);
+        hover = Oskari.util.getColorEffect(hover, EFFECT.LIGHTEN);
     }
     const ButtonNode = bordered ? BorderedButton : BorderlessButton;
     const activeColor = active ? hover : null;

--- a/src/react/theme/ThemeHelper.js
+++ b/src/react/theme/ThemeHelper.js
@@ -1,5 +1,6 @@
 
-import { EFFECT, DEFAULT_COLORS, DEFAULT_FONT } from './constants';
+import { DEFAULT_COLORS, DEFAULT_FONT } from './constants';
+import { EFFECT } from '../../constants';
 
 export const getHeaderTheme = (theme) => {
     const bgColor = theme.color?.header?.bg || theme.color?.primary || DEFAULT_COLORS.HEADER_BG;
@@ -8,8 +9,8 @@ export const getHeaderTheme = (theme) => {
     const funcs = {
         getBgColor: () => bgColor,
         getAccentColor: () => accentColor,
-        getBgBorderColor: () => getColorEffect(accentColor, -10),
-        getBgBorderBottomColor: () => getColorEffect(accentColor, 20),
+        getBgBorderColor: () => Oskari.util.getColorEffect(accentColor, -10),
+        getBgBorderBottomColor: () => Oskari.util.getColorEffect(accentColor, 20),
         getTextColor: () => theme.color?.header?.text || headerTextColor,
         getToolColor: () => theme.color?.header?.icon || funcs.getTextColor(),
         getToolHoverColor: () => accentColor
@@ -27,7 +28,9 @@ export const getNavigationTheme = (theme) => {
 
     let buttonColor = primary;
     if (theme.navigation?.effect === '3D') {
-        buttonColor = `linear-gradient(180deg, ${getColorEffect(primary, EFFECT.DARKEN)} 0%, ${primary} 35%, ${getColorEffect(primary, EFFECT.LIGHTEN)} 100%)`;
+        const start = Oskari.util.getColorEffect(primary, EFFECT.DARKEN);
+        const stop = Oskari.util.getColorEffect(primary, EFFECT.LIGHTEN);
+        buttonColor = `linear-gradient(180deg, ${start} 0%, ${primary} 35%, ${stop} 100%)`;
     }
     const funcs = {
         getPrimary: () => primary,
@@ -55,38 +58,4 @@ export const getTextColor = (bgColor) => {
 export const getFontClass = (theme) => {
     const fontClassSuffix = theme.font || DEFAULT_FONT;
     return 'oskari-theme-font-' + fontClassSuffix;
-};
-
-/* ------------------------------------------------------------------------------ */
-// Note! Copy-pasted from bundles/mapping/mapmodule/oskariStyle!
-// TODO: figure out if these should be shared and from map or src
-/**
- * @method getColorEffect
- * @param {String} color Color to apply the effect on
- * @param {String} effect Oskari style constant (auto, darken, lighten with specifiers minor, normal, major)
- * @return {String} Affected color or undefined if effect or color is missing
- */
-export const getColorEffect = (color, effect) => {
-    if (!effect || !color || effect === EFFECT.NONE) {
-        return;
-    }
-    const minor = 60;
-    const normal = 90;
-    const major = 120;
-    const getEffect = (delta, auto) => Oskari.util.alterBrightness(color, delta, auto);
-    switch (effect) {
-    case EFFECT.AUTO : return getEffect(normal, true);
-    case EFFECT.AUTO_MINOR : return getEffect(minor, true);
-    case EFFECT.AUTO_NORMAL : return getEffect(normal, true);
-    case EFFECT.AUTO_MAJOR : return getEffect(major, true);
-    case EFFECT.DARKEN : return getEffect(-normal);
-    case EFFECT.DARKEN_MINOR : return getEffect(-minor);
-    case EFFECT.DARKEN_NORMAL : return getEffect(-normal);
-    case EFFECT.DARKEN_MAJOR : return getEffect(-major);
-    case EFFECT.LIGHTEN : return getEffect(normal);
-    case EFFECT.LIGHTEN_MINOR : return getEffect(minor);
-    case EFFECT.LIGHTEN_NORMAL : return getEffect(normal);
-    case EFFECT.LIGHTEN_MAJOR : return getEffect(major);
-    default : return getEffect(effect, true);
-    }
 };

--- a/src/react/theme/constants.js
+++ b/src/react/theme/constants.js
@@ -1,14 +1,3 @@
-// OSKARI STYLE CONSTANTS
-// Use same effect keywords that are mentioned in the map feature styling API documentation
-// Note! Copy-pasted from bundles/mapping/mapmodule/oskariStyle!
-// TODO: figure out if these should be shared and from map or src
-const AUTO = 'auto';
-const DARKEN = 'darken';
-const LIGHTEN = 'lighten';
-const MINOR = 'minor';
-const NORMAL = 'normal';
-const MAJOR = 'major';
-
 export const DEFAULT_COLORS = {
     NAV_BG: '#333438',
     HEADER_BG: '#fdf8d9',
@@ -17,19 +6,3 @@ export const DEFAULT_COLORS = {
     DARK_BUTTON_BG: '#141414'
 };
 export const DEFAULT_FONT = 'arial';
-
-export const EFFECT = {
-    NONE: 'none',
-    AUTO,
-    DARKEN,
-    LIGHTEN,
-    AUTO_MINOR: `${AUTO} ${MINOR}`,
-    AUTO_NORMAL: `${AUTO} ${NORMAL}`,
-    AUTO_MAJOR: `${AUTO} ${MAJOR}`,
-    DARKEN_MINOR: `${DARKEN} ${MINOR}`,
-    DARKEN_NORMAL: `${DARKEN} ${NORMAL}`,
-    DARKEN_MAJOR: `${DARKEN} ${MAJOR}`,
-    LIGHTEN_MINOR: `${LIGHTEN} ${MINOR}`,
-    LIGHTEN_NORMAL: `${LIGHTEN} ${NORMAL}`,
-    LIGHTEN_MAJOR: `${LIGHTEN} ${MAJOR}`
-};

--- a/src/react/theme/index.js
+++ b/src/react/theme/index.js
@@ -1,3 +1,3 @@
-export { DEFAULT_COLORS, EFFECT } from './constants';
+export { DEFAULT_COLORS } from './constants';
 export { setGlobalStyle } from './globalStyles';
-export { getColorEffect, getTextColor, getHeaderTheme, getNavigationTheme } from './ThemeHelper';
+export { getTextColor, getHeaderTheme, getNavigationTheme } from './ThemeHelper';

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,5 @@
 import DOMPurify from 'dompurify';
+import { DELTA, EFFECT, DEFAULT_DELTA } from './constants';
 const MobileDetect = require('mobile-detect');
 
 /*
@@ -214,6 +215,47 @@ Oskari.util = (function () {
     };
 
     /**
+     * Convert color to array
+     *
+     * @method colorToArray
+     * @param {String} color hex, rgb or rgba
+     * @return {Array} color as an array [r, g, b(,a)]. Where r,g,b are int 0-255 and a is float 0-1.
+     */
+    util.colorToArray = function (color) {
+        if (typeof color !== 'string') {
+            return [];
+        }
+        const bracket = color.indexOf('(');
+        if (bracket !== -1) {
+            const parts = color.substring(bracket + 1, color.indexOf(')')).split(',');
+            return parts.map((part, i) => {
+                if (i === 3) {
+                    return parseFloat(part);
+                }
+                return parseInt(part);
+            });
+        }
+        let hex = color.charAt(0) === '#' ? color.substring(1) : color;
+        let a;
+        // parse alpha if exists
+        if (hex.length === 4 || hex.length === 8) {
+            const isShort = hex.length === 4;
+            const i = isShort ? 3 : 6;
+            const hexA = isShort ? hex[i] + hex[i] : hex.substring(i);
+            a = parseInt(hexA, 16) / 255;
+            // don't pass alpha to hexToRgb
+            hex = hex.substring(0, i);
+        }
+        // supports short and full hex
+        const parts = util.hexToRgb(hex);
+        if (!parts) {
+            return [];
+        }
+        const { r, g, b } = parts;
+        return typeof a === 'undefined' ? [r,g,b] : [r,g,b,a];
+    };
+
+    /**
      * Convert rgb values to hexadecimal color values
      *
      * @method rgbToHex
@@ -236,6 +278,63 @@ Oskari.util = (function () {
         return parts.join('');
     };
 
+    /**
+     * @method getDeltaForEffect
+     * @param {String} color Color to apply the effect on
+     * @param {String|Number} effect Oskari style constant (auto, darken, lighten with specifiers minor, normal, major) or delta (auto is used)
+     * @return {Number} delta
+     */
+    util.getDeltaForEffect = function (color = '', effect = '') {
+        if (typeof effect === 'number') {
+            return this.isLightColor(color) ? -effect : effect;
+        }
+
+        let delta = DEFAULT_DELTA;
+        Object.keys(DELTA).forEach(key => {
+            if (effect.includes(key)) {
+                delta = DELTA[key];
+            }
+        });
+        if (effect.includes(EFFECT.DARKEN) || (effect.includes(EFFECT.AUTO) && this.isLightColor(color))) {
+            return -delta;
+        }
+        return delta;
+    };
+
+    /**
+     * @method getColorEffect
+     * @param {String} color Color to apply the effect on
+     * @param {String} effect Oskari style constant
+     * @return {String} Affected color (hex or rgba) or original color if failed to apply effect
+     */
+    util.getColorEffect = function (color, effect) {
+        if (!effect || !color || effect === EFFECT.NONE) {
+            return color;
+        }
+        const delta = this.getDeltaForEffect(color, effect);
+        const colors = Oskari.util.colorToArray(color).map((part, i) => {
+            if (i >= 3) {
+                return part;
+            }
+            const clr = part + delta;
+            if (clr > 255) {
+                return 255;
+            } else if (clr < 0) {
+                return 0;
+            }
+            return clr;
+        });
+        if (colors.length === 3) {
+            return '#' + colors.map(part => {
+                const hex = part.toString(16);
+                return hex.length === 1 ? '0' + hex : hex;
+            }).join('');
+        } else if (colors.length === 4) {
+            const [r,g,b,a] = colors;
+            return `rgba(${r},${g},${b},${a})`;
+        }
+        return color;
+    };
     /**
      * Returns a new color string for lighter or darker color than the original.
      * @param {String} colorStr color to change
@@ -274,7 +373,6 @@ Oskari.util = (function () {
         var green = (num & 0x0000FF) + amount;
         if (green > 255) green = 255;
         else if (green < 0) green = 0;
-
         var color = (green | (blue << 8) | (red << 16)).toString(16);
         // Pad with leading zeros
         color = String('000000' + color).slice(-6);
@@ -410,11 +508,11 @@ Oskari.util = (function () {
             r = color[0];
             g = color[1];
             b = color[2];
-        } else if (color[0] === '#' && color.length === 7) {
+        } else if (color[0] === '#' && color.length === 7 || color.length === 9) {
             r = parseInt(color.slice(1, 3), 16);
             g = parseInt(color.slice(3, 5), 16);
             b = parseInt(color.slice(5, 7), 16);
-        } else if (color[0] === '#' && color.length === 4) {
+        } else if (color[0] === '#' && color.length === 4 || color.length === 5) {
             r = parseInt(color[1] + color[1], 16);
             g = parseInt(color[2] + color[2], 16);
             b = parseInt(color[3] + color[3], 16);

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -177,7 +177,7 @@ describe('colorToArray function', () => {
         expect(Oskari.util.colorToArray('FFFFFF')).toEqual([255, 255, 255]);
     });
 
-    test('returns correct parts with shorthand parameter 03FF', () => {
+    test('returns correct parts with shorthand parameter 03F', () => {
         expect.assertions(1);
         expect(Oskari.util.colorToArray('03F')).toEqual([0, 51, 255]);
     });

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -1,5 +1,6 @@
 const jQuery = require('jquery');
 global.jQuery = jQuery;
+import { EFFECT, DELTA, DEFAULT_DELTA } from './constants';
 
 describe('isNumber function', () => {
     test('returns true when parameter is number', () => {
@@ -108,6 +109,11 @@ describe('hexToRgb function', () => {
         expect(Oskari.util.hexToRgb('03F')).toEqual({ "b": 255, "g": 51, "r": 0 });
     });
 
+    test('returns correct value with shorthand parameter #03F', () => {
+        expect.assertions(1);
+        expect(Oskari.util.hexToRgb('#03F')).toEqual({ "b": 255, "g": 51, "r": 0 });
+    });
+
     test('returns correct value with parameter 228B22 (= Green)', () => {
         expect.assertions(1);
         expect(Oskari.util.hexToRgb('228B22')).toEqual({ "b": 34, "g": 139, "r": 34 });
@@ -152,6 +158,180 @@ describe('rgbToHex function', () => {
         expect(() => Oskari.util.rgbToHex()).toThrowError(TypeError);
     });
 
+});
+
+describe('colorToArray function', () => {
+
+    test('returns correct parts with rgb(255,0,0) (= Red)', () => {
+        expect.assertions(1);
+        expect(Oskari.util.colorToArray('rgb(255,0,0)')).toEqual([255, 0, 0]);
+    });
+
+    test('returns correct parts with rgba(0,191,255, 0.5) (= Light blue)', () => {
+        expect.assertions(1);
+        expect(Oskari.util.colorToArray('rgba(0,191,255, 0.5)')).toEqual([0, 191, 255, 0.5]);
+    });
+
+    test('returns correct parts with parameter FFFFFF (= White)', () => {
+        expect.assertions(1);
+        expect(Oskari.util.colorToArray('FFFFFF')).toEqual([255, 255, 255]);
+    });
+
+    test('returns correct parts with shorthand parameter 03FF', () => {
+        expect.assertions(1);
+        expect(Oskari.util.colorToArray('03F')).toEqual([0, 51, 255]);
+    });
+
+    test('returns correct parts with shorthand parameter #03F0', () => {
+        expect.assertions(1);
+        expect(Oskari.util.colorToArray('#03F0')).toEqual([0, 51, 255, 0]);
+    });
+
+    test('returns correct parts with parameter #FFFFFFFF', () => {
+        expect.assertions(1);
+        expect(Oskari.util.colorToArray('#FFFFFFFF')).toEqual([255, 255, 255, 1]);
+    });
+
+    test('returns empty array when invalid parameter is provided', () => {
+        expect.assertions(1);
+        expect(() => Oskari.util.colorToArray('invalid')).toHaveLength(0);
+    });
+
+    test('returns empty array when parameter is not provided', () => {
+        expect.assertions(1)
+        expect(() => Oskari.util.colorToArray()).toHaveLength(0);
+    });
+
+});
+
+describe('getColorEffect and alterBrightness functions should return same', () => {
+    test('hex and positive amount', () => {
+        expect.assertions(1);
+        const hex = '#9932cc';
+        const effect = 10;
+        expect(Oskari.util.getColorEffect(hex, effect)).toEqual(Oskari.util.alterBrightness(hex, effect));
+    });
+    test('hex and negative amount', () => {
+        expect.assertions(1);
+        const hex = '#9932cc';
+        const effect = -10;
+        expect(Oskari.util.getColorEffect(hex, effect)).toEqual(Oskari.util.alterBrightness(hex, effect));
+    });
+    test('hex and auto', () => {
+        expect.assertions(2);
+        const hex = '#9932cc';
+        const delta = DEFAULT_DELTA;
+        expect(Oskari.util.getDeltaForEffect(hex, EFFECT.AUTO)).toEqual(delta);
+        expect(Oskari.util.getColorEffect(hex, EFFECT.AUTO)).toEqual(Oskari.util.alterBrightness(hex, delta));
+    });
+    test('hex and lighten', () => {
+        expect.assertions(2);
+        const hex = '#9932cc';
+        const delta = 60;
+        expect(Oskari.util.getDeltaForEffect(hex, EFFECT.LIGHTEN_MINOR)).toEqual(delta);
+        expect(Oskari.util.getColorEffect(hex, EFFECT.LIGHTEN_MINOR)).toEqual(Oskari.util.alterBrightness(hex, delta));
+    });
+    test('hex and darken', () => {
+        expect.assertions(2);
+        const hex = '#9932cc';
+        const delta = -60;
+        expect(Oskari.util.getDeltaForEffect(hex, EFFECT.DARKEN_MINOR)).toEqual(delta);
+        expect(Oskari.util.getColorEffect(hex, EFFECT.DARKEN_MINOR)).toEqual(Oskari.util.alterBrightness(hex, delta));
+    });
+});
+
+describe('getColorEffect function', () => {
+
+    const rgb = 'rgb(153,50,204)';
+    const rgba = 'rgba(153,50,204,0.5)';
+    const hex = '#9932cc';
+    const a = '50'
+    const hexa = hex + a;
+    const alpha = parseInt(a, 16) / 255;
+
+    test('returns passed color when amount with value 0 is provided as parameters', () => {
+        expect.assertions(1);
+        expect(Oskari.util.getColorEffect(rgb, 0)).toEqual(rgb);
+    });
+
+    test('returns passed color when effect is missing', () => {
+        expect.assertions(1);
+        expect(Oskari.util.getColorEffect(hex)).toEqual(hex);
+    });
+
+    test('returns lighter color when rgb color and positive amount are provided as parameters', () => {
+        expect.assertions(1);
+        expect(Oskari.util.getColorEffect(rgb, 5)).toEqual('#9e37d1');
+    });
+
+    test('returns darker color when rgb color and negative amount are provided as parameters', () => {
+        expect.assertions(1);
+        expect(Oskari.util.getColorEffect(rgb, -5)).toEqual('#942dc7');
+    });
+
+    test('flips change when color is light and amount (auto effect) is provided as parameter', () => {
+        expect.assertions(1);
+        expect(Oskari.util.getColorEffect('ffffff', 5)).toEqual('#fafafa');
+    });
+
+    test('returns white in edge case when trying to lighter white', () => {
+        expect.assertions(1);
+        expect(Oskari.util.getColorEffect('ffffff', EFFECT.LIGHTEN)).toEqual('#ffffff');
+    });
+
+    test('returns black in edge case when trying to darker black', () => {
+        expect.assertions(1);
+        expect(Oskari.util.getColorEffect('000000', EFFECT.DARKEN)).toEqual('#000000');
+    });
+
+    test('returns lighter color when hex color and lighten effect are provided as parameters', () => {
+        expect.assertions(1);
+        expect(Oskari.util.getColorEffect(hex, EFFECT.LIGHTEN)).toEqual('#f38cff');
+    });
+
+    test('returns darker color when hex color and negative amount are provided as parameters', () => {
+        expect.assertions(1);
+        expect(Oskari.util.getColorEffect(hex, EFFECT.DARKEN)).toEqual('#3f0072');
+    });
+
+    test('returns lighter color when rgba color and positive amount are provided as parameters', () => {
+        expect.assertions(1);
+        expect(Oskari.util.getColorEffect(rgba, 5)).toEqual('rgba(158,55,209,0.5)');
+    });
+
+    test('returns darker color when hex color and negative amount are provided as parameters', () => {
+        expect.assertions(1);
+        expect(Oskari.util.getColorEffect(rgba, EFFECT.AUTO)).toEqual('rgba(243,140,255,0.5)');
+    });
+
+    test('returns darker color when hex color with alpha and negative amount are provided as parameters', () => {
+        expect.assertions(1);
+        expect(Oskari.util.getColorEffect(hexa, -5)).toEqual(`rgba(148,45,199,${alpha})`);
+    });
+
+    test('returns darker color when hex color with alpha and darken effect are provided as parameters', () => {
+        expect.assertions(1);
+        expect(Oskari.util.getColorEffect(hexa, EFFECT.DARKEN_MINOR)).toEqual(`rgba(93,0,144,${alpha})`);
+    });
+
+    test('returns darker color when hex color (without "#") with alpha and darken effect are provided as parameters', () => {
+        expect.assertions(1);
+        expect(Oskari.util.getColorEffect(hexa.substring(1), EFFECT.LIGHTEN_MAJOR)).toEqual(`rgba(255,170,255,${alpha})`);
+    });
+
+    test('Returns passed color when rgb color is provided and amount parameter is not provided', () => {
+        expect.assertions(1);
+        expect(Oskari.util.getColorEffect(rgb)).toEqual(rgb);
+    });
+
+    test('Returns passed color when hex color is provided and none effect is not provided', () => {
+        expect.assertions(1);
+        expect(Oskari.util.getColorEffect(hex, EFFECT.NONE)).toEqual(hex);
+    });
+    test('Returns undefined (passed color) when parameters are not provided', () => {
+        expect.assertions(1);
+        expect(Oskari.util.getColorEffect()).toEqual(undefined);
+    });
 });
 
 describe('alterBrightness function', () => {


### PR DESCRIPTION
OpenLayers supports [r,g,b(,a)] color so created first colorToArray. As theme and other components uses also getColorEffect changed util.getColorEffect to return hex  (has always `#` or rgba. For now alter

Not sure where EFFECT constant should be located. If better place isn't found and more constants are added, maybe some alias like oskari-ui could be added for cleaner imports.

Only getColorEffect (mapmodule, theme) used Oskari.util.alterBrightness. New util.getColorEffect doesn't use it because it doesn't support alpha and returns hex so maybe it could be removed or mark as deprecated.

Changes:
- mapmodule had (effect, color) and theme (color, effect)
- getColorEffect returns passed color if fails or no effect to apply (undefined, none, 0).
- getColorEffect returns always #-prefixed hex or rgba if alpha exists

Not sure how intended is to test returning black wihtout amount:
https://github.com/oskariorg/oskari-frontend/blob/2.13.1/src/util.test.js#L192-L200
Because red, green and blue gets NaN values
https://github.com/oskariorg/oskari-frontend/blob/2.13.1/src/util.test.js#L192-L200
And:
https://github.com/oskariorg/oskari-frontend/blob/2.13.1/src/util.test.js#L192-L200
returns 0 which is padded with leaading zeroes to 000000.
If we want black color for fallback/default, then it should be more visible/clearer.

Also getColorBrighness requires #-prefix for hex color but many other function doesn't.
https://github.com/oskariorg/oskari-frontend/blob/2.13.1/src/util.test.js#L192-L200

