### PR TITLE
Layer remove getInspireName

### DIFF
--- a/bundles/admin/admin-layereditor/instance.js
+++ b/bundles/admin/admin-layereditor/instance.js
@@ -23,7 +23,7 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
             this.loc = Oskari.getMsg.bind(null, this.__name);
             this.layerListFormHandler = new LayerListFormHandler();
             this.eventHandlers = {
-                'MapLayerEvent': (event) => {
+                MapLayerEvent: (event) => {
                     if (event.getOperation() !== 'add') {
                         // only handle add layer
                         return;
@@ -36,6 +36,7 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
                 }
             };
         }
+
         _startImpl () {
             this._setupLayerTools();
             this._setupAdminTooling();
@@ -46,6 +47,7 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
             layerService.on('theme.update', () => this._getFlyout().setMapLayerGroups(this.getGroups()));
             layerService.on('dataProvider.update', () => this._getFlyout().setDataProviders(this.getDataProviders()));
         }
+
         /**
          * Fetches reference to the map layer service
          * @return {Oskari.mapframework.service.MapLayerService}
@@ -124,7 +126,7 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
             addSubthemeTool.setIconComponent(<PlusCircleOutlined/>);
             addSubthemeTool.setTooltip(this.loc('addSubtheme'));
             addSubthemeTool.setIconCls('add-sub-theme');
-            addSubthemeTool.setTypes(['layergroup', 'getInspireName']);
+            addSubthemeTool.setTypes(['layergroup', 'getGroups']);
             addSubthemeTool.setCallback(addSubthemeCallback);
             toolingService.addTool(addSubthemeTool);
 
@@ -133,7 +135,7 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
             editThemeTool.setIconComponent(<EditOutlined/>);
             editThemeTool.setTooltip(this.loc('editTheme'));
             editThemeTool.setIconCls('edit-layer');
-            editThemeTool.setTypes(['layergroup', 'getInspireName']);
+            editThemeTool.setTypes(['layergroup', 'getGroups']);
             editThemeTool.setCallback(editGroupCallBack);
             toolingService.addTool(editThemeTool);
 
@@ -333,7 +335,7 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
                     const me = this;
                     jQuery.ajax({
                         type: 'DELETE',
-                        url: Oskari.urls.getRoute('MapLayerGroups', { id: id, deleteLayers: deleteLayers }),
+                        url: Oskari.urls.getRoute('MapLayerGroups', { id, deleteLayers }),
                         success: response => {
                             this.layerListFormHandler.getController().setLoading(false);
                             this.layerListFormHandler.getController().closePopup();
@@ -445,7 +447,7 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
                     this.layerListFormHandler.setLoading(true);
                     jQuery.ajax({
                         type: 'DELETE',
-                        url: Oskari.urls.getRoute('DataProvider', { id: id, deleteLayers: deleteLayers }),
+                        url: Oskari.urls.getRoute('DataProvider', { id, deleteLayers }),
                         success: response => {
                             this.layerListFormHandler.getController().setLoading(false);
                             this.layerListFormHandler.getController().closePopup();

--- a/bundles/admin/admin-layereditor/instance.js
+++ b/bundles/admin/admin-layereditor/instance.js
@@ -111,7 +111,7 @@ Oskari.clazz.defineES('Oskari.admin.admin-layereditor.instance',
                 case 'getOrganizationName':
                     popupKey = FLYOUT.DATA_PROVIDER;
                     break;
-                case 'getInspireName':
+                case 'getGroups':
                     popupKey = FLYOUT.THEME;
                     break;
                 default:

--- a/bundles/framework/layerlist/model/GroupingOption.js
+++ b/bundles/framework/layerlist/model/GroupingOption.js
@@ -4,12 +4,15 @@ export class GroupingOption {
         this.title = title;
         this.method = method;
     }
+
     getKey () {
         return this.key;
     }
+
     getTitle () {
         return this.title;
     }
+
     getMethod () {
         return this.method;
     }

--- a/bundles/framework/layerlist/model/LayerGroup.js
+++ b/bundles/framework/layerlist/model/LayerGroup.js
@@ -144,7 +144,7 @@ export class LayerGroup {
     }
 
     clone () {
-        const clone = new LayerGroup(this.id, this.type, this.name, this.description, this.parentId);
+        const clone = new LayerGroup(this.id, this.groupMethod, this.name, this.description, this.parentId);
         clone.layers = [...this.layers];
         clone.groups = [...this.groups];
         clone.searchIndex = { ...this.searchIndex };

--- a/bundles/framework/layerlist/model/LayerGroup.js
+++ b/bundles/framework/layerlist/model/LayerGroup.js
@@ -1,7 +1,7 @@
 export class LayerGroup {
-    constructor (id, type, title, description, parentId, groups) {
+    constructor (id, groupMethod, title, description, parentId, groups) {
         this.id = id;
-        this.type = type;
+        this.groupMethod = groupMethod;
         this.name = title;
         this.description = description;
         this.layers = [];
@@ -44,11 +44,11 @@ export class LayerGroup {
     }
 
     /**
-     * @method getType
+     * @method groupMethod
      * @return {String}
      */
-    getType () {
-        return this.type;
+    getGroupMethod () {
+        return this.groupMethod;
     }
 
     /**

--- a/bundles/framework/layerlist/model/LayerGroup.js
+++ b/bundles/framework/layerlist/model/LayerGroup.js
@@ -1,7 +1,7 @@
 export class LayerGroup {
-    constructor (id, groupMethod, title, description, parentId, groups) {
+    constructor (id, type, title, description, parentId, groups) {
         this.id = id;
-        this.groupMethod = groupMethod;
+        this.type = type;
         this.name = title;
         this.description = description;
         this.layers = [];
@@ -15,15 +15,19 @@ export class LayerGroup {
     getParentId () {
         return this.parentId;
     }
+
     setParentId (parentId) {
         this.parentId = parentId;
     }
+
     getGroups () {
         return this.groups;
     }
+
     setGroups (newGroups) {
         this.groups = newGroups;
     }
+
     /**
      * @method getId
      * @return {String}
@@ -31,19 +35,22 @@ export class LayerGroup {
     getId () {
         return this.id;
     }
+
     /**
      * @return {Boolean}
      */
     isEditable () {
         return this.id > 0;
     }
+
     /**
-     * @method getGroupMethod
+     * @method getType
      * @return {String}
      */
-    getGroupMethod () {
-        return this.groupMethod;
+    getType () {
+        return this.type;
     }
+
     /**
      * @method setTitle
      * @param {String} name
@@ -51,6 +58,7 @@ export class LayerGroup {
     setTitle (name) {
         this.name = name;
     }
+
     /**
      * @method getTitle
      * @return {String}
@@ -58,12 +66,15 @@ export class LayerGroup {
     getTitle () {
         return this.name || '';
     }
+
     setDescription (description) {
         this.description = description;
     }
+
     getDescription () {
         return this.description;
     }
+
     /**
      * @method addLayer
      * @param {Layer} layer
@@ -76,11 +87,13 @@ export class LayerGroup {
         this.layers.push(layer);
         this.searchIndex[layer.getId()] = this._getSearchIndex(layer);
     }
+
     getLayerCount () {
         return this.getGroups().reduce((prev, cur) => {
             return prev + cur.getLayerCount();
         }, this.layers.length);
     }
+
     /**
      * @method addTool
      * @param {Oskari.mapframework.domain.Tool} tool
@@ -92,6 +105,7 @@ export class LayerGroup {
     getTools () {
         return this.tools;
     }
+
     /**
      * @method getLayers
      * @return {Layer[]}
@@ -99,23 +113,27 @@ export class LayerGroup {
     getLayers () {
         return this.layers;
     }
+
     setLayers (newLayers = []) {
         this.layers = [];
         this.searchIndex = {};
         newLayers.forEach(layer => this.addLayer(layer));
     }
+
     _getSearchIndex (layer) {
-        let val = layer.getName() + ' ' +
-            layer.getInspireName() + ' ' +
-            layer.getOrganizationName();
-        // TODO: maybe filter out undefined texts
+        const index = layer.getGroups().map(group => group.name);
+        index.push(layer.getName());
+        index.push(layer.getOrganizationName());
         if (this._isAdmin) {
-            val = val + ' ' +
-                layer.getId() + ' ' +
-                layer.getLayerName();
+            index.push(layer.getId());
+            index.push(layer.getLayerName());
         }
-        return val.toLowerCase();
+        return index
+            .filter(nonEmpty => nonEmpty)
+            .join(' ')
+            .toLowerCase();
     }
+
     matchesKeyword (layerId, keyword) {
         const searchableIndex = this.searchIndex[layerId];
         let terms = keyword;
@@ -124,8 +142,9 @@ export class LayerGroup {
         }
         return terms.every(key => searchableIndex.indexOf(key.toLowerCase()) !== -1);
     }
+
     clone () {
-        const clone = new LayerGroup(this.id, this.groupMethod, this.name, this.description, this.parentId);
+        const clone = new LayerGroup(this.id, this.type, this.name, this.description, this.parentId);
         clone.layers = [...this.layers];
         clone.groups = [...this.groups];
         clone.searchIndex = { ...this.searchIndex };

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Grouping.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/Grouping.jsx
@@ -2,20 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { GroupingOption } from '../../../model/GroupingOption';
 import { Labelled } from './Labelled';
-import { Select, Option } from 'oskari-ui';
+import { Select } from 'oskari-ui';
 import { Controller } from 'oskari-ui/util';
 
 const Grouping = ({ selected, options, controller }) =>
     <Labelled label={'grouping.title'}>
-        <Select value={selected} onChange={controller.setGrouping} className="t_grouping">
-            {
-                options.map(cur =>
-                    <Option key={cur.getKey()} value={cur.getKey()}>
-                        {cur.getTitle()}
-                    </Option>
-                )
-            }
-        </Select>
+        <Select value={selected} onChange={controller.setGrouping} className="t_grouping"
+            options={options.map(opt => ({ value: opt.key, label: opt.title }))}/>
     </Labelled>;
 
 Grouping.propTypes = {

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapseHandler.js
@@ -1,8 +1,7 @@
-import { StateHandler, controllerMixin } from 'oskari-ui/util';
+import { StateHandler, controllerMixin, Messaging } from 'oskari-ui/util';
 import { groupLayers } from './util';
 import { FILTER_ALL_LAYERS } from '..';
 import { GROUPING_PRESET, GROUPING_DATAPROVIDER } from '../preset';
-import { Messaging } from 'oskari-ui/util';
 
 const ANIMATION_TIMEOUT = 400;
 const LAYER_REFRESH_THROTTLE = 2000;
@@ -107,6 +106,7 @@ class ViewHandler extends StateHandler {
         };
         this.eventHandlers = this._createEventHandlers();
     }
+
     setGroupingType (groupingType = GROUPING_PRESET[0].key) {
         if (this.groupingType === groupingType) {
             // grouping stays the same
@@ -115,6 +115,7 @@ class ViewHandler extends StateHandler {
         this.groupingType = groupingType;
         this.updateLayerGroups();
     }
+
     setFilter (activeId, searchText = '') {
         const previousSearchText = this.filter.searchText;
         // Generate search terms by splitting by * and space
@@ -321,6 +322,7 @@ class ViewHandler extends StateHandler {
         });
         this.updateState({ groups });
     }
+
     _refreshAllLayers () {
         if (this.state.groups.length === 0) {
             return;

--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/preset.js
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/preset.js
@@ -2,7 +2,7 @@ export const GROUPING_PRESET = [
     {
         key: 'THEME',
         localeKey: 'inspire',
-        method: 'getInspireName'
+        method: 'getGroups'
     },
     {
         key: 'ORGANIZATION',

--- a/bundles/mapping/mapmodule/domain/AbstractLayer.js
+++ b/bundles/mapping/mapmodule/domain/AbstractLayer.js
@@ -299,33 +299,7 @@ Oskari.clazz.define(
          * @return {String} organization name under which the layer is listed in UI
          */
         getOrganizationName: function (lang) {
-            if (this._organizationName && typeof this._organizationName === 'object') {
-                if (!lang) {
-                    lang = Oskari.getLang();
-                }
-                var value = this._organizationName[lang];
-                if (!value) {
-                    value = this._organizationName[Oskari.getDefaultLanguage()];
-                }
-                return value;
-            }
-            return this._organizationName;
-        },
-
-        /**
-         * Returns an inspire name for the layer.
-         * If the name is populated with a string, always returns it.
-         * With populated object assumes that the object keys are language codes.
-         * If language param is not given, uses Oskari.getLang()
-         * @method getInspireName
-         * @return {String} inspire theme name under which the layer is listed in UI
-         */
-        getInspireName: function () {
-            const groups = this.getGroups();
-            if (!groups.length) {
-                return '';
-            }
-            return groups[0].name;
+            return Oskari.getLocalized(this._organizationName, lang);
         },
 
         /**


### PR DESCRIPTION
Layer can have more than one group so getInspireName doesn't work reliably. Remove getInspireName and use getGroups.

Using getGroups for search index fixes issue where search by group doesn't find all matching layers
=> search: 'roads' and layer's groups: ['some group', 'roads']  => should found