### PR TITLE
Update readme (node version/sample-application etc refs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # Oskari
 
-[Oskari](http://www.oskari.org/) Map Application Framework aims to provide a framework and a collection of functionality-enhancing bundles and plugins for rapid development of feature-rich GI web applications.
+[Oskari](https://www.oskari.org/) Map Application Framework aims to provide a framework and a collection of functionality-enhancing bundles and plugins for rapid development of feature-rich GI web applications.
 
-Documentation available at [http://www.oskari.org].
+Documentation available at [https://www.oskari.org].
 
 This repository holds the frontend framework code for Oskari. Developing the frontend framework requires a frontend application. You may clone sample frontend application from [https://github.com/oskariorg/sample-application]. The sample application directory should be located next to the frontend framework directory.
 
-You will also need oskari-server to be running that responds to the XHR requests made by the frontend. You can download a pre-compiled copy of the server from [http://www.oskari.org/download]. You may also build it from source by cloning [oskari-server](https://github.com/oskariorg/oskari-server) and [sample-server-extension](https://github.com/oskariorg/sample-server-extension).
+You will also need a oskari-server based server webapp to be running that responds to the XHR requests made by the frontend. You can download a pre-compiled copy of the server from [https://www.oskari.org/download]. You may also build it from source by cloning [sample-server-extension](https://github.com/oskariorg/sample-server-extension).
 
 Oskari frontend applications are built using Webpack.
 
 ## Preparations
 
-Make sure you have at least Node 10.x / NPM 5.x. 
+Make sure you have at least Node 16.x / NPM 6.x. You will need both this repository (`oskari-frontend`) and an oskari-based frontend application like the [sample-application](https://github.com/oskariorg/sample-application).
 
-* Run `npm install` in the frontend framework repository root.
-* Run `npm install` in the frontend application repository root.
+* Run `npm install` in the frontend framework repository root (`oskari-frontend`).
+* Run `npm install ../oskari-frontend` in the frontend application repository root (`sample-application`) when developing code on oskari-frontend repository.
 
-Make sure you have oskari-server running on localhost port 8080 (can be customized on webpack.config.js).
+Make sure you have an oskari-server based webapp running on localhost port 8080 (can be customized on `webpack.config.js`).
 
 ## Run in development
 
@@ -29,7 +29,7 @@ So that the server knows to look for the JS bundle and assets from the right pla
 oskari.client.version=dist/devapp
 ```
 
-To start Webpack dev server run `npm start`. The start script in oskari-frontend package.json defaults to the sample application directory but this can be parameterized for custom apps.
+To start Webpack dev server run `npm run start:dev` on the `sample-application` directory.
 
 When you see "Compiled successfully." in the terminal, you can open the app in the browser at `localhost:8081`.
 
@@ -37,13 +37,13 @@ The dev server has automatic reloading enabled when you save changes to JS code 
 
 ## Build for production
 
-To build minifed JS and assets run: `npm run build`.
+To build minifed JS and assets run: `npm run build` on the `sample-application` directory (or `npm run build:dev` if you have oskari-frontend installed from `../oskari-frontend` instead of GitHub directly).
 
-This will produce optimized files for production under `dist/devapp/servlet/`. The build script in oskari-frontend package.json again defaults to the sample application directory. It also defaults to a version named `devapp`. Both the app and version number can be parameterized for custom apps.
+This will produce optimized files for production under `sample-application/dist/[version]/geoportal/`. The build scripts are provided in the `oskari-frontend` repository, but are run from the application repository folder. It also defaults to a version from `package.json` of the application repository, but can also be passed on command line.
 
 Note: The version number given for the build command needs to match the client version (`oskari.client.version`) in Oskari-server `oskari-ext.properties`.
 
-Special case: If on your production server your application index.jsp location is mapped to something else than the root (eg. `http://yourdomain.com/my-oskari-app/`), but the assets are mapped relative to the root (eg. `http://yourdomain.com/Oskari/dist/...`), you need to add the build parameter `--env absolutePublicPath=true` like this:
+Special case: If on your production server your application index.jsp location is mapped to something else than the root (eg. `https://yourdomain.com/my-oskari-app/`), but the assets are mapped relative to the root (eg. `https://yourdomain.com/Oskari/dist/...`), you need to add the build parameter `--env absolutePublicPath=true` like this:
 
     npm run build -- --env absolutePublicPath=true
 
@@ -64,7 +64,7 @@ Run npm `build` and `start` commands in your application repository root.
 
 Note! Some of the icons have dark/light versions. This means that different icon is shown when the background is either dark or light for example on the toolbar. Other icons have hover versions that are used for automatically generated hover styles. To use the icon from the sprite it is referenced by the image name as class:
 
-```
+```html
     <div class="icon add-area"></div>
 ```
 
@@ -72,7 +72,7 @@ Note! The same script can be used to generate application-specific overrides. Se
 
 ## Dependencies
 
-Note! All the dependencies (even dev-dependencies like Webpack) are under dependencies for a reason. The reason is that this repository is used as dependency for apps and apps inherit the webpack-dependencies automatically instead of having to install and configure their own versions.
+Note! All the dependencies (even dev-dependencies like Webpack) are under dependencies for a reason. The reason is that this repository is used as dependency for apps and apps inherit the webpack-dependencies automatically instead of having to install and configure their own versions. We might separate the build tools to another repository in the future that could be used to have alternative versions of build scripts and/or having the build-related dependencies as devDependencies on the application.
 
 # Reporting issues
 
@@ -80,7 +80,7 @@ All Oskari-related issues should be reported here: https://github.com/oskariorg/
 
 # Contributing
 
-Please read the [contribution guidelines](http://oskari.org/documentation/development/how-to-contribute) before contributing pull requests to the Oskari project.
+Please read the [contribution guidelines](https://oskari.org/contribute) before contributing pull requests to the Oskari project.
 
 ## License
  


### PR DESCRIPTION
- nodejs 10 hasn't worked for builds for some years, updated to 16+ (looks like atleast 18 works too after dependency updates coming in 2.14)
- Change content to reference using this with an application repository like the sample-application
- Change refs to oskari-server to webapp based on oskari-server like sample-server-extension
- Fix links referencing oskari.org website