### PR TITLE
Fix antd styling after update (and bump patch version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@testing-library/react": "16.3.0",
     "@testing-library/user-event": "14.4.3",
     "@zip.js/zip.js": "2.7.73",
-    "antd": "5.27.3",
+    "antd": "5.27.4",
     "async": "3.2.6",
     "babel-loader": "8.4.1",
     "babel-plugin-styled-components": "2.1.4",

--- a/src/react/components/Select.jsx
+++ b/src/react/components/Select.jsx
@@ -3,9 +3,6 @@ import styled from 'styled-components';
 
 // Wrap to styled so components can be referred in component styling.
 const Select = styled(AntSelect)`
-    .ant-select-selector {
-        width: auto !important;
-    }
 `;
 Select.displayName = 'OskariUISelect';
 


### PR DESCRIPTION
The removed CSS:
```css
    .ant-select-selector {
        width: auto !important;
    }
```
Before in featuredata property selection:
<img width="262" height="352" alt="image" src="https://github.com/user-attachments/assets/ebe9e1d8-f811-47eb-9a8b-fb264a1914b1" />
<img width="523" height="530" alt="image" src="https://github.com/user-attachments/assets/9a88dc3a-7eed-476d-96b3-b449b7777a29" />

After:
<img width="240" height="326" alt="image" src="https://github.com/user-attachments/assets/8367eac7-9502-4e29-b082-eb3e43114020" />
<img width="499" height="538" alt="image" src="https://github.com/user-attachments/assets/e70dc937-99c0-40e6-b130-75fd55e22b3f" />
