### PR TITLE
Update dompurify 2.5.8 -> 3.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "core-js": "3.38.1",
     "css-loader": "5.2.7",
     "d3": "7.8.4",
-    "dompurify": "2.5.8",
+    "dompurify": "3.2.5",
     "eslint": "8.57.0",
     "eslint-config-standard": "17.1.0",
     "eslint-import-resolver-webpack": "0.13.9",


### PR DESCRIPTION
Dompurify 3.0 dropped support for msie, but the API etc is the same.