### PR TITLE
Fix 3DTiles from Cesium ION by assetId

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,6 +37,9 @@ module.exports = (env, argv) => {
         .forEach(possibleSrcPath => {
             plugins.push(new CopywebpackPlugin([
                 { from: path.join(__dirname, possibleSrcPath, '../Source/Assets'), to: cesiumTarget + '/Assets' },
+                // This is not available under Build folder:
+                // - oskari-frontend/node_modules/@cesium/engine/Source/ThirdParty/draco_decoder.wasm
+                { from: path.join(__dirname, possibleSrcPath, '../Source/ThirdParty'), to: cesiumTarget + '/ThirdParty' },
                 { from: path.join(__dirname, possibleSrcPath, 'Workers'), to: cesiumTarget + '/Workers' },
                 // { from: path.join(__dirname, possibleSrcPath, 'Widgets'), to: cesiumTarget + '/Widgets' },
                 // copy Cesium's minified third-party scripts


### PR DESCRIPTION
Continuing #2718 and #2406 to fix using 

Shovels in some cesium wasm pieces (https://github.com/CesiumGS/cesium/tree/1.120/packages/engine/Source/ThirdParty) and uses await to wait resolving the URL by assetId before passing it to tileset.

Before the change things began to break with "TypeError: ni.createIfNeeded(...).fetchJson is not a function" 