### PR TITLE
add zindex for antd tabs dropdown

### DIFF
--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -532,6 +532,10 @@ This seems to only happen on the Firefox browser
   z-index: 30050 !important;
 }
 
+.ant-tabs-dropdown {
+  z-index: 30050 !important;
+}
+
 .ant-popover {
   z-index: 30030 !important;
 }


### PR DESCRIPTION
bring tabs dropdown back on top

![image](https://github.com/user-attachments/assets/6e499abb-70f4-4be5-8938-3cfc01720ea2)


