### PR TITLE
Antd5 fixes

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/Footer/OpacitySlider.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/Footer/OpacitySlider.jsx
@@ -28,7 +28,7 @@ export const OpacitySlider = ({ value, onChange }) => {
     }, [value]);
     const isMobile = Oskari.util.isMobile();
     return (
-        <InputGroup compact>
+        <InputGroup>
             <Container $isMobile={isMobile}>
                 <Opacity bordered defaultValue={sliderValue} onChange={instantValueChange} inputOnly={isMobile} />
             </Container>

--- a/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/Footer/StyleSettings.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/Footer/StyleSettings.jsx
@@ -54,7 +54,7 @@ export const StyleSettings = LocaleConsumer(({ layer, onChange }) => {
                     <Message messageKey={'layer.styles.title'} LabelComponent={Label} />
                 )}
                 <Col>
-                    <InputGroup compact>
+                    <InputGroup>
                         {!editStyle && (
                             <StyledSelect
                                 value={currentStyle.getName()}

--- a/src/react/util/extras/Messaging.js
+++ b/src/react/util/extras/Messaging.js
@@ -6,8 +6,8 @@ const ALERT = 'message';
 const SUCCESS = 'success';
 const INFO = 'info';
 const LOADING = 'loading';
-const WARN = 'warn';
-const WARNING = 'warn';
+const WARN = 'warning';
+const WARNING = 'warning';
 const ERROR = 'error';
 
 const getBroker = (options = {}) => {
@@ -64,7 +64,7 @@ const validate = (options) => {
  * The options object for Messaging.
  * @typedef {Object} Messaging~Options
  * @property {string} [type] - Message type. One of ('notification'|'message').
- * @property {string} [level] - Message level. One of ('success'|'info'|'loading'|'warn'|'error').
+ * @property {string} [level] - Message level. One of ('success'|'info'|'loading'|'warning'|'error').
  * @property {ReactNode} content - Content for the message.
  * @property {string} [key] - Message identifier.
  * @property {number} [duration] - Duration for auto-closing. Null means no auto-closing.
@@ -141,11 +141,11 @@ class Messaging {
     }
     /** @param {Messaging~Options} options */
     warn (options) {
-        this.open({ ...validate(options), level: WARN });
+        this.warning(options);
     }
     /** @param {Messaging~Options} options */
     warning (options) {
-        this.warn(options);
+        this.open({ ...validate(options), level: WARNING });
     }
     /** @param {Messaging~Options} options */
     error (options) {
@@ -157,7 +157,7 @@ class Messaging {
     }
     /** @param {string} key */
     close (key) {
-        notification.close(key);
+        notification.destroy(key);
     }
     destroy () {
         notification.destroy();
@@ -183,8 +183,8 @@ Object.defineProperty(Messaging, 'TYPE', {
  * @property {string} SUCCESS Message with success icon.
  * @property {string} INFO Message with info icon.
  * @property {string} LOADING Message with warning loading icon. Only valid for ALERT and MESSAGE types.
- * @property {string} WARN Message with warning icon.
- * @property {string} WARNING Alias for WARN.
+ * @property {string} WARN Alias for WARNING.
+ * @property {string} WARNING Message with warning icon.
  * @property {string} ERROR Message with error icon.
  * @memberof Messaging
  **/


### PR DESCRIPTION
InputGroup has changed from AntD ` Input.Group` to `Space.Compact` and it doesn't have `compact` prop anymore. Remove them to get rid of warning

Messaging refactor `warn` to `warning`. Fixes issue where warning notification and message doesn't have warning icon.
use `destroy(key)` for notification

https://ant.design/docs/react/migration-v5
- The deprecated message.warn in 4.x is now completely removed, please use message.warning instead.
- close was renamed to destroy to be consistent with message