### PR TITLE
MetadataSearch empty fields

### DIFF
--- a/bundles/catalogue/metadatasearch/MetadataStateHandler.js
+++ b/bundles/catalogue/metadatasearch/MetadataStateHandler.js
@@ -185,7 +185,7 @@ class MetadataStateHandler extends StateHandler {
                 fields.push({ ...field, values: sortedValues });
             });
         });
-        this.updateState({ advancedSearchOptions: { fields } });
+        this.updateState({ advancedSearchOptions: { fields, loading: false } });
     }
 
     advancedSearchParamsChanged (key, value) {

--- a/bundles/catalogue/metadatasearch/instance.js
+++ b/bundles/catalogue/metadatasearch/instance.js
@@ -185,15 +185,18 @@ Oskari.clazz.define(
                     // wasn't me or disabled -> do nothing
                     return;
                 }
-
                 if ((!isShown && this.drawCoverage === false) || event.getViewState() === 'close') {
                     this._teardownMetaSearch();
+                }
+                if (isShown) {
+                    this.handler.loadOptions();
                 }
             },
             'Search.TabChangedEvent': function (event) {
                 if (event.getNewTabId() !== this.id) {
                     this._teardownMetaSearch();
                 } else {
+                    this.handler.loadOptions();
                     this.removeFeaturesFromMap();
                 }
             },

--- a/bundles/catalogue/metadatasearch/instance.js
+++ b/bundles/catalogue/metadatasearch/instance.js
@@ -179,16 +179,18 @@ Oskari.clazz.define(
 
             'userinterface.ExtensionUpdatedEvent': function (event) {
                 const isShown = event.getViewState() !== 'close';
+                const name = event.getExtension().getName();
 
                 // ExtensionUpdateEvents are fired a lot, only let metadatacatalogue extension event to be handled when enabled
-                if (![this.getName(), 'Search'].includes(event.getExtension().getName())) {
+                if (![this.getName(), 'Search'].includes(name)) {
                     // wasn't me or disabled -> do nothing
                     return;
                 }
                 if ((!isShown && this.drawCoverage === false) || event.getViewState() === 'close') {
                     this._teardownMetaSearch();
                 }
-                if (isShown) {
+                if (this.getName() === name && isShown) {
+                    // own flyout so Search.TabChangedEvent doesn't trigger load options
                     this.handler.loadOptions();
                 }
             },

--- a/bundles/catalogue/metadatasearch/view/MetadataSearchContainer.jsx
+++ b/bundles/catalogue/metadatasearch/view/MetadataSearchContainer.jsx
@@ -50,42 +50,45 @@ const Container = ({ state, controller }) => {
         displayedCoverageId,
         drawing,
         selectedLayers } = state;
-    return <div>
-        { loading && <FlexRowCentered><Spin/></FlexRowCentered>}
-        {
-            !(loading || searchResultsVisible) &&
-            <>
-                <Description/>
-                <SearchContainer
-                    disabled={drawing}
-                    query={query}
-                    onChange={controller.updateQuery}
-                    onSearch={controller.doSearch}/>
-                <AdvancedSearchContainer
-                    isExpanded={advancedSearchExpanded}
-                    toggleAdvancedSearch={controller.toggleAdvancedSearch}
-                    advancedSearchOptions={advancedSearchOptions}
-                    advancedSearchValues={advancedSearchValues}
-                    controller={controller}
-                    drawing={drawing}/>
-            </>
-        }
-        {
-            (!loading && searchResultsVisible) &&
-            <>
-                <MetadataSearchResultListContainer
-                    searchResults={searchResults}
-                    searchResultsFilter={searchResultsFilter}
-                    displayedCoverageId={displayedCoverageId}
-                    toggleSearch={controller.toggleSearch}
-                    toggleSearchResultsFilter={controller.toggleSearchResultsFilter}
-                    showMetadata={controller.showMetadata}
-                    toggleCoverageArea={controller.toggleCoverageArea}
-                    selectedLayers={selectedLayers}
-                    toggleLayerVisibility={controller.toggleLayerVisibility}/>
-            </>
-        }
-    </div>;
+
+    if (loading) {
+        return (
+            <FlexRowCentered>
+                <Spin/>
+            </FlexRowCentered>
+        );
+    }
+
+    if (searchResultsVisible) {
+        return <MetadataSearchResultListContainer
+            searchResults={searchResults}
+            searchResultsFilter={searchResultsFilter}
+            displayedCoverageId={displayedCoverageId}
+            toggleSearch={controller.toggleSearch}
+            toggleSearchResultsFilter={controller.toggleSearchResultsFilter}
+            showMetadata={controller.showMetadata}
+            toggleCoverageArea={controller.toggleCoverageArea}
+            selectedLayers={selectedLayers}
+            toggleLayerVisibility={controller.toggleLayerVisibility}/>;
+    }
+
+    return (
+        <div>
+            <Description/>
+            <SearchContainer
+                disabled={drawing}
+                query={query}
+                onChange={controller.updateQuery}
+                onSearch={controller.doSearch}/>
+            <AdvancedSearchContainer
+                isExpanded={advancedSearchExpanded}
+                toggleAdvancedSearch={controller.toggleAdvancedSearch}
+                advancedSearchOptions={advancedSearchOptions}
+                advancedSearchValues={advancedSearchValues}
+                controller={controller}
+                drawing={drawing}/>
+        </div>
+    );
 };
 
 Container.propTypes = {

--- a/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchContainer.jsx
+++ b/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchContainer.jsx
@@ -1,28 +1,41 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { METADATA_BUNDLE_LOCALIZATION_ID } from '../../instance';
 import { AdvancedSearchOptions } from './AdvancedSearchOptions';
 import styled from 'styled-components';
+import { Message, Spin } from 'oskari-ui';
 
 const ContainerWithMargin = styled('div')`
     margin-top: 1em;
 `;
 
-export const AdvancedSearchContainer = (props) => {
-    const { isExpanded, toggleAdvancedSearch, advancedSearchOptions, advancedSearchValues, drawing, controller } = props;
-    return (<ContainerWithMargin>
-        { !isExpanded && <a onClick={toggleAdvancedSearch}>{Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'advancedSearch.showMore')}</a>}
-        { isExpanded &&
-            <div>
-                <a onClick={toggleAdvancedSearch}>{Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'advancedSearch.showLess')}</a>
-                <AdvancedSearchOptions
-                    advancedSearchOptions={advancedSearchOptions}
-                    advancedSearchValues={advancedSearchValues}
-                    controller={controller}
-                    drawing={drawing}/>
-            </div>
-        }
-    </ContainerWithMargin>);
+export const AdvancedSearchContainer = ({
+    isExpanded,
+    toggleAdvancedSearch,
+    advancedSearchOptions,
+    advancedSearchValues,
+    drawing,
+    controller
+}) => {
+    const { fields = [], loading } = advancedSearchOptions || {};
+    if (loading) {
+        return <Spin/>;
+    }
+    if (!fields.length) {
+        return null;
+    }
+    return (
+        <ContainerWithMargin>
+            <a onClick={toggleAdvancedSearch}>
+                <Message messageKey={isExpanded ? 'advancedSearch.showLess' : 'advancedSearch.showMore'} />
+            </a>
+            { isExpanded && <AdvancedSearchOptions
+                advancedSearchOptions={advancedSearchOptions}
+                advancedSearchValues={advancedSearchValues}
+                controller={controller}
+                drawing={drawing}/>
+            }
+        </ContainerWithMargin>
+    );
 };
 
 AdvancedSearchContainer.propTypes = {

--- a/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchOptions.jsx
+++ b/bundles/catalogue/metadatasearch/view/advanced-search/AdvancedSearchOptions.jsx
@@ -25,8 +25,7 @@ const showField = ({ field, shownIf }, advancedSearchValues) => {
     });
 };
 
-export const AdvancedSearchOptions = (props) => {
-    const { advancedSearchOptions, advancedSearchValues, drawing, controller } = props;
+export const AdvancedSearchOptions = ({ advancedSearchOptions, advancedSearchValues, drawing, controller }) => {
     const { fields = [] } = advancedSearchOptions || {};
     const hasCoverage = fields.some(({ field }) => field === COVERAGE_FIELD_NAME);
     const fieldOptions = fields.filter(f => showField(f, advancedSearchValues));

--- a/bundles/catalogue/metadatasearch/view/resultlist/MetadataSearchResultListContainer.jsx
+++ b/bundles/catalogue/metadatasearch/view/resultlist/MetadataSearchResultListContainer.jsx
@@ -45,7 +45,7 @@ export const MetadataSearchResultListContainer = (props) => {
 
     const searchResultsFiltered = searchResultsFilter && searchResultsFilter.length ? searchResults.filter((item) => searchResultsFilter.includes(item.natureofthetarget)) : searchResults;
     const hasSearchResults = !!(searchResults && searchResults.length);
-    return <>
+    return <div>
         <FlexRow>
             <SearchResultTitle>{Oskari.getMsg(METADATA_BUNDLE_LOCALIZATION_ID, 'searchResults.resultTitle')}</SearchResultTitle>
             <FlexRight>
@@ -65,7 +65,7 @@ export const MetadataSearchResultListContainer = (props) => {
             displayedCoverageId={displayedCoverageId}
             selectedLayers={selectedLayers}
             toggleLayerVisibility={toggleLayerVisibility}/>
-    </>;
+    </div>;
 };
 
 MetadataSearchResultListContainer.propTypes = {


### PR DESCRIPTION
- load advanced options on search metadata tab or metadata flyout show
- add only fields which have value(s) to options
- use loading to show spinner for advanced options
- show toggle advanced options only when options are available

refactor optional rendering