### PR TITLE
Remove onClick listeners from Message-tag, add debug mechanism that isn't active by default

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,13 +1,13 @@
-import IntlMessageFormat from 'intl-messageformat'
+import IntlMessageFormat from 'intl-messageformat';
 
 /**
  * Adds internalization support for Oskari
  */
 (function (O) {
-    var oskariLang = 'en';
-    var localizations = {};
-    var supportedLocales = null;
-    var log = Oskari.log('Oskari.deprecated');
+    let oskariLang = 'en';
+    const localizations = {};
+    let supportedLocales = null;
+    const log = Oskari.log('Oskari.deprecated');
     // FIXME: remove html from localization files to get rid of these!!
     // These are required by intl-messageformat as instructions for handling HTML-tags in locale strings
     const HTML_CONTEXT_VARIABLE_HANDLERS = {
@@ -76,10 +76,10 @@ import IntlMessageFormat from 'intl-messageformat'
      * @return {string[]} Supported languages
      */
     O.getSupportedLanguages = function () {
-        var langs = [];
-        var supported = O.getSupportedLocales();
-        var locale;
-        var i;
+        const langs = [];
+        const supported = O.getSupportedLocales();
+        let locale;
+        let i;
 
         for (i = 0; i < supported.length; i += 1) {
             locale = supported[i];
@@ -96,12 +96,12 @@ import IntlMessageFormat from 'intl-messageformat'
      * @return {string} Default language
      */
     O.getDefaultLanguage = function () {
-        var supported = O.getSupportedLocales();
+        const supported = O.getSupportedLocales();
 
         if (supported.length === 0) {
             return this.getLang();
         }
-        var locale = supported[0];
+        const locale = supported[0];
 
         if (locale.indexOf('_') !== -1) {
             return locale.substring(0, locale.indexOf('_'));
@@ -121,7 +121,7 @@ import IntlMessageFormat from 'intl-messageformat'
      * @param {string=} value Value
      *
      */
-    var setLocalization = function (lang, key, value) {
+    const setLocalization = function (lang, key, value) {
         if (lang === null || lang === undefined) {
             throw new TypeError(
                 'setLocalization(): Missing lang'
@@ -147,7 +147,7 @@ import IntlMessageFormat from 'intl-messageformat'
      */
     O.getLocalization = function (key, lang, fallbackToDefault) {
         log.deprecated('Oskari.getLocalization()', 'Use Oskari.getMsg() instead.');
-        var l = lang || oskariLang;
+        const l = lang || oskariLang;
         if (key === null || key === undefined) {
             throw new TypeError(
                 'getLocalization(): Missing key'
@@ -159,7 +159,7 @@ import IntlMessageFormat from 'intl-messageformat'
         if (localizations[l] && localizations[l][key]) {
             return localizations[l][key];
         } else {
-            var defaultLang = O.getDefaultLanguage();
+            const defaultLang = O.getDefaultLanguage();
             if (fallbackToDefault && localizations[defaultLang] && localizations[defaultLang][key]) {
                 return localizations[defaultLang][key];
             } else {
@@ -175,7 +175,7 @@ import IntlMessageFormat from 'intl-messageformat'
      *
      */
     O.registerLocalization = function (props, override) {
-        var p,
+        let p,
             pp,
             loc;
 
@@ -232,7 +232,7 @@ import IntlMessageFormat from 'intl-messageformat'
     // ------------------------------------------------
     // Decimal separators
     // ------------------------------------------------
-    var decimalSeparator;
+    let decimalSeparator;
 
     /**
      * @public @method setDecimalSeparator
@@ -265,7 +265,7 @@ import IntlMessageFormat from 'intl-messageformat'
         if (!lang) {
             lang = Oskari.getLang();
         }
-        var value = locale[lang];
+        let value = locale[lang];
         if (!value) {
             value = locale[Oskari.getDefaultLanguage()];
         }
@@ -279,14 +279,14 @@ import IntlMessageFormat from 'intl-messageformat'
         }
         return value;
     };
-    var intlCache = {};
-    function resolvePath(key, path) {
-        var ob = O.getLocalization(key);
-        var parts = path.split('.');
-        for (var i = 0; i < parts.length; i++) {
+    const intlCache = {};
+    function resolvePath (key, path) {
+        let ob = O.getLocalization(key);
+        const parts = path.split('.');
+        for (let i = 0; i < parts.length; i++) {
             ob = ob[parts[i]];
             if (!ob) {
-                if(i === parts.length-1 && ob === '') {
+                if (i === parts.length - 1 && ob === '') {
                     return ob;
                 }
                 return null;
@@ -295,19 +295,19 @@ import IntlMessageFormat from 'intl-messageformat'
         return ob;
     }
     O.getMsg = function (key, path, values) {
-        var message;
+        let message;
         if (!values) {
             message = resolvePath(key, path);
-            if(message === null) {
+            if (message === null) {
                 return path;
             }
             return message;
         }
-        var cacheKey = oskariLang + '_' + key + '_' + path;
-        var formatter = intlCache[cacheKey];
+        const cacheKey = oskariLang + '_' + key + '_' + path;
+        let formatter = intlCache[cacheKey];
         if (!formatter) {
             message = resolvePath(key, path);
-            if(message === null) {
+            if (message === null) {
                 return path;
             }
             formatter = new IntlMessageFormat(message, oskariLang);
@@ -316,11 +316,11 @@ import IntlMessageFormat from 'intl-messageformat'
         const htmlValues = {
             ...values,
             ...HTML_CONTEXT_VARIABLE_HANDLERS
-        }
+        };
         return formatter.format(htmlValues);
     };
     O.getNumberFormatter = function (fractionDigits) {
-        var opts;
+        let opts;
         if (typeof fractionDigits !== 'undefined') {
             opts = {
                 minimumFractionDigits: fractionDigits,
@@ -328,5 +328,5 @@ import IntlMessageFormat from 'intl-messageformat'
             };
         }
         return new Intl.NumberFormat(oskariLang, opts);
-    }
+    };
 }(Oskari));

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -270,7 +270,7 @@ import IntlMessageFormat from 'intl-messageformat';
             value = locale[Oskari.getDefaultLanguage()];
         }
         if (!value) {
-            for (var key in locale) {
+            for (const key in locale) {
                 if (locale[key]) {
                     // any locale will do at this point
                     return locale[key];
@@ -328,5 +328,12 @@ import IntlMessageFormat from 'intl-messageformat';
             };
         }
         return new Intl.NumberFormat(oskariLang, opts);
+    };
+    let _msgDebugMode = 'TBD';
+    O.isMsgDebugMode = function () {
+        if (_msgDebugMode === 'TBD') {
+            _msgDebugMode = Oskari.util.getRequestParam('msgDebugMode', false) === 'true';
+        }
+        return _msgDebugMode;
     };
 }(Oskari));

--- a/src/oskari.es6.js
+++ b/src/oskari.es6.js
@@ -9,17 +9,17 @@ import pkg from '../package.json';
 import { DOMHelper } from './oskari.dom.js';
 import { Customization } from './oskari.customization.js';
 
-let defaultSequence = new Sequence();
-let sequences = {};
+const defaultSequence = new Sequence();
+const sequences = {};
 // keep track of existing loggers
-let loggers = {};
+const loggers = {};
 
-let _urls= {};
+let _urls = {};
 function getUrl (key) {
     return _urls[key];
 }
 
-function encodeParams(params) {
+function encodeParams (params) {
     if (typeof params !== 'object') {
         return '';
     }
@@ -29,7 +29,7 @@ function encodeParams(params) {
         .join('&');
 }
 
-function appendQueryToURL(url, query) {
+function appendQueryToURL (url, query) {
     if (typeof query === 'undefined' || query === '') {
         return url;
     }
@@ -65,77 +65,76 @@ const Oskari = {
     dom: DOMHelper,
     seq: defaultSequence,
     getSeq (type) {
-        if(typeof type === 'undefined') {
+        if (typeof type === 'undefined') {
             return defaultSequence;
         } else if (!sequences[type]) {
             sequences[type] = new Sequence();
         }
         return sequences[type];
     },
-    log(name = 'Oskari') {
+    log (name = 'Oskari') {
         if (loggers[name]) {
             return loggers[name];
         }
-        var log = new Logger(name);
+        const log = new Logger(name);
         loggers[name] = log;
         return log;
     },
     urls: {
-            /**
-             * Oskari.urls.set({
-                  "map" : "https://my.map.com",
-                  "api": "https://api.map.com/action?",
-                  "login" :"https://my.map.com/login",
-                  "register" :"http://some.auth.site.com/register",
-                  "tou" :"http://my.organization/map/tou",
-                });
-                OR
-                Oskari.urls.set('login', 'https://my.map.com/login');
-             */
-            set: function (urlsOrKey, optionalValue) {
-                if (typeof urlsOrKey === 'string') {
-                    _urls[urlsOrKey] = optionalValue;
-                } else if (typeof urlsOrKey === 'object') {
-                    _urls = urlsOrKey || {};
-                } else {
-                    throw new Error('Unrecognized parameter for urls: ' + urlsOrKey);
-                }
-            },
-            /**
-             * Generic url "location" getter
-             * @param  {String} key type of url like "login" or "registration"
-             * @return {String} URL that points to requested functionality
-             */
-            getLocation: function (key) {
-                return getUrl(key);
-            },
-            /**
-             * Action route urls
-             * @param  {String} route optional route name. Returns base url if name is not given.
-             * @param  {Object} optionalParams optional object that will be encoded as querystring parameters for the URL.
-             * @return {String} url to use when making API calls
-             */
-            getRoute: function (route, optionalParams) {
-                var url = appendQueryToURL(getUrl('api') || '/action?', encodeParams(optionalParams));
-
-                if (route) {
-                    return appendQueryToURL(url, 'action_route=' + route);
-                }
-                return url;
-            },
-            /**
-             * Builds an URL by attaching optional parameters to base url
-             * @param {String} url complete baseUrl that might already have querystring
-             * @param {*} optionalParams parameters that should be attached to baseUrl
-             * @returns base url with optional params included as querystring
-             */
-            buildUrl: function (url, optionalParams) {
-                return appendQueryToURL(url, encodeParams(optionalParams));
+        /**
+         * Oskari.urls.set({
+                 "map" : "https://my.map.com",
+                "api": "https://api.map.com/action?",
+                "login" :"https://my.map.com/login",
+                "register" :"http://some.auth.site.com/register",
+                "tou" :"http://my.organization/map/tou",
+            });
+            OR
+            Oskari.urls.set('login', 'https://my.map.com/login');
+            */
+        set: function (urlsOrKey, optionalValue) {
+            if (typeof urlsOrKey === 'string') {
+                _urls[urlsOrKey] = optionalValue;
+            } else if (typeof urlsOrKey === 'object') {
+                _urls = urlsOrKey || {};
+            } else {
+                throw new Error('Unrecognized parameter for urls: ' + urlsOrKey);
             }
+        },
+        /**
+         * Generic url "location" getter
+         * @param  {String} key type of url like "login" or "registration"
+         * @return {String} URL that points to requested functionality
+         */
+        getLocation: function (key) {
+            return getUrl(key);
+        },
+        /**
+         * Action route urls
+         * @param  {String} route optional route name. Returns base url if name is not given.
+         * @param  {Object} optionalParams optional object that will be encoded as querystring parameters for the URL.
+         * @return {String} url to use when making API calls
+         */
+        getRoute: function (route, optionalParams) {
+            const url = appendQueryToURL(getUrl('api') || '/action?', encodeParams(optionalParams));
+
+            if (route) {
+                return appendQueryToURL(url, 'action_route=' + route);
+            }
+            return url;
+        },
+        /**
+         * Builds an URL by attaching optional parameters to base url
+         * @param {String} url complete baseUrl that might already have querystring
+         * @param {*} optionalParams parameters that should be attached to baseUrl
+         * @returns base url with optional params included as querystring
+         */
+        buildUrl: function (url, optionalParams) {
+            return appendQueryToURL(url, encodeParams(optionalParams));
+        }
     }
 };
 
 window.Oskari = Oskari; // TODO: remove when whole of core is ES6
 
 export default Oskari;
-

--- a/src/react/components/Message.jsx
+++ b/src/react/components/Message.jsx
@@ -55,15 +55,18 @@ const Message = ({ bundleKey, messageKey, messageArgs, defaultMsg, getMessage, f
             return fallback;
         }
     }
-
+    const injectedProps = {};
+    if (Oskari.isMsgDebugMode()) {
+        injectedProps.onClick = () => Oskari.log('Message').debug(`Text clicked - ${bundleKey}: ${messageKey}`);
+    }
     if (allowHTML) {
-        return (<LabelComponent dangerouslySetInnerHTML={{ __html: message }}></LabelComponent>);
+        return (<LabelComponent dangerouslySetInnerHTML={{ __html: message }} { ...injectedProps }></LabelComponent>);
     }
 
     return (
         <LabelComponent
             allowTextEllipsis={allowTextEllipsis}
-            onClick={() => Oskari.log().debug(`Text clicked - ${bundleKey}: ${messageKey}`)}>
+            { ...injectedProps }>
             { message } { children }
         </LabelComponent>
     );
@@ -86,7 +89,7 @@ function getMessageUsingOskariGlobal (bundleKey, messageKey, messageArgs) {
         return Oskari.getMsg(bundleKey, messageKey, messageArgs);
     } catch (e) {
         // no locale provider OR bundleKey missing from locale provider
-        Oskari.log().warn(`Message tag used without LocaleProvider or bundleKey not provided when getting: ${messageKey}. Original error: ${e.message}`);
+        Oskari.log('Message').warn(`Message tag used without LocaleProvider or bundleKey not provided when getting: ${messageKey}. Original error: ${e.message}`);
     }
     return messageKey;
 }


### PR DESCRIPTION
Noticed that most localizations that are now shown on React-based UIs with Message-tag automatically add an onClick-listener. This was intended as a debug feature to locate localization keys.

This PR changes the Message tag so the listener is not automatically added. The Oskari global object now has a getter that checks if the debug mode should be active and Message-tags only attaches the listener when it's requested.

To activate debugging:

1) Open the page with `msgDebugMode=true` URL-param like `https://dev.oskari.org/?msgDebugMode=true`
- This makes Message tag add onClick listeners
2) Run in browser console: Oskari.log('Message').enableDebug(true);
- This makes Oskari.log() for 'Message' write the debug() level logging with console.debug()
3) Enable verbose logging on browser console:
- This makes messages logged with console.debug() visible on the console
![image](https://github.com/user-attachments/assets/76431790-9e60-496e-bc0b-b0df729e0af8)

4) Click on some element that has text (and is React-based/using the Message-tag)
-> console now shows a message like:
```
Message: Text clicked - oskariui: buttons.close
```
Where `oskariui` is the localization id (usually also corresponds to bundle id) and `buttons.close` is the localization key on that localization file.