### PR TITLE
AdminLayerEditor subgroup select fix

### DIFF
--- a/bundles/admin/admin-layereditor/instance.js
+++ b/bundles/admin/admin-layereditor/instance.js
@@ -236,6 +236,7 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
                 flyout.show();
             }
         }
+
         getDataProviders () {
             const dataProviders = this._getLayerService().getDataProviders();
             dataProviders.sort(function (a, b) {
@@ -245,11 +246,10 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
         }
 
         getGroups () {
-            const groups = this._getLayerService().getAllLayerGroups();
-            groups.sort(function (a, b) {
-                return Oskari.util.naturalSort(Oskari.getLocalized(a.name), Oskari.getLocalized(b.name));
-            });
-            return groups;
+            // filter runtime groups (negative ids)
+            return this._getLayerService().getAllLayerGroups()
+                .filter(group => group.id > 0)
+                .toSorted((a, b) => Oskari.util.naturalSort(Oskari.getLocalized(a.name), Oskari.getLocalized(b.name)));
         }
 
         /**

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/Groups.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/Groups.jsx
@@ -27,7 +27,7 @@ const SubGroupsListItem = ({ group, layer, controller }) => {
                 </StyledListItem>
                 {subgroup.groups.length > 0 && <SubGroupsListItem group={subgroup} layer={layer} controller={controller}/>}
             </StyledDiv>
-        )}/>
+        )} renderItem={item => item}/>
     );
 };
 

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/Groups.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/Groups.jsx
@@ -15,19 +15,20 @@ const StyledListItem = styled(ListItem)`
 // add subgroups on the list recursively and hierarchically
 const SubGroupsListItem = ({ group, layer, controller }) => {
     return (
-        <List dataSource={group.getGroups().map(subgroup =>
-            <StyledDiv key={subgroup.id}>
-                <StyledListItem>
-                    <Checkbox key={subgroup.id}
-                        onChange={evt => controller.setGroup(evt.target.checked, subgroup)}
-                        checked={!!layer.groups.find(cur => cur === subgroup.id)}
-                    >
-                        {subgroup.getName()}
-                    </Checkbox>
-                </StyledListItem>
-                {subgroup.groups.length > 0 && <SubGroupsListItem group={subgroup} layer={layer} controller={controller}/>}
-            </StyledDiv>
-        )} renderItem={item => item}/>
+        <List dataSource={group.getGroups()}
+            renderItem = {subgroup =>
+                <StyledDiv key={subgroup.id}>
+                    <StyledListItem>
+                        <Checkbox key={subgroup.id}
+                            onChange={evt => controller.setGroup(evt.target.checked, subgroup)}
+                            checked={!!layer.groups.find(cur => cur === subgroup.id)}
+                        >
+                            {subgroup.getName()}
+                        </Checkbox>
+                    </StyledListItem>
+                    {subgroup.groups.length > 0 && <SubGroupsListItem group={subgroup} layer={layer} controller={controller}/>}
+                </StyledDiv>
+            }/>
     );
 };
 

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/Groups.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/Groups.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Checkbox, Collapse, CollapsePanel, List, ListItem, Message } from 'oskari-ui';
+import { Checkbox, Collapse, List, ListItem, Message } from 'oskari-ui';
 import { Controller } from 'oskari-ui/util';
 import { StyledFormField } from '../styled';
 import styled from 'styled-components';


### PR DESCRIPTION
`renderItem` was missing from List so subgroups wan't rendered. 
https://github.com/oskariorg/oskari-frontend/blob/2.13.2/bundles/admin/admin-layereditor/view/AdminLayerForm/GeneralTabPane/Groups.jsx#L29
Fixes issue where admin couldn't select subgroups for layer. 
Moved rendering to renderItem from dataSource.

Remove runtime groups from admin LayerList groups select.

![image](https://github.com/user-attachments/assets/21d3db8e-7916-4540-a919-8fdef28183f2)
