### PR TITLE
Fix getting url for preloading timeseries images

### DIFF
--- a/bundles/mapping/mapmodule/plugin/wmslayer/OskariImageWMS.js
+++ b/bundles/mapping/mapmodule/plugin/wmslayer/OskariImageWMS.js
@@ -5,6 +5,7 @@ export class OskariImageWMS extends olSourceImageWMS {
      * Return currently shown image url
      */
     getImageUrl () {
-        return this.image_.src_;
+        // WMSLayerPlugin sets up the load function that injects this value to image on updateLayerParams()
+        return this.image?._oskariGetMapUrl;
     }
 }

--- a/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/wmslayer/WmsLayerPlugin.ol.js
@@ -244,6 +244,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.WmsLayerPlugin',
                 if (typeof layerSource.getTileLoadFunction === 'function') {
                     var originalTileLoadFunction = new OskariTileWMS().getTileLoadFunction();
                     layerSource.setTileLoadFunction(function (image, src) {
+                        image._oskariGetMapUrl = src;
                         if (src.length >= 2048) {
                             me._imagePostFunction(image, src, proxyUrl);
                         } else {
@@ -255,6 +256,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.WmsLayerPlugin',
                 else if (typeof layerSource.getImageLoadFunction === 'function') {
                     var originalImageLoadFunction = new OskariImageWMS().getImageLoadFunction();
                     layerSource.setImageLoadFunction(function (image, src) {
+                        image._oskariGetMapUrl = src;
                         if (src.length >= 2048) {
                             me._imagePostFunction(image, src, proxyUrl);
                         } else {


### PR DESCRIPTION
Probably broke on the OpenLayers 7.x -> 9.x update on (#2406), most likely from this change in OpenLayers: https://github.com/openlayers/openlayers/commit/2522fd76be64dffa843e60652fccadb45a43763e