### PR TITLE
Add styling for printing (with browser functionality)

### DIFF
--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -90,6 +90,38 @@ body, button, input, select, textarea {
   line-height: 21px;
 }
 
+/**
+Print profile to make the map printable since it uses vw/vh sizes:
+- hides announcement banners and guided tour popup
+- hides the main navigation under oskari root el
+- hides all map-plugins other than logo and scalebar
+- makes the oskari root el "full size" on page
+- adds a border for debugging mostly
+
+If the screen is not "big enough" the page will have an empty section where map could be.
+On 3D, cesium seems to render for printing in a way that messes up aspect ratio, but couldn't find a nice fix for that.
+*/
+@media print {
+  /* Hide any page header element, the main oskari nav, announcement banner and Guided Tour */
+  header, .oskari-root-el nav, .oskari-root-el .t_banner.t_announcements, .oskari-react-tmp-container .t_popup.t_GuidedTour {
+    display: none !important;
+    visibility: hidden !important;
+  }
+  .oskari-root-el .mappluginsContainer:not(:has(.mapplugin.scalebar, .mapplugin.logoplugin)) {
+    display: none !important;
+  }
+  .oskari-root-el {
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    box-sizing: border-box;
+    width: 99%;
+    height: 99%;
+    border: 1px dashed;
+  }
+}
+
 em {
   font-style: italic;
 }

--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -102,14 +102,16 @@ If the screen is not "big enough" the page will have an empty section where map 
 On 3D, cesium seems to render for printing in a way that messes up aspect ratio, but couldn't find a nice fix for that.
 */
 @media print {
-  /* Hide any page header element, the main oskari nav, announcement banner and Guided Tour */
-  header, .oskari-root-el nav, .oskari-root-el .t_banner.t_announcements, .oskari-react-tmp-container .t_popup.t_GuidedTour {
+  /* Hide the main oskari nav, announcement banner and Guided Tour */
+  .oskari-root-el nav, .oskari-root-el .t_banner.t_announcements, .oskari-react-tmp-container .t_popup.t_GuidedTour {
     display: none !important;
     visibility: hidden !important;
   }
+  /* Hide most map plugins */
   .oskari-root-el .mappluginsContainer:not(:has(.mapplugin.scalebar, .mapplugin.logoplugin)) {
     display: none !important;
   }
+  /* Make the Oskari element "full screen" */
   .oskari-root-el {
     position: absolute;
     top: 0;


### PR DESCRIPTION
Fixes an issue where browser printing looks like this:
![image](https://github.com/user-attachments/assets/060cdb3e-d8c3-45fc-8255-1558b9c63dd7)

