### PR TITLE
Publisher handlers remove react

### DIFF
--- a/bundles/framework/publisher2/handler/PanelGeneralInfoHandler.js
+++ b/bundles/framework/publisher2/handler/PanelGeneralInfoHandler.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { StateHandler, controllerMixin } from 'oskari-ui/util';
 import { GeneralInfoForm } from '../view/form/GeneralInfoForm';
 
@@ -17,8 +16,8 @@ class UIHandler extends StateHandler {
         this.updateState({ name, domain, language });
     }
 
-    getPanelContent () {
-        return <GeneralInfoForm {...this.getState()} controller={this.getController()}/>;
+    getPanelComponent () {
+        return GeneralInfoForm;
     }
 
     getValues () {

--- a/bundles/framework/publisher2/handler/PanelLayoutHandler.js
+++ b/bundles/framework/publisher2/handler/PanelLayoutHandler.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { LayoutForm } from '../view/form/LayoutForm';
 import { StateHandler, controllerMixin } from 'oskari-ui/util';
 import { getDefaultMapTheme } from '../../..//mapping/mapmodule/util/MapThemeHelper.js';
@@ -56,6 +55,7 @@ class UIHandler extends StateHandler {
         const { map = {} } = Oskari.app.getTheming().getTheme();
         this.setState({
             mapTheme: map,
+            presets: this.getPresetOptions(),
             infoBoxPreviewVisible: false
         });
         this.eventHandlers = {
@@ -96,8 +96,8 @@ class UIHandler extends StateHandler {
         this.syncTheme();
     }
 
-    getPanelContent () {
-        return <LayoutForm {...this.getState()} presets={this.getPresetOptions()} controller={this.getController()}/>;
+    getPanelComponent () {
+        return LayoutForm;
     }
 
     getPresetOptions () {

--- a/bundles/framework/publisher2/handler/PanelMapLayersHandler.js
+++ b/bundles/framework/publisher2/handler/PanelMapLayersHandler.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { controllerMixin } from 'oskari-ui/util';
 import { ToolPanelHandler } from './ToolPanelHandler';
 import { LAYERLIST_ID } from '../../../mapping/mapmodule/publisher/layers/MapLayerListTool';
@@ -94,8 +93,8 @@ class UIHandler extends ToolPanelHandler {
         }
     }
 
-    getPanelContent () {
-        return <MapLayers {...this.getState()} controller={this.getController()}/>;
+    getPanelComponent () {
+        return MapLayers;
     }
 
     updateSelectedLayers (silent) {

--- a/bundles/framework/publisher2/handler/PanelMapPreviewHandler.js
+++ b/bundles/framework/publisher2/handler/PanelMapPreviewHandler.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { StateHandler, controllerMixin } from 'oskari-ui/util';
 import { MapPreviewForm } from '../view/form/MapPreviewForm';
 
@@ -54,8 +53,8 @@ class UIHandler extends StateHandler {
         this.setPreview(preview);
     }
 
-    getPanelContent () {
-        return <MapPreviewForm {...this.getState()} controller={this.getController()}/>;
+    getPanelComponent () {
+        return MapPreviewForm;
     }
 
     setPreview (preview) {

--- a/bundles/framework/publisher2/handler/PanelToolLayoutHandler.js
+++ b/bundles/framework/publisher2/handler/PanelToolLayoutHandler.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { StateHandler, controllerMixin } from 'oskari-ui/util';
 import { ToolLayout } from '../view/form/ToolLayout';
 
@@ -36,8 +35,8 @@ class UIHandler extends StateHandler {
             .forEach(eventName => this.sandbox.registerForEventByName(this, eventName));
     }
 
-    getPanelContent () {
-        return <ToolLayout {...this.getState()} controller={this.getController()}/>;
+    getPanelComponent () {
+        return ToolLayout;
     }
 
     switchControlSides () {

--- a/bundles/framework/publisher2/handler/PublisherSidebarHandler.js
+++ b/bundles/framework/publisher2/handler/PublisherSidebarHandler.js
@@ -83,11 +83,12 @@ class PublisherSidebarUIHandler extends StateHandler {
         const collapseItems = this.panels.map(({ id, label, tooltip, handler, tooltipArgs }) => {
             // extra panels have label and optionally tooltip, check them for PANELS from localization
             const info = tooltip || this.loc(`BasicView.${id}.tooltip`, tooltipArgs, null);
+            const Component = handler.getPanelComponent();
             return {
                 key: id,
                 label: label || this.loc(`BasicView.${id}.label`),
                 extra: info ? <InfoIcon title={info} /> : null,
-                children: handler.getPanelContent()
+                children: <Component {...handler.getState()} controller={handler.getController()} />
             };
         });
         const { uuid } = data;
@@ -100,7 +101,8 @@ class PublisherSidebarUIHandler extends StateHandler {
             this.log.error(`Couldn't find handler for: ${id} to update collapse items.`);
             return;
         }
-        const children = handler.getPanelContent();
+        const Component = handler.getPanelComponent();
+        const children = <Component {...handler.getState()} controller={handler.getController()} />;
         const collapseItems = this.getState().collapseItems
             .map(item => item.key === id ? { ...item, children } : item);
         this.updateState({ collapseItems });

--- a/bundles/framework/publisher2/handler/PublisherSidebarHandler.js
+++ b/bundles/framework/publisher2/handler/PublisherSidebarHandler.js
@@ -1,7 +1,5 @@
-import React from 'react';
-import { showModal } from 'oskari-ui/components/window';
-import { ValidationErrorMessage } from '../view/dialog/ValidationErrorMessage';
-import { ReplaceConfirmDialogContent } from '../view//dialog/ReplaceConfirmDialogContent';
+import { showValidationErrorPopup } from '../view/dialog/ValidationErrorMessage';
+import { showReplacePopup } from '../view//dialog/ReplaceConfirmDialogContent';
 import { StateHandler, controllerMixin, Messaging } from 'oskari-ui/util';
 
 import { mergeValues } from '../util/util';
@@ -137,18 +135,11 @@ class PublisherSidebarUIHandler extends StateHandler {
      *
      */
     showValidationErrorMessage (errors = []) {
-        const title = this.loc('BasicView.error.title');
-        const onClose = () => this.closeValidationErrorMessage();
-        // TODO: move to jsx
-        const content = <ValidationErrorMessage errors={errors} closeCallback={onClose}/>;
-        this.validationErrorMessageDialog = showModal(title, content, onClose);
-    };
-
-    closeValidationErrorMessage () {
-        if (this.validationErrorMessageDialog) {
-            this.validationErrorMessageDialog.close();
-        }
-        this.validationErrorMessageDialog = null;
+        const onClose = () => {
+            this.validationErrorMessageDialog?.close();
+            this.validationErrorMessageDialog = null;
+        };
+        this.validationErrorMessageDialog = showValidationErrorPopup(errors, onClose);
     }
 
     /**
@@ -157,23 +148,15 @@ class PublisherSidebarUIHandler extends StateHandler {
      *
      */
     showReplaceConfirm () {
-        const title = this.loc('BasicView.confirm.replace.title');
-        // TODO: move to jsx
-        const content = <ReplaceConfirmDialogContent
-            okCallback={() => {
-                this.publishMap(false);
-                this.closeReplaceConfirm();
-            }}
-            closeCallback={() => this.closeReplaceConfirm()}/>;
-
-        this.replaceConfirmDialog = showModal(title, content);
-    }
-
-    closeReplaceConfirm () {
-        if (this.replaceConfirmDialog) {
-            this.replaceConfirmDialog.close();
-        }
-        this.replaceConfirmDialog = null;
+        const onClose = () => {
+            this.replaceConfirmDialog?.close();
+            this.replaceConfirmDialog = null;
+        };
+        const onConfirm = () => {
+            this.publishMap(false);
+            onClose();
+        };
+        this.replaceConfirmDialog = showReplacePopup(onConfirm, onClose);
     }
 
     save (asNew) {

--- a/bundles/framework/publisher2/handler/PublisherSidebarHandler.js
+++ b/bundles/framework/publisher2/handler/PublisherSidebarHandler.js
@@ -37,7 +37,6 @@ class PublisherSidebarUIHandler extends StateHandler {
         this.service = instance.getService();
         this.loc = instance.loc;
         this.panels = []; // [{ id, label, tooltip, handler }]
-        this.uuid = null;
     }
 
     getSandbox () {
@@ -45,8 +44,6 @@ class PublisherSidebarUIHandler extends StateHandler {
     }
 
     init (data) {
-        this.uuid = data.uuid;
-
         const toolGroups = this.service.createToolGroupings();
         const getTools = groupId => groupId === 'toolLayout' ? Object.values(toolGroups).flat() : toolGroups[groupId];
 
@@ -93,10 +90,6 @@ class PublisherSidebarUIHandler extends StateHandler {
 
     getPanels () {
         return this.panels;
-    }
-
-    isEdit () {
-        return !!this.uuid;
     }
 
     getAppSetupToPublish () {
@@ -165,7 +158,7 @@ class PublisherSidebarUIHandler extends StateHandler {
             this.showValidationErrorMessage(errors);
             return;
         }
-        if (this.uuid && !asNew) {
+        if (this.service.getUuid() && !asNew) {
             this.showReplaceConfirm();
             return;
         }
@@ -178,8 +171,9 @@ class PublisherSidebarUIHandler extends StateHandler {
             publishedFrom: Oskari.app.getUuid(),
             pubdata: JSON.stringify(appSetup)
         };
-        if (this.uuid && !asNew) {
-            payload.uuid = this.uuid;
+        const uuid = this.service.getUuid();
+        if (uuid && !asNew) {
+            payload.uuid = uuid;
         }
 
         fetch(Oskari.urls.getRoute('AppSetup'), {

--- a/bundles/framework/publisher2/handler/PublisherSidebarHandler.js
+++ b/bundles/framework/publisher2/handler/PublisherSidebarHandler.js
@@ -81,11 +81,9 @@ class PublisherSidebarUIHandler extends StateHandler {
 
         this.panels.forEach(({ id, handler }) => {
             handler.init(data);
+            this.updateState({ [id]: handler.getState() });
             handler.addStateListener(state => this.updateState({ [id]: state }));
-            // this.updateState({ [id]: handler.getState() });
         });
-        const state = this.panels.reduce((state, panel) => ({ ...state, [panel.id]: panel.handler.getState() }), {});
-        this.updateState(state);
     }
 
     getPanels () {

--- a/bundles/framework/publisher2/handler/ToolPanelHandler.js
+++ b/bundles/framework/publisher2/handler/ToolPanelHandler.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { PublisherToolsList } from '../view/form/PublisherToolsList';
 import { StateHandler, controllerMixin } from 'oskari-ui/util';
 import { mergeValues } from '../util/util';
@@ -36,13 +35,11 @@ class UIHandler extends StateHandler {
         this.updateState({ tools });
     }
 
-    getPanelContent () {
+    getPanelComponent () {
+        return PublisherToolsList;
+        // don't render empty panel (panel without component is filtered from collapse)
         const { tools } = this.getState();
-        if (!tools.length) {
-            // don't render empty panel (collapse without content/children is filtered)
-            return null;
-        }
-        return <PublisherToolsList tools={tools} controller={this.getController()}/>;
+        return tools.length ? PublisherToolsList : null;
     }
 
     setToolEnabled (tool, enabled) {

--- a/bundles/framework/publisher2/handler/ToolPanelHandler.js
+++ b/bundles/framework/publisher2/handler/ToolPanelHandler.js
@@ -17,9 +17,7 @@ class UIHandler extends StateHandler {
         this.allAvailableTools.forEach((tool) => {
             try {
                 tool.init(data);
-                if (tool.isDisplayed()) {
-                    tools.push(tool);
-                }
+                tools.push(tool);
             } catch (err) {
                 Oskari.log('ToolPanelHandler').error('Error initializing publisher tool:', tool);
             }
@@ -27,7 +25,7 @@ class UIHandler extends StateHandler {
         // Note that handler is for extra component. Every tool doesn't have extra + handler
         // Trigger re-render if handlers state changes
         tools.forEach(tool => tool.getComponent().handler?.addStateListener(() => this.notify()));
-        const visible = tools.length > 0;
+        const visible = tools.some(tool => tool.isDisplayed());
         this.updateState({ tools, visible });
     }
 

--- a/bundles/framework/publisher2/handler/ToolPanelHandler.js
+++ b/bundles/framework/publisher2/handler/ToolPanelHandler.js
@@ -7,7 +7,8 @@ class UIHandler extends StateHandler {
         super();
         this.allAvailableTools = Array.isArray(tools) ? tools.toSorted((a, b) => a.index - b.index) : [];
         this.setState({
-            tools: []
+            tools: [],
+            visible: false
         });
     }
 
@@ -26,20 +27,16 @@ class UIHandler extends StateHandler {
         // Note that handler is for extra component. Every tool doesn't have extra + handler
         // Trigger re-render if handlers state changes
         tools.forEach(tool => tool.getComponent().handler?.addStateListener(() => this.notify()));
-        this.updateState({ tools });
+        const visible = tools.length > 0;
+        this.updateState({ tools, visible });
     }
 
     setPanelVisibility (visible) {
-        // Remove tools from state to hide panel
-        const tools = visible ? this.allAvailableTools.filter(tool => tool.isDisplayed()) : [];
-        this.updateState({ tools });
+        this.updateState({ visible });
     }
 
     getPanelComponent () {
         return PublisherToolsList;
-        // don't render empty panel (panel without component is filtered from collapse)
-        const { tools } = this.getState();
-        return tools.length ? PublisherToolsList : null;
     }
 
     setToolEnabled (tool, enabled) {
@@ -50,6 +47,7 @@ class UIHandler extends StateHandler {
 
     getValues () {
         const { tools } = this.getState();
+        // TODO: !visible return {} ??
         let values = {};
         tools.forEach(tool => {
             values = mergeValues(values, tool.getValues());

--- a/bundles/framework/publisher2/service/PublisherService.js
+++ b/bundles/framework/publisher2/service/PublisherService.js
@@ -10,6 +10,7 @@ export class PublisherService {
         this.isActive = false;
         this.storedLayers = [];
         this.storedPlugins = [];
+        this.uuid = null;
     }
 
     getName () {
@@ -80,9 +81,11 @@ export class PublisherService {
         if (isActive) {
             this.removeLayers();
             this.removePlugins();
+            this.uuid = data?.uuid;
         } else {
             this.addStoredLayers();
             this.addStoredPlugins();
+            this.uuid = null;
         }
     }
 
@@ -93,6 +96,10 @@ export class PublisherService {
      */
     getIsActive () {
         return this.isActive;
+    }
+
+    getUuid () {
+        return this.uuid;
     }
 
     /**

--- a/bundles/framework/publisher2/tools/AbstractPublisherPanel.js
+++ b/bundles/framework/publisher2/tools/AbstractPublisherPanel.js
@@ -6,7 +6,7 @@ export class AbstractPublisherPanel {
         this.sandbox = sandbox;
         // override (included tools should have id as group)
         this.id = null;
-        // override to use own custom StateHandler (must implement init and getPanelContent functions)
+        // override to use own custom StateHandler (must implement init and getPanelComponent functions)
         this.handlerImpl = ToolPanelHandler;
         this.handler = null;
     }
@@ -36,7 +36,7 @@ export class AbstractPublisherPanel {
         const Handler = this.handlerImpl;
         try {
             const handler = new Handler(this.sandbox, tools);
-            if (!(handler instanceof StateHandler) || typeof handler.init !== 'function' || typeof handler.getPanelContent !== 'function') {
+            if (!(handler instanceof StateHandler) || typeof handler.init !== 'function' || typeof handler.getPanelComponent !== 'function') {
                 throw new Error('Incompatible handler');
             }
             this.handler = handler;

--- a/bundles/framework/publisher2/view/MapLayers/MapLayers.jsx
+++ b/bundles/framework/publisher2/view/MapLayers/MapLayers.jsx
@@ -39,7 +39,7 @@ export const MapLayers = ({ layers, baseLayers, tools, layerListPluginActive, co
     return (
         <Content className='t_layers'>
             <Card size='small' title={<Message messageKey='BasicView.layers.tools' />}>
-                <PublisherToolsList tools={tools} controller={controller} groupId='layers' />
+                <PublisherToolsList tools={tools} controller={controller} />
             </Card>
             {layerListPluginActive && (
                 <Card size='small' title={<Message messageKey='BasicView.layers.baseLayers' />}>

--- a/bundles/framework/publisher2/view/PublisherPanel.jsx
+++ b/bundles/framework/publisher2/view/PublisherPanel.jsx
@@ -16,7 +16,7 @@ const Actions = styled(ButtonContainer)`
     padding-right: 15px;
 `;
 
-export const PublisherPanel = ({ panels, isEdit, controller, onClose, ...statesById }) => {
+export const PublisherPanel = ({ panels, statesById, isEdit, controller, onClose }) => {
     const items = panels
         .filter(({ id }) => statesById[id]?.visible !== false)
         .map(({ id, label, tooltip, handler }) => {
@@ -51,6 +51,7 @@ export const PublisherPanel = ({ panels, isEdit, controller, onClose, ...statesB
 
 PublisherPanel.propTypes = {
     panels: PropTypes.array.isRequired,
+    statesById: PropTypes.object.isRequired,
     isEdit: PropTypes.bool.isRequired,
     controller: PropTypes.object.isRequired,
     onClose: PropTypes.func.isRequired

--- a/bundles/framework/publisher2/view/PublisherPanel.jsx
+++ b/bundles/framework/publisher2/view/PublisherPanel.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Collapse, Button, Message } from 'oskari-ui';
 import { LocaleProvider } from 'oskari-ui/util';
+import { InfoIcon } from 'oskari-ui/components/icons';
 import { ButtonContainer, SecondaryButton } from 'oskari-ui/components/buttons';
 import { PANEL_GENERAL_INFO_ID } from '../handler/PublisherSidebarHandler';
 import { BUNDLE_KEY } from '../constants';
@@ -15,23 +16,33 @@ const Actions = styled(ButtonContainer)`
     padding-right: 15px;
 `;
 
-export const PublisherPanel = ({ collapseItems, uuid, controller, onClose }) => {
-    // Don't render empty panels
-    const items = collapseItems.filter(item => item.children);
+export const PublisherPanel = ({ panels, isEdit, controller, onClose, ...statesById }) => {
+    const items = panels
+        .filter(({ id }) => statesById[id]?.visible !== false)
+        .map(({ id, label, tooltip, handler }) => {
+            const Component = handler.getPanelComponent();
+            return {
+                key: id,
+                label,
+                extra: tooltip ? <InfoIcon title={tooltip} /> : null,
+                children: <Component {...statesById[id]} controller={handler.getController()} />
+            };
+        });
+
     return (
         <LocaleProvider value={{ bundleKey: BUNDLE_KEY }}>
             <CollapseWrapper>
-                <Collapse defaultActiveKey={[PANEL_GENERAL_INFO_ID]} items={items}/>;
+                <Collapse defaultActiveKey={[PANEL_GENERAL_INFO_ID]} items={items}/>
             </CollapseWrapper>
             <Actions>
                 <SecondaryButton type='cancel' onClick={onClose} />
-                { !!uuid && (
+                { isEdit && (
                     <Button onClick={() => controller.save(true)}>
                         <Message messageKey='BasicView.buttons.saveNew'/>
                     </Button>
                 )}
                 <Button type='primary' onClick={() => controller.save()}>
-                    <Message messageKey={`BasicView.buttons.${uuid ? 'replace' : 'save'}`} />
+                    <Message messageKey={`BasicView.buttons.${isEdit ? 'replace' : 'save'}`} />
                 </Button>
             </Actions>
         </LocaleProvider>
@@ -39,8 +50,8 @@ export const PublisherPanel = ({ collapseItems, uuid, controller, onClose }) => 
 };
 
 PublisherPanel.propTypes = {
-    collapseItems: PropTypes.array.isRequired,
-    uuid: PropTypes.string,
+    panels: PropTypes.array.isRequired,
+    isEdit: PropTypes.bool.isRequired,
     controller: PropTypes.object.isRequired,
     onClose: PropTypes.func.isRequired
 };

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -36,17 +36,16 @@ class PublisherSidebar {
         const panels = this.handler.getPanels();
         const title = <Message bundleKey={BUNDLE_KEY} messageKey={`BasicView.${isEdit ? 'titleEdit' : 'title'}`} />;
         const onClose = () => this.cancel();
-        // TODO: don't spread state ??
         const controls = showSidePanel(
             title,
-            <PublisherPanel {...statesById} panels={panels} isEdit={isEdit} controller={controller} onClose={ onClose } />,
+            <PublisherPanel statesById={statesById} panels={panels} isEdit={isEdit} controller={controller} onClose={ onClose } />,
             onClose,
             PANEL_OPTIONS
         );
 
         this.panelControls = {
             ...controls,
-            update: statesById => controls.update(title, <PublisherPanel {...statesById} panels={panels} isEdit={isEdit} controller={controller} onClose={ onClose } />)
+            update: statesById => controls.update(title, <PublisherPanel statesById={statesById} panels={panels} isEdit={isEdit} controller={controller} onClose={ onClose } />)
         };
     }
 

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -30,21 +30,23 @@ class PublisherSidebar {
             return;
         }
 
-        const state = this.handler.getState();
+        const statesById = this.handler.getState();
         const controller = this.handler.getController();
-        const title = <Message bundleKey={BUNDLE_KEY} messageKey={`BasicView.${state.uuid ? 'titleEdit' : 'title'}`} />;
+        const isEdit = this.handler.isEdit();
+        const panels = this.handler.getPanels();
+        const title = <Message bundleKey={BUNDLE_KEY} messageKey={`BasicView.${isEdit ? 'titleEdit' : 'title'}`} />;
         const onClose = () => this.cancel();
-
+        // TODO: don't spread state ??
         const controls = showSidePanel(
             title,
-            <PublisherPanel {...state} controller={controller} onClose={ onClose } />,
+            <PublisherPanel {...statesById} panels={panels} isEdit={isEdit} controller={controller} onClose={ onClose } />,
             onClose,
             PANEL_OPTIONS
         );
 
         this.panelControls = {
             ...controls,
-            update: state => controls.update(title, <PublisherPanel {...state} controller={controller} onClose={ onClose } />)
+            update: statesById => controls.update(title, <PublisherPanel {...statesById} panels={panels} isEdit={isEdit} controller={controller} onClose={ onClose } />)
         };
     }
 

--- a/bundles/framework/publisher2/view/PublisherSidebar.js
+++ b/bundles/framework/publisher2/view/PublisherSidebar.js
@@ -32,7 +32,7 @@ class PublisherSidebar {
 
         const statesById = this.handler.getState();
         const controller = this.handler.getController();
-        const isEdit = this.handler.isEdit();
+        const isEdit = !!this.instance.getService().getUuid();
         const panels = this.handler.getPanels();
         const title = <Message bundleKey={BUNDLE_KEY} messageKey={`BasicView.${isEdit ? 'titleEdit' : 'title'}`} />;
         const onClose = () => this.cancel();

--- a/bundles/framework/publisher2/view/dialog/ReplaceConfirmDialogContent.jsx
+++ b/bundles/framework/publisher2/view/dialog/ReplaceConfirmDialogContent.jsx
@@ -3,15 +3,21 @@ import PropTypes from 'prop-types';
 import { Button, Message } from 'oskari-ui';
 import { SecondaryButton } from 'oskari-ui/components/buttons';
 import { ButtonContainer, DialogContentContainer } from './Styled';
+import { showModal } from 'oskari-ui/components/window';
 import { LocaleProvider } from 'oskari-ui/util';
+import { BUNDLE_KEY } from '../../constants';
 
-export const ReplaceConfirmDialogContent = ({ okCallback, closeCallback }) => {
-    return <LocaleProvider value={{ bundleKey: 'Publisher2' }}>
+const POPUP_OPTIONS = {
+    id: BUNDLE_KEY + '-confirm'
+};
+
+const ReplaceConfirmDialogContent = ({ onConfirm, onClose }) => {
+    return <LocaleProvider value={{ bundleKey: BUNDLE_KEY }}>
         <DialogContentContainer>
             <Message messageKey='BasicView.confirm.replace.msg'/>
             <ButtonContainer>
-                <SecondaryButton type='cancel' onClick={closeCallback}/>
-                <Button type='primary' onClick={okCallback}>
+                <SecondaryButton type='cancel' onClick={onClose}/>
+                <Button type='primary' onClick={onConfirm}>
                     <Message messageKey='BasicView.buttons.replace'/>
                 </Button>
             </ButtonContainer>
@@ -20,6 +26,15 @@ export const ReplaceConfirmDialogContent = ({ okCallback, closeCallback }) => {
 };
 
 ReplaceConfirmDialogContent.propTypes = {
-    okCallback: PropTypes.func,
-    closeCallback: PropTypes.func
+    onConfirm: PropTypes.func.isRequired,
+    onClose: PropTypes.func.isRequired
+};
+
+export const showReplacePopup = (onConfirm, onClose) => {
+    return showModal(
+        <Message bundleKey={BUNDLE_KEY} messageKey='BasicView.confirm.replace.title' />,
+        <ReplaceConfirmDialogContent onConfirm={onConfirm} onClose={onClose}/>,
+        onClose,
+        POPUP_OPTIONS
+    );
 };

--- a/bundles/framework/publisher2/view/dialog/ValidationErrorMessage.jsx
+++ b/bundles/framework/publisher2/view/dialog/ValidationErrorMessage.jsx
@@ -3,7 +3,12 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Message } from 'oskari-ui';
 import { PrimaryButton } from 'oskari-ui/components/buttons';
+import { showModal } from 'oskari-ui/components/window';
 import { BUNDLE_KEY } from '../../constants';
+
+const POPUP_OPTIONS = {
+    id: BUNDLE_KEY + '-validation'
+};
 
 const MessageContainer = styled('div')`
     margin: 1em;
@@ -20,7 +25,7 @@ const ButtonContainer = styled('div')`
     justify-content: center;
 `;
 
-export const ValidationErrorMessage = ({ errors, closeCallback }) => {
+const ValidationErrorMessage = ({ errors, closeCallback }) => {
     return <MessageContainer>
         <ErrorList>
             { errors.map(({ error, field, args }) => (
@@ -38,4 +43,13 @@ export const ValidationErrorMessage = ({ errors, closeCallback }) => {
 ValidationErrorMessage.propTypes = {
     errors: PropTypes.array,
     closeCallback: PropTypes.func
+};
+
+export const showValidationErrorPopup = (errors, onClose) => {
+    return showModal(
+        <Message bundleKey={BUNDLE_KEY} messageKey='BasicView.error.title' />,
+        <ValidationErrorMessage errors={errors} closeCallback={onClose}/>,
+        onClose,
+        POPUP_OPTIONS
+    );
 };

--- a/bundles/framework/publisher2/view/form/PublisherToolsList.jsx
+++ b/bundles/framework/publisher2/view/form/PublisherToolsList.jsx
@@ -17,13 +17,14 @@ const ToolContainer = styled('div')`
 `;
 
 export const PublisherToolsList = ({ tools, controller }) => {
-    if (!tools.length) {
+    const visibleTools = tools.filter(tool => tool.isDisplayed());
+    if (!visibleTools.length) {
         return null;
     }
-    const group = tools[0].getGroup();
+    const group = visibleTools[0].getGroup();
     return (
         <Content className={`t_tools t_${group}`}>
-            {tools.map((tool) => {
+            {visibleTools.map((tool) => {
                 const { id } = tool.getTool();
                 return (
                     <ToolContainer key={id} className='t_tool' data-id={id} data-enabled={tool.isEnabled()}>


### PR DESCRIPTION
- Remove react from handlers. `getPanelContent` => `getPanelComponent` and move shoModal to popups (confirm, error).
- Store uuid to service
- toggle panel by `visible` state (previously return null if tools empty)
- add all intialized tools to state and render visible tools only