### PR TITLE
Publisher flyout tou

### DIFF
--- a/bundles/framework/publisher2/Flyout.js
+++ b/bundles/framework/publisher2/Flyout.js
@@ -24,7 +24,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.Flyout',
     function (instance) {
         this.instance = instance;
         this.container = null;
-        this.hasAcceptedTou = null;
+        this.hasAcceptedTou = Oskari.user().isLoggedIn() ? null : false;
     }, {
         /**
          * @method getName

--- a/bundles/framework/publisher2/Flyout.js
+++ b/bundles/framework/publisher2/Flyout.js
@@ -48,7 +48,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.Flyout',
             });
         },
         setAcceptTou () {
-            this.instance.getSandbox().postRequestByName('Publisher.PublishMapEditorRequest');
+            this.instance.setPublishMode(true);
             this.instance.getService().markTouAccepted(response => {
                 this.hasAcceptedTou = response;
             });
@@ -72,10 +72,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.Flyout',
         },
         getActions: function () {
             return {
-                close: () => this.instance.getFlyout().close(),
-                continue: () => this.instance.getSandbox().postRequestByName('Publisher.PublishMapEditorRequest'),
+                close: () => this.close(),
+                continue: () => this.instance.setPublishMode(true),
                 acceptTou: () => this.setAcceptTou(),
-                showTou: () => this.showTouPopup()
+                showTou: () => this.instance.getService().getTouArticle(content => showTouPopup(content))
             };
         },
         getLayers: function () {

--- a/bundles/framework/publisher2/Flyout.js
+++ b/bundles/framework/publisher2/Flyout.js
@@ -53,15 +53,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.publisher2.Flyout',
                 this.hasAcceptedTou = response;
             });
         },
-        showTouPopup () {
-            this.instance.getService().getTouArticle(response => {
-                const content = response || {
-                    title: this.instance.loc('BasicView.error.title'),
-                    body: this.instance.loc('StartView.tou.notfound')
-                };
-                showTouPopup(content);
-            });
-        },
         getUrls: function () {
             const { termsOfUseUrl, loginUrl, registerUrl } = this.instance.conf || {};
             return {

--- a/bundles/framework/publisher2/resources/locale/en.js
+++ b/bundles/framework/publisher2/resources/locale/en.js
@@ -193,6 +193,7 @@ Oskari.registerLocalization(
                 "continueAndAccept": "Accept and continue"
             },
             "tou": {
+                "title": "Terms of Use",
                 "notfound": "Terms of Use could not be found.",
                 "reject": "Reject",
                 "accept": "Accept"

--- a/bundles/framework/publisher2/resources/locale/fi.js
+++ b/bundles/framework/publisher2/resources/locale/fi.js
@@ -193,6 +193,7 @@ Oskari.registerLocalization(
                 "continueAndAccept": "Hyväksy ehdot ja jatka"
             },
             "tou": {
+                "title": "Käyttöehdot",
                 "notfound": "Käyttöehtoja ei löytynyt.",
                 "reject": "Hylkää",
                 "accept": "Hyväksy"

--- a/bundles/framework/publisher2/resources/locale/fr.js
+++ b/bundles/framework/publisher2/resources/locale/fr.js
@@ -159,6 +159,7 @@ Oskari.registerLocalization(
                 "continueAndAccept": "Accepter et continuer"
             },
             "tou": {
+                "title": "Les conditions d'utilisation",
                 "notfound": "Impossible de trouver les conditions d'utilisation.",
                 "reject": "Refuser",
                 "accept": "Accepter"

--- a/bundles/framework/publisher2/resources/locale/is.js
+++ b/bundles/framework/publisher2/resources/locale/is.js
@@ -147,6 +147,7 @@ Oskari.registerLocalization(
                 "continueAndAccept": "Samþykkja og halda áfram"
             },
             "tou": {
+                "title": "Notandaskilmálar",
                 "notfound": "Notandaskilmálar fundust ekki",
                 "reject": "Hafna",
                 "accept": "Samþykkja"

--- a/bundles/framework/publisher2/resources/locale/ru.js
+++ b/bundles/framework/publisher2/resources/locale/ru.js
@@ -160,6 +160,7 @@ Oskari.registerLocalization(
                 "continueAndAccept": "Принять и продолжить"
             },
             "tou": {
+                "title": "Условия использования",
                 "notfound": "Условия использования не могут быть найдены.",
                 "reject": "Отклонить",
                 "accept": "Принять"

--- a/bundles/framework/publisher2/resources/locale/sv.js
+++ b/bundles/framework/publisher2/resources/locale/sv.js
@@ -191,6 +191,7 @@ Oskari.registerLocalization(
                 "continueAndAccept": "Godkänn användningsvillkor och fortsätt"
             },
             "tou": {
+                "title": "Användningsvillkoren",
                 "notfound": "Användningsvillkoren kunde inte hittas",
                 "reject": "Avvisa",
                 "accept": "Acceptera"

--- a/bundles/framework/publisher2/view/dialog/TouPopup.jsx
+++ b/bundles/framework/publisher2/view/dialog/TouPopup.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { showPopup } from 'oskari-ui/components/window';
+import { Message } from 'oskari-ui';
 import { BUNDLE_KEY } from '../../constants';
 
 const POPUP_OPTIONS = {
@@ -11,12 +12,16 @@ const Content = styled.div`
     padding: 20px;
 `;
 
-export const showTouPopup = ({ title, body }) => {
+export const showTouPopup = (tou) => {
+    const { title, body } = tou || {};
     // no need to update
-    const content = (
-        <Content>
-            <div dangerouslySetInnerHTML={{ __html: body }} />
-        </Content>
+    const content = body
+        ? <div dangerouslySetInnerHTML={{ __html: body }} />
+        : <Message bundleKey={BUNDLE_KEY} messageKey='StartView.tou.notfound' />;
+    showPopup(
+        title || <Message bundleKey={BUNDLE_KEY} messageKey='StartView.tou.title' />,
+        <Content>{content}</Content>,
+        () => {},
+        POPUP_OPTIONS
     );
-    showPopup(title, content, () => {}, POPUP_OPTIONS);
 };

--- a/bundles/framework/publisher2/view/dialog/TouPopup.jsx
+++ b/bundles/framework/publisher2/view/dialog/TouPopup.jsx
@@ -13,13 +13,16 @@ const Content = styled.div`
 `;
 
 export const showTouPopup = (tou) => {
-    const { title, body } = tou || {};
+    const { title, body, dummy } = tou || {};
     // no need to update
-    const content = body
+    const content = body && !dummy
         ? <div dangerouslySetInnerHTML={{ __html: body }} />
         : <Message bundleKey={BUNDLE_KEY} messageKey='StartView.tou.notfound' />;
+    const popupTitle = title && !dummy
+        ? title
+        : <Message bundleKey={BUNDLE_KEY} messageKey='StartView.tou.title' />;
     showPopup(
-        title || <Message bundleKey={BUNDLE_KEY} messageKey='StartView.tou.title' />,
+        popupTitle,
         <Content>{content}</Content>,
         () => {},
         POPUP_OPTIONS


### PR DESCRIPTION
Mark hasAcceptedTou as `false` for guest user => don't show spinner & fetch for guest

React popup shows always header => add `Terms of Use` title if response doesn't have it. Move not found functionality to popup from flyout.

3.0.0:
![image](https://github.com/user-attachments/assets/4d60c0a2-92bd-493f-99d5-0f35ebf6651b)

3.1.0 (develop):
![image](https://github.com/user-attachments/assets/6d5e79e5-c49f-4816-a3d4-6380702633ea)

this:
![image](https://github.com/user-attachments/assets/a4538d7b-f033-4346-a561-498b0a79c4d7)

