### PR TITLE
Statsgrid2016 table tool toggle fix

### DIFF
--- a/bundles/statistics/statsgrid2016/publisher/StatsTableTool.js
+++ b/bundles/statistics/statsgrid2016/publisher/StatsTableTool.js
@@ -5,7 +5,7 @@ Oskari.clazz.define('Oskari.mapframework.publisher.tool.StatsTableTool', functio
 
     groupedSiblings: false,
     templates: {},
-    id: 'grid',
+    id: 'table',
     title: 'grid',
     /**
      * Initialize tool


### PR DESCRIPTION
Rollback StatsTableTool id change made in: https://github.com/oskariorg/oskari-frontend/pull/2646

Id is used to toggle flyout and old flyoutmanager still has 'table' id
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/statistics/statsgrid2016/plugin/TogglePlugin.js#L52
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/statistics/statsgrid2016/FlyoutManager.js#L18

Reason why worked in published map:
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/statistics/statsgrid2016/instance.js#L73-L74
