### PR TITLE
Only add (browser) printing border for geoportal

### DIFF
--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -118,8 +118,11 @@ On 3D, cesium seems to render for printing in a way that messes up aspect ratio,
     left: 0;
 
     box-sizing: border-box;
-    width: 99%;
-    height: 99%;
+    width: 100%;
+    height: 100%;
+  }
+  /* add a border when not embedded/published map */
+  .oskari-root-el:not(:has(.oskari-map-container-el.published)) {
     border: 1px dashed;
   }
 }


### PR DESCRIPTION
Continuing: #2835 and #2839 

With `box-sizing: border-box;` we can just have the size to 100%, the border just looked weird on preview and scaled back by the browser, but with actual size for printing the 100% works well.

Don't add border when printing embedded maps:
![image](https://github.com/user-attachments/assets/5876db09-5c58-40ef-b2d7-ac280b1ea13b)

Without this:
![image](https://github.com/user-attachments/assets/e94120d9-d1ac-476f-a93f-355d170930f1)
