### PR TITLE
Tuning the base class for bundles

### DIFF
--- a/src/BasicBundle.js
+++ b/src/BasicBundle.js
@@ -29,13 +29,21 @@ Oskari.clazz.define('Oskari.BasicBundle', function () {
     },
 
     /**
+     * Returns reference to the application sandbox.
+     * Sandbox is used for interacting with other bundles
+     * @memberof BasicBundle
+     */
+    getSandbox: function () {
+        return this.sandbox;
+    },
+    /**
      * @memberof BasicBundle
      * @param {Oskari.mapframework.event.Event} event A Oskari event object.
      * Event is handled forwarded to correct {@link BasicBundle#eventHandlers|eventHandler}
      * if found or discarded if not.
      */
     onEvent: function (event) {
-        var handler = this.eventHandlers[event.getName()];
+        const handler = this.eventHandlers[event.getName()];
         if (!handler) {
             return;
         }
@@ -101,5 +109,5 @@ Oskari.clazz.define('Oskari.BasicBundle', function () {
         sandbox.unregister(this);
     }
 }, {
-    'protocol': ['Oskari.bundle.BundleInstance', 'Oskari.mapframework.module.Module']
+    protocol: ['Oskari.bundle.BundleInstance', 'Oskari.mapframework.module.Module']
 });

--- a/src/react/BaseModule.js
+++ b/src/react/BaseModule.js
@@ -1,0 +1,88 @@
+export class BaseModule {
+    constructor (name = 'BaseModule' + Oskari.getSeq('BaseModule').nextVal()) {
+        // override
+        this._name = name;
+        this._sandbox = undefined;
+        this._eventListeners = undefined;
+    }
+
+    getName () {
+        return this._name;
+    }
+
+    /**
+     * Sets the sandbox for module and registers the module in sandbox
+     * @param {Oskari.Sandbox} sandbox the sandbox this module operates in
+     */
+    start (sandbox) {
+        this._sandbox = sandbox;
+        sandbox.register(this);
+    }
+
+    /**
+     * Removes any event listeners that might have been added and unregisters the module from sandbox.
+     */
+    stop () {
+        this.off();
+        this.getSandbox().unregister(this);
+    }
+
+    getSandbox () {
+        return this._sandbox;
+    }
+
+    init () {
+        // called by sandbox when start() calls sandbox.register(this)
+        // can be overridden, but mostly you can do stuff in start() instead
+    }
+
+    // listen to events
+    on (eventName, handlerFn) {
+        if (!eventName) {
+            throw new Error('Tried to register listener without event name');
+        }
+        if (typeof handlerFn !== 'function') {
+            throw new Error('Tried to register listener for event without the handler');
+        }
+
+        if (!this._eventListeners) {
+            // create only if needed/module actually listens something
+            this._eventListeners = Oskari.createStore('listener', {
+                // otherwise returns true from store.noop() as default value
+                defaultValue: () => undefined
+            });
+        }
+        if (this._eventListeners.listener(eventName)) {
+            // This would overwrite the previous listener for bundle itself
+            //  and register the module multiple times to sandbox -> would trigger multiple calls per event
+            throw new Error('Tried to register listener for same event we are already listening. This is not supported yet.');
+        }
+        this._eventListeners.listener(eventName, handlerFn);
+        this.getSandbox().registerForEventByName(this, eventName);
+    }
+
+    // stop listening to events
+    off (eventName) {
+        if (!this._eventListeners) {
+            // nothing registered, nothing needs to be removed
+            return;
+        }
+        if (eventName) {
+            this.getSandbox().unregisterFromEventByName(this, eventName);
+            this._eventListeners.reset(eventName);
+        } else {
+            // if not defined, remove all listeners
+            this._eventListeners.listener().forEach(evtName => this.off(evtName));
+        }
+    }
+
+    // called by sandbox when event this listens has been triggered
+    // this is framework function, use on() to register listeners.
+    onEvent (event) {
+        const handler = this._eventListeners?.listener(event.getName());
+        if (!handler) {
+            return;
+        }
+        return handler(event);
+    }
+};

--- a/src/react/BasicBundleInstance.js
+++ b/src/react/BasicBundleInstance.js
@@ -1,0 +1,101 @@
+export class BasicBundleInstance {
+    constructor (name = 'BasicBundleInstance') {
+        // override
+        this._name = name;
+        this._loc = undefined;
+        this._sandbox = undefined;
+        this._listeners = {
+            event: Oskari.createStore('listener'),
+            request: Oskari.createStore('handler')
+        };
+    }
+
+    getName () {
+        if (this._name !== 'BasicBundleInstance') {
+            // default overridden
+            return this._name;
+        }
+        if (this.mediator?.bundleId) {
+            this._name = this.mediator.bundleId;
+        } else {
+            Oskari.log('BasicBundleInstance').warn('Defaulting name to bundle id:', this._name);
+        }
+        return this._name;
+    }
+
+    loc (key, args) {
+        if (!this._loc) {
+            this._loc = Oskari.getMsg.bind(null, this.getName());
+        }
+        return this._loc(key, args);
+    }
+
+    start (sandbox) {
+        this._sandbox = sandbox;
+        sandbox.register(this);
+    }
+
+    stop () {
+        this.off();
+        this.getSandbox().unregister(this);
+    }
+
+    getSandbox () {
+        return this._sandbox;
+    }
+
+    init () {
+        // called by sandbox when the bundle is registered to sandbox
+    }
+
+    on (eventName, handlerFn) {
+        if (!eventName) {
+            throw new Error('Tried to register listener without event name');
+        }
+        if (typeof handlerFn !== 'function') {
+            throw new Error('Tried to register listener for event without the handler');
+        }
+        // TODO: register to sandbox
+        this.getSandbox().registerForEventByName(this, eventName);
+        this._listeners.event.listener(eventName, handlerFn);
+    }
+
+    off (eventName) {
+        if (eventName) {
+            this.getSandbox().unregisterFromEventByName(this, eventName);
+            this._listeners.event.reset(eventName);
+        } else {
+            // if not defined, remove all listeners
+            this._listeners.event.listener().forEach(evtName => this.off(evtName));
+        }
+    }
+
+    addRequestHandler (requestName, handlerFn) {
+        if (!requestName) {
+            throw new Error('Tried to register handler without request name');
+        }
+        this.getSandbox().requestHandler(requestName, (req) => handlerFn(req));
+        this._listeners.request.handler(requestName, handlerFn);
+    }
+
+    removeRequestHandler (requestName) {
+        if (requestName) {
+            // remove single request handler
+            this.getSandbox().requestHandler(requestName, null);
+            this._listeners.request.reset(requestName);
+        } else {
+            // remove all request handlers
+            this._listeners.request.handler().forEach(reqName => this.requestHandler(reqName));
+        }
+    }
+
+    // called by sandbox when event this listens has been triggered
+    // this is framework function, use on() to register listeners.
+    onEvent (event) {
+        const handler = this._listeners.event.listener(event.getName());
+        if (!handler) {
+            return;
+        }
+        return handler(event);
+    }
+};

--- a/src/react/BasicBundleInstance.js
+++ b/src/react/BasicBundleInstance.js
@@ -70,6 +70,38 @@ export class BasicBundleInstance extends BaseModule {
         }
     }
 
+    // FIXME: this doesn't work:
+    /*
+    This was the plan:
+```
+class BaseRequest {
+    constructor (name = 'BaseRequest' + Oskari.getSeq('BaseModule').nextVal()) {
+        this.name = name;
+    }
+
+    getName () {
+        return this.name;
+    }
+}
+
+class HelloRequest extends BaseRequest {
+    constructor(id) {
+        super('HelloRequest');
+        this._id = id;
+    }
+
+    getId () {
+        return this._id;
+    }
+};
+```
+Then on bundle:
+```
+    this.registerRequestImpl(HelloRequest);
+    this.addRequestHandler('HelloRequest', (req) => console.log(req));
+```
+Or even just: `this.addRequestHandler(HelloRequest, (req) => console.log(req));`
+     */
     registerRequestImpl (bundleRequestClass) {
         // we should find a way for es classes to register for metadata without creating the random name
         Oskari.clazz.defineES('Oskari.random.Request' + Oskari.getSeq('BaseRequest').nextVal(), bundleRequestClass, {

--- a/src/react/BasicBundleInstance.js
+++ b/src/react/BasicBundleInstance.js
@@ -6,7 +6,6 @@ export class BasicBundleInstance extends BaseModule {
     constructor (name = DEFAULT_NAME) {
         super(name);
         this._loc = undefined;
-        this._requestHandlers = undefined;
     }
 
     /**
@@ -18,17 +17,6 @@ export class BasicBundleInstance extends BaseModule {
         // do the usual startup like registering to sandboc
         super.start(sandbox);
         // start() here is for documentation purposes as it's something bundles will likely override
-    }
-
-    /**
-     * If you need to do any cleanup when the bundle is stopped, this is the place to do it.
-     * If you override this, remember to call super.stop() that handles the usual cleanup for event listeners and request handlers.
-     */
-    stop () {
-        // do the usual
-        super.stop();
-        // and remove any requests handlers in case the bundle added some
-        this.removeRequestHandler();
     }
 
     /**
@@ -45,73 +33,10 @@ export class BasicBundleInstance extends BaseModule {
         return this._loc(key, args);
     }
 
-    addRequestHandler (requestName, handlerFn) {
-        if (!requestName) {
-            throw new Error('Tried to register handler without request name');
-        }
-        if (typeof handlerFn !== 'function') {
-            throw new Error(`Tried to register handler for ${requestName} without handlerFn`);
-        }
-        if (!this._requestHandlers) {
-            this._requestHandlers = Oskari.createStore('handler');
-        }
-        this.getSandbox().requestHandler(requestName, (req) => handlerFn(req));
-        this._requestHandlers.handler(requestName, handlerFn);
-    }
-
-    removeRequestHandler (requestName) {
-        if (requestName) {
-            // remove single request handler
-            this.getSandbox().requestHandler(requestName, null);
-            this._listeners.request.reset(requestName);
-        } else {
-            // remove all request handlers
-            this._listeners.request.handler().forEach(reqName => this.removeRequestHandler(reqName));
-        }
-    }
-
-    // FIXME: this doesn't work:
-    /*
-    This was the plan:
-```
-class BaseRequest {
-    constructor (name = 'BaseRequest' + Oskari.getSeq('BaseModule').nextVal()) {
-        this.name = name;
-    }
-
-    getName () {
-        return this.name;
-    }
-}
-
-class HelloRequest extends BaseRequest {
-    constructor(id) {
-        super('HelloRequest');
-        this._id = id;
-    }
-
-    getId () {
-        return this._id;
-    }
-};
-```
-Then on bundle:
-```
-    this.registerRequestImpl(HelloRequest);
-    this.addRequestHandler('HelloRequest', (req) => console.log(req));
-```
-Or even just: `this.addRequestHandler(HelloRequest, (req) => console.log(req));`
-     */
-    registerRequestImpl (bundleRequestClass) {
-        // we should find a way for es classes to register for metadata without creating the random name
-        Oskari.clazz.defineES('Oskari.random.Request' + Oskari.getSeq('BaseRequest').nextVal(), bundleRequestClass, {
-            protocol: ['Oskari.mapframework.request.Request']
-        });
-    }
-
     // jump through some additional hoops to default name as the bundleId if it hasn't been overridden
     /**
      * Tries to use bundle id as name if name isn't given for constructor
+     * @see BaseModule.getName()
      * @returns String the name of the bundle (used for referencing on sandbox, mapping the correct localization file)
      */
     getName () {


### PR DESCRIPTION
- Addition to Oskari.BasicBundle: add getSandbox() so we don't teach using internals directly
- Added an initial version for base class that can be easily imported for bundles instead of using the `Oskari.clazz.get('Oskari.BasicBundle')`

Things to consider:
- sandbox register uses the concept of "module"
- bundle factory/index.js uses "bundle instance"
=> resolved by doing a more generic BaseModule.js that can be extended for modules to be registered to sandbox and eventlistening and BaseBundleInstance that adds localization function to that. In the future this could also have function to register request handler etc.
