### PR TITLE
announcements tools reactification

### DIFF
--- a/bundles/admin/admin-announcements/publisher/AnnouncementToolComponent.jsx
+++ b/bundles/admin/admin-announcements/publisher/AnnouncementToolComponent.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import { Message, Checkbox, Button } from 'oskari-ui';
+import styled from 'styled-components';
+
+const Col = styled('div')`
+    display: flex;
+    flex-direction: column;
+`;
+
+const SelectedAnnouncements = styled('div')`
+    display: flex;
+    flex-direction: column;
+    margin-top: 1em;
+`;
+
+const SelectedAnnouncementsTitle = styled('div')`
+    font-weight: bold;
+`;
+
+const SelectedAnnouncementsText = styled('div')`
+    font-style: italic;
+`;
+
+const SelectedAnnouncement = ({ announcement, lang }) => {
+    return <SelectedAnnouncementsText>{ Oskari.getLocalized(announcement.locale, lang)?.title }</SelectedAnnouncementsText>;
+};
+
+const SelectButton = styled(Button)`
+    margin-top: 0.5em;
+    width: 50%;
+`;
+
+SelectedAnnouncement.propTypes = {
+    announcement: PropTypes.object,
+    lang: PropTypes.string
+};
+
+export const AnnouncementToolComponent = ({ state, controller }) => {
+    const { noUI, announcements, selectedAnnouncements } = state;
+
+    return (
+        <Col>
+            <Checkbox checked={noUI} onChange={ evt => controller.setNoUI(evt.target.checked) }>
+                <Message bundleKey={'admin-announcements'} messageKey={'publisher.noUI'}/>
+            </Checkbox>
+
+            <SelectedAnnouncements>
+                <SelectedAnnouncementsTitle>{Oskari.getMsg('admin-announcements', 'publisher.selectedAnnouncementsTitle')}</SelectedAnnouncementsTitle>
+                { announcements
+                    .filter((ann) => selectedAnnouncements?.includes(ann.id))
+                    .map((announcement) => {
+                        return <SelectedAnnouncement key={ announcement.id } announcement={announcement} lang={state?.lang}/>;
+                    })
+                }
+            </SelectedAnnouncements>
+            <SelectButton onClick={() => controller.showPopup()}>
+                <Message bundleKey={'admin-announcements'} messageKey={'tool.buttonLabel'}/>
+            </SelectButton>
+
+        </Col>);
+};
+
+AnnouncementToolComponent.propTypes = {
+    state: PropTypes.object,
+    controller: PropTypes.object
+};

--- a/bundles/admin/admin-announcements/publisher/AnnouncementToolComponent.jsx
+++ b/bundles/admin/admin-announcements/publisher/AnnouncementToolComponent.jsx
@@ -46,7 +46,7 @@ export const AnnouncementToolComponent = ({ state, controller }) => {
             </Checkbox>
 
             <SelectedAnnouncements>
-<Message LabelComponent={SelectedAnnouncementsTitle} bundleKey={'admin-announcements'} messageKey={'publisher.selectedAnnouncementsTitle'} />
+                <Message LabelComponent={SelectedAnnouncementsTitle} bundleKey={'admin-announcements'} messageKey={'publisher.selectedAnnouncementsTitle'} />
                 { announcements
                     .filter((ann) => selectedAnnouncements?.includes(ann.id))
                     .map((announcement) => {

--- a/bundles/admin/admin-announcements/publisher/AnnouncementToolComponent.jsx
+++ b/bundles/admin/admin-announcements/publisher/AnnouncementToolComponent.jsx
@@ -46,7 +46,7 @@ export const AnnouncementToolComponent = ({ state, controller }) => {
             </Checkbox>
 
             <SelectedAnnouncements>
-                <SelectedAnnouncementsTitle>{Oskari.getMsg('admin-announcements', 'publisher.selectedAnnouncementsTitle')}</SelectedAnnouncementsTitle>
+<Message LabelComponent={SelectedAnnouncementsTitle} bundleKey={'admin-announcements'} messageKey={'publisher.selectedAnnouncementsTitle'} />
                 { announcements
                     .filter((ann) => selectedAnnouncements?.includes(ann.id))
                     .map((announcement) => {

--- a/bundles/admin/admin-announcements/publisher/AnnouncementsPopup.jsx
+++ b/bundles/admin/admin-announcements/publisher/AnnouncementsPopup.jsx
@@ -1,0 +1,103 @@
+import { showPopup } from 'oskari-ui/components/window';
+import React from 'react';
+import { Checkbox, Message, WarningIcon } from 'oskari-ui';
+import styled from 'styled-components';
+import { getDateRange, isOutdated } from '../../../framework/announcements/service/util';
+import { PrimaryButton } from 'oskari-ui/components/buttons';
+
+const PopupContentContainer = styled('div')`
+    margin: 1em;
+    width: 25vw;
+    display: flex;
+    flex-direction: column;
+`;
+
+const Disclaimer = styled('div')`
+    margin-bottom: 1em;
+    flex-grow: 0;
+`;
+
+const PopupContent = styled('div')`
+    flex-grow: 1;
+    max-height: 50vh;
+    overflow-y: auto;
+`;
+
+const Footer = styled('div')`
+    flex-grow: 0;
+    margin: 0 auto;
+`;
+
+const Row = styled('div')`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+`;
+
+const ColHeading = styled('div')`
+    font-weight: bold;
+`;
+
+const Col = styled('div')`
+`;
+
+const getContent = (state, controller, onClose) => {
+    const { announcements, selectedAnnouncements, lang } = state;
+    /*
+    let { announcements } = state;
+    announcements = announcements.concat(announcements).concat(announcements).concat(announcements);
+    */
+    const title = <Message bundleKey='admin-announcements' messageKey='tool.popup.title'/>;
+
+    const content = <PopupContentContainer>
+        <Disclaimer>
+            <Message bundleKey='admin-announcements' messageKey='tool.popup.disclaimer'/>
+        </Disclaimer>
+        <PopupContent>
+            <Row>
+                <ColHeading>
+                    <Message bundleKey='admin-announcements' messageKey='tool.announcementsName'></Message>
+                </ColHeading>
+                <ColHeading>
+                    <Message bundleKey='admin-announcements' messageKey='tool.announcementsTime'></Message>
+                </ColHeading>
+            </Row>
+            {announcements.map((announcement) => {
+                const dateRange = getDateRange(announcement);
+                const daterangeOutdated = isOutdated(announcement);
+
+                return <Row key={announcement.id}>
+                    <Col>
+                        <Checkbox
+                            onChange={(e) => controller.updateSelectedAnnouncements(e.target.checked, announcement.id)}
+                            checked = { !daterangeOutdated && !!selectedAnnouncements?.includes(announcement.id)}
+                            disabled={daterangeOutdated}>
+                            {Oskari.getLocalized(announcement.locale, lang)?.title} {daterangeOutdated && <WarningIcon/>}
+                        </Checkbox>
+                    </Col>
+                    <Col>{dateRange}</Col>
+                </Row>;
+            })}
+        </PopupContent>
+        <Footer>
+            <PrimaryButton type={'close'} onClick={onClose}/>
+        </Footer>
+    </PopupContentContainer>;
+
+    return {
+        title,
+        content
+    };
+};
+
+export const showAnnouncementsPopup = (state, controller, onClose) => {
+    const { title, content } = getContent(state, controller, onClose);
+    const controls = showPopup(title, content, onClose, {});
+    return {
+        ...controls,
+        update: (state) => {
+            const { title, content } = getContent(state, controller, onClose);
+            controls.update(title, content);
+        }
+    };
+};

--- a/bundles/admin/admin-announcements/publisher/AnnouncementsTool.js
+++ b/bundles/admin/admin-announcements/publisher/AnnouncementsTool.js
@@ -1,320 +1,167 @@
 import { Messaging } from 'oskari-ui/util';
-import { getDateRange, isOutdated } from '../../../framework/announcements/service/util';
+import { AbstractPublisherTool } from '../../../framework/publisher2/tools/AbstractPublisherTool';
+import { AnnouncementToolComponent } from './AnnouncementToolComponent';
+import { AnnouncementsToolHandler } from './AnnouncementsToolHandler';
 
-Oskari.clazz.define('Oskari.admin.bundle.admin-announcements.publisher.AnnouncementsTool',
-    function () {
+class AnnouncementsTool extends AbstractPublisherTool {
+    constructor (...args) {
+        super(...args);
+        this.index = 1;
+        this.group = 'additional';
+        this.handler = new AnnouncementsToolHandler(this);
+
         this.sandbox = Oskari.getSandbox();
         this.lang = Oskari.getLang();
         this.localization = Oskari.getLocalization('admin-announcements');
-        this.announcements = {};
         this.allowedLocations = ['top left', 'top center', 'top right'];
         this.lefthanded = 'top right';
         this.righthanded = 'top left';
-        this.index = 8;
-        this.pluginName = 'AnnouncementsPlugin';
-        this.data = [];
-        this.selectedAnnouncements = [];
-        this.groupedSiblings = true;
-        this.announcementsPopup = null;
+    }
 
-        this.templates = {
-            announcements: jQuery(
-                '<div class="publisher-layout-announcements" class="tool-options">' +
-                    '<div>' +
-                        '<input type="text" name="publisher-announcements" disabled />' +
-                        '<button/>' +
-                    '</div>' +
-                '</div>'),
-            announcementsPopup: jQuery(
-                '<div>' +
-                    '<div class="publisher-announcements-disclaimer">' + this.localization.tool.popup.disclaimer + '</div>' +
-                    '<div class="publisher-announcements-inputs">' +
-                        '<h4>' + this.localization.tool.announcementsName + '</h4><h4>' + this.localization.tool.announcementsTime + '</h4>' +
-                        '<div class="ann-column ann-title"></div>' +
-                        '<div class="ann-column ann-time"/></div>' +
-                    '</div>' +
-                '</div>'),
-            inputCheckbox: jQuery('<div><input type="checkbox" name="announcement"/><label></label></div>')
-        };
-        this.noUI = false;
-    }, {
+    init (data) {
+        this.data = data;
+        const selectedAnnouncements = [];
+        this.noUI = data?.configuration?.announcements?.conf?.plugin?.config?.noUI === true;
+        const service = this.sandbox.getService('Oskari.framework.announcements.service.AnnouncementsService');
 
-        init: function (data) {
-            const me = this;
-            me.data = data;
-            me.selectedAnnouncements = [];
+        if (data?.configuration?.announcements?.conf?.plugin) {
+            const enabled = data.configuration.announcements.conf.plugin.id === this.getTool()?.id;
+            this.setEnabled(enabled);
 
-            me.noUI = data?.configuration?.announcements?.conf?.plugin?.config?.noUI === true;
-
-            const service = me.sandbox.getService('Oskari.framework.announcements.service.AnnouncementsService');
-
-            if (data.configuration && data.configuration.announcements && data.configuration.announcements.conf && data.configuration.announcements.conf.plugin) {
-                const myId = me.getTool().id;
-                const enabled = data.configuration.announcements.conf.plugin.id === myId;
-                me.setEnabled(enabled);
-            }
-
-            service.fetchAnnouncements((err, data) => {
-                if (err) {
-                    Messaging.error(this.localization.messages.getAdminAnnouncementsFailed);
-                    return;
-                }
-                me.announcements = data;
-                const toolPluginAnnouncementsConf = me._getToolPluginAnnouncementsConf();
-                if (toolPluginAnnouncementsConf !== null) {
-                    me.getPlugin().updateAnnouncements(toolPluginAnnouncementsConf.config.announcements);
-                    toolPluginAnnouncementsConf.config.announcements.forEach(announcementId => {
-                        const announcement = me.announcements.find(ann => ann.id === announcementId);
-                        if (announcement !== undefined && me.isAnnouncementValid(announcement)) {
-                            // make sure there are no duplicates
-                            const alreadyAdded = me.selectedAnnouncements.some(ann => ann.id === announcement.id);
-                            if (!alreadyAdded) {
-                                me.selectedAnnouncements.push(announcement);
-                            }
-                        }
-                    });
-                }
-                me.updateSelectedInput();
-            });
-        },
-        _setEnabledImpl: function (enabled) {
-            if (enabled && this.selectedAnnouncements) {
-                this.getPlugin().updateAnnouncements(this.selectedAnnouncements);
-            }
-        },
-
-        getName: function () {
-            return 'Oskari.framework.announcements.publisher.AnnouncementsTool';
-        },
-
-        /**
-         * Check if Announcement is inside the given timeframe
-         * @method @private isAnnouncementValid
-         * @param  {Object} announcement announcement
-         * @return {Boolean} true if announcement is valid
-         */
-        isAnnouncementValid: function (announcement) {
-            const announcementEnd = new Date(announcement.endDate);
-            const currentDate = new Date();
-            return currentDate.getTime() <= announcementEnd.getTime();
-        },
-
-        /**
-         * @method onEvent
-         * @param {Oskari.mapframework.event.Event} event a Oskari event object
-         * Event is handled forwarded to correct #eventHandlers if found or discarded if not.
-         */
-        onEvent: function (event) {
-            const handler = this.eventHandlers[event.getName()];
-            if (!handler) {
-                return;
-            }
-            return handler.apply(this, [event]);
-        },
-
-        /**
-        * Get tool object.
-        * @method getTool
-        *
-        * @returns {Object} tool description
-        */
-        getTool: function () {
-            return {
-                id: 'Oskari.framework.announcements.plugin.AnnouncementsPlugin',
-                title: 'AnnouncementsPlugin',
-                config: {}
-            };
-        },
-
-        /**
-        * Get extra options.
-        * @method getExtraOptions
-        * @public
-        *
-        * @returns {Object} jQuery element
-        */
-        getExtraOptions: function () {
-            const me = this;
-            const buttonLabel = me.localization.tool.buttonLabel;
-            const template = me.templates.announcements.clone();
-
-            // Set the button handler
-            template.find('button').html(buttonLabel).on('click', function () {
-                if (me.announcementsPopup === null) {
-                    me._openAnnouncementsDialog(jQuery(this));
-                }
-            });
-
-            const labelNoUI = me.localization.publisher.noUI;
-
-            var input = Oskari.clazz.create(
-                'Oskari.userinterface.component.CheckboxInput'
-            );
-
-            input.setTitle(labelNoUI);
-            input.setHandler(function (checked) {
-                if (checked === 'on') {
-                    me.noUI = true;
-                    me.getPlugin().teardownUI();
-                } else {
-                    me.noUI = false;
-                    me.getPlugin().redrawUI(Oskari.util.isMobile());
-                }
-            });
-
-            input.setChecked(me.noUI);
-
-            var inputEl = input.getElement();
-            if (inputEl.style) {
-                inputEl.style.width = 'auto';
-            }
-
-            template.append(inputEl);
-
-            return template;
-        },
-
-        /**
-         * Creates and opens the dialog from which to choose the announcements.
-         *
-         * @method _openAnnouncementsDialog
-         */
-        _openAnnouncementsDialog: function () {
-            const me = this;
-            const popup = Oskari.clazz.create('Oskari.userinterface.component.Popup');
-            const closeButton = Oskari.clazz.create('Oskari.userinterface.component.Button');
-            const title = me.localization.tool.popup.title;
-            const content = me.templates.announcementsPopup.clone();
-
-            closeButton.setTitle(me.localization.tool.popup.close);
-            closeButton.setHandler(function () {
-                popup.close(true);
-                me.announcementsPopup = null;
-            });
-
-            me.announcements.forEach(announcement => {
-                const { title } = Oskari.getLocalized(announcement.locale);
-                const dateRange = getDateRange(announcement);
-
-                const announcementInput = me.templates.inputCheckbox.clone();
-                const idPrefix = 'oskari_announcement_select_';
-                announcementInput.find('input[type=checkbox]').attr({
-                    id: idPrefix + announcement.id,
-                    value: announcement.id
-                });
-                announcementInput.find('label').html(title).attr({
-                    'for': idPrefix + announcement.id
-                });
-
-                if (isOutdated(announcement)) {
-                    content.find('div.ann-time').append('<div>' + dateRange + '<div class="icon-warning-light"></div></div>');
-                    announcementInput.find('input[type=checkbox]').prop('disabled', true);
-                    content.find('div.ann-title').append(announcementInput);
-                } else {
-                    content.find('div.ann-time').append('<div>' + dateRange + '</div>');
-                    me.selectedAnnouncements.forEach(ann => {
-                        if (ann.id === announcement.id) {
-                            announcementInput.find('input[type=checkbox]').prop('checked', true);
-                        }
-                    });
-                    content.find('div.ann-title').append(announcementInput);
-                }
-            });
-
-            // Announcement is selected
-            content.find('input[name=announcement]').on('change', function () {
-                const selectedId = parseInt(this.value);
-                const announcement = me.announcements.find(item => item.id === selectedId);
-                // check if announcement is already checked, if is, add/remove accordingly
-                if (!this.checked) {
-                    me.selectedAnnouncements = me.selectedAnnouncements.filter(function (ann) {
-                        return ann.id !== announcement.id;
-                    });
-                } else {
-                    me.selectedAnnouncements.push(announcement);
-                }
-                me.getPlugin().updateAnnouncements(me.selectedAnnouncements);
-                me.updateSelectedInput();
-            });
-
-            popup.show(title, content, [closeButton]);
-            me.announcementsPopup = popup;
-        },
-        // Shows user the currently selected announcement titles next to the tool (informative input/non-functional)
-        updateSelectedInput: function () {
-            jQuery('div.basic_publisher').find('input[name=publisher-announcements]').val(this.selectedAnnouncements.map(i => Oskari.getLocalized(i.locale, this.lang)?.title).toString());
-        },
-        /**
-         * @private @method _getToolPluginAnnouncementsConf
-         * @return {Object / null} config or null if not found
-         */
-        _getToolPluginAnnouncementsConf: function () {
-            var me = this;
-            var isConfig = !!((me.data && me.data.configuration));
-            var isPlugin = !!((isConfig && me.data.configuration.announcements &&
-            me.data.configuration.announcements.conf && me.data.configuration.announcements.conf.plugin));
-            var toolPlugin = null;
-            if (isPlugin) {
-                toolPlugin = me.data.configuration.announcements.conf.plugin;
-            }
-            return toolPlugin;
-        },
-
-        _getAnnouncementsSelection: function () {
-            const me = this;
-            const announcementsSelection = {};
-            var pluginValues = me.getPlugin().getSelectedAnnouncements();
-            if (pluginValues.announcements) {
-                announcementsSelection.announcements = pluginValues.announcements;
-            }
-            return announcementsSelection;
-        },
-
-        /**
-        * Get values.
-        * @method getValues
-        * @public
-        *
-        * @returns {Object} tool value object
-        */
-        getValues: function () {
-            const me = this;
-
-            if (!this.isEnabled()) {
-                return null;
-            }
-            const pluginConfig = { id: me.getTool().id, config: me.getPlugin().getConfig() };
-            const announcementsSelection = me._getAnnouncementsSelection();
-
-            if (announcementsSelection && !jQuery.isEmptyObject(announcementsSelection)) {
-                pluginConfig.config.announcements = announcementsSelection.announcements;
-            }
-
-            if (me.noUI) {
-                pluginConfig.config.noUI = me.noUI;
-            }
-
-            return {
-                configuration: {
-                    announcements: {
-                        conf: {
-                            plugin: pluginConfig
-                        }
-                    }
-                }
-            };
-        },
-
-        /**
-        * Stop _stopImpl.
-        * @method _stopImpl
-        */
-        _stopImpl: function () {
-            if (this.announcementsPopup) {
-                this.announcementsPopup.close(true);
+            const location = data?.configuration?.announcements?.conf?.plugin?.config?.location?.classes;
+            const plugin = this.getPlugin();
+            if (plugin && location) {
+                plugin.setLocation(location);
             }
         }
-    }, {
-        extend: ['Oskari.mapframework.publisher.tool.AbstractPluginTool'],
+
+        service.fetchAnnouncements((err, data) => {
+            if (err) {
+                Messaging.error(this.localization.messages.getAdminAnnouncementsFailed);
+                return;
+            }
+            const announcements = data;
+            const toolPluginAnnouncementsConf = this.getToolPluginAnnouncementsConf();
+            if (toolPluginAnnouncementsConf !== null) {
+                this.getPlugin().updateAnnouncements(toolPluginAnnouncementsConf.config.announcements);
+                toolPluginAnnouncementsConf.config.announcements.forEach(announcementId => {
+                    const announcement = announcements.find(ann => ann.id === announcementId);
+                    if (announcement !== undefined && this.isAnnouncementValid(announcement)) {
+                        // make sure there are no duplicates
+                        const alreadyAdded = selectedAnnouncements.some(ann => ann.id === announcement.id);
+                        if (!alreadyAdded) {
+                            selectedAnnouncements.push(announcement.id);
+                        }
+                    }
+                });
+            }
+
+            this.handler.init({
+                noUI: this.noUI,
+                announcements,
+                selectedAnnouncements
+            });
+        });
+    }
+
+    stop () {
+        this.handler.closePopup();
+        const plugin = this.getPlugin();
+        if (plugin) {
+            plugin.teardownUI();
+        }
+    }
+
+    getTool () {
+        return {
+            id: 'Oskari.framework.announcements.plugin.AnnouncementsPlugin',
+            title: Oskari.getMsg('admin-announcements', 'publisher.toolLabel'),
+            config: this.state.pluginConfig
+        };
+    }
+
+    getComponent () {
+        return {
+            component: AnnouncementToolComponent,
+            handler: this.handler
+        };
+    }
+
+    /**
+    * Get values.
+    * @method getValues
+    * @public
+    *
+    * @returns {Object} tool value object
+    */
+    getValues () {
+        if (!this.isEnabled()) {
+            return null;
+        }
+
+        const pluginConfig = { id: this.getTool().id, config: this.getPlugin().getConfig() };
+
+        const { noUI, selectedAnnouncements } = this.handler.getState();
+        if (noUI) {
+            pluginConfig.config.noUI = noUI;
+        }
+        pluginConfig.config.announcements = selectedAnnouncements;
+
+        return {
+            configuration: {
+                announcements: {
+                    conf: {
+                        plugin: pluginConfig
+                    }
+                }
+            }
+        };
+    }
+
+    /**
+     * @private @method _getToolPluginAnnouncementsConf
+     * @return {Object / null} config or null if not found
+     */
+    /*
+    getToolPluginAnnouncementsConf () {
+        const toolPlugin = !!this.data?.configuration?.announcements?.conf?.plugin || null;
+        return toolPlugin;
+    }
+        */
+
+    /**
+     * @private @method _getToolPluginAnnouncementsConf
+     * @return {Object / null} config or null if not found
+     */
+    getToolPluginAnnouncementsConf () {
+        const isConfig = !!((this.data && this.data.configuration));
+        const isPlugin = !!((isConfig && this.data?.configuration?.announcements?.conf?.plugin));
+        let toolPlugin = null;
+        if (isPlugin) {
+            toolPlugin = this.data.configuration.announcements.conf.plugin;
+        }
+        return toolPlugin;
+    }
+
+    /**
+     * Check if Announcement is inside the given timeframe
+     * @method @private isAnnouncementValid
+     * @param  {Object} announcement announcement
+     * @return {Boolean} true if announcement is valid
+     */
+    isAnnouncementValid (announcement) {
+        const announcementEnd = new Date(announcement.endDate);
+        const currentDate = new Date();
+        return currentDate.getTime() <= announcementEnd.getTime();
+    }
+}
+
+// Attach protocol to make this discoverable by Oskari publisher
+Oskari.clazz.defineES('Oskari.publisher.AnnouncementsTool',
+    AnnouncementsTool,
+    {
         protocol: ['Oskari.mapframework.publisher.Tool']
-    });
+    }
+);
+
+export { AnnouncementsTool };

--- a/bundles/admin/admin-announcements/publisher/AnnouncementsTool.js
+++ b/bundles/admin/admin-announcements/publisher/AnnouncementsTool.js
@@ -65,11 +65,8 @@ class AnnouncementsTool extends AbstractPublisherTool {
     }
 
     stop () {
+        super.stop();
         this.handler.closePopup();
-        const plugin = this.getPlugin();
-        if (plugin) {
-            plugin.teardownUI();
-        }
     }
 
     getTool () {

--- a/bundles/admin/admin-announcements/publisher/AnnouncementsToolHandler.js
+++ b/bundles/admin/admin-announcements/publisher/AnnouncementsToolHandler.js
@@ -1,0 +1,78 @@
+import { StateHandler, controllerMixin } from 'oskari-ui/util';
+import { showAnnouncementsPopup } from './AnnouncementsPopup';
+class UIHandler extends StateHandler {
+    constructor (tool) {
+        super();
+        this.tool = tool;
+
+        this.setState({
+            lang: Oskari.getLang(),
+            noUI: false,
+            announcements: [],
+            selectedAnnouncements: []
+        });
+    };
+
+    init (config) {
+        this.updateState({
+            noUI: config?.noUI,
+            announcements: config?.announcements,
+            selectedAnnouncements: config?.selectedAnnouncements || []
+        });
+    }
+
+    setNoUI (value) {
+        this.updateState({
+            noUI: value
+        });
+
+        const plugin = this.tool?.getPlugin();
+        if (!plugin) {
+            return;
+        }
+
+        if (value) {
+            plugin.teardownUI();
+        } else {
+            plugin.redrawUI(Oskari.util.isMobile());
+        }
+    }
+
+    updateSelectedAnnouncements (checked, id) {
+        const { selectedAnnouncements } = this.state;
+        const newSelectedAnnouncements = selectedAnnouncements.filter(selectedId => selectedId !== id);
+        if (checked) {
+            newSelectedAnnouncements.push(id);
+        }
+        this.updateState({
+            selectedAnnouncements: newSelectedAnnouncements
+        });
+
+        if (this.popupControls) {
+            this.popupControls.update(this.state, this.controller, this.closePopup);
+        }
+    }
+
+    showPopup () {
+        if (this.popupControls) {
+            this.popupControls.close();
+            return;
+        }
+        this.popupControls = showAnnouncementsPopup(this.state, this.controller, () => this.closePopup());
+    }
+
+    closePopup () {
+        if (this.popupControls) {
+            this.popupControls.close();
+        }
+        this.popupControls = null;
+    }
+}
+
+const wrapped = controllerMixin(UIHandler, [
+    'setNoUI',
+    'updateSelectedAnnouncements',
+    'showPopup'
+]);
+
+export { wrapped as AnnouncementsToolHandler };

--- a/bundles/admin/admin-announcements/resources/locale/en.js
+++ b/bundles/admin/admin-announcements/resources/locale/en.js
@@ -55,6 +55,8 @@ Oskari.registerLocalization(
             "announcementsTime": "Valid"
         },
         "publisher": {
+            "toolLabel": "Announcements",
+            "selectedAnnouncementsTitle": "Selected announcements",
             "noUI": "Hide user interface (Use RPC interface)"
         }
     }

--- a/bundles/admin/admin-announcements/resources/locale/fi.js
+++ b/bundles/admin/admin-announcements/resources/locale/fi.js
@@ -55,6 +55,8 @@ Oskari.registerLocalization(
                 "announcementsTime": "Voimasssa"
             },
             "publisher": {
+                "toolLabel": "Ilmoitukset",
+                "selectedAnnouncementsTitle": "Valitut ilmoitukset",
                 "noUI": "Piilota käyttöliittymä (käytä RPC-rajapinnan kautta)"
             }
         }

--- a/bundles/admin/admin-announcements/resources/locale/sv.js
+++ b/bundles/admin/admin-announcements/resources/locale/sv.js
@@ -56,6 +56,8 @@ Oskari.registerLocalization(
                 "announcementsTime": "Datumintervall"
             },
             "publisher": {
+                "toolLabel": "Aviseringar",
+                "selectedAnnouncementsTitle": "Valda aviseringar",
                 "noUI": "Dölj användargränsnittet (Använd via RPC gränssnitt)"
             }
         }

--- a/bundles/framework/publisher2/resources/locale/en.js
+++ b/bundles/framework/publisher2/resources/locale/en.js
@@ -64,7 +64,6 @@ Oskari.registerLocalization(
             "maptools": {
                 "label": "Tools",
                 "tooltip": "Select available map tools. Check a placement in the map preview.",
-                "AnnouncementsPlugin": "Announcements",
                 "TimeseriesControlPlugin": "Time series player",
                 "FeaturedataPlugin": "Feature data",
                 "GetInfoPlugin": "Feature query tool",

--- a/bundles/framework/publisher2/resources/locale/fi.js
+++ b/bundles/framework/publisher2/resources/locale/fi.js
@@ -64,7 +64,6 @@ Oskari.registerLocalization(
             "maptools": {
                 "label": "Kartalla näytettävät työkalut",
                 "tooltip": "Valitse kartalla käytettävissä olevat työkalut. Tarkista asettelu esikatselukartasta.",
-                "AnnouncementsPlugin": "Ilmoitukset",
                 "TimeseriesControlPlugin": "Aikasarjatoistin",
                 "FeaturedataPlugin": "Kohdetietotaulukko",
                 "GetInfoPlugin": "Kohdetietojen kyselytyökalu",

--- a/bundles/framework/publisher2/resources/locale/sv.js
+++ b/bundles/framework/publisher2/resources/locale/sv.js
@@ -64,7 +64,6 @@ Oskari.registerLocalization(
             "maptools": {
                 "label": "Verktyg",
                 "tooltip": "Välj verktygen som visas på kartan. Du kan se deras placering på den förhandsvisade kartan.",
-                "AnnouncementsPlugin": "Aviseringar",
                 "TimeseriesControlPlugin": "Tidseriespelare",
                 "FeaturedataPlugin": "Objektuppgifter",
                 "GetInfoPlugin": "Frågverktyg för visande av objektuppgifter",

--- a/bundles/framework/publisher2/view/PanelReactTools.js
+++ b/bundles/framework/publisher2/view/PanelReactTools.js
@@ -3,6 +3,7 @@ import { LocaleProvider } from 'oskari-ui/util';
 import ReactDOM from 'react-dom';
 import { ToolPanelHandler } from '../handler/ToolPanelHandler';
 import { PublisherToolsList } from './form/PublisherToolsList';
+import { ThemeProvider } from 'oskari-ui/util';
 
 /**
  * @class Oskari.mapframework.bundle.publisher.view.PanelAdditionalTools
@@ -82,12 +83,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.view.PanelReactTools'
             const contentPanel = this.panel.getContainer();
 
             ReactDOM.render(
-                <LocaleProvider value={{ bundleKey: 'Publisher2' }}>
-                    <PublisherToolsList
-                        state={this.handler.getState()}
-                        controller={this.handler.getController()}
-                    />
-                </LocaleProvider>,
+                <ThemeProvider>
+                    <LocaleProvider value={{ bundleKey: 'Publisher2' }}>
+                        <PublisherToolsList
+                            state={this.handler.getState()}
+                            controller={this.handler.getController()}
+                        />
+                    </LocaleProvider>
+                </ThemeProvider>,
                 contentPanel[0]
             );
         },


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5d5afdd1-2c96-44b6-9618-60a7689d219a)

There is still something weird about closing the plugin when exiting publisher (it doesn't always close) but that might get fixed in another pr at a later time. I'm not entirely positive that the old implementation excels at that department either. 

Also, add themeprovider to panel
![image](https://github.com/user-attachments/assets/7fe02f80-7f27-44ab-bff2-eb795b13470c)
