### PR TITLE
Mobile CSS: add duplicated height for fallback on older browsers

### DIFF
--- a/resources/css/portal.css
+++ b/resources/css/portal.css
@@ -51,6 +51,8 @@ body {
 body.oskari-root-el {
   margin: 0;
   padding: 0;
+  /* Uses vh if svh is not recognized */
+  height: 100vh;
   height: 100svh;
   width: 100%;
 }


### PR DESCRIPTION
Define both vh and svh in case the browser doesn't recognize svh, it should use the vh value.