### PR TITLE
Statistics search selections async fix

### DIFF
--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -188,39 +188,36 @@ class SearchController extends AsyncStateHandler {
         }
     }
 
-    handleMultipleIndicatorParams (indicators) {
+    async handleMultipleIndicatorParams (selectedIndicators) {
         const combinedSelectors = [];
         const regionsets = new Set();
 
-        const promise = new Promise((resolve, reject) => {
-            indicators.forEach((indId, index) => {
-                this.handleSingleIndicatorParams(indId, (params) => {
-                    // include missing regionsets
-                    params.regionsets.forEach(rs => regionsets.add(rs));
-                    params.selectors.forEach((selector) => {
-                        const existing = combinedSelectors.find(s => s.id === selector.id);
-                        // Note: selectors may come from metadata cache, don't mess up cached data
-                        if (!existing) {
-                            combinedSelectors.push({ ...selector });
-                        } else {
-                            const values = existing.values.map(s => s.value);
-                            const newValues = selector.values.filter(v => !values.includes(v.value));
-                            if (newValues.length) {
-                                existing.values = [...existing.values, ...newValues].sort((a, b) => b.value - a.value);
-                            }
+        for (const indId of selectedIndicators) {
+            await this.handleSingleIndicatorParams(indId, (params) => {
+                // include missing regionsets
+                params.regionsets.forEach(rs => regionsets.add(rs));
+                params.selectors.forEach((selector) => {
+                    console.log(selector);
+                    const existing = combinedSelectors.find(s => s.id === selector.id);
+                    // Note: selectors may come from metadata cache, don't mess up cached data
+                    if (!existing) {
+                        combinedSelectors.push({ ...selector });
+                    } else {
+                        const values = existing.values.map(s => s.value);
+                        const newValues = selector.values.filter(v => !values.includes(v.value));
+                        if (newValues.length) {
+                            existing.values = [...existing.values, ...newValues].sort((a, b) => b.value - a.value);
                         }
-                    });
+                    }
                 });
-                if (index === indicators.length - 1) resolve();
             });
-        });
-        promise.then(() => {
-            const indicatorParams = {
-                selectors: combinedSelectors,
-                regionsets: [...regionsets]
-            };
-            this.setIndicatorParams(indicatorParams);
-        });
+        };
+
+        const indicatorParams = {
+            selectors: combinedSelectors,
+            regionsets: [...regionsets]
+        };
+        this.setIndicatorParams(indicatorParams);
     }
 
     async handleSingleIndicatorParams (indicatorId, cb) {

--- a/bundles/statistics/statsgrid/handler/SearchHandler.js
+++ b/bundles/statistics/statsgrid/handler/SearchHandler.js
@@ -197,7 +197,6 @@ class SearchController extends AsyncStateHandler {
                 // include missing regionsets
                 params.regionsets.forEach(rs => regionsets.add(rs));
                 params.selectors.forEach((selector) => {
-                    console.log(selector);
                     const existing = combinedSelectors.find(s => s.id === selector.id);
                     // Note: selectors may come from metadata cache, don't mess up cached data
                     if (!existing) {


### PR DESCRIPTION
Use aync-await instead of promise to set state after all indicator params are handled.  Fixes issue where multiple indicators (selectors/values varies) are selected and search flyout doesn't show all combined selectors/values. Promise was resolved before all indicator params were handled => flyout renders partial state.

Noticed that Promise works but resolve call is inside forEach loop instead of inside callback function. Could be also fixed by moving resolve() call inside callback.