### PR TITLE
Theme set colors fix

### DIFF
--- a/src/oskari.customization.js
+++ b/src/oskari.customization.js
@@ -117,8 +117,17 @@ const setThemeColors = (theme = {}) => {
     }
     _themeColors = { ...theme.color };
     // Add theme colors to predefined colors
-    const colors = [...COLORS, ...Object.values(_themeColors)];
-    setColors([...new Set(colors)]);
+    const colorsFromTheme = Object.values(_themeColors).reduce((colors, cur) => {
+        if (Array.isArray(cur)) {
+            return [...colors, ...cur];
+        }
+        if (typeof cur === 'object') {
+            return [...colors, ...Object.values(cur)];
+        }
+        return [...colors, cur];
+    }, []).filter(color => Oskari.util.colorToArray(color).length);
+
+    setColors([...new Set([...COLORS, ...colorsFromTheme])]);
 };
 
 export const Customization = {


### PR DESCRIPTION
reduce objects and arrays. Validate colors by colorToArray which returns empty array for invalid color.

Fixes issue where theme.color contains objects instead of color strings and color picker causes error. e.g. oskari sample app Finland view:
https://github.com/oskariorg/sample-server-extension/blob/master/app-resources/src/main/resources/json/apps/geoportal-3067_stylized.json#L14-L18

`Oskari.custom.getColors()` should return array containing only valid color strings