### PR TITLE
Remove lodash expose

### DIFF
--- a/packages/framework/bundle/oskariui/bundle.js
+++ b/packages/framework/bundle/oskariui/bundle.js
@@ -46,10 +46,6 @@ Oskari.clazz.define("Oskari.mapframework.bundle.oskariui.OskariUIBundle", functi
 			"type" : "text/css",
 			"src" : "../../../../bundles/framework/oskariui/resources/bootstrap-grid.css"
         },{
-            "type" : "text/javascript",
-            "expose" : "_",
-            "src" : "../../../../libraries/lodash/2.3.0/lodash.js"
-        },{
 			"type" : "text/javascript",
 			"src" : "../../../../bundles/framework/oskariui/DomManager.js"
 		}, {


### PR DESCRIPTION
webpack-dev-server complains about multiple global `_` variable being exposed so removed expose to it (everything seems to work anyways).

Related PR to PTI as KOMU didn't work after this: https://github.com/nls-oskari/pti-frontend/pull/144
