### PR TITLE
Small fixes

### DIFF
--- a/bundles/mapping/mapmodule/publisher/layers/MapLayerListTool.js
+++ b/bundles/mapping/mapmodule/publisher/layers/MapLayerListTool.js
@@ -8,7 +8,7 @@ class MapLayerListTool extends AbstractPublisherTool {
     constructor (...args) {
         super(...args);
         this.index = 5;
-        this.group = 'additional';
+        this.group = 'layers';
         this.handler = new MapLayerListHandler(this);
     }
 


### PR DESCRIPTION
Fix MapLayerListTool publisher group

BackgroundLayerSelectionPlugin renders content before all layers are available => props validation warning on missing title. First added `|| ''` after `getName` but it's not nice to render empty buttons even for short time. Refactored to use filtered (title) list for render.