### PR TITLE
Fix postinstall script for non-devmode installs

### DIFF
--- a/webpack/hacks/postinstall.js
+++ b/webpack/hacks/postinstall.js
@@ -11,6 +11,7 @@ if (!fs.existsSync(pathToCesium)) {
 // try again with non-dev-mode
 if (!fs.existsSync(pathToCesium)) {
     // something went terribly wrong
+    throw new Error('Couldn\'t find @cesium');
 } else {
     // Overwrites node_modules/@cesium/engine/Source/Core/buildModuleUrl.js
     // with a modified on to fix issues with Webpack 4.x

--- a/webpack/hacks/postinstall.js
+++ b/webpack/hacks/postinstall.js
@@ -6,7 +6,7 @@ const srcFileCesiumHack = path.join(__dirname, 'cesium', 'buildModuleUrl.js.modi
 let pathToCesium = path.join(__dirname, '..', '..', 'node_modules', '@cesium');
 if (!fs.existsSync(pathToCesium)) {
     // installed in non-dev-mode
-    pathToCesium = path.join(__dirname, '..', '..', '@cesium');
+    pathToCesium = path.join(__dirname, '..', '..', '..', '@cesium');
 }
 // try again with non-dev-mode
 if (!fs.existsSync(pathToCesium)) {


### PR DESCRIPTION
Running `npm run build` with defaults on for example sample-application doesn't work correctly without this. Only works when oskari-frontend is installed as "dev mode" from a folder next to an app with `npm install ../oskari-frontend`. The change forces install to throw an error if the postinstall script can't find Cesium and do its thing. This makes installing oskari-frontend  on an app throw an error instead of finding out afterwards when running `npm run build` for the application.

Apparently this can be added for an app to make npm run build work:
https://www.npmjs.com/package/@open-wc/webpack-import-meta-loader