### PR TITLE
Small fixes

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -163,7 +163,7 @@ Oskari.registerLocalization(
                         "typeFormats": "Värde typ",
                         "textFormats": "Textformatering",
                         "link": "Länk",
-                        "image": "Image",
+                        "image": "Bild",
                         "number": "Nummer",
                         "phone": "Telefonnummer"
                     },

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.jsx
@@ -23,14 +23,13 @@ const ScaleSlider = styled(Slider)`
     .ant-slider-track {
         background-color: #0091ff;
     }
-    .ant-slider-handle {
-        border: #0091ff solid 2px;
+    .ant-slider-mark-text {
+        padding-bottom: 3px;
+        white-space: nowrap;
+        font-size: 11px;
     }
     &:hover .ant-slider-track {
         background-color: #003fc3 !important;
-    }
-    &:hover .ant-slider-handle {
-        border: #003fc3 solid 2px !important;
     }
 `;
 
@@ -38,11 +37,6 @@ const SliderContainer = styled('div')`
     height: 200px;
     padding-top: 15px;
     padding-bottom: 15px;
-
-    .ant-slider-mark-text {
-        padding-bottom: 3px;
-        font-size: 11px;
-    }
 `;
 
 const ScaleInput = styled(Numeric)`
@@ -52,11 +46,11 @@ const ScaleInput = styled(Numeric)`
 
 const PlusIcon = styled(PlusCircleOutlined)`
     text-align: left;
-    margin-left: 8px;
+    margin-left: 10px;
 `;
 const MinusIcon = styled(MinusCircleOutlined)`
     text-align: left;
-    margin-left: 8px;
+    margin-left: 10px;
 `;
 
 const Scale = ({ layer, scales = [], controller, getMessage }) => {

--- a/bundles/catalogue/metadata/instance.js
+++ b/bundles/catalogue/metadata/instance.js
@@ -70,16 +70,16 @@ Oskari.clazz.define('Oskari.catalogue.bundle.metadata.MetadataBundleInstance',
         /**
          * Adds the metadata tool for layer
          * @method  @private _addTool
-         * @param  {String| Number} layerId layer to process
+         * @param  {Object} layer Oskari layer of any type to process
          * @param  {Boolean} suppressEvent true to not send event about updated layer (optional)
          */
         _addTool: function (layer, suppressEvent) {
-            const service = this.getLayerService();
-            if (!layer || !layer.getMetadataIdentifier()) {
+            const uuid = layer?.getMetadataIdentifier();
+            if (!uuid) {
                 return;
             }
+            const service = this.getLayerService();
             const layerId = layer.getId();
-            const uuid = layer.getMetadataIdentifier();
             // add feature data tool for layer
             const tool = Oskari.clazz.create('Oskari.mapframework.domain.Tool');
             tool.setName('metadata');
@@ -117,8 +117,10 @@ Oskari.clazz.define('Oskari.catalogue.bundle.metadata.MetadataBundleInstance',
                     // only handle add layer
                     return;
                 }
-                if (event.getLayerId()) {
-                    this._addTool(event.getLayerId());
+                const layerId = event.getLayerId();
+                if (layerId) {
+                    const layer = this.getLayerService()?.findMapLayer(layerId);
+                    this._addTool(layer);
                 } else {
                     // ajax call for all layers
                     this._setupLayerTools();

--- a/bundles/catalogue/metadata/resources/locale/fi.js
+++ b/bundles/catalogue/metadata/resources/locale/fi.js
@@ -322,8 +322,8 @@ Oskari.registerLocalization({
                     "description": "Informaatio koskaa kohdetyyppiä."
                 },
                 "propertyType": {
-                    "label": "Property type",
-                    "description": "Information applies to a property type"
+                    "label": "Ominaisuustyyppi",
+                    "description": "Informaatio koskee kohdetyypin ominaispiirrettä."
                 },
                 "fieldSession": {
                     "label": "Maastotyöskentely",

--- a/bundles/catalogue/metadata/resources/locale/sv.js
+++ b/bundles/catalogue/metadata/resources/locale/sv.js
@@ -45,7 +45,7 @@ Oskari.registerLocalization({
                 "value": ""
             },
             "label": {
-                "layerList": "Karttatasot",
+                "layerList": "Kartlager",
                 "abstractTextData": "Sammanfattning text (data)",
                 "abstractTextService": "Sammanfattning text (tjänst)",
                 "accessConstraints": "Åtkomstrestriktioner",

--- a/bundles/catalogue/metadataflyout/view/MetadataPanel.js
+++ b/bundles/catalogue/metadataflyout/view/MetadataPanel.js
@@ -108,7 +108,7 @@ Oskari.clazz.define('Oskari.catalogue.bundle.metadataflyout.view.MetadataPanel',
                     '        <h2>' + this.locale.heading.onlineResource + '</h2>' +
                     '        <ul>' +
                     '        <% _.forEach(onlineResources, function (onlineResource) { %>' +
-                    '            <% if (onlineResource.url.length) { %>' +
+                    '            <% if (onlineResource.url) { %>' +
                     '                <li><a href="<%= onlineResource.url %>"><%= onlineResource.name && onlineResource.name.length ? onlineResource.name : onlineResource.url %></a></li>' +
                     '            <% } %>' +
                     '        <% }); %>' +
@@ -274,7 +274,7 @@ Oskari.clazz.define('Oskari.catalogue.bundle.metadataflyout.view.MetadataPanel',
                     '        <h2>' + this.locale.heading.onlineResource + '</h2>' +
                     '        <ul>' +
                     '        <% _.forEach(onlineResources, function (onlineResource) { %>' +
-                    '            <% if (onlineResource.url.length) { %>' +
+                    '            <% if (onlineResource.url) { %>' +
                     '                <li><a href="<%= onlineResource.url %>"><%= onlineResource.name && onlineResource.name.length ? onlineResource.name : onlineResource.url %></a></li>' +
                     '            <% } %>' +
                     '        <% }); %>' +

--- a/bundles/framework/backendstatus/resources/locale/fi.js
+++ b/bundles/framework/backendstatus/resources/locale/fi.js
@@ -3,7 +3,7 @@ Oskari.registerLocalization(
     "lang": "fi",
     "key": "BackendStatus",
     "value": {
-        "title": "Backend Status",
+        "title": "Tilatiedot",
         "desc": "",
         "feedback": {
             "missing_backendstatus_status": {

--- a/bundles/framework/findbycoordinates/resources/locale/sv.js
+++ b/bundles/framework/findbycoordinates/resources/locale/sv.js
@@ -3,8 +3,8 @@ Oskari.registerLocalization(
     "lang": "sv",
     "key": "findbycoordinates",
     "value": {
-        "title": "FindByCoordinates",
-        "desc": "FindByCoordinates",
+        "title": "Sök närmaste adress",
+        "desc": "",
         "tool": {
             "tooltip": "Sök närmaste adress genom att klicka kartan."
         },

--- a/bundles/framework/printout/resources/locale/en.js
+++ b/bundles/framework/printout/resources/locale/en.js
@@ -40,7 +40,6 @@ Oskari.registerLocalization(
             },
             "content": {
                 "label": "Additional content",
-                "tooltip": "",
                 "pngNote": "PNG-print will not include additional information.",
                 "mapTitle": {
                     "placeholder": "Title"

--- a/bundles/framework/printout/resources/locale/fi.js
+++ b/bundles/framework/printout/resources/locale/fi.js
@@ -40,7 +40,6 @@ Oskari.registerLocalization(
             },
             "content": {
                 "label": "Näytettävät tiedot",
-                "tooltip": "Valitse tulosteessa näytettävät tiedot.",
                 "pngNote": "PNG-tulosteelle ei lisätä alla olevia tietoja.",
                 "mapTitle": {
                     "placeholder": "Otsikko"

--- a/bundles/framework/printout/resources/locale/sv.js
+++ b/bundles/framework/printout/resources/locale/sv.js
@@ -40,7 +40,6 @@ Oskari.registerLocalization(
             },
             "content": {
                 "label": "Synlig information",
-                "tooltip": "",
                 "pngNote": "Tilläggsinformationen ingår ej i PNG-utskriftet.",
                 "mapTitle": {
                     "placeholder": "Rubrik"

--- a/bundles/mapping/mapmodule/resources/locale/en.js
+++ b/bundles/mapping/mapmodule/resources/locale/en.js
@@ -86,7 +86,6 @@ Oskari.registerLocalization(
                 "noAttributeData": "No attributes to show, please open feature data to see hidden attributes."
             },
             "PublisherToolbarPlugin": {
-                "test": "test",
                 "history": {
                     "reset": "Move to the original map view",
                     "back": "Move to previous view",

--- a/bundles/mapping/mapmodule/resources/locale/sv.js
+++ b/bundles/mapping/mapmodule/resources/locale/sv.js
@@ -81,7 +81,6 @@ Oskari.registerLocalization(
                 "noAttributeData": "Inga attributer att visa, vänligen öppna objektuppgifterna för att se de dolda attributerna."
             },
             "PublisherToolbarPlugin": {
-                "test": "test",
                 "history": {
                     "reset": "Gå tillbaka till standardvyn för kartvyn",
                     "back": "Tillbaka till föregående vy",

--- a/bundles/statistics/statsgrid/components/classification/editclassification/ColorSelect.jsx
+++ b/bundles/statistics/statsgrid/components/classification/editclassification/ColorSelect.jsx
@@ -13,7 +13,6 @@ const ColorSet = styled.div`
     height: 20px;
     display: flex;
     flex-flow: row nowrap;
-    margin-top: 5px;
 `;
 
 const Color = styled.div`


### PR DESCRIPTION
Fixes:
- pass layer instead of layerId to metadata _addTool => fixes: `TypeError: e.getMetadataIdentifier is not a function`
- statistics legend color select alignment
- admin layereditor scale slider 
- removed/fixed some localizations
- metadataflyout removed length check => fixes JS error with empty object e.g. onlineReources `[{}]`

![image](https://github.com/user-attachments/assets/23bd1476-15bf-4c44-bb28-090fbb8929b1)
=>
![image](https://github.com/user-attachments/assets/a3bc6d56-7ab8-4215-a65f-a0aff54b785c)

Removed handle border as Antd uses :after to render handle. Maybe we should use Semantic DOM: track, tracks, handle and rail to override styling to avoid styling issues after updating Antd. Also style overrides should be handled in common/oskariui Slider instead of own styling in every component.