### PR TITLE
Add box-sizing reset CSS

### DIFF
--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -19,6 +19,11 @@ footer, header, nav, section, audio, video {
   display: block;
 }
 
+/* Resets margins to proper values on for example thematic maps search flyout */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 a img {
   border: 0;
 }

--- a/src/react/components/buttons/IconButton.jsx
+++ b/src/react/components/buttons/IconButton.jsx
@@ -82,10 +82,10 @@ const getPredefinedIcon = (type) => {
         return <Backward/>;
     }
     if (type === 'delete') {
-        return <DeleteOutlined />
+        return <DeleteOutlined />;
     }
     return null;
-}
+};
 
 const getConfirmProps = (type) => {
     if (type === 'delete') {


### PR DESCRIPTION
Add sizing reset that is in there on dev-server, but not on built-product after AntD 4 -> 5 upgrade. Fixes for example:

![image](https://github.com/user-attachments/assets/17c7d284-3983-431b-98d5-a86c8db8947c)

-> 

![image](https://github.com/user-attachments/assets/ff256a46-670c-49e0-a98e-9e8761847aff)
