### PR TITLE
Metadata show flyout on startup

### DIFF
--- a/bundles/catalogue/metadata/instance.js
+++ b/bundles/catalogue/metadata/instance.js
@@ -39,6 +39,11 @@ Oskari.clazz.define('Oskari.catalogue.bundle.metadata.MetadataBundleInstance',
             Object.getOwnPropertyNames(this.eventHandlers).forEach(p => this.sandbox.registerForEventByName(this, p));
 
             this._setupLayerTools();
+            const { current } = this.state || {};
+            if (current) {
+                const metadata = Array.isArray(current) ? current[0] : current;
+                this.showMetadata(metadata);
+            }
         },
         /**
          * Fetches reference to the map layer service


### PR DESCRIPTION
Handle metadata='uuid' param:
https://github.com/oskariorg/oskari-server/blob/master/service-csw/src/main/java/fi/nls/oskari/control/metadata/MetadataParamsHandler.java

Not sure why param handler uses allMetadata array

