### PR TITLE
Remove duplicated state handling from RichEditor

### DIFF
--- a/src/react/components/RichEditor.jsx
+++ b/src/react/components/RichEditor.jsx
@@ -1,10 +1,10 @@
-import React, { useState, useRef, useMemo, useEffect } from 'react';
+import React, { useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import JoditEditor from 'jodit-react';
 
 export const RichEditor = (props) => {
     const editor = useRef(null);
-    const [content, setContent] = useState('');
+    const content = props.value || '';
     const config = useMemo(
         () => ({
             language: Oskari.getLang(),
@@ -22,20 +22,17 @@ export const RichEditor = (props) => {
                 'redo'],
             readonly: false, // all options from https://xdsoft.net/jodit/docs/,
             toolbarAdaptive: false,
+            // Init field with empty placeholder
+            // TODO: use some placeholder by lang?
+            // would require localizations on oskariui loc bundle/key
             placeholder: ''
         }),
-        [props.value]
+        [Oskari.getLang()]
+        // Never really changes, but might change if we add placeholders AND lang is changed
     );
-
-    useEffect(() => {
-        if (props.value !== undefined) {
-            setContent(props.value);
-        }
-    }, []);
 
     function onBlur (newContent) {
         props.onChange({ target: { value: newContent } });
-        setContent(newContent);
     }
 
     return (

--- a/src/react/components/icons/Info.jsx
+++ b/src/react/components/icons/Info.jsx
@@ -6,7 +6,6 @@ import styled from 'styled-components';
 import { ThemeConsumer } from 'oskari-ui/util';
 import { getNavigationTheme } from 'oskari-ui/theme';
 
-
 const StyledInfoIcon = styled(QuestionCircleOutlined)`
     cursor: pointer;
     color: #0290ff;
@@ -19,11 +18,10 @@ const StyledInfoIcon = styled(QuestionCircleOutlined)`
 `;
 
 /**
- * 
  * @param {String} title Icon tooltip
  * @param {Number} size Font size in pixels
  * @param {Object} style Additional styles
- * @returns 
+ * @returns
  */
 export const Info = ThemeConsumer(({ theme = {}, children, title, size = 16, style, space = true, placement = 'top' }) => {
     const helper = getNavigationTheme(theme);
@@ -47,5 +45,5 @@ Info.propTypes = {
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     size: PropTypes.number,
     style: PropTypes.object,
-    space: PropTypes.bool,
+    space: PropTypes.bool
 };

--- a/src/react/components/icons/Metadata.jsx
+++ b/src/react/components/icons/Metadata.jsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import { ThemeConsumer } from 'oskari-ui/util';
 import { getNavigationTheme } from 'oskari-ui/theme';
 
-
 const StyledMetadataIcon = styled(InfoCircleOutlined)`
     cursor: pointer;
     color: #0290ff;
@@ -20,7 +19,7 @@ const StyledMetadataIcon = styled(InfoCircleOutlined)`
  * @param {Number} metadataId Metadata ID
  * @param {Number} size Font size in pixels
  * @param {Object} style Additional styles
- * @returns 
+ * @returns
  */
 export const Metadata = ThemeConsumer(({ theme = {}, metadataId, layerId, size = 16, style }) => {
     if (!metadataId || !Oskari.getSandbox().hasHandler('catalogue.ShowMetadataRequest')) return null;
@@ -31,8 +30,8 @@ export const Metadata = ThemeConsumer(({ theme = {}, metadataId, layerId, size =
 
     const onClick = () => {
         Oskari.getSandbox().postRequestByName('catalogue.ShowMetadataRequest', [
-            { layerId:layerId }
-    ]);
+            { layerId }
+        ]);
     };
 
     return (


### PR DESCRIPTION
Continuing #2693 

Removal of internal state from RichEditor component fixes an issue were the editor throws a JS error when pasting HTML-content for the first time:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'cache')
    at jodit-react.js:2:19666
    at jodit-react.js:2:11779
    at Array.forEach (<anonymous>)
    at n.value (jodit-react.js:2:11767)
    at o.value (jodit-react.js:2:11686)
    at i.value (jodit-react.js:2:11686)
    at i.value (jodit-react.js:2:11480)
    at new i (jodit-react.js:2:19862)
    at h (jodit-react.js:2:130221)
    at jodit-react.js:2:421866
```
The problem was caused by triggering both the internal state change AND the props.onChange() that does an update for the editor component usually.

Now pasting HTML gives the popup that is expected even on the first paste:
![image](https://github.com/user-attachments/assets/ee5214ad-c0bc-416f-ac89-7910b509e303)


Some ESLint/formatting fixes to unrelated components.