### PR TITLE
add last login & created to admin user editing form

### DIFF
--- a/bundles/admin/admin-users/handler/AdminUsersHandler.js
+++ b/bundles/admin/admin-users/handler/AdminUsersHandler.js
@@ -240,7 +240,9 @@ class UIHandler extends StateHandler {
             email: '',
             password: '',
             rePassword: '',
-            roles: []
+            roles: [],
+            created: '',
+            lastLogin: ''
         };
     }
 

--- a/bundles/admin/admin-users/resources/locale/en.js
+++ b/bundles/admin/admin-users/resources/locale/en.js
@@ -22,6 +22,8 @@ Oskari.registerLocalization(
             "addRole": "Select role(s)",
             "noMatch": "No results matched",
             "searchResults": "Search results",
+            "created": "Account created",
+            "lastLogin": "Previous login",
             "passwordRequirements": {
                 "title": "Password requirements: ",
                 "length": "Minimum length:  {length}",

--- a/bundles/admin/admin-users/resources/locale/fi.js
+++ b/bundles/admin/admin-users/resources/locale/fi.js
@@ -22,6 +22,8 @@ Oskari.registerLocalization(
             "addRole": "Valitse rooli(t)",
             "noMatch": "Ei hakutuloksia.",
             "searchResults": "Hakutulokset",
+            "created": "Tili luotu",
+            "lastLogin": "Edellinen kirjautuminen",
             "passwordRequirements": {
                 "title": "Salasanan vaatimukset: ",
                 "length": "Vähimmäispituus:  {length}",
@@ -45,7 +47,7 @@ Oskari.registerLocalization(
                 "fetch": "Roolien haku epäonnistui",
                 "save": "Roolin tallennus epäonnistui.",
                 "delete": "Roolin poistaminen epäonnistui."
-            },               
+            },
             "types": {
                 "system": "Järjestelmäroolit",
                 "other": "Lisäroolit"

--- a/bundles/admin/admin-users/resources/locale/sv.js
+++ b/bundles/admin/admin-users/resources/locale/sv.js
@@ -22,6 +22,8 @@ Oskari.registerLocalization(
             "addRole": "Välj rol(ler)",
             "noMatch": "Inga sökresultat.",
             "searchResults": "Sökresultat",
+            "created": "Konto skapad",
+            "lastLogin": "Tidigare inloggning",
             "passwordRequirements": {
                 "title": "Lösenordskrav: ",
                 "length": "Minsta längd:  {length}",

--- a/bundles/admin/admin-users/view/UserForm.jsx
+++ b/bundles/admin/admin-users/view/UserForm.jsx
@@ -32,6 +32,14 @@ export const UserForm = ({ state, controller, isExternal }) => {
                     error={errors.includes('roles')}
                     onChange={value => controller.updateUserFormState('roles', value)}/>
             </LabelledField>
+            <LabelledField>
+                <StyledLabel><Message messageKey='users.created' /></StyledLabel>
+                <StyledLabel>{Oskari.util.formatDate(userFormState.created)}</StyledLabel>
+            </LabelledField>
+            <LabelledField>
+                <StyledLabel><Message messageKey='users.lastLogin' /></StyledLabel>
+                <StyledLabel>{Oskari.util.formatDate(userFormState.lastLogin)}</StyledLabel>
+            </LabelledField>
             <ButtonContainer>
                 <SecondaryButton
                     type='cancel'


### PR DESCRIPTION
See also pr for backend: https://github.com/oskariorg/oskari-server/pull/1161 

Add info of user creation date & last login to admin user editing form.

We probably should also have this same info in users list but for it to be useful we might need to have a table-like design with sorting and stuff, which atm (when we only fetch n users / page) isn't possible.

![image](https://github.com/user-attachments/assets/75c2a025-dc24-46ca-ba6b-e8ac8e5cdc26)
