### PR TITLE
Oskari-ui themed slider and button

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Scale.jsx
@@ -19,20 +19,6 @@ const FieldLabel = styled('div')`
     padding-bottom: 5px;
 `;
 
-const ScaleSlider = styled(Slider)`
-    .ant-slider-track {
-        background-color: #0091ff;
-    }
-    .ant-slider-mark-text {
-        padding-bottom: 3px;
-        white-space: nowrap;
-        font-size: 11px;
-    }
-    &:hover .ant-slider-track {
-        background-color: #003fc3 !important;
-    }
-`;
-
 const SliderContainer = styled('div')`
     height: 200px;
     padding-top: 15px;
@@ -104,7 +90,7 @@ const Scale = ({ layer, scales = [], controller, getMessage }) => {
                 onChange={value => controller.setMinAndMaxScale([minscale, value])} />
             <PlusIcon />
             <SliderContainer>
-                <ScaleSlider
+                <Slider
                     vertical
                     range
                     reversed

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/TimeSeries/TimeSeriesMetadataToggleLevel.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/TimeSeries/TimeSeriesMetadataToggleLevel.jsx
@@ -9,10 +9,6 @@ const SliderContainer = styled('div')`
     padding-right: 15px;
     padding-top: 10px;
     padding-bottom: 10px;
-
-    .ant-slider-mark-text {
-        font-size: 11px;
-    }
 `;
 
 export const TimeSeriesMetadataToggleLevel = ({ layer, disabled, scales, controller }) => {

--- a/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/Footer/OpacitySlider.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/LayerBox/Footer/OpacitySlider.jsx
@@ -1,9 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { InputGroup } from 'oskari-ui';
+import { InputGroup, Opacity } from 'oskari-ui';
 import { Timeout } from 'oskari-ui/util';
-import { Opacity } from 'oskari-ui';
 
 const OPACITY_EVENT_FIRING_DELAY = 100;
 

--- a/bundles/framework/publisher2/view/PanelLayout.js
+++ b/bundles/framework/publisher2/view/PanelLayout.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { PanelToolStyles } from './PanelToolStyles';
+import { ThemeProvider } from 'oskari-ui/util';
 /**
  * @class Oskari.mapframework.bundle.publisher.view.PanelToolLayout
  *
@@ -130,11 +131,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelLayout',
             contentPanel.append(styleEditor);
 
             ReactDOM.render(
-                <PanelToolStyles
-                    mapTheme={this.mapModule.getMapTheme()}
-                    changeTheme={(theme) => this.updateTheme(theme)}
-                    fonts={this.fonts}
-                />,
+                <ThemeProvider>
+                    <PanelToolStyles
+                        mapTheme={this.mapModule.getMapTheme()}
+                        changeTheme={(theme) => this.updateTheme(theme)}
+                        fonts={this.fonts}/>
+                </ThemeProvider>,
                 styleEditor[0]
             );
 

--- a/bundles/framework/publisher2/view/PanelToolStyles.jsx
+++ b/bundles/framework/publisher2/view/PanelToolStyles.jsx
@@ -21,18 +21,12 @@ const StyledColorPicker = styled('div')`
     width: 165px;
 `;
 
-const StyledSlider = styled(Slider)`
+const SliderContainer = styled('div')`
     width: 285px;
-    margin: 0 15px 0 5px;
-    .ant-slider-track {
-        background-color: #0091ff;
-    }
-    &:hover .ant-slider-track {
-        background-color: #003fc3 !important;
-    }
+    margin-left: 5px;
 `;
 
-const SliderContainer = styled('div')`
+const ButtonRounding = styled('div')`
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -46,6 +40,7 @@ const StyledNumberInput = styled(NumberInput)`
 const NumberInputContainer = styled('div')`
     display: flex;
     flex-direction: row;
+    margin-left: 15px;
 `;
 
 const NumberSuffix = styled('span')`
@@ -186,11 +181,12 @@ export const PanelToolStyles = ({ mapTheme, changeTheme, fonts }) => {
             </Field>
             <Field>
                 <Message bundleKey={BUNDLE_KEY} messageKey='BasicView.layout.fields.buttonRounding' />
-                <SliderContainer>
-                    <StyledSlider
-                        value={buttonRounding}
-                        onChange={val => setButtonRounding(val)}
-                    />
+                <ButtonRounding>
+                    <SliderContainer>
+                        <Slider noMargin
+                            value={buttonRounding}
+                            onChange={val => setButtonRounding(val)}/>
+                    </SliderContainer>
                     <NumberInputContainer>
                         <StyledNumberInput
                             min={0}
@@ -202,7 +198,7 @@ export const PanelToolStyles = ({ mapTheme, changeTheme, fonts }) => {
                             %
                         </NumberSuffix>
                     </NumberInputContainer>
-                </SliderContainer>
+                </ButtonRounding>
             </Field>
             <Field>
                 <Message bundleKey={BUNDLE_KEY} messageKey='BasicView.layout.fields.effect' />

--- a/bundles/mapping/time-control-3d/view/TimeControl3d.jsx
+++ b/bundles/mapping/time-control-3d/view/TimeControl3d.jsx
@@ -4,6 +4,7 @@ import { Controller } from 'oskari-ui/util';
 import styled from 'styled-components';
 import { TimeControl } from './TimeControl3d/TimeControl';
 import { DateControl } from './TimeControl3d/DateControl';
+import { Divider } from './TimeControl3d/styled';
 import { validateDate, validateTime } from '../../mapmodule/util/time';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
@@ -130,6 +131,7 @@ export const TimeControl3d = ({ controller, date, time, isMobile }) => {
                 dateValue={dateValue}
                 currentTimeHandler={changeTimeAndDate}
             />
+            <Divider />
             <TimeControl
                 isMobile={isMobile}
                 changeHandler={changeTime}

--- a/bundles/mapping/time-control-3d/view/TimeControl3d/DateControl.jsx
+++ b/bundles/mapping/time-control-3d/view/TimeControl3d/DateControl.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Message, Slider } from 'oskari-ui';
+import { Message, ThemedSlider } from 'oskari-ui';
 import { Row, Col, StyledButton, DateSliderContainer, CalendarIcon, ColFixed } from './styled';
-import { ThemeConsumer } from 'oskari-ui/util';
-import { getHeaderTheme } from 'oskari-ui/theme';
 import { Input } from './Input';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
@@ -14,10 +12,7 @@ dayjs.extend(customParseFormat);
  */
 const DAYS = 365;
 
-export const DateControl = ThemeConsumer(({ theme, isMobile, changeHandler, sliderDateValue, dateValue, currentTimeHandler }) => {
-    const helper = getHeaderTheme(theme);
-    const color = helper.getAccentColor();
-    const hover = Oskari.util.getColorEffect(color, 30);
+export const DateControl = ({ isMobile, changeHandler, sliderDateValue, dateValue, currentTimeHandler }) => {
     const changeSliderDate = (val) => {
         const d = new Date(2019, 0, val);
         const timeToSet = dayjs(d).format('D/M');
@@ -54,9 +49,8 @@ export const DateControl = ThemeConsumer(({ theme, isMobile, changeHandler, slid
             {!isMobile &&
                 <ColFixed>
                     <DateSliderContainer>
-                        <Slider
+                        <ThemedSlider
                             noMargin
-                            theme={theme}
                             marks={marksForDate()}
                             min={1} max={DAYS} step={1}
                             value={sliderDateValue}
@@ -66,13 +60,13 @@ export const DateControl = ThemeConsumer(({ theme, isMobile, changeHandler, slid
                 </ColFixed>
             }
             <Col>
-                <StyledButton hover={hover} color={color} onClick={setCurrentTime}>
+                <StyledButton onClick={setCurrentTime}>
                     <Message messageKey={'present'} />
                 </StyledButton>
             </Col>
         </Row>
     );
-});
+};
 
 DateControl.propTypes = {
     isMobile: PropTypes.bool.isRequired,

--- a/bundles/mapping/time-control-3d/view/TimeControl3d/DateControl.jsx
+++ b/bundles/mapping/time-control-3d/view/TimeControl3d/DateControl.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Message } from 'oskari-ui';
-import { Row, Col, ColFixed, StyledButton, StyledDateSlider, CalendarIcon } from './styled';
+import { Message, Slider } from 'oskari-ui';
+import { Row, Col, StyledButton, DateSliderContainer, CalendarIcon, ColFixed } from './styled';
 import { ThemeConsumer } from 'oskari-ui/util';
 import { getHeaderTheme } from 'oskari-ui/theme';
 import { Input } from './Input';
@@ -53,14 +53,16 @@ export const DateControl = ThemeConsumer(({ theme, isMobile, changeHandler, slid
             </Col>
             {!isMobile &&
                 <ColFixed>
-                    <StyledDateSlider
-                        color={color}
-                        hover={hover}
-                        marks={marksForDate()}
-                        min={1} max={DAYS} step={1}
-                        value={sliderDateValue}
-                        onChange={changeSliderDate}
-                        tooltip={{ open: false }}/>
+                    <DateSliderContainer>
+                        <Slider
+                            noMargin
+                            theme={theme}
+                            marks={marksForDate()}
+                            min={1} max={DAYS} step={1}
+                            value={sliderDateValue}
+                            onChange={changeSliderDate}
+                            tooltip={{ open: false }}/>
+                    </DateSliderContainer>
                 </ColFixed>
             }
             <Col>

--- a/bundles/mapping/time-control-3d/view/TimeControl3d/Input.jsx
+++ b/bundles/mapping/time-control-3d/view/TimeControl3d/Input.jsx
@@ -2,19 +2,12 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { StyledInput } from './styled';
 
-export const Input = ({ value, changeHandler, children }) => {
-    const onChange = event => {
-        const val = event.target.value;
-        changeHandler(val);
-    };
-
-    return (
-        <Fragment>
-            { children }
-            <StyledInput value={value} onChange={onChange} />
-        </Fragment>
-    );
-};
+export const Input = ({ value, changeHandler, children }) => (
+    <Fragment>
+        { children }
+        <StyledInput value={value} onChange={(event) => changeHandler(event.target.value)} />
+    </Fragment>
+);
 
 Input.propTypes = {
     value: PropTypes.string.isRequired,

--- a/bundles/mapping/time-control-3d/view/TimeControl3d/TimeSlider.jsx
+++ b/bundles/mapping/time-control-3d/view/TimeControl3d/TimeSlider.jsx
@@ -1,16 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { InputGroup, Slider } from 'oskari-ui';
+import { InputGroup, ThemedSlider } from 'oskari-ui';
 import { TimeBorder, StyledPlayButton } from './styled';
 import { PlayButton } from './PlayButton';
-import { ThemeConsumer } from 'oskari-ui/util';
-import { getHeaderTheme } from 'oskari-ui/theme';
 
 const MINUTES = 1439;
-export const TimeSlider = ThemeConsumer(({ theme, isMobile, changeHandler, sliderTimeValue, playing, playHandler }) => {
-    const helper = getHeaderTheme(theme);
-    const color = helper.getAccentColor();
-    const hover = Oskari.util.getColorEffect(color, 30);
+export const TimeSlider = ({ isMobile, changeHandler, sliderTimeValue, playing, playHandler }) => {
     const clickPlayButton = () => {
         playHandler(!playing);
     };
@@ -30,13 +25,12 @@ export const TimeSlider = ThemeConsumer(({ theme, isMobile, changeHandler, slide
 
     return (
         <InputGroup block>
-            <StyledPlayButton onClick={clickPlayButton} hover={hover} color={color}>
+            <StyledPlayButton onClick={clickPlayButton}>
                 <PlayButton initial={playing} />
             </StyledPlayButton>
             <TimeBorder isMobile={isMobile}>
-                <Slider
+                <ThemedSlider
                     noMargin
-                    theme={theme}
                     useThick={isMobile}
                     marks={marksForTime}
                     min={0} max={MINUTES}
@@ -46,7 +40,7 @@ export const TimeSlider = ThemeConsumer(({ theme, isMobile, changeHandler, slide
             </TimeBorder>
         </InputGroup>
     );
-});
+};
 TimeSlider.propTypes = {
     isMobile: PropTypes.bool.isRequired,
     sliderTimeValue: PropTypes.number.isRequired,

--- a/bundles/mapping/time-control-3d/view/TimeControl3d/TimeSlider.jsx
+++ b/bundles/mapping/time-control-3d/view/TimeControl3d/TimeSlider.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { InputGroup } from 'oskari-ui';
-import { StyledTimeSlider, TimeBorder, StyledPlayButton } from './styled';
+import { InputGroup, Slider } from 'oskari-ui';
+import { TimeBorder, StyledPlayButton } from './styled';
 import { PlayButton } from './PlayButton';
 import { ThemeConsumer } from 'oskari-ui/util';
 import { getHeaderTheme } from 'oskari-ui/theme';
@@ -34,9 +34,9 @@ export const TimeSlider = ThemeConsumer(({ theme, isMobile, changeHandler, slide
                 <PlayButton initial={playing} />
             </StyledPlayButton>
             <TimeBorder isMobile={isMobile}>
-                <StyledTimeSlider
-                    color={color}
-                    hover={hover}
+                <Slider
+                    noMargin
+                    theme={theme}
                     useThick={isMobile}
                     marks={marksForTime}
                     min={0} max={MINUTES}

--- a/bundles/mapping/time-control-3d/view/TimeControl3d/styled.jsx
+++ b/bundles/mapping/time-control-3d/view/TimeControl3d/styled.jsx
@@ -1,8 +1,6 @@
 import styled from 'styled-components';
-import { Button, Slider, Select } from 'oskari-ui';
+import { Button, Select } from 'oskari-ui';
 import { CalendarOutlined, ClockCircleOutlined } from '@ant-design/icons';
-
-const thickSlider = 8; // default is 4
 
 export const CalendarIcon = styled(CalendarOutlined)`
     margin-right: 15px;
@@ -66,69 +64,7 @@ export const StyledPlayButton = styled(ThemedButton)`
     width: 40px;
 `;
 
-const StyledSlider = styled(Slider)`
-    &&& {
-        height: ${props => props.useThick ? 12 + thickSlider : 16}px;
-    }
-    .ant-slider-mark {
-        top: -21px;
-    }
-    .ant-slider-mark-text {
-        color: #ffffff;
-    }
-    .ant-slider-dot {
-        background: #3c3c3c;
-        border-radius: 0%;
-        border: 0;
-        margin-left: 0px;
-        width: 2px;
-        top: 0px;
-        height: ${props => props.useThick ? thickSlider : 4}px;
-    }
-    .ant-slider-dot:last-child {
-        margin-left: 0px;
-    }
-    .ant-slider-rail {
-        ${props => props.useThick ? 'height: ' + thickSlider + 'px;' : ''}
-        background: #ffffff !important;
-    }
-    .ant-slider-track {
-        ${props => props.useThick ? 'height: ' + thickSlider + 'px;' : ''}
-        background: ${props => props.color};
-    }
-    .ant-slider-handle {
-        top: -2px;
-        width: 8px;
-        height: ${props => props.useThick ? 12 + thickSlider : 16}px;
-        border-radius: 6px;
-        border: solid 1px #3c3c3c;
-        background-color: ${props => props.color} !important;
-
-        &:focus .ant-slider-track,
-        &:active .ant-slider-track,
-        &:hover .ant-slider-track {
-            background: ${props => props.hover} !important;
-        }
-        ::after {
-            display: none;
-        }
-    }
-    &:hover .ant-slider-track {
-        background: ${props => props.hover} !important;
-    }
-    &:hover .ant-slider-handle {
-        border: solid 1px #3c3c3c !important;
-        background-color: ${props => props.color} !important;
-    }
-`;
-
-export const StyledTimeSlider = styled(StyledSlider)`
-    &&& {
-        margin: 0px;
-    }
-`;
-
-export const StyledDateSlider = styled(StyledSlider)`
+export const DateSliderContainer = styled.div`
     width: 93%;
     margin-top: 20px;
 `;
@@ -155,6 +91,9 @@ export const ColFixed = styled.div`
     width: auto;
     max-width: 100%;
     position: relative;
+`;
+export const Divider = styled.div`
+    margin-bottom: 30px;
 `;
 export const TimeBorder = styled.div(({ isMobile }) => ({
     borderRadius: '4px',

--- a/bundles/mapping/time-control-3d/view/TimeControl3d/styled.jsx
+++ b/bundles/mapping/time-control-3d/view/TimeControl3d/styled.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Button, Select } from 'oskari-ui';
+import { ThemedButton, Select } from 'oskari-ui';
 import { CalendarOutlined, ClockCircleOutlined } from '@ant-design/icons';
 
 export const CalendarIcon = styled(CalendarOutlined)`
@@ -38,27 +38,14 @@ export const StyledInput = styled.input`
     text-align: center;
 `;
 
-const ThemedButton = styled(Button)`
-    background: ${props => props.color};
-    border: none;
-    font-size: 16px;
-    fill: currentColor;
-
-    &:focus,
-    &:active,
-    &&&:hover {
-        background: ${props => props.hover};
-        color: inherit;
-        border: none;
-    }
-`;
-
 export const StyledButton = styled(ThemedButton)`
+    font-size: 16px;
     width: 100%;
     height: 40px;
 `;
 
 export const StyledPlayButton = styled(ThemedButton)`
+    font-size: 16px;
     padding: 0;
     height: 42px;
     width: 40px;

--- a/bundles/statistics/statsgrid/components/classification/editclassification/EditClassification.jsx
+++ b/bundles/statistics/statsgrid/components/classification/editclassification/EditClassification.jsx
@@ -9,13 +9,9 @@ import { EditTwoTone } from '@ant-design/icons';
 import { getEditOptions } from '../../../helper/ClassificationHelper';
 import { LAYER_ID } from '../../../constants';
 
-// remove mark dots (.ant-slider-dot)
 const Container = styled.div`
     background-color: #fafafa;
     padding: 6px 12px;
-    .ant-slider-dot {
-        display: none;
-    }
 `;
 
 const MethodContainer = styled.div`
@@ -103,7 +99,7 @@ export const EditClassification = ({
             <Color values = {values} disabled = {disabled} colorsets = {options.colorsets} controller = {controller}/>
 
             <Message messageKey='classify.labels.transparency'/>
-            <Slider
+            <Slider hideDots
                 value = {opacity}
                 disabled = {disabled}
                 onChange = {onOpacityChange}

--- a/bundles/statistics/statsgrid/components/classification/editclassification/SizeSlider.jsx
+++ b/bundles/statistics/statsgrid/components/classification/editclassification/SizeSlider.jsx
@@ -43,7 +43,7 @@ export const SizeSlider = ({
     return (
         <div>
             <Message messageKey="classify.labels.pointSize"/>
-            <Slider
+            <Slider hideDots
                 value = {internalRange}
                 disabled = {disabled}
                 onChange={onChange}

--- a/bundles/statistics/statsgrid2016/components/classification/editclassification/EditClassification.jsx
+++ b/bundles/statistics/statsgrid2016/components/classification/editclassification/EditClassification.jsx
@@ -7,13 +7,9 @@ import { Color } from './Color';
 import { Checkbox, Message, Slider } from 'oskari-ui';
 import { EditTwoTone } from '@ant-design/icons';
 
-// remove mark dots (.ant-slider-dot)
 const Container = styled.div`
     background-color: #fafafa;
     padding: 6px 12px;
-    .ant-slider-dot {
-        display: none;
-    }
 `;
 
 const MethodContainer = styled.div`
@@ -98,7 +94,7 @@ export const EditClassification = ({
             <Color values = {values} disabled = {disabled} colorsets = {options.colorsets} controller = {controller}/>
 
             <Message messageKey='classify.labels.transparency'/>
-            <Slider
+            <Slider hideDots
                 value = {values.transparency}
                 disabled = {disabled}
                 onChange = {value => handleChange('transparency', value)}

--- a/bundles/statistics/statsgrid2016/components/classification/editclassification/SizeSlider.jsx
+++ b/bundles/statistics/statsgrid2016/components/classification/editclassification/SizeSlider.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Slider, Message } from 'oskari-ui';
-import styled from 'styled-components';
 
 // Overrride -50% translateX
 const SLIDER_PROPS = {
@@ -24,27 +23,6 @@ const SLIDER_PROPS = {
     }
 };
 
-const StyledSlider = styled(Slider)`
-    .ant-slider-track {
-        background-color: #0091ff;
-    }
-    .ant-slider-handle {
-        border: #0091ff solid 2px;
-        margin-top: -6px;
-    }
-    &:hover .ant-slider-track {
-        background-color: #003fc3 !important;
-    }
-    &:hover .ant-slider-handle {
-        border: #003fc3 solid 2px !important;
-    }
-    .ant-slider-dot {
-        width: 6px;
-        height: 6px;
-        left: 1px;
-    }
-`;
-
 export const SizeSlider = ({
     values,
     controller,
@@ -65,7 +43,7 @@ export const SizeSlider = ({
     return (
         <div>
             <Message messageKey="classify.labels.pointSize"/>
-            <StyledSlider
+            <Slider hideDots
                 value = {range}
                 disabled = {disabled}
                 onChange={onChange}

--- a/src/react/components/Button.jsx
+++ b/src/react/components/Button.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { Button as AntButton } from 'antd';
+import { ThemeConsumer } from 'oskari-ui/util';
+import { getNavigationTheme } from 'oskari-ui/theme';
 
 export const Button = ({ children, className, loading = false, ...other }) => {
     let modifiedClass = className || '';
@@ -11,5 +14,29 @@ export const Button = ({ children, className, loading = false, ...other }) => {
 };
 
 Button.propTypes = {
+    children: PropTypes.any
+};
+
+const StyledButton = styled(Button)`
+    background: ${props => props.theme.getAccent()};
+    border: none;
+    color: inherit;
+    fill: currentColor;
+
+    &:focus,
+    &:active,
+    &&&:hover {
+        background: ${props => props.theme.getAccentHover()};
+        color: inherit;
+        border: none;
+    }
+`;
+
+export const ThemedButton = ThemeConsumer(({ theme, children, ...other }) => {
+    return <StyledButton theme={getNavigationTheme(theme)} {...other}>{children}</StyledButton>;
+});
+
+ThemedButton.propTypes = {
+    theme: PropTypes.object.isRequired,
     children: PropTypes.any
 };

--- a/src/react/components/Opacity.jsx
+++ b/src/react/components/Opacity.jsx
@@ -8,12 +8,6 @@ const StyledSlider = styled('div')`
     width: 100%;
     padding: 0 10px 0 5px;
     float: left;
-    .ant-slider-track {
-        background-color: #0091ff;
-    }
-    &:hover .ant-slider-track {
-        background-color: #003fc3 !important;
-    }
     ${props => props.bordered && (
         `
             border-radius: 4px 0 0 4px;

--- a/src/react/components/Slider.jsx
+++ b/src/react/components/Slider.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Slider as AntSlider } from 'antd';
 import styled from 'styled-components';
+import { ThemeConsumer } from 'oskari-ui/util';
 import { getNavigationTheme, DEFAULT_COLORS } from 'oskari-ui/theme';
 
 const normal = 4;
@@ -43,26 +44,31 @@ const ThemedAntSlider = styled(AntSlider)`
         top: 0px;
         height: ${props => props.useThick ? thick : normal}px;
     }
+    &:hover .ant-slider-track,
+    &:hover .ant-slider-handle {
+        background-color: ${props => props.theme.getAccentHover()} !important;
+    }
 `;
 
 const getThemedStyle = (theme, vertical, useThick) => {
-    const width = vertical ? 'height' : 'width';
-    const height = vertical ?  'width' : 'height';
+    const handleSize = vertical ? 'height' : 'width';
+    const thickness = vertical ?  'width' : 'height';
+    const alignment = vertical ? 'left' : 'top';
     const size = useThick ? thick : normal;
     return {
         track: {
-            [height]: `${size}px`,
-            backgroundColor: theme.getButtonHoverColor()
+            [thickness]: `${size}px`,
+            backgroundColor: theme.getAccent()
         },
         rail: {
-            [height]: `${size}px`,
+            [thickness]: `${size}px`,
             backgroundColor: theme.getTextColor()
         },
         handle: {
-            backgroundColor: theme.getButtonHoverColor(),
-            [width]: '8px',
-            [height]: `${size + handler}px`,
-            top: '-2px',
+            backgroundColor: theme.getAccent(),
+            [handleSize]: '8px',
+            [thickness]: `${size + handler}px`,
+            [alignment]: '-2px',
             borderRadius: '6px',
             border: 'solid 1px #3c3c3c'
         }
@@ -70,10 +76,11 @@ const getThemedStyle = (theme, vertical, useThick) => {
 };
 
 export const Slider = ({ theme, useThick, vertical, ...rest }) => {
-    if (!theme) {
-        return <StyledAntSlider vertical= {vertical} {...rest} />
-    }
+    return <StyledAntSlider vertical= {vertical} {...rest} />
+};
+
+export const ThemedSlider = ThemeConsumer(({ theme, useThick, vertical, ...rest }) => {
     const helper = getNavigationTheme(theme);
     const style = getThemedStyle(helper, vertical, useThick);
     return <ThemedAntSlider styles={style} theme={helper} useThick={useThick} vertical={vertical} {...rest} />
-};
+});

--- a/src/react/components/Slider.jsx
+++ b/src/react/components/Slider.jsx
@@ -40,9 +40,9 @@ const ThemedAntSlider = styled(AntSlider)`
     .ant-slider-dot {
         background: #3c3c3c;
         border: none;
-        width: 2px;
         top: 0px;
-        height: ${props => props.useThick ? thick : normal}px;
+        ${props => props.vertical ? 'height': 'width'}: 2px;
+        ${props => props.vertical ? 'width': 'height'}: ${props => props.useThick ? thick : normal}px;
     }
     &:hover .ant-slider-track,
     &:hover .ant-slider-handle {

--- a/src/react/components/Slider.jsx
+++ b/src/react/components/Slider.jsx
@@ -1,29 +1,35 @@
 import React from 'react';
 import { Slider as AntSlider } from 'antd';
 import styled from 'styled-components';
-import { getNavigationTheme } from 'oskari-ui/theme';
+import { getNavigationTheme, DEFAULT_COLORS } from 'oskari-ui/theme';
 
 const normal = 4;
 const thick = 8;
 const handler = 12;
+const hover = DEFAULT_COLORS.SLIDER_HOVER;
 
-// TODO colors should come from theme-variables
 const StyledAntSlider = styled(AntSlider)`
-    &.ant-slider-vertical {
-        .ant-slider-handle {
-            margin-bottom: 0;
-        }
-        .ant-slider-mark {
-            top: 2px;
-        }
+    .ant-slider-mark-text {
+        white-space: nowrap;
+        font-size: 11px;
     }
+    .ant-slider-dot {
+        ${props => props.hideDots ? 'display: none;' : ''}
+    }
+    &:hover .ant-slider-handle::after {
+        box-shadow: 0 0 0 2px ${hover};
+    }
+    ${props => props.noMargin ? 'margin: 0;' : ''}
+
 `;
+
 const ThemedAntSlider = styled(StyledAntSlider)`
     .ant-slider-mark {
         top: -21px;
     }
     .ant-slider-mark-text {
         color: ${props => props.theme.getTextColor()};
+        font-size: 11px;
     }
     .ant-slider-handle::after {
         display: none;
@@ -44,11 +50,11 @@ const getThemedStyle = (theme, vertical, useThick) => {
     return {
         track: {
             [height]: `${size}px`,
-            background: theme.getButtonHoverColor()
+            backgroundColor: theme.getButtonHoverColor()
         },
         rail: {
             [height]: `${size}px`,
-            background: theme.getTextColor()
+            backgroundColor: theme.getTextColor()
         },
         handle: {
             backgroundColor: theme.getButtonHoverColor(),
@@ -64,8 +70,8 @@ const getThemedStyle = (theme, vertical, useThick) => {
 export const Slider = ({ theme, useThick, vertical, ...props }) => {
     if (theme) {
         const helper = getNavigationTheme(theme);
-        const styles = getThemedStyle(helper, vertical, useThick);
-        return <ThemedAntSlider styles={styles} theme={helper} useThick={useThick} {...props} />
+        const style = getThemedStyle(helper, vertical, useThick);
+        return <ThemedAntSlider styles={style} theme={helper} useThick={useThick} {...props} />
     }
-    return <StyledAntSlider {...props} />
+    return <StyledAntSlider styles={style} vertical= {vertical} {...props} />
 };

--- a/src/react/components/Slider.jsx
+++ b/src/react/components/Slider.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { Slider as AntSlider } from 'antd';
 import styled from 'styled-components';
+import { getNavigationTheme } from 'oskari-ui/theme';
+
+const normal = 4;
+const thick = 8;
+const handler = 12;
 
 // TODO colors should come from theme-variables
 const StyledAntSlider = styled(AntSlider)`
@@ -13,7 +18,54 @@ const StyledAntSlider = styled(AntSlider)`
         }
     }
 `;
+const ThemedAntSlider = styled(StyledAntSlider)`
+    .ant-slider-mark {
+        top: -21px;
+    }
+    .ant-slider-mark-text {
+        color: ${props => props.theme.getTextColor()};
+    }
+    .ant-slider-handle::after {
+        display: none;
+    }
+    .ant-slider-dot {
+        background: #3c3c3c;
+        border: none;
+        width: 2px;
+        top: 0px;
+        height: ${props => props.useThick ? thick : normal}px;
+    }
+`;
 
-export const Slider = (props) => (
-    <StyledAntSlider {...props} />
-);
+const getThemedStyle = (theme, vertical, useThick) => {
+    const width = vertical ? 'height' : 'width';
+    const height = vertical ?  'width' : 'height';
+    const size = useThick ? thick : normal;
+    return {
+        track: {
+            [height]: `${size}px`,
+            background: theme.getButtonHoverColor()
+        },
+        rail: {
+            [height]: `${size}px`,
+            background: theme.getTextColor()
+        },
+        handle: {
+            backgroundColor: theme.getButtonHoverColor(),
+            [width]: '8px',
+            [height]: `${size + handler}px`,
+            top: '-2px',
+            borderRadius: '6px',
+            border: 'solid 1px #3c3c3c'
+        }
+    };
+};
+
+export const Slider = ({ theme, useThick, vertical, ...props }) => {
+    if (theme) {
+        const helper = getNavigationTheme(theme);
+        const styles = getThemedStyle(helper, vertical, useThick);
+        return <ThemedAntSlider styles={styles} theme={helper} useThick={useThick} {...props} />
+    }
+    return <StyledAntSlider {...props} />
+};

--- a/src/react/components/Slider.jsx
+++ b/src/react/components/Slider.jsx
@@ -9,6 +9,7 @@ const handler = 12;
 const hover = DEFAULT_COLORS.SLIDER_HOVER;
 
 const StyledAntSlider = styled(AntSlider)`
+    ${props => props.noMargin ? 'margin: 0;' : ''}
     .ant-slider-mark-text {
         white-space: nowrap;
         font-size: 11px;
@@ -19,13 +20,14 @@ const StyledAntSlider = styled(AntSlider)`
     &:hover .ant-slider-handle::after {
         box-shadow: 0 0 0 2px ${hover};
     }
-    ${props => props.noMargin ? 'margin: 0;' : ''}
-
 `;
 
-const ThemedAntSlider = styled(StyledAntSlider)`
+const ThemedAntSlider = styled(AntSlider)`
+    &&& {
+        ${props => props.noMargin ? 'margin: 0;' : ''}
+    }
     .ant-slider-mark {
-        top: -21px;
+        ${props => props.vertical ? '' : 'top: -18px;'}
     }
     .ant-slider-mark-text {
         color: ${props => props.theme.getTextColor()};
@@ -67,11 +69,11 @@ const getThemedStyle = (theme, vertical, useThick) => {
     };
 };
 
-export const Slider = ({ theme, useThick, vertical, ...props }) => {
-    if (theme) {
-        const helper = getNavigationTheme(theme);
-        const style = getThemedStyle(helper, vertical, useThick);
-        return <ThemedAntSlider styles={style} theme={helper} useThick={useThick} {...props} />
+export const Slider = ({ theme, useThick, vertical, ...rest }) => {
+    if (!theme) {
+        return <StyledAntSlider vertical= {vertical} {...rest} />
     }
-    return <StyledAntSlider styles={style} vertical= {vertical} {...props} />
+    const helper = getNavigationTheme(theme);
+    const style = getThemedStyle(helper, vertical, useThick);
+    return <ThemedAntSlider styles={style} theme={helper} useThick={useThick} vertical={vertical} {...rest} />
 };

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -3,7 +3,7 @@ import 'antd/dist/reset.css';
 
 export { Alert } from './components/Alert';
 export { Badge } from './components/Badge';
-export { Button } from './components/Button';
+export { Button, ThemedButton } from './components/Button';
 export { Checkbox } from './components/Checkbox';
 export { Collapse, Panel as CollapsePanel } from './components/Collapse';
 export { Confirm } from './components/Confirm';
@@ -18,7 +18,7 @@ export { Popover } from './components/Popover';
 export { Radio } from './components/Radio';
 export { SearchInput } from './components/SearchInput';
 export { Select, Option } from './components/Select';
-export { Slider } from './components/Slider';
+export { Slider, ThemedSlider } from './components/Slider';
 export { Space } from './components/Space';
 export { Spin } from './components/Spin';
 export { Steps } from './components/Steps';

--- a/src/react/theme/ThemeHelper.js
+++ b/src/react/theme/ThemeHelper.js
@@ -54,6 +54,7 @@ export const getAntdTheme = (theme) => {
 
 export const getNavigationTheme = (theme) => {
     const primary = theme.navigation?.color?.primary || DEFAULT_COLORS.DARK_BUTTON_BG;
+    const accent = theme.navigation?.color?.accent || theme.color.accent || DEFAULT_COLORS.ACCENT;
     const textColor = getTextColor(primary);
     let borderRadius = 0;
     if (theme?.navigation?.roundness) {
@@ -68,9 +69,11 @@ export const getNavigationTheme = (theme) => {
     }
     const funcs = {
         getPrimary: () => primary,
+        getAccent: () => accent,
+        getAccentHover: () => Oskari.util.getColorEffect(accent, 30),
         getTextColor: () => theme.navigation?.color?.text || textColor,
         getButtonColor: () => buttonColor,
-        getButtonHoverColor: () => theme.navigation?.color?.accent || theme.color.accent || DEFAULT_COLORS.ACCENT,
+        getButtonHoverColor: () => accent,
         // like 50%
         getButtonRoundness: () => `${borderRadius}%`,
         // like 0.5 for calc() usage

--- a/src/react/theme/ThemeHelper.js
+++ b/src/react/theme/ThemeHelper.js
@@ -30,6 +30,11 @@ export const getAntdTheme = (theme) => {
                 // colorFillContentHover: accentColor
                 // fixes an issue where close icon has white bg while hovering
                 colorBgContainer: 'inherit'
+            },
+            Slider: {
+                handleColor: DEFAULT_COLORS.SLIDER_BG,
+                trackBg: DEFAULT_COLORS.SLIDER_BG,
+                trackHoverBg: DEFAULT_COLORS.SLIDER_HOVER,
             }
         },
         token: {

--- a/src/react/theme/constants.js
+++ b/src/react/theme/constants.js
@@ -3,6 +3,8 @@ export const DEFAULT_COLORS = {
     HEADER_BG: '#fdf8d9',
     ACCENT: '#ffd400',
     // 141414 -> rgb(20,20,20)
-    DARK_BUTTON_BG: '#141414'
+    DARK_BUTTON_BG: '#141414',
+    SLIDER_BG: '#0091ff',
+    SLIDER_HOVER: '#003fc3'
 };
 export const DEFAULT_FONT = 'arial';


### PR DESCRIPTION
Add slider styling to common Slider and remove antd class styling from components. Use semantic styling and AntD theme to simplify color overrides.  For now only common Slider and ZoomSlider have AntD style overrides.

Add themed slider and button (accent color). Use them in TimeControl3D. 

Every component didn't have same color for Slider. For now every component gets same color from AntD theme if ThemeProvider is used

![image](https://github.com/user-attachments/assets/8592cb52-7e95-4891-affd-c93660d802a0)
