### PR TITLE
Statsgrid fixes

### DIFF
--- a/bundles/statistics/statsgrid/handler/IndicatorFormHandler.js
+++ b/bundles/statistics/statsgrid/handler/IndicatorFormHandler.js
@@ -163,7 +163,6 @@ class IndicatorFormController extends StateHandler {
     }
 
     async saveData () {
-        this.updateState({ loading: true });
         const { dataByRegions, regionset, selection } = this.getState();
 
         const data = {};
@@ -182,6 +181,7 @@ class IndicatorFormController extends StateHandler {
             return;
         }
         try {
+            this.updateState({ loading: true });
             const indicator = this.getFullIndicator();
             await saveIndicatorData(indicator, data, regionset);
             const indicatorInfo = `Indicator: ${indicator.id}, selection: ${selection}, regionset: ${regionset}.`;

--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -375,12 +375,15 @@ class SearchController extends AsyncStateHandler {
         const multiSelections = [];
         Object.keys(selections).forEach(key => {
             const metaSelector = metadata.selectors.find(selector => selector.id === key);
-            // use metadata for validity check. Params have combined selectors.
-            const checkAllowed = value => metaSelector.values.find(obj => obj.value === value);
             if (!metaSelector) {
-                indSearchValues.error = 'indicatorMetadataError';
+                // Only allowed selections are used for get/add indicator
+                // multi indicator selections may have selection which is missing from single indicator selectors
+                // skip selection and don't add error
                 return;
             }
+            // use metadata for validity check. Params have combined selectors.
+            const checkAllowed = value => metaSelector.values.find(obj => obj.value === value);
+
             const values = selections[key];
             // single
             if (!Array.isArray(values)) {

--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -199,8 +199,9 @@ class SearchController extends AsyncStateHandler {
                     params.regionsets.forEach(rs => regionsets.add(rs));
                     params.selectors.forEach((selector) => {
                         const existing = combinedSelectors.find(s => s.id === selector.id);
+                        // Note: selectors may come from metadata cache, don't mess up cached data
                         if (!existing) {
-                            combinedSelectors.push(selector);
+                            combinedSelectors.push({ ...selector });
                         } else {
                             const values = existing.values.map(s => s.value);
                             const newValues = selector.values.filter(v => !values.includes(v.value));


### PR DESCRIPTION
- set loading after data exists check to avoid neverending spinner (no valid data for saving)
- create copy from seletor to avoid messing up cached object (could be fixed by returning deep cloned object)
- don't add error if metadata selector is missing. Fixes issue where every single indicator doesn't have all multi indicator selections. Indicator is added with valid/allowed selections.