### PR TITLE
Coordinatetool rpconly fix

### DIFF
--- a/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
+++ b/bundles/framework/coordinatetool/plugin/CoordinateToolPlugin.js
@@ -58,6 +58,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.coordinatetool.plugin.Coordinate
             this.addToPluginContainer(this.getElement());
             this.refresh();
         },
+        setNoUI: function (value) {
+            this._config.noUI = value;
+        },
         hasUI: function () {
             return !this._config.noUI;
         },

--- a/bundles/framework/coordinatetool/publisher/CoordinateToolHandler.js
+++ b/bundles/framework/coordinatetool/publisher/CoordinateToolHandler.js
@@ -12,6 +12,7 @@ class UIHandler extends StateHandler {
     };
 
     init (config) {
+        super.init(config);
         this.updateState({
             ...config,
             noUI: config?.noUI,
@@ -25,10 +26,16 @@ class UIHandler extends StateHandler {
             noUI: value
         });
 
+        const plugin = this.tool?.getPlugin() || null;
+        if (!plugin) {
+            return;
+        }
+
+        plugin.setNoUI(value);
         if (value) {
-            this.tool.getPlugin().teardownUI(true);
+            plugin.teardownUI(true);
         } else {
-            this.tool.getPlugin().redrawUI(Oskari.util.isMobile());
+            plugin.redrawUI(Oskari.util.isMobile());
         }
     }
 

--- a/bundles/framework/coordinatetool/publisher/CoordinateToolHandler.js
+++ b/bundles/framework/coordinatetool/publisher/CoordinateToolHandler.js
@@ -12,7 +12,6 @@ class UIHandler extends StateHandler {
     };
 
     init (config) {
-        super.init(config);
         this.updateState({
             ...config,
             noUI: config?.noUI,

--- a/bundles/mapping/mapmodule/publisher/getinfo/GetInfoTool.js
+++ b/bundles/mapping/mapmodule/publisher/getinfo/GetInfoTool.js
@@ -13,7 +13,7 @@ class GetInfoTool extends AbstractPublisherTool {
 
     init (data) {
         super.init(data);
-        const pluginConfig = this.getPlugin().getConfig() || {};
+        const pluginConfig = this.getPlugin()?.getConfig() || {};
         this.handler.init(pluginConfig);
     }
 


### PR DESCRIPTION
fixed a bug where xy-tool never was toggled visible again in publisher when the map was initially saved with "rpc only" flag set. 