### PR TITLE
Reset cursor for olPopups to override map cursor setting

### DIFF
--- a/bundles/mapping/infobox/resources/scss/infobox.ol.scss
+++ b/bundles/mapping/infobox/resources/scss/infobox.ol.scss
@@ -75,6 +75,8 @@ div.olPopup {
     overflow: auto/*\0/ !important*/;
     /*height: 400px*//*\0/ !important*/;
     z-index: 16000;
+    /* Reset cursor for popups when map cursor has been set */
+    cursor: auto;
 
     &.center-left {
       margin-left:10px;


### PR DESCRIPTION
Fixes an issue where for example an RPC-application sets the map cursor with: https://oskari.org/examples/rpc-api/#/setCursorStyle

And opens an infobox with https://oskari.org/examples/rpc-api/#/infoBoxSimple

This results in the cursor being the one set for map even when hovering over an infobox.