### PR TITLE
Publisher fixes

### DIFF
--- a/bundles/framework/publisher2/handler/ToolPanelHandler.js
+++ b/bundles/framework/publisher2/handler/ToolPanelHandler.js
@@ -3,7 +3,7 @@ import { StateHandler, controllerMixin } from 'oskari-ui/util';
 class UIHandler extends StateHandler {
     constructor (tools, consumer) {
         super();
-        this.allAvailableTools = tools ? [...tools] : [];
+        this.allAvailableTools = Array.isArray(tools) ? tools.toSorted((a, b) => a.index - b.index) : [];
         this.setState({
             tools: []
         });

--- a/bundles/framework/publisher2/view/CollapseContent.jsx
+++ b/bundles/framework/publisher2/view/CollapseContent.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Collapse } from 'oskari-ui';
 import { PropTypes } from 'prop-types';
+import { PANEL_GENERAL_INFO_ID } from './PublisherSideBarHandler';
 
 export const CollapseContent = ({ controller }) => {
     const [items, setItems] = useState(controller.getCollapseItems());
@@ -8,7 +9,7 @@ export const CollapseContent = ({ controller }) => {
         controller.addStateListener(() => { setItems(controller.getCollapseItems()); });
     }, []);
 
-    return <Collapse items={items}/>;
+    return <Collapse defaultActiveKey={[PANEL_GENERAL_INFO_ID]} items={items}/>;
 };
 
 CollapseContent.propTypes = {

--- a/bundles/statistics/statsgrid/publisher/ClassificationTool.js
+++ b/bundles/statistics/statsgrid/publisher/ClassificationTool.js
@@ -5,6 +5,9 @@ class ClassificationTool extends AbstractStatsPluginTool {
         super(...args);
         this.index = 1;
         this.id = 'allowClassification';
+        this.state = {
+            enabled: true // enabled for default
+        };
     }
 
     init (data) {
@@ -32,6 +35,12 @@ class ClassificationTool extends AbstractStatsPluginTool {
             return;
         }
         handler.updateClassificationState('editEnabled', true);
+    }
+
+    // override to include config always. setEnabled checks explicitly if false
+    getValues () {
+        const id = this._getToolId();
+        return this.getConfiguration({ [id]: this.isEnabled() });
     }
 };
 


### PR DESCRIPTION
- open general panel on publiher start
- sort all tools (moved to base handler)
- fix allow classification which defaults to true => requires specific handling than other stats tools. Init state.enabled to trigger handler sync.

Note! accidently commited export in: https://github.com/oskariorg/oskari-frontend/pull/2812 => it has to be merged first