### PR TITLE
Fix banner visibility for print media

### DIFF
--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -103,7 +103,7 @@ On 3D, cesium seems to render for printing in a way that messes up aspect ratio,
 */
 @media print {
   /* Hide the main oskari nav, announcement banner and Guided Tour */
-  .oskari-root-el nav, .oskari-root-el .t_banner.t_announcements, .oskari-react-tmp-container .t_popup.t_GuidedTour {
+  .oskari-root-el nav, .oskari-react-tmp-container .t_banner.t_announcements, .oskari-react-tmp-container .t_popup.t_GuidedTour {
     display: none !important;
     visibility: hidden !important;
   }


### PR DESCRIPTION
Continues #2835. Banner goes under tmp-container, not root-el