### PR TITLE
MapPlugins bottom container pointer events

### DIFF
--- a/bundles/mapping/mapmodule/resources/scss/mapmodule.ol.scss
+++ b/bundles/mapping/mapmodule/resources/scss/mapmodule.ol.scss
@@ -103,6 +103,7 @@ div.olMap {
     left: 0;
     display: flex;
     flex-wrap: wrap;
+    pointer-events: none;
 }
 
 div.mapplugins {


### PR DESCRIPTION
Disable pointer events to bottom container with CSS. Fixes issue where map didn't receive events over container (map click, draw move,..)

For some reason bottom plugins are wrapped with extra 'plugins-bottom' div/container which didn't have pointer-events none. 
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/mapping/mapmodule/util/PluginContainerHelper.js#L34-L35
mapplugins div has it. 
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/mapping/mapmodule/resources/scss/mapmodule.ol.scss#L109
So only added it for wrapper div