### PR TITLE
Legend metadata link

### DIFF
--- a/bundles/framework/maplegend/MapLegendList.jsx
+++ b/bundles/framework/maplegend/MapLegendList.jsx
@@ -9,7 +9,7 @@ export const MapLegendList = ({ legendList }) => {
         return (
             <Fragment>
                 { title }
-                <MetadataIcon metadataId={uuid} layerId={layerId} style={{ margin: '0 0 0 10px' }} stopEvent={true}/>
+                <MetadataIcon metadataId={uuid} layerId={layerId} style={{ margin: '0 0 0 10px' }}/>
             </Fragment>
         );
     };

--- a/bundles/framework/maplegend/MapLegendList.jsx
+++ b/bundles/framework/maplegend/MapLegendList.jsx
@@ -9,7 +9,7 @@ export const MapLegendList = ({ legendList }) => {
         return (
             <Fragment>
                 { title }
-                <MetadataIcon metadataId={uuid} layerId={layerId} style={{ margin: '0 0 0 10px' }} />
+                <MetadataIcon metadataId={uuid} layerId={layerId} style={{ margin: '0 0 0 10px' }} stopEvent={true}/>
             </Fragment>
         );
     };

--- a/bundles/framework/maplegend/instance.js
+++ b/bundles/framework/maplegend/instance.js
@@ -121,9 +121,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.MapLegendBundleInstanc
             MapLayerEvent: function (event) {
                 // do refresh ui in any case so we get the metadata - icon in case it was missing
                 this.refreshUI();
-                if (event.getOperation() === 'update') {
-                    return;
-                }
 
                 if (event.getOperation() !== 'add') {
                     // only handle add layer

--- a/bundles/framework/maplegend/instance.js
+++ b/bundles/framework/maplegend/instance.js
@@ -119,8 +119,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.maplegend.MapLegendBundleInstanc
                 this.refreshUI();
             },
             MapLayerEvent: function (event) {
+                // do refresh ui in any case so we get the metadata - icon in case it was missing
+                this.refreshUI();
                 if (event.getOperation() === 'update') {
-                    this.refreshUI();
                     return;
                 }
 

--- a/src/react/components/icons/Metadata.jsx
+++ b/src/react/components/icons/Metadata.jsx
@@ -21,7 +21,7 @@ const StyledMetadataIcon = styled(InfoCircleOutlined)`
  * @param {Object} style Additional styles
  * @returns
  */
-export const Metadata = ThemeConsumer(({ theme = {}, metadataId, layerId, size = 16, style, stopEvent = false }) => {
+export const Metadata = ThemeConsumer(({ theme = {}, metadataId, layerId, size = 16, style }) => {
     if (!metadataId || !Oskari.getSandbox().hasHandler('catalogue.ShowMetadataRequest')) return null;
 
     const helper = getNavigationTheme(theme);
@@ -40,9 +40,7 @@ export const Metadata = ThemeConsumer(({ theme = {}, metadataId, layerId, size =
             style={{ fontSize: `${size}px`, ...style }}
             onClick={(evt) => {
                 onClick();
-                if (stopEvent) {
-                    evt.stopPropagation();
-                }
+                evt.stopPropagation();
             }}
             $hoverColor={hover}
             $bgColor={bgColor}
@@ -53,6 +51,5 @@ export const Metadata = ThemeConsumer(({ theme = {}, metadataId, layerId, size =
 Metadata.propTypes = {
     metadataId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     size: PropTypes.number,
-    style: PropTypes.object,
-    stopEvent: PropTypes.bool
+    style: PropTypes.object
 };

--- a/src/react/components/icons/Metadata.jsx
+++ b/src/react/components/icons/Metadata.jsx
@@ -21,7 +21,7 @@ const StyledMetadataIcon = styled(InfoCircleOutlined)`
  * @param {Object} style Additional styles
  * @returns
  */
-export const Metadata = ThemeConsumer(({ theme = {}, metadataId, layerId, size = 16, style }) => {
+export const Metadata = ThemeConsumer(({ theme = {}, metadataId, layerId, size = 16, style, stopEvent = false }) => {
     if (!metadataId || !Oskari.getSandbox().hasHandler('catalogue.ShowMetadataRequest')) return null;
 
     const helper = getNavigationTheme(theme);
@@ -38,7 +38,12 @@ export const Metadata = ThemeConsumer(({ theme = {}, metadataId, layerId, size =
         <StyledMetadataIcon
             className='t_icon t_metadata'
             style={{ fontSize: `${size}px`, ...style }}
-            onClick={onClick}
+            onClick={(evt) => {
+                onClick();
+                if (stopEvent) {
+                    evt.stopPropagation();
+                }
+            }}
             $hoverColor={hover}
             $bgColor={bgColor}
         />
@@ -48,5 +53,6 @@ export const Metadata = ThemeConsumer(({ theme = {}, metadataId, layerId, size =
 Metadata.propTypes = {
     metadataId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     size: PropTypes.number,
-    style: PropTypes.object
+    style: PropTypes.object,
+    stopEvent: PropTypes.bool
 };


### PR DESCRIPTION
metadata icons in collapse headers now appear on first load and clicking the link does not open collapse

<img width="728" height="339" alt="image" src="https://github.com/user-attachments/assets/32d29e9a-28a3-4253-921a-6d290558d60e" />
