### PR TITLE
Publisher map size

### DIFF
--- a/bundles/framework/publisher2/handler/PanelMapPreviewHandler.js
+++ b/bundles/framework/publisher2/handler/PanelMapPreviewHandler.js
@@ -1,32 +1,24 @@
 import { StateHandler, controllerMixin } from 'oskari-ui/util';
 import { PUBLISHER_BUNDLE_ID } from '../view/PublisherSideBarHandler';
 
-export const CUSTOM_MAP_SIZE_ID = 'custom';
-const MAP_SIZE_FILL_ID = 'fill';
+export const CUSTOM_MAP_SIZE = 'custom';
+const DEFAULT_MAP_SIZE = 'fill';
 export const MAP_SIZES = [{
-    id: MAP_SIZE_FILL_ID,
-    width: '',
-    height: '',
-    selected: true, // default option
-    valid: true
+    value: 'fill'
 }, {
-    id: 'small',
+    value: 'small',
     width: 580,
-    height: 387,
-    valid: true
+    height: 387
 }, {
-    id: 'medium',
+    value: 'medium',
     width: 700,
-    height: 600,
-    valid: true
+    height: 600
 }, {
-    id: 'large',
+    value: 'large',
     width: 1240,
-    height: 700,
-    valid: true
+    height: 700
 }, {
-    id: CUSTOM_MAP_SIZE_ID,
-    valid: true
+    value: CUSTOM_MAP_SIZE
 }];
 
 export const CUSTOM_MAP_SIZE_LIMITS = {
@@ -41,55 +33,61 @@ class UIHandler extends StateHandler {
         super();
         this.mapmodule = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule');
         this.state = {
-            id: MAP_SIZE_FILL_ID
+            preview: DEFAULT_MAP_SIZE,
+            customSize: {},
+            errors: []
         };
     }
 
     init (data) {
-        const selectedId = data?.metadata?.preview || MAP_SIZE_FILL_ID;
-        const selectedMapSize = MAP_SIZES.find(size => size.id === selectedId);
-        if (selectedId === CUSTOM_MAP_SIZE_ID) {
-            selectedMapSize.width = data?.metadata?.size?.width || '';
-            selectedMapSize.height = data?.metadata?.size?.height || '';
+        if (!data?.metadata) {
+            return;
         }
-        this.updateMapSize(selectedMapSize);
+        const { preview: stored, size = {} } = data.metadata;
+        // use default size if stored preview size isn't in options (e.g. 'desktop')
+        const preview = MAP_SIZES.find(opt => opt.value === stored)?.value || DEFAULT_MAP_SIZE;
+        if (preview === CUSTOM_MAP_SIZE) {
+            this.updateState({ customSize: size });
+        }
+        // use set preview to adjust map size
+        this.setPreview(preview);
     }
 
-    updateMapSize (mapSize) {
-        this.updateState({
-            ...mapSize
-        });
-        if (mapSize.valid) {
-            this.adjustDataContainer();
+    setPreview (preview) {
+        const { value, ...size } = MAP_SIZES.find(opt => opt.value === preview) || {};
+        if (!value) {
+            return;
+        }
+        this.updateState({ preview });
+        if (preview === CUSTOM_MAP_SIZE) {
+            // use setter to validate values
+            this.setCustomSize(this.getState().customSize);
+            return;
+        }
+        this.adjustMapSize(size);
+    }
+
+    setCustomSize (customSize) {
+        const errors = this.validateSize(customSize);
+        this.updateState({ customSize, errors });
+        if (!errors.length) {
+            this.adjustMapSize(customSize);
         }
     }
 
-    /**
-     * @method adjustDataContainer
-     * This horrific thing is what sets the left panel components, container and map size.
-     */
-    adjustDataContainer () {
-        const selectedSize = this.getSelectedMapSize();
-        const size = selectedSize.valid ? selectedSize : this.getActiveMapSize();
-
-        const mapDiv = this.mapmodule.getMapEl();
-        mapDiv.width(size.width || '100%');
-        mapDiv.height(size.height || '100%');
+    adjustMapSize (size) {
+        this.mapmodule.setMapSize(size);
     }
 
-    /**
-     * @private @method getActiveMapSize
-     * Returns an object containing the active map size.
-     * This will differ from selected size if selected size is invalid.
-     *
-     * @return {Object} size
-     */
-    getActiveMapSize () {
-        const mapDiv = this.mapmodule.getMapEl();
-        return {
-            width: mapDiv.width(),
-            height: mapDiv.height()
-        };
+    validateSize ({ width, height }) {
+        const errors = [];
+        if (!width || width < CUSTOM_MAP_SIZE_LIMITS.minWidth || width > CUSTOM_MAP_SIZE_LIMITS.maxWidth) {
+            errors.push('width');
+        }
+        if (!height || height < CUSTOM_MAP_SIZE_LIMITS.minHeight || height > CUSTOM_MAP_SIZE_LIMITS.maxHeight) {
+            errors.push('height');
+        }
+        return errors;
     }
 
     /**
@@ -98,63 +96,44 @@ class UIHandler extends StateHandler {
     * @public
     **/
     stop () {
-        // restore "fill" as default size setting
-        this.updateMapSize(MAP_SIZES.find(size => size.id === MAP_SIZE_FILL_ID));
-
+        // TODO: this should be handled on publisher close (instance, publisher,..) not on panel remove
         window.setTimeout(() => {
             // calculate new sizes AFTER the publisher panel has been removed from page
             // otherwise the publisher panel that we have while stopping is taking up space
             // from the map and the map size is calculated wrong
-            this.adjustDataContainer();
+            this.adjustMapSize();
         }, 200);
     }
 
     getValues () {
-        const selected = this.getSelectedMapSize();
-        const values = {
-            metadata: {
-                preview: selected.id
+        const { customSize, preview } = this.getState();
+        const metadata = { preview };
+        if (preview === CUSTOM_MAP_SIZE) {
+            metadata.size = customSize;
+        } else {
+            const { width, height } = MAP_SIZES.find(opt => opt.value === preview) || {};
+            if (width && height) {
+                metadata.size = { width, height };
             }
-        };
-
-        if (!isNaN(parseInt(selected.width)) && !isNaN(parseInt(selected.height))) {
-            values.metadata.size = {
-                width: selected.width,
-                height: selected.height
-            };
         }
-        return values;
+        return { metadata };
     }
 
     validate () {
-        const errors = [];
-        if (!this.getSelectedMapSize().valid) {
-            errors.push({
+        const { errors, preview } = this.getState();
+        if (preview === CUSTOM_MAP_SIZE && errors.length) {
+            return [{
                 field: 'size',
                 error: Oskari.getMsg(PUBLISHER_BUNDLE_ID, 'BasicView.error.size', CUSTOM_MAP_SIZE_LIMITS)
-            });
+            }];
         }
-        return errors;
-    }
-
-    /**
-     * @private @method getSelectedMapSize
-     * Returns an object containing the user seleted/set map size and the corresponding size option
-     *
-     * @return {Object} size
-     */
-    getSelectedMapSize () {
-        return {
-            ...this.state
-        };
+        return [];
     }
 }
 
 const wrapped = controllerMixin(UIHandler, [
-    'validate',
-    'getValues',
-    'getSelectedMapSize',
-    'updateMapSize'
+    'setPreview',
+    'setCustomSize'
 ]);
 
 export { wrapped as PanelMapPreviewHandler };

--- a/bundles/framework/publisher2/view/PublisherSideBarHandler.js
+++ b/bundles/framework/publisher2/view/PublisherSideBarHandler.js
@@ -220,9 +220,8 @@ class PublisherSidebarUIHandler extends StateHandler {
     renderMapPreviewPanel () {
         return <div className={'t_size'}>
             <MapPreviewForm
-                onChange={(value) => { this.mapPreviewPanelHandler.updateMapSize(value); }}
-                mapSizeOptions={MAP_SIZES}
-                initialSelection={this.mapPreviewPanelHandler.getSelectedMapSize() || null}/>
+                state={this.mapPreviewPanelHandler.getState()}
+                controller={this.mapPreviewPanelHandler.getController()} />
         </div>;
     }
 

--- a/bundles/framework/publisher2/view/form/MapPreviewForm.jsx
+++ b/bundles/framework/publisher2/view/form/MapPreviewForm.jsx
@@ -1,116 +1,62 @@
-import React, { useEffect, useState } from 'react';
-import { Radio, TextInput, Message } from 'oskari-ui';
+import React from 'react';
+import { Radio, Message, NumberInput } from 'oskari-ui';
 import { Info } from 'oskari-ui/components/icons/Info';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { CUSTOM_MAP_SIZE_ID, CUSTOM_MAP_SIZE_LIMITS } from '../../handler/PanelMapPreviewHandler';
+import { CUSTOM_MAP_SIZE, CUSTOM_MAP_SIZE_LIMITS, MAP_SIZES } from '../../handler/PanelMapPreviewHandler';
 import { PUBLISHER_BUNDLE_ID } from '../PublisherSideBarHandler';
 
-const Row = styled('div')`
+const InputContainer = styled('div')`
     margin-top: 0.5em;
     display: flex;
     flex-direction: row;
+`;
 
-    .ant-input.customsize {
-        width: 80px;
-    }
-    input.error {
-        border: 1px solid red;
-    }
+const SizeInput = styled(NumberInput)`
+    width: 80px;
 `;
 
 const CustomSeparator = styled('div')`
     margin: auto 0.5em;
 `;
 
-const RowContainer = styled('div')`
+const RadioGroup = styled(Radio.Group)`
     display: flex;
     flex-direction: column;
 `;
 
-const Label = (props) => {
-    const { option } = props;
-    let extraInfo = '';
-    if (option.id !== CUSTOM_MAP_SIZE_ID && !isNaN(parseInt(option.width)) && !isNaN(parseInt(option.height))) {
-        extraInfo = '(' + option.width + ' x ' + option.height + 'px)';
-    }
-    return <Message messageKey={ 'BasicView.sizes.' + option.id}>{ extraInfo }</Message>;
-};
-
-Label.propTypes = {
-    option: PropTypes.any
-};
+const getLabel = ({ value, width, height }) => <Message messageKey={`BasicView.sizes.${value}`}>{ width && height ? `(${width} x ${height})` : '' }</Message>;
 
 export const MapPreviewTooltip = () => <Info title={<Message messageKey='BasicView.size.tooltip' messageArgs={CUSTOM_MAP_SIZE_LIMITS} />}/>;
 
-export const MapPreviewForm = (props) => {
-    const { onChange, mapSizeOptions, initialSelection } = props;
-    const [selected, setSelected] = useState(initialSelection?.id || mapSizeOptions.find(option => option.selected).id);
-    const [customWidth, setCustomWidth] = useState(initialSelection?.width ? initialSelection?.width : null);
-    const [customHeight, setCustomHeight] = useState(initialSelection?.height ? initialSelection?.height : null);
-    const [errors, setErrors] = useState({});
-
-    const isValidWidth = (width) => {
-        return selected !== CUSTOM_MAP_SIZE_ID || (width >= CUSTOM_MAP_SIZE_LIMITS.minWidth && width <= CUSTOM_MAP_SIZE_LIMITS.maxWidth);
-    };
-
-    const isValidHeight = (height) => {
-        return selected !== CUSTOM_MAP_SIZE_ID || (height >= CUSTOM_MAP_SIZE_LIMITS.minHeight && height <= CUSTOM_MAP_SIZE_LIMITS.maxHeight);
-    };
-
-    const widthChanged = (value) => {
-        setErrors({ ...errors, width: !isValidWidth(value) });
-        setCustomWidth(value);
-    };
-
-    const heightChanged = (value) => {
-        setErrors({ ...errors, height: !isValidHeight(value) });
-        setCustomHeight(value);
-    };
-
-    useEffect(() => {
-        const selectedOption = mapSizeOptions.find(option => option.id === selected);
-        let valid = true;
-        if (selected === CUSTOM_MAP_SIZE_ID) {
-            valid = isValidWidth(customWidth) && isValidHeight(customHeight);
-            selectedOption.width = customWidth;
-            selectedOption.height = customHeight;
-        }
-        selectedOption.valid = valid;
-        onChange(selectedOption);
-    }, [selected, customWidth, customHeight]);
-
-    const customInputDisabled = selected !== CUSTOM_MAP_SIZE_ID;
-    return <RowContainer>
-        <Radio.Group value={selected} onChange={(evt) => setSelected(evt.target.value)}>
-            { mapSizeOptions.map((option) => {
-                return <Row key={option.id}>
-                    <Radio.Choice key={'radio_' + option.id} value={option.id}><Label option={option}/></Radio.Choice>
-                </Row>;
-            })}
-        </Radio.Group>
-        {
-            <Row>
-                <TextInput
-                    placeholder={Oskari.getMsg(PUBLISHER_BUNDLE_ID, 'BasicView.sizes.width')}
-                    disabled={customInputDisabled}
-                    className={!customInputDisabled && errors?.width ? 'customsize error' : 'customsize'}
-                    onChange={((evt) => { widthChanged(evt.currentTarget.value); })}
-                    value={customWidth}/>
-                <CustomSeparator>X</CustomSeparator>
-                <TextInput
-                    placeholder={Oskari.getMsg(PUBLISHER_BUNDLE_ID, 'BasicView.sizes.height')}
-                    disabled={customInputDisabled}
-                    className={!customInputDisabled && errors?.height ? 'customsize error' : 'customsize'}
-                    onChange={((evt) => { heightChanged(evt.currentTarget.value); })}
-                    value={customHeight}/>
-            </Row>
-        }
-    </RowContainer>;
+export const MapPreviewForm = ({ state, controller }) => {
+    const { preview, customSize, errors } = state;
+    const options = MAP_SIZES.map(opt => ({ value: opt.value, label: getLabel(opt) }));
+    // don't show error for initial value
+    const getStatus = key => typeof customSize[key] !== 'undefined' && errors.includes(key) ? 'error' : undefined;
+    return (
+        <div>
+            <RadioGroup value={preview} onChange={evt => controller.setPreview(evt.target.value)} options={options}/>
+            { preview === CUSTOM_MAP_SIZE && (
+                <InputContainer>
+                    <SizeInput
+                        placeholder={Oskari.getMsg(PUBLISHER_BUNDLE_ID, 'BasicView.sizes.width')}
+                        onChange={width => controller.setCustomSize({ ...customSize, width })}
+                        status={getStatus('width')}
+                        value={customSize.width}/>
+                    <CustomSeparator>X</CustomSeparator>
+                    <SizeInput
+                        placeholder={Oskari.getMsg(PUBLISHER_BUNDLE_ID, 'BasicView.sizes.height')}
+                        status={getStatus('height')}
+                        onChange={height => controller.setCustomSize({ ...customSize, height })}
+                        value={customSize.height}/>
+                </InputContainer>
+            )}
+        </div>
+    );
 };
 
 MapPreviewForm.propTypes = {
-    mapSizeOptions: PropTypes.array,
-    initialSelection: PropTypes.object,
-    onChange: PropTypes.func
+    state: PropTypes.object.isRequired,
+    controller: PropTypes.object.isRequired
 };

--- a/bundles/framework/publisher2/view/form/MapPreviewForm.jsx
+++ b/bundles/framework/publisher2/view/form/MapPreviewForm.jsx
@@ -41,14 +41,7 @@ Label.propTypes = {
     option: PropTypes.any
 };
 
-export const MapPreviewTooltip = () => {
-    let tooltip = Oskari.getMsg(PUBLISHER_BUNDLE_ID, 'BasicView.size.tooltip');
-    tooltip = tooltip.replace('{minWidth}', CUSTOM_MAP_SIZE_LIMITS.minWidth);
-    tooltip = tooltip.replace('{maxWidth}', CUSTOM_MAP_SIZE_LIMITS.maxWidth);
-    tooltip = tooltip.replace('{minHeight}', CUSTOM_MAP_SIZE_LIMITS.minHeight);
-    tooltip = tooltip.replace('{maxHeight}', CUSTOM_MAP_SIZE_LIMITS.maxHeight);
-    return <Info title={tooltip}/>;
-};
+export const MapPreviewTooltip = () => <Info title={<Message messageKey='BasicView.size.tooltip' messageArgs={CUSTOM_MAP_SIZE_LIMITS} />}/>;
 
 export const MapPreviewForm = (props) => {
     const { onChange, mapSizeOptions, initialSelection } = props;

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -623,10 +623,16 @@ Oskari.clazz.define(
         },
         /**
          * @method getMapEl
-         * Get jQuery reference to map element
+         * Get reference to map element
          */
         getMapDOMEl: function () {
             return this._mapDivEl;
+        },
+        setMapSize: function (size = {}) {
+            const { width = '100%', height = '100%' } = size;
+            const mapDiv = this.getMapEl();
+            mapDiv.width(width);
+            mapDiv.height(height);
         },
         /**
          * @method getMap


### PR DESCRIPTION
Old published map might have preview selection which doesn't exist in options list. Code assumed that option is always found and caused JS error with unknown selection (e.g. `desktop`). Use default `fill` if not found on init.

Refactored panel by removing internal state. Handler & save requires same values than was stored to internal state. Also MAP_SIZE constant was mutated (custom size and valid) and stored to state.