### PR TITLE
Add documentation for RPC function getting layer groups

### DIFF
--- a/api/framework/rpc/bundle.md
+++ b/api/framework/rpc/bundle.md
@@ -113,6 +113,7 @@ Returns all the layers available on map. If layer has minimum zoom level and max
         opacity: layerOpacity,
         visible: layerVisibility,
         name : layerName,
+        description: layerDescription,
         minZoom: minZoomLevel,
         maxZoom: maxZoomLevel,
         config: layerAttributesDataBlock


### PR DESCRIPTION
Add the documentation for the RPC function getGroupsWithLayerIds() added in the PR https://github.com/oskariorg/oskari-frontend/pull/2807.

Additionally, add the description property to getAllLayers().