### PR TITLE
Add a ~setterId for map cursor to detect unintentional reseting

### DIFF
--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
@@ -253,7 +253,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
                 this.markerPopupControls = showMarkerPopup(() => this.removeMarkers(), () => this.closeMarkerPopup());
             }
 
-            this.getMapModule().setCursorStyle('crosshair');
+            this.getMapModule().setCursorStyle('crosshair', this.getName());
         },
         /**
          * Stops the marker location selector
@@ -267,7 +267,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
             if (this.popupControls) {
                 this.popupCleanup();
             }
-            this.getMapModule().setCursorStyle('');
+            this.getMapModule().setCursorStyle('', this.getName());
             if (!selectDefault) {
                 return;
             }


### PR DESCRIPTION
Resolves an issue where for example both findbycoordinates and markersplugin try reseting the map cursor to default after they are closed. However there's a race condition where one can set the crosshair before the other resets it back to default. This handles the case so when something sets a cursor, it needs to be the one reseting it as well. Other functionalities can still change the cursor if they changed it to non-default.

Also removed the jQuery part of setting the style.