### PR TITLE
Statgrid fixes

### DIFF
--- a/bundles/statistics/statsgrid/components/RegionsetViewer.js
+++ b/bundles/statistics/statsgrid/components/RegionsetViewer.js
@@ -30,6 +30,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.RegionsetViewer', function (ins
         }
         this._lastRenderCache.highlightRegionId = activeRegion;
     },
+    flushLastRenderStateCache: function () {
+        this._lastRenderStateForSelectedRegionOptimizing = {};
+    },
     isOnlyActiveRegionChange: function (state = {}) {
         const sameRegionset = this._lastRenderStateForSelectedRegionOptimizing.regionset === state.regionset;
         const sameIndicator = this._lastRenderStateForSelectedRegionOptimizing.activeIndicator === state.activeIndicator;

--- a/bundles/statistics/statsgrid/handler/StatisticsHandler.js
+++ b/bundles/statistics/statsgrid/handler/StatisticsHandler.js
@@ -194,6 +194,7 @@ class StatisticsController extends AsyncStateHandler {
         }
         this.updateState({ loading: true });
         try {
+            this.instance.regionsetViewer?.flushLastRenderStateCache();
             let active;
             const indicatorsToAdd = [];
             // async/await doesn't work with forEach()
@@ -206,7 +207,7 @@ class StatisticsController extends AsyncStateHandler {
                 }
             };
             const isSeriesActive = active ? !!active.series : false;
-            this.updateState({ activeIndicator, isSeriesActive, activeRegion, regionset, indicators: indicatorsToAdd, loading: false });
+            this.updateState({ activeIndicator, isSeriesActive, activeRegion, regionset, indicators: indicatorsToAdd });
             // reset active
             if (!active) {
                 this.setActiveIndicator();
@@ -214,6 +215,7 @@ class StatisticsController extends AsyncStateHandler {
         } catch (error) {
             this.log.warn('Failed to set stored state', error.message);
         }
+        this.updateState({ loading: false });
     }
 
     async onCacheUpdate (indicator, onlyData) {

--- a/bundles/statistics/statsgrid/view/Form/ClipboardPopup.jsx
+++ b/bundles/statistics/statsgrid/view/Form/ClipboardPopup.jsx
@@ -48,7 +48,7 @@ ClipboardPopup.propTypes = {
 };
 
 export const showClipboardPopup = (controller, onClose) => {
-    const title = <Message messageKey='userIndicators.flyoutTitle' bundleKey={BUNDLE_KEY} />;
+    const title = <Message messageKey='userIndicators.import.title' bundleKey={BUNDLE_KEY} />;
     return showPopup(
         title,
         <LocaleProvider value={{ bundleKey: BUNDLE_KEY }}>


### PR DESCRIPTION
Use button's localization for clipboard popup title: "Import from the clipboard"

Sandbox reset state usually sets same state for published map. If active regionset is not same than original/init state, then regionset viewer handles update state as only active region change (regionset and indicator are same). Stats layer is removed on reset state and regionset viewer doesn't add it again. Added cache flush on setStoredState to render regions&add map. Also moved set loading false to end of function if something get wrong to stop spinner.