### PR TITLE
Statsgrid fixes

### DIFF
--- a/bundles/statistics/statsgrid/handler/IndicatorHelper.js
+++ b/bundles/statistics/statsgrid/handler/IndicatorHelper.js
@@ -127,6 +127,7 @@ const processMetadata = (meta) => {
         const label = locParams[id] || id;
         const selector = { id, values, time, label };
         if (time) {
+            values.sort((a, b) => Oskari.util.naturalSort(a.value, b.value, true));
             selectors.unshift(selector);
         } else {
             selectors.push(selector);

--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -251,10 +251,13 @@ class SearchController extends AsyncStateHandler {
         const hasValidSelection = (id, allowed, time) => {
             const cur = current[id];
             if (time) {
+                if (!Array.isArray(cur)) {
+                    return false;
+                }
                 if (searchTimeseries) {
                     return cur.length === 2 && cur[0] < cur[1];
                 }
-                return Array.isArray(cur) && cur.some(value => allowed.includes(value));
+                return cur.some(value => allowed.includes(value));
             }
             return allowed.includes(cur);
         };

--- a/bundles/statistics/statsgrid/view/search/IndicatorCollapse.jsx
+++ b/bundles/statistics/statsgrid/view/search/IndicatorCollapse.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Message, Collapse } from 'oskari-ui';
+import { Message, Collapse, Badge } from 'oskari-ui';
 import { IconButton } from 'oskari-ui/components/buttons';
 import { IndicatorRow } from './IndicatorRow';
 import styled from 'styled-components';
@@ -8,8 +8,14 @@ import styled from 'styled-components';
 const StyledCollapse = styled(Collapse)`
     margin-top: 20px;
 `;
-const RemoveAll = styled(IconButton)`
+const Extra = styled.div`
     height: 20px;
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    > * {
+        margin-left: 5px;
+    }
 `;
 
 const Content = ({ indicators = [], removeIndicator, showMetadata }) => {
@@ -31,17 +37,18 @@ Content.propTypes = {
 };
 
 const PanelExtra = ({ indicators = [], removeAll }) => {
-    if (indicators.length < 2) {
-        return null;
-    }
+    const showDelete = indicators.length !== 0;
     return (
-        <div onClick={e => e.stopPropagation()}>
-            <RemoveAll
+        <Extra onClick={e => e.stopPropagation()}>
+            { showDelete && <IconButton
                 type='delete'
+                iconSize={18}
                 confirm={{ title: <Message messageKey='indicatorList.removeAll' /> }}
                 title={<Message messageKey='indicatorList.removeAll' />}
                 onConfirm={() => removeAll()}/>
-        </div>
+            }
+            <Badge count={indicators.length}/>
+        </Extra>
     );
 };
 PanelExtra.propTypes = {

--- a/bundles/statistics/statsgrid/view/search/IndicatorParams.jsx
+++ b/bundles/statistics/statsgrid/view/search/IndicatorParams.jsx
@@ -24,7 +24,7 @@ const StyledSelect = styled(Select)`
     width: 100%;
 `;
 
-const TimeSeriesParams = ({ id, options, selectedValues, controller }) => (
+const TimeSeriesParams = ({ id, options, selectedValues = [], controller }) => (
     <Timeseries>
         <TimeseriesField>
             <b><Message messageKey='parameters.from' /></b>
@@ -47,7 +47,7 @@ const TimeSeriesParams = ({ id, options, selectedValues, controller }) => (
 TimeSeriesParams.propTypes = {
     id: PropTypes.string.isRequired,
     options: PropTypes.array.isRequired,
-    selectedValues: PropTypes.array.isRequired,
+    selectedValues: PropTypes.array,
     controller: PropTypes.object.isRequired
 };
 


### PR DESCRIPTION
Check that array exists before auto select years for timeseries. Fixes issue where 'Get data as time series' is clicked before Indicator is selected => caused JS error.

Remove isRequired prop validation from selected time value even statsgrid uses async state handler TimeParamSelect should get selected value. Select indicator populates selectors and auto select immediately set selections.

Sort time values before storing to cache. It looks like my indicator year selectors aren't sorted in backend.



