### PR TITLE
TimeSeriesRange published state

### DIFF
--- a/bundles/framework/timeseries/publisher/TimeseriesTool.js
+++ b/bundles/framework/timeseries/publisher/TimeseriesTool.js
@@ -110,15 +110,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.timeseries.TimeseriesTool',
         * @returns {Object} tool value object
         */
         getValues: function () {
-            var me = this;
-
-            if (me.state.enabled) {
+            if (this.state.enabled) {
                 return {
                     configuration: {
                         timeseries: {
                             conf: {
                                 plugins: [{ id: this.getTool().id, config: this.controlConfig }]
-                            }
+                            },
+                            state: this.getSandbox().getStatefulComponents().timeseries.getState()
                         }
                     }
                 };

--- a/bundles/framework/timeseries/service/TimeseriesMetadataService.js
+++ b/bundles/framework/timeseries/service/TimeseriesMetadataService.js
@@ -36,9 +36,9 @@ export class TimeseriesMetadataService {
      * @param {Function} success called with updated years array based on the loaded features
      * @param {Function} error called if there's a problem loading the features
      */
-    setBbox (bbox = {}, success, error) {
+    setBbox (bbox, success, error) {
         const sandbox = Oskari.getSandbox();
-        if (Object.keys(bbox).length !== 4) {
+        if (!bbox || Object.keys(bbox).length !== 4) {
             this.clearPreviousFeatures();
             error('Invalid bbox');
             return;

--- a/bundles/framework/timeseries/view/TimeSeriesRange/YearRangeSlider.jsx
+++ b/bundles/framework/timeseries/view/TimeSeriesRange/YearRangeSlider.jsx
@@ -3,8 +3,7 @@ import React from 'react';
 import { TimeSeriesSlider } from 'oskari-ui/components/TimeSeries/TimeSeriesSlider';
 import { ThemeProvider } from 'oskari-ui/util';
 
-export const YearRangeSlider = (props) => {
-    const { start, end, dataYears, isMobile, onChange, value, range } = props;
+export const YearRangeSlider = ({ start, end, dataYears, isMobile, onChange, value, range }) => {
     const marks = {
         [start]: start,
         [end]: end
@@ -45,5 +44,8 @@ YearRangeSlider.propTypes = {
     start: PropTypes.number.isRequired,
     end: PropTypes.number.isRequired,
     dataYears: PropTypes.arrayOf(PropTypes.number).isRequired,
-    isMobile: PropTypes.bool.isRequired
+    isMobile: PropTypes.bool.isRequired,
+    onChange: PropTypes.func.isRequired,
+    value: PropTypes.any,
+    range: PropTypes.bool
 };

--- a/src/react/components/TimeSeries/TimeSeriesSlider.jsx
+++ b/src/react/components/TimeSeries/TimeSeriesSlider.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { sliderTypes, timeUnits } from './util/constants';
 import { getDifferenceCalculator, calculateSvgX } from './util/calculation';
@@ -226,7 +226,7 @@ export const TimeSeriesSlider = ThemeConsumer(({
                         )}
                         {markers.map((mark, index) => {
                             return (
-                                <>
+                                <Fragment key={mark}>
                                     <Marker
                                         key={mark}
                                         transform={`translate(${calcDataPointX(mark, widthUnit, min, 35, calculator)}, -10)`}
@@ -236,7 +236,7 @@ export const TimeSeriesSlider = ThemeConsumer(({
                                         {mark}
                                     </Marker>
                                     <LineMarker key={`line-marker-${index}`} $theme={navigationTheme} width={2} height={3} transform={`translate(${calcDataPointX(mark, widthUnit, min, 2, calculator)}, 0)`} />
-                                </>
+                                </Fragment>
                             )
                         })}
                     </g>


### PR DESCRIPTION
Somehow oskari-ui TimeSeriesSlider doesn't update handleX value (drag elem) on setBbox updateState. Changed to use same `updateValue` than prev/forward icons. This also fixes issue where timeseries layer with metadata layer is added outside toggle level and zoomed in and selected time is outdated (start value because select midrange outside toggle level didn't request selected time from WMSAnimator/delegate).

Store time to published map state

In local environment embedded map sometimes have bbox `null` and default value {} didn't work. Changed to !bbox to avoid js error

Add key for TimeSeriesSlider markers

