### PR TITLE
Admin layereditor remove default style button

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -118,7 +118,7 @@ Oskari.registerLocalization(
                 "updateFailedWithReason": "Capablities re-check failed: {reason}",
                 "validate": "Layer definitions doesn't respond to service's capabilities",
                 "rasterStyle" : {
-                    "defaultStyle" : "Selected default style doesn't exist anymore. Please select a new default style.",
+                    "defaultStyle" : "Selected default style doesn't exist anymore. Please select a new default style or remove default style.",
                     "additionalLegend": "The map layer has been given a legend that overrides the default legend provided by the service. The overriding legend was linked to a style that is no longer available. Please update the layer legend. The problematic style is marked with a ( ! ).",
                     "globalWithStyles": "The layer has more than one style available in the service. However, the layer has been defined with a single default legend. Consider removing the current default legend to be able to use the style based legends."
                 }
@@ -186,6 +186,7 @@ Oskari.registerLocalization(
                     "title": "Styles and map legends",
                     "styleDesc": "The style options are fetched automatically from the GetCapabilities response.",
                     "unavailable": "Style defined in the service: not available",
+                    "removeDefault": "Remove default style",
                     "legendImage": "Default legend",
                     "serviceLegend": "Map legend defined in the service",
                     "overriddenLegend": "Replaced legend URL",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -118,7 +118,7 @@ Oskari.registerLocalization(
                 "updateFailedWithReason": "GetCapabilities päivitys epäonnistui: {reason}",
                 "validate": "Tason tiedot eivät vastaa rajapinnan määrityksiä",
                 "rasterStyle" : {
-                    "defaultStyle" : "Nyt valittua oletustyyliä ei löydy palvelusta. Valitse uusi oletustyyli.",
+                    "defaultStyle" : "Nyt valittua oletustyyliä ei löydy palvelusta. Valitse uusi oletustyyli tai poista oletustyyli.",
                     "additionalLegend": "Tasolle on tallennettu erikseen rajapintapalvelun oman karttaselitteen yliajava karttaselite, jolle ei löydy tyyliä. Päivitä karttaselitteen tiedot. Poistuneen/ei-toimivan karttaselitteen nimessä on ( ! )-merkki.",
                     "globalWithStyles": "Tasolle on määritetty vain yksi yleinen oletuskarttaselite, vaikka sillä olisi rajapintapalvelusta useita tyylejä käytettävissä. Poista oletuskarttaselite ja määritä mahdolliset tyylikohtaiset karttaselitteet."
                 }
@@ -186,6 +186,7 @@ Oskari.registerLocalization(
                     "title": "Esitystyylit ja karttaselitteet",
                     "styleDesc": "Tyylit määritellään GetCapabilities-vastausviestissä, josta ne haetaan valintalistalle.",
                     "unavailable": "Palvelussa määritelty esitystyyli: ei saatavilla",
+                    "removeDefault": "Poista oletustyyli",
                     "legendImage": "Oletuskarttaselite",
                     "serviceLegend": "Palvelussa määritelty karttaselite",
                     "overriddenLegend": "Korvaava karttaselite",

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -117,7 +117,7 @@ Oskari.registerLocalization(
                 "updateFailed": "Uppdatering misslyckades.",
                 "updateFailedWithReason": "Uppdatering misslyckades: {reason}",
                 "rasterStyle" : {
-                    "defaultStyle" : "Den valda standardstilen finns inte längre i tjänsten. Vänligen välj en ny standardstil.",
+                    "defaultStyle" : "Den valda standardstilen finns inte längre i tjänsten. Vänligen välj en ny standardstil eller ta bort standardstilen.",
                     "additionalLegend": "För kartlagret finns en teckenförklaring utan giltig stil. Vänligen uppdatera förklaringen. Den icke fungerande stilen är markerad med ( ! ) ",
                     "globalWithStyles": "Till kartlagret har endast en standard teckenförklaring fastställts, men det finns ytterliga stilar med förklaringar tillgängliga på gränssnittet. Du kan ta bort standardvalet för att kunna utnyttja dessa."
                 }
@@ -185,6 +185,7 @@ Oskari.registerLocalization(
                     "title": "Stilar och kartförklaringar",
                     "styleDesc": "Stilalternativen hämtas automatiskt från GetCapabilities-svaret.",
                     "unavailable": "I tjänsten definierad stil: ej tillgänglig",
+                    "removeDefault": "Ta bort standardstilen",
                     "legendImage": "Generella kartförklaringar",
                     "serviceLegend": "I tjänsten definierad kartförklaring",
                     "overriddenLegend": "Adress för kartförklaring",

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/RasterStyle/RasterStyleSelect.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/RasterStyle/RasterStyleSelect.jsx
@@ -1,9 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { Message, Option } from 'oskari-ui';
 import { LocaleConsumer, Controller } from 'oskari-ui/util';
+import { IconButton } from 'oskari-ui/components/buttons';
 import { DefaultStyle, StyleField, StyleSelect, StyledFormField } from '../styled';
 import { GLOBAL_LEGEND } from './helper';
+
+const UnavailableWrapper = styled.div`
+    display: flex;
+    & button {
+        margin-left: 1em;
+    }
+`;
 
 const RasterStyleSelect = ({ selected, styles, defaultName, setSelected, controller, getMessage }) => {
     const isDefaultStyle = name => name === defaultName;
@@ -20,17 +29,24 @@ const RasterStyleSelect = ({ selected, styles, defaultName, setSelected, control
         controller.setStyle(defaultStyle);
     };
 
-    let showInvailable = false;
+    let showUnavailable = false;
     if (styles.length === 0) {
-        showInvailable = true;
+        showUnavailable = true;
     } else if (styles.length === 1 && styles[0].name === GLOBAL_LEGEND) {
-        showInvailable = true;
+        showUnavailable = true;
     }
-
-    if (showInvailable) {
+    if (showUnavailable) {
         return (
             <StyledFormField>
-                <Message messageKey='styles.raster.unavailable'/>
+                <UnavailableWrapper>
+                    <Message messageKey='styles.raster.unavailable'/>
+                    { defaultName &&
+                        <IconButton type='delete'
+                            onClick={() => onDefaultStyleChange(defaultName, false)}
+                            title={<Message messageKey='styles.raster.removeDefault' />}
+                        />
+                    }
+                </UnavailableWrapper>
             </StyledFormField>
         );
     }


### PR DESCRIPTION
show remove default style button if no styles available. This fixes issue where service (capa) doesn't have any styles defined and layer has default style and admin can't remove default style because style select isn't rendered.