### PR TITLE
try to determine checked for maplegend even when there are async layers

### DIFF
--- a/bundles/framework/maplegend/publisher/MapLegendTool.js
+++ b/bundles/framework/maplegend/publisher/MapLegendTool.js
@@ -1,6 +1,7 @@
 import { AbstractPublisherTool } from '../../../framework/publisher2/tools/AbstractPublisherTool';
 
 const BUNDLE_ID = 'maplegend';
+
 class MapLegendTool extends AbstractPublisherTool {
     constructor (...args) {
         super(...args);
@@ -22,6 +23,7 @@ class MapLegendTool extends AbstractPublisherTool {
     }
 
     init (data) {
+        this.data = data;
         const myData = data?.configuration[BUNDLE_ID];
         if (myData) {
             this.storePluginConf(myData.conf);
@@ -35,6 +37,17 @@ class MapLegendTool extends AbstractPublisherTool {
     }
 
     onLayersChanged () {
+        const { alreadyInitialized } = this.state;
+        const layers = [...this.getSandbox().findAllSelectedMapLayers()];
+        const confLayers = this.data?.configuration?.mapfull?.conf?.layers || [];
+        if (layers?.length === confLayers?.length && !alreadyInitialized) {
+            this.state.alreadyInitialized = true;
+            if (this.data?.configuration && this.data?.configuration[BUNDLE_ID] && !this.isDisabled()) {
+                this.setEnabled(true);
+                return;
+            }
+        }
+
         if (this.isEnabled() && this.isDisabled()) {
             // disable if layers changed and there is no longer layers with legends on map
             this.setEnabled(false);


### PR DESCRIPTION
seems to work for a simple async case where nothing surprising happens.

I'm guessing that if we open a published map for editing, that originally has
* map legend - checkbox checked 
* some layer in the original config that had a maplegend but which doesn't exist anymore and loading fails
* we later add a map layer that has a legend 

=> checkbox might be turned on by surprise but maybe this is something of a corner case... 