### PR TITLE
Metadatasearch localization fixes

### DIFF
--- a/bundles/catalogue/metadatasearch/MetadataStateHandler.js
+++ b/bundles/catalogue/metadatasearch/MetadataStateHandler.js
@@ -18,8 +18,7 @@ class MetadataStateHandler extends StateHandler {
             query: '',
             advancedSearchExpanded: false,
             advancedSearchOptions: null,
-            advancedSearchValues: {
-            },
+            advancedSearchValues: {},
             loading: false,
             drawing: false,
             searchResultsVisible: false,
@@ -179,10 +178,9 @@ class MetadataStateHandler extends StateHandler {
             const emptyOption = Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'advancedSearch.emptyOption');
             options?.fields?.forEach((field) => {
                 const newField = Object.assign({}, field);
-                let sortedValues = field.values.sort((a, b) => Oskari.util.naturalSort(a.val, b.val));
-                sortedValues.forEach((value) => { value.value = value.val; });
-                if (!newField.multi) {
-                    sortedValues = [{ val: emptyOption, value: '' }].concat(sortedValues);
+                const sortedValues = field.values.sort((a, b) => Oskari.util.naturalSort(a.val, b.val)).map(({ val }) => ({ label: val, value: val }));
+                if (sortedValues.length && !newField.multi) {
+                    sortedValues.unshift({ label: emptyOption, value: '' });
                 }
                 newField.values = sortedValues;
                 sortedOptions.fields.push(newField);

--- a/bundles/catalogue/metadatasearch/MetadataStateHandler.js
+++ b/bundles/catalogue/metadatasearch/MetadataStateHandler.js
@@ -189,31 +189,10 @@ class MetadataStateHandler extends StateHandler {
         });
     }
 
-    updateAdvancedSearchValues (newValues) {
-        this.updateState({
-            advancedSearchValues: newValues
-        });
-    }
-
     advancedSearchParamsChanged (key, value) {
-        const { advancedSearchValues } = this.getState();
-        advancedSearchValues[key] = value;
-        this.updateAdvancedSearchValues(advancedSearchValues);
-    }
-
-    advancedSearchParamsChangedMulti (key, value) {
-        if (!value || !value.target) {
-            return;
-        }
-        const { advancedSearchValues } = this.getState();
-        const checked = !!value.target.checked;
-
-        const newMultiValue = advancedSearchValues[key]?.filter(item => item !== value.target.value) || [];
-        if (checked) {
-            newMultiValue.push(value.target.value);
-        }
-        advancedSearchValues[key] = newMultiValue;
-        this.updateAdvancedSearchValues(advancedSearchValues);
+        this.updateState({
+            advancedSearchValues: { ...this.getState().advancedSearchValues, [key]: value }
+        });
     }
 
     advancedSearchCoverageStartDrawing (evt) {
@@ -249,7 +228,6 @@ const wrapped = controllerMixin(MetadataStateHandler, [
     'toggleAdvancedSearch',
     'toggleSearchResultsFilter',
     'advancedSearchParamsChanged',
-    'advancedSearchParamsChangedMulti',
     'advancedSearchCoverageStartDrawing',
     'advancedSearchCoverageCancelDrawing',
     'updateCoverageFeature',

--- a/bundles/catalogue/metadatasearch/instance.js
+++ b/bundles/catalogue/metadatasearch/instance.js
@@ -1,5 +1,5 @@
 import { MetadataStateHandler } from './MetadataStateHandler';
-import { Messaging } from 'oskari-ui/util';
+import { Messaging, LocaleProvider } from 'oskari-ui/util';
 import { MetadataSearchContainer } from './view/MetadataSearchContainer';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -362,7 +362,10 @@ Oskari.clazz.define(
         },
 
         renderSearch: function () {
-            ReactDOM.render(<MetadataSearchContainer state={this.handler.getState()} controller={this.handler.getController()} />, this.contentElement);
+            ReactDOM.render(
+                <LocaleProvider value={{ bundleKey: METADATA_BUNDLE_LOCALIZATION_ID }}>
+                    <MetadataSearchContainer state={this.handler.getState()} controller={this.handler.getController()} />
+                </LocaleProvider>, this.contentElement);
         },
 
         /* ----------- Tile and Flyout ------------- */

--- a/bundles/catalogue/metadatasearch/resources/locale/en.js
+++ b/bundles/catalogue/metadatasearch/resources/locale/en.js
@@ -34,6 +34,12 @@ Oskari.registerLocalization({
             "service-OGC:WFS": "WFS service",
             "dataset": "Dataset",
             "series": "Dataset series",
+            "service": "Service",
+            "discovery": "Discovery",
+            "download": "Download",
+            "other": "Other",
+            "transformation": "Transformation",
+            "view": "View",
             "resourceTypes": {
                 "service-discovery": "Discovery service",
                 "service-download": "Download service",

--- a/bundles/catalogue/metadatasearch/resources/locale/fi.js
+++ b/bundles/catalogue/metadatasearch/resources/locale/fi.js
@@ -34,6 +34,12 @@ Oskari.registerLocalization({
             "service-OGC:WFS": "WFS-palvelu",
             "dataset": "Aineisto",
             "series": "Aineistosarja",
+            "service": "Palvelu",
+            "discovery": "Haku",
+            "download": "Lataus",
+            "other": "Muu",
+            "transformation": "Muunnos",
+            "view": "Katselu",
             "resourceTypes": {
                 "service-discovery": "Hakupalvelu",
                 "service-download": "Latauspalvelu",

--- a/bundles/catalogue/metadatasearch/resources/locale/sv.js
+++ b/bundles/catalogue/metadatasearch/resources/locale/sv.js
@@ -34,6 +34,12 @@ Oskari.registerLocalization({
             "service-OGC:WFS": "WFS-tjänst",
             "dataset": "Dataset",
             "series": "Serie",
+            "service": "Tjänst",
+            "discovery": "Upptäck",
+            "download": "Ladda ned",
+            "other": "Annan",
+            "transformation": "Omvandling",
+            "view": "Visa",
             "resourceTypes": {
                 "service-discovery": "Söktjänst",
                 "service-download": "Nedladdningstjänst",

--- a/bundles/catalogue/metadatasearch/service/MetadataSearchService.js
+++ b/bundles/catalogue/metadatasearch/service/MetadataSearchService.js
@@ -7,9 +7,8 @@ export class MetadataSearchService {
     }
 
     doSearch (params, onSuccess) {
-        const epsg = Oskari.getSandbox().getMap().getSrsName();
         if (!params.srs) {
-            params.srs = epsg;
+            params.srs = Oskari.getSandbox().getMap().getSrsName();
         }
         // create POST payload from params
         const payload = Object.keys(params)

--- a/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchDropdown.jsx
+++ b/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchDropdown.jsx
@@ -1,25 +1,25 @@
 import React from 'react';
+import { Message } from 'oskari-ui';
 import { AdvancedSearchInputLabel, AdvancedSearchRowContainer, AdvancedSearchSelect } from './AdvancedSearchStyledComponents';
-import { Option } from 'oskari-ui';
 import PropTypes from 'prop-types';
+
 export const AdvancedSearchDropdown = (props) => {
-    const { title, options, onChange, selected, disabled } = props;
-    const hasOptions = options && options?.values?.length && options.values.length > 0;
-    if (!hasOptions) {
+    const { field, options, onChange, selected = '', disabled } = props;
+    if (!options.length) {
         return null;
     }
     return <AdvancedSearchRowContainer>
-        <AdvancedSearchInputLabel>{title}</AdvancedSearchInputLabel>
-        <AdvancedSearchSelect onChange={onChange} value={selected} disabled={disabled}>
-            { options.values.map(value => <Option key={value.val} value={value.value}>{value.val}</Option>) }
-        </AdvancedSearchSelect>
+        <AdvancedSearchInputLabel>
+            <Message messageKey={`advancedSearch.${field}`} defaultMsg={field}/>
+        </AdvancedSearchInputLabel>
+        <AdvancedSearchSelect onChange={onChange} value={selected} disabled={disabled} options={options} />
     </AdvancedSearchRowContainer>;
 };
 
 AdvancedSearchDropdown.propTypes = {
-    title: PropTypes.string,
-    options: PropTypes.object,
-    onChange: PropTypes.func,
+    field: PropTypes.string.isRequired,
+    options: PropTypes.array.isRequired,
+    onChange: PropTypes.func.isRequired,
     selected: PropTypes.string,
     disabled: PropTypes.bool
 };

--- a/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchMulti.jsx
+++ b/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchMulti.jsx
@@ -1,39 +1,41 @@
 import React from 'react';
 import { AdvancedSearchCheckboxGroupContainer, AdvancedSearchInputLabel, AdvancedSearchRowContainer } from './AdvancedSearchStyledComponents';
-import { METADATA_BUNDLE_LOCALIZATION_ID } from '../../instance';
 import { PropTypes } from 'prop-types';
-import { Checkbox } from 'oskari-ui';
+import { Checkbox, Message } from 'oskari-ui';
 
 export const AdvancedSearchMulti = (props) => {
-    const { title, options, onChange, selected, disabled } = props;
-    const hasOptions = options && options?.values?.length && options.values.length > 0;
-    if (!hasOptions) {
+    const { field, options, onChange, selected = [], disabled } = props;
+    if (!options.length) {
         return null;
     }
+    const onCheckbox = (value, checked) => {
+        const values = checked ? [...selected, value] : selected.filter(val => val !== value);
+        onChange(values);
+    };
     return <AdvancedSearchRowContainer>
-        <AdvancedSearchInputLabel>{title}</AdvancedSearchInputLabel>
+        <AdvancedSearchInputLabel>
+            <Message messageKey={`advancedSearch.${field}`} defaultMsg={field}/>
+        </AdvancedSearchInputLabel>
         {
             <AdvancedSearchCheckboxGroupContainer>
-                {options.values.map(value => <Checkbox disabled={disabled}
-                    key={value.val}
-                    value={value.val}
-                    onChange={onChange}
-                    checked={isChecked(selected, value.val)}>
-                    {Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'advancedSearch.' + value.val)}
-                </Checkbox>)}
+                {options.map(({ value, label }) =>
+                    <Checkbox
+                        disabled={disabled}
+                        key={value}
+                        value={value}
+                        onChange={evt => onCheckbox(value, evt.target.checked)}
+                        checked={selected.includes(value)}>
+                        <Message messageKey={`advancedSearch.${value}`} defaultMsg={label || value}/>
+                    </Checkbox>)}
             </AdvancedSearchCheckboxGroupContainer>
         }
     </AdvancedSearchRowContainer>;
 };
 
-const isChecked = (selected, value) => {
-    return selected?.includes(value);
-};
-
 AdvancedSearchMulti.propTypes = {
-    title: PropTypes.string,
-    options: PropTypes.object,
-    onChange: PropTypes.func,
+    field: PropTypes.string.isRequired,
+    options: PropTypes.array.isRequired,
+    onChange: PropTypes.func.isRequired,
     selected: PropTypes.array,
     disabled: PropTypes.bool
 };

--- a/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchOptions.jsx
+++ b/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchOptions.jsx
@@ -1,35 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { METADATA_BUNDLE_LOCALIZATION_ID } from '../../instance';
 import { AdvancedSearchDropdown } from './AdvancedSearchDropdown';
 import { FlexColumnContainer } from './AdvancedSearchStyledComponents';
 import { AdvancedSearchMulti } from './AdvancedSearchMulti';
 import { AdvancedSearchCoverage } from './AdvancedSearchCoverage';
+
 const COVERAGE_FIELD_NAME = 'coverage';
+
 export const AdvancedSearchOptions = (props) => {
     const { advancedSearchOptions, advancedSearchValues, drawing, controller } = props;
-    const hasCoverage = advancedSearchOptions?.fields?.find((field) => field.field === COVERAGE_FIELD_NAME) || null;
-    return <FlexColumnContainer>
-        { advancedSearchOptions &&
-            // coverage should be rendered separately
-            advancedSearchOptions?.fields?.filter((field) => field.field !== COVERAGE_FIELD_NAME).map((field) => {
-                if (field.multi) {
-                    return <AdvancedSearchMulti
-                        key={field.field}
-                        disabled={drawing}
-                        title={Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'advancedSearch.' + field.field)}
-                        options={getByField(field.field, advancedSearchOptions)}
-                        selected={advancedSearchValues[field.field]}
-                        onChange={(value) => controller.advancedSearchParamsChangedMulti(field.field, value)}/>;
-                }
+    const { fields = [] } = advancedSearchOptions || {};
+    const hasCoverage = fields.some(({ field }) => field === COVERAGE_FIELD_NAME);
+    // coverage should be rendered separately
+    const fieldOptions = fields.filter(({ field }) => field !== COVERAGE_FIELD_NAME);
 
-                return <AdvancedSearchDropdown
-                    key={field.field}
+    return <FlexColumnContainer>
+        {
+            fieldOptions.map(({ field, multi, values }) => {
+                const Node = multi ? AdvancedSearchMulti : AdvancedSearchDropdown;
+                return <Node
+                    key={field}
+                    field={field}
                     disabled={drawing}
-                    title={Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'advancedSearch.' + field.field)}
-                    options={getByField(field.field, advancedSearchOptions)}
-                    selected={advancedSearchValues[field.field]}
-                    onChange={(value) => controller.advancedSearchParamsChanged(field.field, value)}/>;
+                    options={values}
+                    selected={advancedSearchValues[field]}
+                    onChange={value => controller.advancedSearchParamsChanged(field, value)}/>;
             })
         }
 
@@ -42,10 +37,6 @@ export const AdvancedSearchOptions = (props) => {
                 coverageFeature={advancedSearchValues?.coverage}/>
         }
     </FlexColumnContainer>;
-};
-
-const getByField = (fieldName, optionsArray) => {
-    return optionsArray?.fields?.find((item) => item.field === fieldName) || null;
 };
 
 AdvancedSearchOptions.propTypes = {

--- a/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchOptions.jsx
+++ b/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchOptions.jsx
@@ -7,12 +7,29 @@ import { AdvancedSearchCoverage } from './AdvancedSearchCoverage';
 
 const COVERAGE_FIELD_NAME = 'coverage';
 
+const showField = ({ field, shownIf }, advancedSearchValues) => {
+    if (field === COVERAGE_FIELD_NAME) {
+        // coverage should be rendered separately
+        return false;
+    }
+    if (!Array.isArray(shownIf)) {
+        return true;
+    }
+    // e.g. [{type:'service}]
+    return shownIf.some(obj => {
+        return Object.keys(obj).some(key => {
+            const selected = advancedSearchValues[key];
+            const value = obj[key];
+            return Array.isArray(selected) ? selected.includes(value) : selected === value;
+        });
+    });
+};
+
 export const AdvancedSearchOptions = (props) => {
     const { advancedSearchOptions, advancedSearchValues, drawing, controller } = props;
     const { fields = [] } = advancedSearchOptions || {};
     const hasCoverage = fields.some(({ field }) => field === COVERAGE_FIELD_NAME);
-    // coverage should be rendered separately
-    const fieldOptions = fields.filter(({ field }) => field !== COVERAGE_FIELD_NAME);
+    const fieldOptions = fields.filter(f => showField(f, advancedSearchValues));
 
     return <FlexColumnContainer>
         {


### PR DESCRIPTION
In new metadatasearch advanced search localization is under `advancedSearch` so if localization isn't found then path is show. Has to use default value to get rid of path prefix from shown value. Changed to use LocaleProvider + Message component instead of Oskari.getMsg to have deafault value.

Added handling for shownIf => field is show only if conditions come true.

hasAdvancedSearchValues didn't handle correctly empty array (multi option). Removed it and used parsed params to check if there is search values.

Added some missing localization from metadatacatalogue.

Some refactoring:
- changed to use antd option syntax for values (label, value) because (val, value) looked odd and options can be passed to Select as prop instead of children
- removed advancedSearchParamsChangedMulti => didn't like that event is passed as value and one setter is enough