### PR TITLE
Statsgrid size slider

### DIFF
--- a/bundles/statistics/statsgrid/components/classification/editclassification/SizeSlider.jsx
+++ b/bundles/statistics/statsgrid/components/classification/editclassification/SizeSlider.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Slider, Message } from 'oskari-ui';
-import styled from 'styled-components';
 
 // Overrride -50% translateX
 const SLIDER_PROPS = {
@@ -24,27 +23,6 @@ const SLIDER_PROPS = {
     }
 };
 
-const StyledSlider = styled(Slider)`
-    .ant-slider-track {
-        background-color: #0091ff;
-    }
-    .ant-slider-handle {
-        border: #0091ff solid 2px;
-        margin-top: -6px;
-    }
-    &:hover .ant-slider-track {
-        background-color: #003fc3 !important;
-    }
-    &:hover .ant-slider-handle {
-        border: #003fc3 solid 2px !important;
-    }
-    .ant-slider-dot {
-        width: 6px;
-        height: 6px;
-        left: 1px;
-    }
-`;
-
 export const SizeSlider = ({
     values,
     controller,
@@ -65,7 +43,7 @@ export const SizeSlider = ({
     return (
         <div>
             <Message messageKey="classify.labels.pointSize"/>
-            <StyledSlider
+            <Slider
                 value = {internalRange}
                 disabled = {disabled}
                 onChange={onChange}


### PR DESCRIPTION
Remove custom styling as it brakes ui.
![image](https://github.com/user-attachments/assets/dc5e184f-fd23-4760-9228-87cff226b0b3)

If we need to override colors (slider, hover), it should be done in common Slider.jsx component instead of SizeSlider. I can't imagine any reason why SizeSlider should use different colors than other sliders.

![image](https://github.com/user-attachments/assets/903148a7-0e2e-4470-945a-c33470cda9ce)
=> Size slider has same style than Transparency slider 