### PR TITLE
Update AntD 5.12.5 -> 5.20.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@testing-library/jest-dom": "5.7.0",
     "@testing-library/react": "12.1.5",
     "@testing-library/user-event": "14.4.3",
-    "antd": "5.12.5",
+    "antd": "5.20.4",
     "babel-loader": "8.3.0",
     "babel-plugin-styled-components": "2.1.4",
     "babel-plugin-transform-remove-strict-mode": "0.0.2",

--- a/src/react/components/window/Header.jsx
+++ b/src/react/components/window/Header.jsx
@@ -14,7 +14,6 @@ const Container = styled('div')`
     padding: 8px 10px;
     margin: 0px;
     cursor: ${props => props.isDraggable ? 'grab' : undefined};
-    width: 100%;
 `;
 const ToolsContainer = styled('div')`
     display: flex;


### PR DESCRIPTION
Removal of CSS width for Header-component fixes these:
![image](https://github.com/user-attachments/assets/bea043ae-0dd1-4512-910b-f542be6a2914)

![image](https://github.com/user-attachments/assets/e6300ddc-08dd-473d-b6e0-9bb832d6c184)
