### PR TITLE
Fix service metadata before saving

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/MetadataId.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/MetadataId.jsx
@@ -21,7 +21,7 @@ export const MetadataId = ({ layer, controller }) => {
                 <StyledFormField>
                     <Message messageKey='metadata.overridden'/>
                     {renderButton &&
-                        <MetadataButton onClick={() => controller.showLayerMetadata(layer.id)}/>
+                        <MetadataButton onClick={() => controller.showLayerMetadata(layer.isNew ? layer.metadataid : layer.id)}/>
                     }
                     <TextInput
                         value={layer.metadataid}

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/ServiceMetadata.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdditionalTabPane/ServiceMetadata.jsx
@@ -26,7 +26,7 @@ export const ServiceMetadata = ({ capabilities, controller, hasHandler, layerId 
         <Tooltip title={metadataUuid}>
             <Message messageKey='metadata.service' />
             {hasHandler &&
-                <MetadataButton onClick={() => controller.showLayerMetadata(layerId)}/>
+                <MetadataButton onClick={() => controller.showLayerMetadata(layerId || metadataUuid)}/>
             }
         </Tooltip>
     );

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -1178,8 +1178,15 @@ class UIHandler extends StateHandler {
     }
 
     showLayerMetadata (layerId) {
+        // this works even when the layer hasn't been saved yet
+        let payload = { uuid: layerId };
+        if (typeof layerId === 'number') {
+            // this works only when layer has been saved
+            // (and supports the attributes override for metadata service url)
+            payload = { layerId };
+        }
         Oskari.getSandbox().postRequestByName('catalogue.ShowMetadataRequest', [
-            { layerId: layerId }
+            payload
         ]);
     }
 


### PR DESCRIPTION
Continues oskariorg/oskari-server#1062 and fixes the frontend for service metadata when the layer hasn't been saved yet. Without this the frontend requests server to show metadata with layerId, but the layer hasn't been saved yet so it has no id.