### PR TITLE
Metadata layerlist and localization fix

### DIFF
--- a/bundles/catalogue/metadata/resources/locale/en.js
+++ b/bundles/catalogue/metadata/resources/locale/en.js
@@ -44,7 +44,7 @@ Oskari.registerLocalization({
                 "errorStatistic": "Error statistic",
                 "value": "Value"
             },
-            "heading": {
+            "label": {
                 "layerList": "Map layers",
                 "abstractTextData": "Abstract text (data)",
                 "abstractTextService": "Abstract text (service)",

--- a/bundles/catalogue/metadata/resources/locale/en.js
+++ b/bundles/catalogue/metadata/resources/locale/en.js
@@ -95,7 +95,7 @@ Oskari.registerLocalization({
                 "topologicalConsistency": "Topological consistency"
             }
         },
-        "codeLists": {
+        "codes": {
             "gmd:MD_CharacterSetCode": {
                 "ucs2": {
                     "label": "UCS2",

--- a/bundles/catalogue/metadata/resources/locale/fr.js
+++ b/bundles/catalogue/metadata/resources/locale/fr.js
@@ -69,7 +69,7 @@ Oskari.registerLocalization(
                 "reportConformance": "Conformité",
                 "conformanceResult": "Résultat de conformité",
                 "quantitativeResult": "Résultat quantitatif",
-                "responsibleParty": "Partie responsable",
+                "responsibleParties": "Partie responsable",
                 "resourceIdentifiers": "Identificateur de la ressource",
                 "languages": "Langue de la ressource",
                 "scopeCodes": "Type de ressource",

--- a/bundles/catalogue/metadata/resources/locale/is.js
+++ b/bundles/catalogue/metadata/resources/locale/is.js
@@ -8,7 +8,7 @@ Oskari.registerLocalization(
         "flyout": {
             "title": "Lýsigögn",
             "tab": {
-                "abstract": "Grunnupplýsingar",
+                "basic": "Grunnupplýsingar",
                 "inspire": "Inspire lýsigögn",
                 "jhs": "ISO 19115 lýsigögn",
                 "quality": "Gæði gagna",
@@ -50,7 +50,7 @@ Oskari.registerLocalization(
                 "operatesOn": "Starfar á",
                 "otherConstraints": "Aðrar takmarkanir",
                 "reportConformance": "Samræmi",
-                "responsibleParty": "Ábyrgðaraðili",
+                "responsibleParties": "Ábyrgðaraðili",
                 "resourceIdentifiers": "Kennimerki auðlindar",
                 "languages": "Tungumál auðlindar",
                 "scopeCodes": "Tegund auðlindar",
@@ -432,6 +432,6 @@ Oskari.registerLocalization(
                     "description": "Orku-, vatns- og úrganskerfi og samskiptagrunnkerfi og þjónustur. Dæmi: rafmagn búið til með vatnsafli, orkugjafar úr jarðhita, sól og kjarnorku, hreinsun og dreifing á vatni, skólpsöfnun og förgun, dreifing á rafmagni og gasi, gagnaflutningar, fjarskipti, útvarp, fjarskiptanet."
                 }
             }
-        },
+        }
     }
 });

--- a/bundles/catalogue/metadata/resources/locale/ru.js
+++ b/bundles/catalogue/metadata/resources/locale/ru.js
@@ -8,7 +8,7 @@ Oskari.registerLocalization(
         "flyout": {
             "title": "Метаданные",
             "tab": {
-                "abstract": "Основная информация",
+                "basic": "Основная информация",
                 "inspire": "Метаданные Inspire",
                 "jhs": "Метаданные ISO 19115",
                 "quality": "Качество данных",

--- a/bundles/catalogue/metadata/resources/locale/sv.js
+++ b/bundles/catalogue/metadata/resources/locale/sv.js
@@ -95,7 +95,7 @@ Oskari.registerLocalization({
                 "topologicalConsistency": "Topologisk konsistens"
             }
         },
-        "codeLists": {
+        "codes": {
             "gmd:MD_CharacterSetCode": {
                 "ucs2": {
                     "label": "UCS2",

--- a/bundles/catalogue/metadata/view/tab/ActionsTabPane.jsx
+++ b/bundles/catalogue/metadata/view/tab/ActionsTabPane.jsx
@@ -13,6 +13,7 @@ const Margin = styled.div`
 `;
 
 export const ActionsTabPane = ({ metadataURL, controller, layers, hideLink }) => {
+    const hasLayers = layers.length > 0;
     return (
         <Content>
             { !hideLink &&
@@ -20,7 +21,7 @@ export const ActionsTabPane = ({ metadataURL, controller, layers, hideLink }) =>
                     <Link url={metadataURL}><Message messageKey='flyout.actions.xml' /></Link>
                 </Margin>
             }
-            <Label labelKey='layerList'/>
+            { hasLayers && <Label labelKey='layerList'/> }
             <LayerList>
                 { layers.map(layer => (
                     <li key={layer.layerId}>


### PR DESCRIPTION
- don't show label for empty layer list
- get requested uuid from layer if layerId is used
- get layers also by csw repsonse fileIdentifier if not same than requested
=> fixes issue where metadata is requested with layerId and layer has url encoded uuid and csw response not

Fix localization keys