### PR TITLE
Clear drawcontrols only when stopping current draw

### DIFF
--- a/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
+++ b/bundles/mapping/drawtools/plugin/DrawPlugin.ol.js
@@ -364,13 +364,21 @@ Oskari.clazz.define(
                 // try to finish unfinished (currently drawn) feature
                 this.forceFinishDrawing();
             }
-            if (id && !supressEvent) {
-                this.sendDrawingEvent(true);
+            // only clear state if the stopped id is the current id
+            // otherwise sending startDraw with id 2 and stop with id 1 will
+            // remove the draw control from the draw id 2 when the requested one was 1
+            const clearingAllOrCurrentDrawing = typeof id === 'undefined' || id === this.getRequestId();
+            if (clearingAllOrCurrentDrawing) {
+                if (id && !supressEvent) {
+                    this.sendDrawingEvent(true);
+                }
+                // remove draw and modify controls
+                this._cleanupInternalState();
+                // enable gfi
+                this._gfiTimeout = setTimeout(() => this.getMapModule().setDrawingMode(false), 500);
+            } else {
+                Oskari.log('DrawPlugin').info(`Called stop with id '${id}' and draw is currently active with id '${this.getRequestId()}'.`);
             }
-            // remove draw and modify controls
-            this._cleanupInternalState();
-            // enable gfi
-            this._gfiTimeout = setTimeout(() => this.getMapModule().setDrawingMode(false), 500);
         },
         /**
          * @method forceFinishDrawing


### PR DESCRIPTION
Fixes issues when:
1) Sending a startDrawingRequest with id 'asdf'
2) Sending a startDrawingRequest with id 'qwer'
3) Sending a stopDrawingRequest with id 'asdf'

What happens is that startDrawing with id 'qwer' is also stopped and the DrawingEvent triggered by the stop with 'asdf' will have the current sketch and id of 'qwer' (the current draw, not the one that was stopped).

After this the DrawingEvent is not sent if the current id doesn't match the stopped id and the active draw id will remain in "drawing" mode.