### PR TITLE
MetadataFlyout actions tab layers fix

### DIFF
--- a/bundles/catalogue/metadataflyout/view/MetadataPanel.js
+++ b/bundles/catalogue/metadataflyout/view/MetadataPanel.js
@@ -772,7 +772,7 @@ Oskari.clazz.define('Oskari.catalogue.bundle.metadataflyout.view.MetadataPanel',
             if (!Oskari.dom.isEmbedded()) {
                 var me = this,
                     container = me._tabs['actions'].getContainer(),
-                    layers = me._maplayerService.getLayersByMetadataId(me._model.uuid);
+                    layers = me._maplayerService.getLayersByMetadataId(me._model.fileIdentifier);
 
                 container.find('table.metadataSearchResult').remove();
                 container.append(me._templates['layerList']());

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -976,9 +976,10 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
          * @return {Oskari.mapframework.domain.AbstractLayer[]}
          */
         getLayersByMetadataId: function (metadataIdentifier) {
-            return this._loadedLayersList.filter(function (layer) {
-                return layer.getMetadataIdentifier() === metadataIdentifier;
-            });
+            if (!metadataIdentifier) {
+                return [];
+            }
+            return this._loadedLayersList.filter(layer => layer.getMetadataIdentifier() === metadataIdentifier);
         },
         /**
          * @method  @public registerLayerFilter Register layer filter


### PR DESCRIPTION
Seems that metadata response has uuid under fileIdentifier key not uuid (undefined).
Changed to return empty list if metadata uuid is missing

Fixes issue where all layers without linked metadata (undefined) are shown in metadata actions tab instead of layers which have same metadata uuid linked.