### PR TITLE
fix storing the map rotation in publisher

### DIFF
--- a/bundles/mapping/maprotator/publisher/MapRotator.js
+++ b/bundles/mapping/maprotator/publisher/MapRotator.js
@@ -21,10 +21,25 @@ class MapRotatorTool extends AbstractPublisherTool {
         }
 
         // saved configuration -> restore.
-        const conf = data.configuration[this.bundleName].conf || {};
+        const bundleData = data.configuration[this.bundleName];
+        const conf = bundleData?.conf || {};
         this.handler.init(conf);
         this.storePluginConf(conf);
+        this.storePluginState(bundleData?.state || {});
         this.setEnabled(true);
+    }
+
+    storePluginState (state) {
+        this.state.pluginState = state || {};
+    }
+
+    setEnabled (enabled) {
+        super.setEnabled(enabled);
+        if (enabled && this.state.pluginState?.degrees) {
+            this.getPlugin().setRotation(this.state.pluginState?.degrees);
+        } else {
+            this.getMapmodule().getMap().getView().setRotation(0);
+        }
     }
 
     isDisplayed () {


### PR DESCRIPTION
Bring back the functionality to store the map rotation on init, (that was lost in translation when ecmascripting/reactifying this. 