### PR TITLE
Admin LayerEditor partial style fixes

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VectorStyle/HoverModal.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VectorStyle/HoverModal.jsx
@@ -122,7 +122,7 @@ export const HoverModal = ({ layer, controller }) => {
         setContent(newContent);
     };
     const geometryType = getGeometryType(layer);
-    
+
     return (
         <Fragment>
             <ButtonContainer>

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VectorStyle/HoverModal.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VectorStyle/HoverModal.jsx
@@ -8,7 +8,6 @@ import { recognizeChanges } from 'oskari-ui/components/StyleEditor/util'
 import { IconButton } from 'oskari-ui/components/buttons';
 import { Controller } from 'oskari-ui/util';
 import { getGeometryType } from '../../../LayerHelper';
-import { SUPPORTED_FORMATS } from 'oskari-ui/components/StyleEditor/constants';
 import { EFFECT } from '../../../../../../../src/constants';
 
 const Row = styled.div`
@@ -123,7 +122,6 @@ export const HoverModal = ({ layer, controller }) => {
         setContent(newContent);
     };
     const geometryType = getGeometryType(layer);
-    const styleTabs = SUPPORTED_FORMATS.includes(geometryType) ? [geometryType] : SUPPORTED_FORMATS;
     
     return (
         <Fragment>
@@ -169,7 +167,7 @@ export const HoverModal = ({ layer, controller }) => {
                     <Switch size='small' checked={useStyle} onChange={value => setUseStyle(value)} />
                     <Message messageKey='styles.hover.useStyle' />
                 </RowItem>
-                { useStyle && <StyleEditor tabs={styleTabs}
+                { useStyle && <StyleEditor geometryType={geometryType}
                     oskariStyle={ featureStyle }
                     onChange={updated => setFeatureStyle({ ...featureStyle, ...updated })}/>
                 }

--- a/src/react/components/StyleEditor.jsx
+++ b/src/react/components/StyleEditor.jsx
@@ -69,10 +69,7 @@ export const StyleEditor = ({ oskariStyle, onChange, format, geometryType }) => 
     let [form] = Form.useForm();
     // if we don't clone the input here the mappings
     //  between form <> style, the values can get mixed up due to mutability
-    const style = {
-        ...Oskari.custom.getDefaultStyle(),
-        ...oskariStyle
-    };
+    const style = Oskari.util.deepClone(Oskari.custom.getDefaultStyle(), oskariStyle);
 
     const formats = constants.SUPPORTED_FORMATS.includes(geometryType)
         ? [geometryType] : constants.SUPPORTED_FORMATS;

--- a/src/react/components/StyleEditor.jsx
+++ b/src/react/components/StyleEditor.jsx
@@ -65,7 +65,7 @@ const styleExceptionHandler = (exceptionStyle, oldStyle) => {
     return exceptionStyle;
 };
 
-export const StyleEditor = ({ oskariStyle, onChange, format, geometryType }) => {
+export const StyleEditor = ({ oskariStyle = {}, onChange, format, geometryType }) => {
     let [form] = Form.useForm();
     // if we don't clone the input here the mappings
     //  between form <> style, the values can get mixed up due to mutability

--- a/src/react/components/StyleEditor/Preview/StyleMapper.js
+++ b/src/react/components/StyleEditor/Preview/StyleMapper.js
@@ -32,13 +32,15 @@ const getPropsForFormat = (format, style) => {
 }
 
 const getAreaPropsFromStyle = (style) => {
+    const { fill = {} } = style;
+    const stroke = style.stroke?.area || {};
     return {
-        color: style.fill.color,
-        strokecolor: style.stroke.area.color,
-        size: style.stroke.area.width,
-        strokestyle: style.stroke.area.lineDash,
-        linejoin: style.stroke.area.lineJoin,
-        pattern: style.fill.area.pattern
+        color: fill.color,
+        strokecolor: stroke.color,
+        size: stroke.width,
+        strokestyle: stroke.lineDash,
+        linejoin: stroke.lineJoin,
+        pattern: fill.area?.pattern
     };
 };
 

--- a/src/util.js
+++ b/src/util.js
@@ -908,5 +908,10 @@ Oskari.util = (function () {
         return false;
     };
 
+    util.deepClone = (source = {}, ...merges) => {
+        // TODO: remove jQuery dependency
+        return jQuery.extend(true, {}, source, ...merges);
+    };
+
     return util;
 }());

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -1039,3 +1039,66 @@ describe('isValidDomain function', () => {
         expect(Oskari.util.isValidDomain('3434')).toEqual(false);
     });
 });
+
+describe('deepClone function', () => {
+    const obj = {foo: {bar : 1}};
+
+    test('returns new reference', () => {
+        expect(Oskari.util.deepClone(obj)).not.toBe(obj);
+    });
+
+    test('returns equal content', () => {
+        expect(Oskari.util.deepClone(obj)).toEqual(obj);
+    });
+
+    test('returns merged content', () => {
+        const merge1 = {foo: {baz: {test: true}}};
+        const merge2 = {foo: {bar: 2}};
+        const merge3 = {test: [2]};
+        const merged = {foo: {bar: 2, baz: {test: true}}, test: [2]};
+        expect(Oskari.util.deepClone(obj, merge1, merge2, merge3)).toEqual(merged);
+    });
+
+    test('returns whole style on merge', () => {
+        const color = '#000000';
+        const size = 1;
+        const style = {
+            "image": {
+                "shape": 5,
+                "size": 3,
+                "fill": {
+                    "color": "#FAEBD7"
+                }
+            },
+            "fill": {
+                "area": {
+                    "pattern": -1
+                },
+                "color": "#FAEBD7"
+            },
+            "stroke": {
+                "area": {
+                    "color": "#000000",
+                    "lineDash": "solid",
+                    "width": 1,
+                    "lineJoin": "round"
+                },
+                "color": "#000000",
+                "lineCap": "round",
+                "lineDash": "solid",
+                "width": 1,
+                "lineJoin": "round"
+            }
+        };
+        const merge = {
+            stroke: {},
+            fill: { color },
+            image: { size }
+        };
+
+        const merged = Oskari.util.deepClone(style, merge);
+        style.image.size = size;
+        style.fill.color = color;
+        expect(style).toEqual(merged);
+    });
+});


### PR DESCRIPTION
Fixes issues with StyleEditor and partial styles (edit hover style or partial style defined via text editor). 

StyleEditor used shallow merge for blank + given and if given style didn't have whole style definitions for example:
`{ ...blank, ...{ fill: {} }` => `{ image: {...}, stroke: {...}, fill: {} }` 
=> `style.fill.area.pattern` is missing

Fix geometryType for hover style editor.