### PR TITLE
AdminUsers role select fix

### DIFF
--- a/bundles/framework/admin-users/view/AdminUsersFlyout.jsx
+++ b/bundles/framework/admin-users/view/AdminUsersFlyout.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Tabs, Message } from 'oskari-ui';
 import { RolesTab } from './RolesTab';
 import { UsersTab } from './UsersTab';
@@ -36,4 +37,9 @@ export const AdminUsersFlyout = ({ state, controller, isExternal = false }) => {
             />
         </div>
     );
+};
+AdminUsersFlyout.propTypes = {
+    state: PropTypes.object.isRequired,
+    controller: PropTypes.object.isRequired,
+    isExternal: PropTypes.bool
 };

--- a/bundles/framework/admin-users/view/RoleBlock.jsx
+++ b/bundles/framework/admin-users/view/RoleBlock.jsx
@@ -1,14 +1,23 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { TextInput, Message } from 'oskari-ui';
 import { UserOutlined } from '@ant-design/icons';
 import { Block, Button, ButtonContainer } from './styled';
 
+const ADMIN = 'admin';
+
 export const RoleBlock = ({ role, controller, isSystemRole, editingRole }) => {
-    const { id, name } = role;
+    const { id, name, type } = role;
     if (isSystemRole) {
         return (
             <Block>
                 <span>{name}</span>
+                { type === ADMIN &&
+                    <Button
+                        icon={<UserOutlined />}
+                        title={<Message messageKey='roles.showUsers'/>}
+                        onClick={() => controller.showUsersByRole(id)} />
+                }
             </Block>
         );
     }
@@ -40,4 +49,10 @@ export const RoleBlock = ({ role, controller, isSystemRole, editingRole }) => {
             </ButtonContainer>
         </Block>
     );
+};
+RoleBlock.propTypes = {
+    role: PropTypes.object.isRequired,
+    controller: PropTypes.object.isRequired,
+    editingRole: PropTypes.object,
+    isSystemRole: PropTypes.bool
 };

--- a/bundles/framework/admin-users/view/RoleSelect.jsx
+++ b/bundles/framework/admin-users/view/RoleSelect.jsx
@@ -27,7 +27,6 @@ export const RoleSelect = ({ state, value, error, multiple, onlyAdmin, onChange 
         className='t_roles'
         mode={multiple ? 'multiple' : null}
         status={error ? 'error' : null}
-        allowClear = {!!multiple}
         onChange={(value) => onChange(value)}
         placeholder={<Message messageKey='usersByRole.selectRole' />}
         value={value}

--- a/bundles/framework/admin-users/view/RoleSelect.jsx
+++ b/bundles/framework/admin-users/view/RoleSelect.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Select, Message } from 'oskari-ui';
+
+const ADMIN = 'admin';
+const GUEST = 'anonymous';
+
+const getOptionGroup = (type, roles) => {
+    const options = roles.map(({ name, id }) => ({ label: name, value: id }));
+    return {
+        title: type,
+        label: <Message messageKey={`roles.types.${type}`} />,
+        options
+    };
+};
+
+export const RoleSelect = ({ state, value, error, multiple, onlyAdmin, onChange }) => {
+    const { roles, systemRoles } = state;
+    const system = onlyAdmin
+        ? systemRoles.filter(role => role.type === ADMIN)
+        : systemRoles.filter(role => role.type !== GUEST);
+    const options = [
+        getOptionGroup('system', system),
+        getOptionGroup('other', roles)
+    ];
+    return <Select
+        className='t_roles'
+        mode={multiple ? 'multiple' : null}
+        status={error ? 'error' : null}
+        allowClear = {!!multiple}
+        onChange={(value) => onChange(value)}
+        placeholder={<Message messageKey='usersByRole.selectRole' />}
+        value={value}
+        options={options}/>;
+};
+
+RoleSelect.propTypes = {
+    state: PropTypes.object.isRequired,
+    value: PropTypes.any,
+    onChange: PropTypes.func.isRequired,
+    multiple: PropTypes.bool,
+    onlyAdmin: PropTypes.bool,
+    error: PropTypes.bool
+};

--- a/bundles/framework/admin-users/view/RoleSelect.jsx
+++ b/bundles/framework/admin-users/view/RoleSelect.jsx
@@ -30,6 +30,7 @@ export const RoleSelect = ({ state, value, error, multiple, onlyAdmin, onChange 
         onChange={(value) => onChange(value)}
         placeholder={<Message messageKey='usersByRole.selectRole' />}
         value={value}
+        style={multiple ? { width: 210 } : null}
         options={options}/>;
 };
 

--- a/bundles/framework/admin-users/view/RolesTab.jsx
+++ b/bundles/framework/admin-users/view/RolesTab.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import { Message } from 'oskari-ui';
 import { PrimaryButton } from 'oskari-ui/components/buttons';
 import { RoleBlock } from './RoleBlock';
@@ -47,4 +48,8 @@ export const RolesTab = ({ state, controller }) => {
             { systemRoles.map(role => <RoleBlock key={role.id} role={role} controller={controller} isSystemRole/>) }
         </Content>
     );
+};
+RolesTab.propTypes = {
+    state: PropTypes.object.isRequired,
+    controller: PropTypes.object.isRequired
 };

--- a/bundles/framework/admin-users/view/RolesTab.jsx
+++ b/bundles/framework/admin-users/view/RolesTab.jsx
@@ -25,7 +25,7 @@ export const RolesTab = ({ state, controller }) => {
         controller.addRole(roleName);
         setStatus('');
         setRoleName('');
-    }
+    };
     const { roles, systemRoles, editingRole } = state;
     return (
         <Content>

--- a/bundles/framework/admin-users/view/UserField.jsx
+++ b/bundles/framework/admin-users/view/UserField.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Message } from 'oskari-ui';
 import { getMandatoryIcon } from 'oskari-ui/util/validators';
 import { LabelledField, StyledLabel, StyledInput } from './styled';
@@ -25,4 +26,13 @@ export const UserField = ({ field, value, controller, error, readonly = false, t
             />
         </LabelledField>
     );
+};
+UserField.propTypes = {
+    field: PropTypes.string.isRequired,
+    value: PropTypes.string,
+    controller: PropTypes.object.isRequired,
+    type: PropTypes.string,
+    error: PropTypes.bool,
+    readonly: PropTypes.bool,
+    mandatory: PropTypes.bool
 };

--- a/bundles/framework/admin-users/view/UserForm.jsx
+++ b/bundles/framework/admin-users/view/UserForm.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Message, Label, Select } from 'oskari-ui';
+import PropTypes from 'prop-types';
+import { Message, Select } from 'oskari-ui';
 import { PrimaryButton, SecondaryButton, DeleteButton, ButtonContainer } from 'oskari-ui/components/buttons';
 import styled from 'styled-components';
 import { UserField } from './UserField';
@@ -72,4 +73,10 @@ export const UserForm = ({ userFormState, roles, controller, isExternal }) => {
             </ButtonContainer>
         </Content>
     );
+};
+UserForm.propTypes = {
+    userFormState: PropTypes.object.isRequired,
+    controller: PropTypes.object.isRequired,
+    roles: PropTypes.array.isRequired,
+    isExternal: PropTypes.bool
 };

--- a/bundles/framework/admin-users/view/UserForm.jsx
+++ b/bundles/framework/admin-users/view/UserForm.jsx
@@ -1,28 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Message, Select } from 'oskari-ui';
+import { Message } from 'oskari-ui';
 import { PrimaryButton, SecondaryButton, DeleteButton, ButtonContainer } from 'oskari-ui/components/buttons';
-import styled from 'styled-components';
 import { UserField } from './UserField';
+import { RoleSelect } from './RoleSelect';
 import { Content, LabelledField, StyledLabel } from './styled';
-
-const StyledSelect = styled(Select)`
-    width: 210px;
-`;
 
 const FIELDS = ['user', 'firstName', 'lastName', 'email'];
 const PASS_FIELDS = ['password', 'rePassword'];
 
-const getRoleOptions = (roles, systemRole) => {
-    const filtered = roles.filter(role => role.systemRole === systemRole);
-    return filtered.map(role => ({
-        label: role.name,
-        value: role.id
-    }));
-};
-
-export const UserForm = ({ userFormState, roles, controller, isExternal }) => {
-    const { errors = [], passwordErrors = {}, id, password } = userFormState;
+export const UserForm = ({ state, controller, isExternal }) => {
+    const { userFormState } = state;
+    const { errors = [], passwordErrors = {}, id, password, roles } = userFormState;
     const passwordRequired = !id || password.length > 0;
     return (
         <Content>
@@ -36,24 +25,13 @@ export const UserForm = ({ userFormState, roles, controller, isExternal }) => {
             )}
             <LabelledField>
                 <StyledLabel><Message messageKey='users.addRole' /></StyledLabel>
-                <StyledSelect
-                    className='t_roles'
-                    mode='multiple'
-                    allowClear
-                    onChange={(value) => controller.updateUserFormState('roles', value)}
-                    defaultValue={userFormState.roles}
-                    status={errors.includes('roles') ? 'error' : null}
-                    options={[
-                        {
-                            label: <Message messageKey='roles.types.system' />,
-                            options: getRoleOptions(roles, true)
-                        },
-                        {
-                            label: <Message messageKey='roles.types.other' />,
-                            options: getRoleOptions(roles, false)
-                        }
-                    ]}
-                />
+                <RoleSelect
+                    multiple
+                    style={{ width: 210 }}
+                    state={state}
+                    value={roles}
+                    error={errors.includes('roles')}
+                    onChange={value => controller.updateUserFormState('roles', value)}/>
             </LabelledField>
             <ButtonContainer>
                 <SecondaryButton
@@ -75,8 +53,7 @@ export const UserForm = ({ userFormState, roles, controller, isExternal }) => {
     );
 };
 UserForm.propTypes = {
-    userFormState: PropTypes.object.isRequired,
+    state: PropTypes.object.isRequired,
     controller: PropTypes.object.isRequired,
-    roles: PropTypes.array.isRequired,
     isExternal: PropTypes.bool
 };

--- a/bundles/framework/admin-users/view/UserForm.jsx
+++ b/bundles/framework/admin-users/view/UserForm.jsx
@@ -27,7 +27,6 @@ export const UserForm = ({ state, controller, isExternal }) => {
                 <StyledLabel><Message messageKey='users.addRole' /></StyledLabel>
                 <RoleSelect
                     multiple
-                    style={{ width: 210 }}
                     state={state}
                     value={roles}
                     error={errors.includes('roles')}

--- a/bundles/framework/admin-users/view/UsersByRoleTab.jsx
+++ b/bundles/framework/admin-users/view/UsersByRoleTab.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Message } from 'oskari-ui';
 import styled from 'styled-components';
-import { Block, Content } from './styled';
+import { Block, Content, Button } from './styled';
 import { RoleSelect } from './RoleSelect';
 
 const Margin = styled.div`
@@ -26,6 +26,7 @@ export const UsersByRoleTab = ({ state, controller }) => {
                 return (
                     <Block key={id}>
                         <span>{user}{details}</span>
+                        <Button type='edit' onClick={() => controller.editUserFromRoles(id, user)} />
                     </Block>
                 );
             })}

--- a/bundles/framework/admin-users/view/UsersByRoleTab.jsx
+++ b/bundles/framework/admin-users/view/UsersByRoleTab.jsx
@@ -1,41 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Select, Message } from 'oskari-ui';
+import { Message } from 'oskari-ui';
 import styled from 'styled-components';
 import { Block, Content } from './styled';
+import { RoleSelect } from './RoleSelect';
 
-const StyledSelect = styled(Select)`
+const Margin = styled.div`
     margin-bottom: 20px;
 `;
-const ADMIN = 'admin';
-
-const getOptionGroup = (type, roles) => {
-    const options = roles.map(({ name, id }) => ({ label: name, value: id }));
-    return {
-        title: type,
-        label: <Message messageKey={`roles.types.${type}`} />,
-        options
-    };
-};
 
 export const UsersByRoleTab = ({ state, controller }) => {
-    const { usersByRole, roles, systemRoles } = state;
-    const { users = [], roleId } = usersByRole;
-
+    const { users = [], roleId } = state.usersByRole;
     const showNoUsers = roleId && users.length === 0;
-    const onlyAdmin = systemRoles.filter(role => role.type === ADMIN);
-    const options = [
-        getOptionGroup('system', onlyAdmin),
-        getOptionGroup('other', roles)
-    ];
     return (
         <Content>
-            <StyledSelect
-                className='t_roles'
-                onChange={(value) => controller.showUsersByRole(value)}
-                placeholder={<Message messageKey='usersByRole.selectRole' />}
-                defaultValue={roleId}
-                options={options}/>
+            <RoleSelect
+                onlyAdmin
+                state={state}
+                value={roleId}
+                onChange={controller.showUsersByRole}/>
+            <Margin />
             {users.map(item => {
                 const { id, user, firstName, lastName } = item;
                 const details = firstName || lastName ? ` (${firstName} ${lastName})` : '';
@@ -43,8 +27,8 @@ export const UsersByRoleTab = ({ state, controller }) => {
                     <Block key={id}>
                         <span>{user}{details}</span>
                     </Block>
-                )})
-            }
+                );
+            })}
             {showNoUsers && <Message messageKey='usersByRole.noUsers' />}
         </Content>
     );

--- a/bundles/framework/admin-users/view/UsersByRoleTab.jsx
+++ b/bundles/framework/admin-users/view/UsersByRoleTab.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Select, Message } from 'oskari-ui';
 import styled from 'styled-components';
 import { Block, Content } from './styled';
@@ -47,4 +48,8 @@ export const UsersByRoleTab = ({ state, controller }) => {
             {showNoUsers && <Message messageKey='usersByRole.noUsers' />}
         </Content>
     );
+};
+UsersByRoleTab.propTypes = {
+    state: PropTypes.object.isRequired,
+    controller: PropTypes.object.isRequired
 };

--- a/bundles/framework/admin-users/view/UsersTab.jsx
+++ b/bundles/framework/admin-users/view/UsersTab.jsx
@@ -25,19 +25,18 @@ const SearchText = styled('span')`
 
 export const UsersTab = ({ state, controller, isExternal }) => {
     const [filter, setFilter] = useState('');
-    const { userFormState, userPagination, users, roles } = state;
-    if (userFormState) {
+    if (state.userFormState) {
         return (
             <Content>
                 <UserForm
-                    userFormState={userFormState}
-                    roles={roles}
+                    state={state}
                     controller={controller}
                     isExternal={isExternal}
                 />
             </Content>
         );
     }
+    const { userPagination, users } = state;
     return (
         <Content>
             <SearchContainer>

--- a/bundles/framework/admin-users/view/UsersTab.jsx
+++ b/bundles/framework/admin-users/view/UsersTab.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import { SearchInput, Pagination, Message } from 'oskari-ui';
 import styled from 'styled-components';
 import { UserForm } from './UserForm';
@@ -84,4 +85,9 @@ export const UsersTab = ({ state, controller, isExternal }) => {
             )}
         </Content>
     );
+};
+UsersTab.propTypes = {
+    state: PropTypes.object.isRequired,
+    controller: PropTypes.object.isRequired,
+    isExternal: PropTypes.bool
 };

--- a/bundles/framework/admin-users/view/UsersTab.jsx
+++ b/bundles/framework/admin-users/view/UsersTab.jsx
@@ -54,7 +54,7 @@ export const UsersTab = ({ state, controller, isExternal }) => {
                 )}
             </SearchContainer>
             {userPagination.search && (
-                <SearchText><Message messageKey='users.searchResults' /> ("{userPagination.search}"):</SearchText>
+                <SearchText><Message messageKey='users.searchResults' />{` ("${userPagination.search}"):`}</SearchText>
             )}
             {users.length > 0 && users.map(item => {
                 const { id, user, firstName, lastName } = item;

--- a/bundles/framework/admin-users/view/UsersTab.jsx
+++ b/bundles/framework/admin-users/view/UsersTab.jsx
@@ -56,19 +56,19 @@ export const UsersTab = ({ state, controller, isExternal }) => {
             {userPagination.search && (
                 <SearchText><Message messageKey='users.searchResults' /> ("{userPagination.search}"):</SearchText>
             )}
-            {(users && users.length > 0) && users.map(item => {
+            {users.length > 0 && users.map(item => {
                 const { id, user, firstName, lastName } = item;
                 const details = firstName || lastName ? ` (${firstName} ${lastName})` : '';
                 return (
                     <Block key={id}>
                         <span>{user}{details}</span>
                         <ButtonContainer>
-                            <Button type='edit' onClick={() => controller.setEditingUser(id)} />
+                            <Button type='edit' onClick={() => controller.editUserById(id)} />
                             <Button type='delete' onConfirm={() => controller.deleteUser(id)} />
                         </ButtonContainer>
                     </Block>
-                )})
-            }
+                );
+            })}
             {(!users || users.length === 0) && <Message messageKey='users.noMatch'/>}
             {userPagination.totalCount > userPagination.limit && (
                 <Footer>

--- a/src/react/components/buttons/IconButton.jsx
+++ b/src/react/components/buttons/IconButton.jsx
@@ -32,8 +32,8 @@ const BorderlessButton = styled(Button)`
     padding: 0px;
     pointer-events: ${props => props.disabled ? 'none' : 'auto'};
     font-size: ${props => props.$iconSize}px;
-    &:hover {
-        color: ${props => props.$hover} !important;
+    &&&:hover {
+        color: ${props => props.$hover};
         background: none;
     }
     &:disabled {


### PR DESCRIPTION
Roles was splitted to roles and systemRoles in previous PR and forget to made changes to user form select => role select options were empty.

Changes:
- Added own RoleSelect component to fix issue.
- Added props validation and some eslint fixes
- Added show users icon for admin role
- Added edit user icons for users by role tab. If fetched users doesn't include selected user, triggers search.
- Fixed IconButton hover background
