### PR TITLE
Statsgrid2016 publisher tool fix

### DIFF
--- a/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
@@ -1,5 +1,6 @@
 Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractStatsPluginTool', function () {
 }, {
+    id: 'AbstractStatsPluginTool',
     getStatsgridConf: function (initialData) {
         const conf = initialData?.configuration?.statsgrid?.conf || {};
         // Setup the plugin location whenever any of the stats tools parse initial config.
@@ -15,8 +16,12 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractStatsPluginTool'
     getComponent: function () {
         return {};
     },
-    getTitle: function () {
-        return Oskari.getMsg('Publisher2', `BasicView.data.${this.title}`);
+    getToolInfo: function () {
+        return {
+            id: 'Oskari.statistics.statsgrid.Plugin.' + this.id,
+            title: Oskari.getMsg('Publisher2', `BasicView.data.${this.title}`),
+            hasNoPlugin: true
+        };
     },
     /**
     * @method @private _isStatsActive

--- a/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
@@ -15,6 +15,9 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractStatsPluginTool'
     getComponent: function () {
         return {};
     },
+    getTitle: function () {
+        return Oskari.getMsg('Publisher2', `BasicView.data.${this.title}`);
+    },
     /**
     * @method @private _isStatsActive
     * @return true when stats layer is on the map, false if removed

--- a/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/AbstractStatsPluginTool.js
@@ -12,7 +12,9 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.AbstractStatsPluginTool'
     getStatsgridBundle: function () {
         return Oskari.getSandbox().findRegisteredModuleInstance('StatsGrid');
     },
-
+    getComponent: function () {
+        return {};
+    },
     /**
     * @method @private _isStatsActive
     * @return true when stats layer is on the map, false if removed

--- a/bundles/statistics/statsgrid2016/publisher/ClassificationToggleTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/ClassificationToggleTool.js
@@ -11,12 +11,10 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationToggleTool
     },
     getTool: function () {
         return {
-            id: 'Oskari.statistics.statsgrid.TogglePlugin',
-            title: this.getTitle(),
+            ...this.getToolInfo(),
             config: {
                 classification: true
-            },
-            hasNoPlugin: true
+            }
         };
     },
     _setEnabledImpl: function (enabled) {

--- a/bundles/statistics/statsgrid2016/publisher/ClassificationToggleTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/ClassificationToggleTool.js
@@ -3,6 +3,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationToggleTool
     index: 1,
     group: 'data',
     id: 'classification',
+    title: 'allowHidingClassification',
 
     init: function (data) {
         const conf = this.getStatsgridConf(data);
@@ -11,7 +12,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationToggleTool
     getTool: function () {
         return {
             id: 'Oskari.statistics.statsgrid.TogglePlugin',
-            title: 'allowHidingClassification',
+            title: this.getTitle(),
             config: {
                 classification: true
             },

--- a/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
@@ -2,6 +2,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationTool', fun
 }, {
     index: 1,
     group: 'data',
+    title: 'allowClassification',
 
     init: function (data) {
         const conf = this.getStatsgridConf(data);
@@ -15,7 +16,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationTool', fun
     getTool: function () {
         return {
             id: 'Oskari.statistics.statsgrid.ClassificationPlugin',
-            title: 'allowClassification',
+            title: this.getTitle(),
             config: {
                 allowClassification: false
             },

--- a/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/ClassificationTool.js
@@ -2,6 +2,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationTool', fun
 }, {
     index: 1,
     group: 'data',
+    id: 'allowClassification',
     title: 'allowClassification',
 
     init: function (data) {
@@ -15,12 +16,10 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.ClassificationTool', fun
     },
     getTool: function () {
         return {
-            id: 'Oskari.statistics.statsgrid.ClassificationPlugin',
-            title: this.getTitle(),
+            ...this.getToolInfo(),
             config: {
                 allowClassification: false
-            },
-            hasNoPlugin: true
+            }
         };
     },
     _setEnabledImpl: function (enabled) {

--- a/bundles/statistics/statsgrid2016/publisher/DiagramTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/DiagramTool.js
@@ -3,6 +3,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.DiagramTool', function (
     index: 1,
     group: 'data',
     id: 'diagram',
+    title: 'displayDiagram',
 
     init: function (data) {
         const conf = this.getStatsgridConf(data);
@@ -11,7 +12,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.DiagramTool', function (
     getTool: function () {
         return {
             id: 'Oskari.statistics.statsgrid.TogglePlugin',
-            title: 'displayDiagram',
+            title: this.getTitle(),
             config: {
                 diagram: true
             },

--- a/bundles/statistics/statsgrid2016/publisher/DiagramTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/DiagramTool.js
@@ -11,12 +11,10 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.DiagramTool', function (
     },
     getTool: function () {
         return {
-            id: 'Oskari.statistics.statsgrid.TogglePlugin',
-            title: this.getTitle(),
+            ...this.getToolInfo(),
             config: {
                 diagram: true
-            },
-            hasNoPlugin: true
+            }
         };
     },
     _setEnabledImpl: function (enabled) {

--- a/bundles/statistics/statsgrid2016/publisher/OpacityTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/OpacityTool.js
@@ -3,6 +3,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.OpacityTool', function (
 {
     index: 1,
     group: 'data',
+    id: 'transparent',
     title: 'transparent',
 
     init: function (data) {
@@ -11,12 +12,10 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.OpacityTool', function (
     },
     getTool: function () {
         return {
-            id: 'Oskari.statistics.statsgrid.ClassificationPlugin',
-            title: this.getTitle(),
+            ...this.getToolInfo(),
             config: {
                 transparent: false
-            },
-            hasNoPlugin: true
+            }
         };
     },
     _setEnabledImpl: function (enabled) {

--- a/bundles/statistics/statsgrid2016/publisher/OpacityTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/OpacityTool.js
@@ -3,6 +3,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.OpacityTool', function (
 {
     index: 1,
     group: 'data',
+    title: 'transparent',
 
     init: function (data) {
         const conf = this.getStatsgridConf(data);
@@ -11,7 +12,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.OpacityTool', function (
     getTool: function () {
         return {
             id: 'Oskari.statistics.statsgrid.ClassificationPlugin',
-            title: 'transparent',
+            title: this.getTitle(),
             config: {
                 transparent: false
             },

--- a/bundles/statistics/statsgrid2016/publisher/SeriesToggleTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/SeriesToggleTool.js
@@ -11,12 +11,10 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.SeriesToggleTool', funct
     },
     getTool: function () {
         return {
-            id: 'Oskari.statistics.statsgrid.TogglePlugin',
-            title: this.getTitle(),
+            ...this.getToolInfo(),
             config: {
                 series: true
-            },
-            hasNoPlugin: true
+            }
         };
     },
     _setEnabledImpl: function (enabled) {

--- a/bundles/statistics/statsgrid2016/publisher/SeriesToggleTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/SeriesToggleTool.js
@@ -3,6 +3,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.SeriesToggleTool', funct
     index: 1,
     group: 'data',
     id: 'series',
+    title: 'allowHidingSeriesControl',
 
     init: function (data) {
         const conf = this.getStatsgridConf(data);
@@ -11,7 +12,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.SeriesToggleTool', funct
     getTool: function () {
         return {
             id: 'Oskari.statistics.statsgrid.TogglePlugin',
-            title: 'allowHidingSeriesControl',
+            title: this.getTitle(),
             config: {
                 series: true
             },

--- a/bundles/statistics/statsgrid2016/publisher/StatsTableTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/StatsTableTool.js
@@ -6,6 +6,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.StatsTableTool', functio
     groupedSiblings: false,
     templates: {},
     id: 'table',
+    title: 'grid',
     /**
      * Initialize tool
      * @params {} state data
@@ -27,7 +28,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.StatsTableTool', functio
     getTool: function () {
         return {
             id: 'Oskari.statistics.statsgrid.TogglePlugin',
-            title: 'grid',
+            title: this.getTitle(),
             config: {
                 grid: true
             },

--- a/bundles/statistics/statsgrid2016/publisher/StatsTableTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/StatsTableTool.js
@@ -5,7 +5,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.StatsTableTool', functio
 
     groupedSiblings: false,
     templates: {},
-    id: 'table',
+    id: 'grid',
     title: 'grid',
     /**
      * Initialize tool
@@ -27,12 +27,10 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.StatsTableTool', functio
     */
     getTool: function () {
         return {
-            id: 'Oskari.statistics.statsgrid.TogglePlugin',
-            title: this.getTitle(),
+            ...this.getToolInfo(),
             config: {
                 grid: true
-            },
-            hasNoPlugin: true
+            }
         };
     },
     /**


### PR DESCRIPTION
This fixes issue where publishing thematic map didn't have statsgrid tools in publisher.

Publisher tool fixes for old statsgrid2016. Publisher uses PanelReactTools for rendering statistics tools. It requires that tool has `getComponent` function and `getTool` has to return actual title instead of localization key. Also tool's id is used for key in React render so it has to be unique. Tools have `hasNoPlugin` and id isn't used to create plugin instance so used prefixed tool ids to get unique ids.

