### PR TITLE
Add ThemeProvider for announcements

### DIFF
--- a/bundles/framework/announcements/Flyout.js
+++ b/bundles/framework/announcements/Flyout.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { FlyoutContent } from './view/';
-import { LocaleProvider } from 'oskari-ui/util';
+import { LocaleProvider, ThemeProvider } from 'oskari-ui/util';
 
 /**
  * @class Oskari.framework.bundle.announcements.Flyout
@@ -62,11 +62,13 @@ Oskari.clazz.define('Oskari.framework.bundle.announcements.Flyout',
             }
             const content = (
                 <LocaleProvider value={{ bundleKey: this.instance.getName() }}>
-                    <FlyoutContent
-                        { ...state }
-                        toolController = {this.announcementsHandler.getToolController()}
-                        controller={this.announcementsHandler.getController()}
-                    />
+                    <ThemeProvider>
+                        <FlyoutContent
+                            { ...state }
+                            toolController = {this.announcementsHandler.getToolController()}
+                            controller={this.announcementsHandler.getController()}
+                        />
+                    </ThemeProvider>
                 </LocaleProvider>
             );
             ReactDOM.render(content, this.container);

--- a/src/react/theme/ThemeHelper.js
+++ b/src/react/theme/ThemeHelper.js
@@ -17,6 +17,7 @@ export const getHeaderTheme = (theme) => {
     return funcs;
 };
 
+// https://ant.design/docs/react/customize-theme
 export const getAntdTheme = (theme) => {
     // Note! The theme parameter is not used here,
     //  but the Oskari theme is passed here so we _could_ make some adjustments based on that


### PR DESCRIPTION
For passing AntD theme config.
Previous:
![image](https://github.com/user-attachments/assets/8119b637-6115-466e-9909-fb7a60d13964)

After:
![image](https://github.com/user-attachments/assets/5a47d2db-c0c5-4e4f-9aa3-ef2bc643266d)

Probably would benefit from some additional tuning but the font and roundings are fixed with this.