### PR TITLE
Fix 3DTiles layers after recent Cesium update

### DIFF
--- a/bundles/mapping/mapmodule/mapmodule.olcs.js
+++ b/bundles/mapping/mapmodule/mapmodule.olcs.js
@@ -62,12 +62,12 @@ class MapModuleOlCesium extends MapModuleOl {
      * @return {ol/Map}
      */
     createMap () {
-        var me = this;
+        const me = this;
         olProjProj4.register(window.proj4);
         // this is done BEFORE enhancement writes the values to map domain
         // object... so we will move the map to correct location
         // by making a MapMoveRequest in application startup
-        var controls = olControlDefaults({
+        const controls = olControlDefaults({
             zoom: false,
             attribution: true,
             attributionOptions: {
@@ -76,17 +76,17 @@ class MapModuleOlCesium extends MapModuleOl {
             rotate: false
         });
 
-        var map = new OLMap({
+        const map = new OLMap({
             keyboardEventTarget: document,
             target: this.getMapDOMEl(),
-            controls: controls,
+            controls,
             interactions: me._olInteractionDefaults,
             moveTolerance: 2
         });
 
-        var projection = olProj.get(me.getProjection());
+        const projection = olProj.get(me.getProjection());
         map.setView(new OLView({
-            projection: projection,
+            projection,
             // actual startup location is set with MapMoveRequest later on
             // still these need to be set to prevent errors
             center: [0, 0],
@@ -96,7 +96,7 @@ class MapModuleOlCesium extends MapModuleOl {
         const creditContainer = document.createElement('div');
         creditContainer.className = 'cesium-credit-container';
         this._map3D = new OLCesium({
-            map: map,
+            map,
             time: () => this.getJulianTime(),
             sceneOptions: {
                 showCredit: true,
@@ -109,7 +109,7 @@ class MapModuleOlCesium extends MapModuleOl {
         });
         this._map3D.container_.appendChild(creditContainer);
 
-        var scene = this._map3D.getCesiumScene();
+        const scene = this._map3D.getCesiumScene();
         // Vector features sink in the ground. This allows sunken features to be visible through the ground.
         // Setting olcs property 'altitudeMode': 'clampToGround' to vector layer had some effect but wasn't good enough.
         // DepthTestAgainstTerrain should be enabled when 3D-tiles (buildings) are visible.
@@ -131,7 +131,7 @@ class MapModuleOlCesium extends MapModuleOl {
         this._setupMapEvents(map);
         this._fixDuplicateOverlays(true);
 
-        var updateReadyStatus = function () {
+        const updateReadyStatus = function () {
             scene.postRender.removeEventListener(updateReadyStatus);
             me._mapReady = true;
             me._notifyMapReadySubscribers();

--- a/bundles/mapping/tiles3d/plugin/Tiles3DLayerPlugin.js
+++ b/bundles/mapping/tiles3d/plugin/Tiles3DLayerPlugin.js
@@ -51,7 +51,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.Tiles3DLayerPlugin',
          */
         _initImpl: function () {
             // register domain builder
-            var mapLayerService = this.getSandbox().getService('Oskari.mapframework.service.MapLayerService');
+            const mapLayerService = this.getSandbox().getService('Oskari.mapframework.service.MapLayerService');
             if (mapLayerService) {
                 const registerType = this.layertype + 'layer';
                 const clazz = 'Oskari.mapframework.mapmodule.Tiles3DLayer';
@@ -144,7 +144,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.Tiles3DLayerPlugin',
                 if (tableContent.length === 0) {
                     return;
                 }
-                let content = [{ html: `<table>${tableContent}</table>` }];
+                const content = [{ html: `<table>${tableContent}</table>` }];
                 const location = me.getMapModule().getMouseLocation(movement.position);
                 // Request info box
                 const infoRequestBuilder = Oskari.requestBuilder('InfoBox.ShowInfoBoxRequest');
@@ -216,11 +216,11 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.Tiles3DLayerPlugin',
             // no-op - 3DTiles scale limits or runtime changes to config not supported at this time
         }
     }, {
-        'extend': ['Oskari.mapping.mapmodule.AbstractMapLayerPlugin'],
+        extend: ['Oskari.mapping.mapmodule.AbstractMapLayerPlugin'],
         /**
          * @static @property {string[]} protocol array of superclasses
          */
-        'protocol': [
+        protocol: [
             'Oskari.mapframework.module.Module',
             'Oskari.mapframework.ui.module.common.mapmodule.Plugin'
         ]

--- a/bundles/mapping/tiles3d/plugin/Tiles3DLayerPlugin.js
+++ b/bundles/mapping/tiles3d/plugin/Tiles3DLayerPlugin.js
@@ -186,18 +186,21 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.Tiles3DLayerPlugin',
             const url = ionAssetId
                 ? Cesium.IonResource.fromAssetId(ionAssetId, { server: ionAssetServer, accessToken: ionAccessToken })
                 : layer.getLayerUrl();
+
+            this.__addTileset(layer, url, options);
+        },
+        __addTileset: async function (layer, url, options = {}) {
             // Common settings for the dynamicScreenSpaceError optimization
             // copied from Cesium.Cesium3DTileset api doc:
             // https://cesium.com/docs/cesiumjs-ref-doc/Cesium3DTileset.html
-            var tileset = new Cesium.Cesium3DTileset({
-                url,
+            // https://cesium.com/learn/cesiumjs/ref-doc/Cesium3DTileset.html
+            const tileset = await Cesium.Cesium3DTileset.fromUrl(url, {
                 dynamicScreenSpaceError: true,
                 dynamicScreenSpaceErrorDensity: 0.00278,
                 dynamicScreenSpaceErrorFactor: 4.0,
                 dynamicScreenSpaceErrorHeightFalloff: 0.25,
                 ...options
             });
-
             this._disablePointCloudShadows(tileset);
             this._applyOskariStyle(tileset, layer);
             this.getMapModule().addLayer(tileset);


### PR DESCRIPTION
Fixes 3dtiles layers after Cesium update on #2406.

"Cesium3DTileset constructor parameter options.url, Cesium3DTileset.ready, and Cesium3DTileset.readyPromise have been removed. Use Cesium3DTileset.fromUrl instead."
From: https://github.com/CesiumGS/cesium/blob/1.123/CHANGES.md?plain=1#L538

Also documenting here that ol-cesium 2.20 declares peerDepency for ol 7-9 so we can't update to OpenLayers 10 at this point.

