### PR TITLE
remove padding from content and increase z-index

### DIFF
--- a/src/react/components/window/Modal.jsx
+++ b/src/react/components/window/Modal.jsx
@@ -1,19 +1,22 @@
 import React from 'react';
 import { Modal as AntModal } from 'antd';
 import { ThemeConsumer } from '../../util/contexts';
-import styled from 'styled-components';
 import { Header } from 'oskari-ui/components/window/Header';
-const StyledModal = styled(AntModal)`
-    .ant-modal-body {
-        padding: 0 0 0.5em 0;
+
+const styles = {
+    body: {
+        padding: '0 0 0.5em 0'
+    },
+    content: {
+        padding: '0'
     }
-`;
+};
 
 export const Modal = ThemeConsumer(({children, title,  options={}, theme={}}) => {
-    return <StyledModal open={true} closable={false} centered={true} footer={null}>
+    return <AntModal zIndex={100000} styles={styles} open={true} closable={false} centered={true} footer={null}>
         <div>
             <Header title={title} isDraggable={false}/>
             {children}
         </div>
-    </StyledModal>;
+    </AntModal>;
 });


### PR DESCRIPTION
AntD added padding for content and we are using showModal like showPopup => Header is in body and AntD title isn't used. Remove content padding. Increase z-index (use same than jQuery/divmanazer overlay/modal). AntD default 1000 isn't enough.

![image](https://github.com/user-attachments/assets/ac276912-180c-41cd-abcc-49360c78b78d)

===>
![image](https://github.com/user-attachments/assets/05e9dae2-697d-4ba4-b1d1-8e66279de1ba)
