### PR TITLE
Stats series speed select padding fix

### DIFF
--- a/bundles/statistics/statsgrid/resources/css/seriesplayback.css
+++ b/bundles/statistics/statsgrid/resources/css/seriesplayback.css
@@ -35,11 +35,10 @@
 .stats-series-speed label {
   display: block;
 }
-.stats-series-speed select {
+.statsgrid-series-control-plugin .stats-series-speed select {
     width: 100px;
     height: 24px;
-    padding-top: 0;
-    padding-bottom: 0;
+    padding: 0 5px;
 }
 
 .statsgrid-series-control-plugin .line-svg g.drag-handle circle{

--- a/bundles/statistics/statsgrid2016/resources/css/seriesplayback.css
+++ b/bundles/statistics/statsgrid2016/resources/css/seriesplayback.css
@@ -35,11 +35,10 @@
 .stats-series-speed label {
   display: block;
 }
-.stats-series-speed select {
+.statsgrid-series-control-plugin .stats-series-speed select {
     width: 100px;
     height: 24px;
-    padding-top: 0;
-    padding-bottom: 0;
+    padding: 0 5px;
 }
 
 .statsgrid-series-control-plugin .line-svg g.drag-handle circle{


### PR DESCRIPTION
increase series speed select style specificity to override padding from forms.css

Adding `:not([class*="jodit-"])` increased specificity:
https://github.com/oskariorg/oskari-frontend/commit/72665b67e8a4738cd0f3f40f26cc9c2fe469699c