### PR TITLE
Infobox use header colors from options

### DIFF
--- a/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
+++ b/bundles/mapping/infobox/plugin/openlayerspopup/OpenlayersPopupPlugin.ol.js
@@ -182,9 +182,9 @@ Oskari.clazz.define(
             const mapTheme = mapModule.getMapTheme();
             if (mapTheme) {
                 colourScheme = {
-                    ...colourScheme,
                     bgColour: mapTheme?.infobox?.header?.bg,
-                    titleColour: mapTheme?.infobox?.header?.text
+                    titleColour: mapTheme?.infobox?.header?.text,
+                    ...colourScheme
                 };
             }
 


### PR DESCRIPTION
change to override theme colors with provided colors

` const center = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule').getMapCenter();`
`Oskari.getSandbox().postRequestByName('InfoBox.ShowInfoBoxRequest', ['id', 'Title', [{html:'Content'}], center, { colourScheme: { bgColour: '#0091FF'} }]);`

