### PR TITLE
Fix for postinstall script

### DIFF
--- a/webpack/hacks/postinstall.js
+++ b/webpack/hacks/postinstall.js
@@ -2,6 +2,10 @@ const fs = require('fs-extra');
 const path = require('path');
 
 const srcFileCesiumHack = path.join(__dirname, 'cesium', 'buildModuleUrl.js.modified');
+if (!fs.existsSync(path.join(__dirname, srcFileCesiumHack))) {
+    // possibly running on oskari-frontend-contrib
+    return;
+}
 const destFileCesiumHack = path.join(__dirname, '..', '..', 'node_modules', '@cesium', 'engine', 'Source', 'Core', 'buildModuleUrl.js');
 // Overwrites node_modules/@cesium/engine/Source/Core/buildModuleUrl.js
 // with a modified on to fix issues with Webpack 4.x

--- a/webpack/hacks/postinstall.js
+++ b/webpack/hacks/postinstall.js
@@ -2,11 +2,11 @@ const fs = require('fs-extra');
 const path = require('path');
 
 const srcFileCesiumHack = path.join(__dirname, 'cesium', 'buildModuleUrl.js.modified');
-if (!fs.existsSync(path.join(__dirname, srcFileCesiumHack))) {
-    // possibly running on oskari-frontend-contrib
-    return;
+if (fs.existsSync(path.join(__dirname, srcFileCesiumHack))) {
+    const destFileCesiumHack = path.join(__dirname, '..', '..', 'node_modules', '@cesium', 'engine', 'Source', 'Core', 'buildModuleUrl.js');
+    // Overwrites node_modules/@cesium/engine/Source/Core/buildModuleUrl.js
+    // with a modified on to fix issues with Webpack 4.x
+    fs.copyFile(srcFileCesiumHack, destFileCesiumHack);
+} else {
+    // possibly running on oskari-frontend-contrib or cesium is not available
 }
-const destFileCesiumHack = path.join(__dirname, '..', '..', 'node_modules', '@cesium', 'engine', 'Source', 'Core', 'buildModuleUrl.js');
-// Overwrites node_modules/@cesium/engine/Source/Core/buildModuleUrl.js
-// with a modified on to fix issues with Webpack 4.x
-fs.copyFile(srcFileCesiumHack, destFileCesiumHack);


### PR DESCRIPTION
When application uses both oskari-frontend and oskari-frontend-contrib the postinstall is run on oskari-frontend-contrib context as well. This checks if cesium is available before trying to copy it so in case of contrib the install doesn't fail.