### PR TITLE
Disable storybook

### DIFF
--- a/.storybook/README.md
+++ b/.storybook/README.md
@@ -1,0 +1,5 @@
+This config is for `"@storybook/react": "6.3.7"` but after other dependency updates, running storybook no longer works properly. Newer version of storybook uses webpack 5 while we are still using webpack 4.
+
+When we have time we should make it work and generate a gallery to show available UI components on oskari.org.
+
+As for now, since it doesn't work currently, it's easier to just remove the dependency as it flags vulnerable dependencies even when its not used.

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.stories.js_disabled
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.stories.js_disabled
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { storiesOf } from '@storybook/react';
+// See .storybook/README.md
+// import { storiesOf } from '@storybook/react';
 import { Scale } from './Scale';
 
 import '../../../../../../src/global';

--- a/bundles/admin/admin-layereditor/view/LayerWizard/LayerTypeSelection.stories.js_disabled
+++ b/bundles/admin/admin-layereditor/view/LayerWizard/LayerTypeSelection.stories.js_disabled
@@ -1,10 +1,12 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+// See .storybook/README.md
+// import { storiesOf } from '@storybook/react';
 import { LayerTypeSelection } from './LayerTypeSelection';
 
 const defaultProps = {
     types: ['WFS', 'WMS', 'WMTS']
 };
+
 storiesOf('LayerTypeSelection', module)
     .add('with text', () => {
         const storyProps = {

--- a/bundles/framework/language-selector/components/stories/LanguageChanger.stories.js_disabled
+++ b/bundles/framework/language-selector/components/stories/LanguageChanger.stories.js_disabled
@@ -1,5 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+// See .storybook/README.md
+// import { storiesOf } from '@storybook/react';
 import '../../../../../src/global';
 import '../../resources/locale/en';
 import '../../resources/locale/fi';
@@ -9,6 +10,7 @@ import { LanguageChanger } from '../LanguageChanger';
 
 Oskari.setSupportedLocales(['en_US', 'fi_FI', 'sv_SE', 'fr_FR']);
 Oskari.setLang('fi');
+
 storiesOf('LanguageChanger', module)
     .add('English', () => {
         Oskari.setLang('en');

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.stories.js_disabled
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.stories.js_disabled
@@ -1,5 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+// See .storybook/README.md
+// import { storiesOf } from '@storybook/react';
 import { initServices, getBundleInstance } from '../../test.util';
 import { LayerCollapse, LayerCollapseHandler } from '.';
 import { LocaleProvider } from 'oskari-ui/util';

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@babel/preset-react": "7.24.7",
     "@babel/runtime-corejs3": "7.25.0",
     "@cesium/engine": "10.1.0",
-    "@storybook/react": "6.3.7",
     "@testing-library/jest-dom": "5.7.0",
     "@testing-library/react": "12.1.5",
     "@testing-library/user-event": "14.4.3",


### PR DESCRIPTION
Remove storybook for now as it doesn't work properly after other dependency updates and flags vulnerabilities from the old version.

Storybook isn't actively used on Oskari development, but is a nice way to develop components separately in a sandbox. It would also provide a nice way to generate a UI component gallery on oskari.org so it's something that we should pursue when we have the time to make an updated version work properly.