### PR TITLE
margin: auto for correct alignment

### DIFF
--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -543,3 +543,8 @@ This seems to only happen on the Firefox browser
 .ant-message, .ant-notification {
   z-index: 30010 !important;
 }
+
+/*fix the misalignment of checkbox input with it's label*/
+.ant-checkbox-wrapper {
+  margin: auto 0;
+}

--- a/src/react/components/Checkbox.jsx
+++ b/src/react/components/Checkbox.jsx
@@ -9,6 +9,7 @@ const StyledCheckbox = styled(AntCheckbox)`
     }
 
     .ant-checkbox {
+        margin-top: auto;
         margin-bottom: auto;
     }
 `;


### PR DESCRIPTION
fix the alignment of label <> input that broke in antd upgrade

![image](https://github.com/user-attachments/assets/f7e2f78f-6e9f-44b2-8c3c-d1295327af8e)
