### PR TITLE
Allow apps to use shared Jest-config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -30,6 +30,7 @@ As an example if you see something like this as an error:
 
 You need to add the module (path after node_modules) to the list below (here it's 'earcut')
          */
-        'node_modules/(?!(ol|color-parse|color-space|color-rgba|color-name|antd|earcut|rc-util|jsts|geotiff|quick-lru|rbush|quickselect|pbf|mapbox-to-css-font)).+\\.js$'
+        // oskari-frontend is included to make sharing jest.config possible when oskari-frontend is a dependency of the app being tested (for example pti-frontend)
+        'node_modules/(?!(oskari-frontend|ol|color-parse|color-space|color-rgba|color-name|antd|earcut|rc-util|jsts|geotiff|quick-lru|rbush|quickselect|pbf|mapbox-to-css-font)).+\\.js$'
     ]
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oskari-frontend",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Oskari frontend",
   "keywords": [
     "oskari",


### PR DESCRIPTION
By default dependencies under node_modules are not included in transformations -> import statements don't work. We need to enable transform for oskari-frontend so applications that use oskari-frontend can use the jest-config that is located under oskari-frontend.