### PR TITLE
Mydata published snippet

### DIFF
--- a/bundles/framework/mydata/handler/PublishedMapsHandler.js
+++ b/bundles/framework/mydata/handler/PublishedMapsHandler.js
@@ -30,7 +30,22 @@ class MapsHandler extends StateHandler {
         if (this.popupControls) {
             this.popupCleanup();
         }
-        this.popupControls = showSnippetPopup(view, () => this.popupCleanup());
+        this.popupControls = showSnippetPopup(view, () => this.popupCleanup(), this.getParamsForHtml());
+    }
+
+    refreshHtmlSnippet () {
+        if (!this.popupControls) {
+            return;
+        }
+        this.popupControls.update(this.getParamsForHtml());
+    }
+
+    getParamsForHtml () {
+        const { x, y, zoom } = this.sandbox.getMap().getLocation();
+        return {
+            zoomLevel: zoom,
+            coord: `${x}_${y}`
+        };
     }
 
     refreshViewsList () {
@@ -250,7 +265,8 @@ class MapsHandler extends StateHandler {
         const handlers = {
             'Publisher.MapPublishedEvent': (event) => {
                 this.refreshViewsList();
-            }
+            },
+            'AfterMapMoveEvent': event => this.refreshHtmlSnippet(event)
         };
         Object.getOwnPropertyNames(handlers).forEach(p => this.sandbox.registerForEventByName(this, p));
         return handlers;

--- a/bundles/framework/mydata/handler/PublishedMapsHandler.js
+++ b/bundles/framework/mydata/handler/PublishedMapsHandler.js
@@ -266,7 +266,7 @@ class MapsHandler extends StateHandler {
             'Publisher.MapPublishedEvent': (event) => {
                 this.refreshViewsList();
             },
-            'AfterMapMoveEvent': event => this.refreshHtmlSnippet(event)
+            'AfterMapMoveEvent': event => this.refreshHtmlSnippet()
         };
         Object.getOwnPropertyNames(handlers).forEach(p => this.sandbox.registerForEventByName(this, p));
         return handlers;

--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -302,6 +302,8 @@ Oskari.clazz.define(
             }
 
             me._map = me.createMap();
+            // createMap registers epsg codes for proj4, store decimals after that
+            me._sandbox.getMap().setSrsDecimals(me.getProjectionDecimals(me._projectionCode));
 
             if (me._options?.crosshair) {
                 me.toggleCrosshair(true);
@@ -593,8 +595,7 @@ Oskari.clazz.define(
          * @return {Integer} projetion decimals (decimal count spefied by units)
          */
         getProjectionDecimals: function (srs) {
-            var me = this;
-            var units = me.getProjectionUnits(srs);
+            const units = this.getProjectionUnits(srs);
             if (units === 'm') {
                 return 0;
             } else if (units === 'degrees') {

--- a/bundles/mapping/mapmodule/service/map.state.js
+++ b/bundles/mapping/mapmodule/service/map.state.js
@@ -55,6 +55,7 @@ import { UnsupportedLayerReason } from '../domain/UnsupportedLayerReason';
 
         // @property {String} _projectionCode SRS projection code, defaults to 'EPSG:3067'
         this._projectionCode = 'EPSG:3067';
+        this._projectionDecimals = 6;
 
         this._layerSupportedChecks = {};
     }, {
@@ -137,6 +138,14 @@ import { UnsupportedLayerReason } from '../domain/UnsupportedLayerReason';
          */
         getZoom: function () {
             return this._zoom;
+        },
+        getLocation: function () {
+            const decimals = this._projectionDecimals;
+            return {
+                x: this.getX().toFixed(decimals),
+                y: this.getY().toFixed(decimals),
+                zoom: this.getZoom()
+            };
         },
         /**
          * @method setScale
@@ -291,6 +300,9 @@ import { UnsupportedLayerReason } from '../domain/UnsupportedLayerReason';
          */
         setSrsName: function (projectionCode) {
             this._projectionCode = projectionCode;
+        },
+        setSrsDecimals: function (decimals) {
+            this._projectionDecimals = decimals;
         },
         /**
          * @method getSrsName


### PR DESCRIPTION
Add toggle to SnippetPopup to add map location query params (coords & zoomLevel) to iframe url.

Added `getLocation()` function for `Map`. Could be also formatted in snippet functionality but maybe other functionalities (e.g. url popup, marker label, ...) could benefit from it.  ~8 decimals for metric coordinates looks little odd.

Changes for snippet were made in: https://github.com/oskariorg/oskari-frontend/pull/2826/