### PR TITLE
keep temp feature on map until explicitly discarded or saved

### DIFF
--- a/src/react/components/FeatureEditor/DrawingHelper.js
+++ b/src/react/components/FeatureEditor/DrawingHelper.js
@@ -20,13 +20,19 @@ const fakeModule = {
 };
 
 const startDrawing = (type, isMulti = false, currentGeometry, listener) => {
+
+    const sandbox = Oskari.getSandbox();
+
+    // clear old drawing in case there might a previous sketch on the map
+    sandbox.postRequestByName('DrawTools.StopDrawingRequest',
+        [DRAW_OPERATION_ID, true, true]);
+
     const drawParams = {
         allowMultipleDrawing: true,
         showMeasureOnMap: true,
         geojson: currentGeometry,
         allowMultipleDrawing: isMulti ? 'multiGeom' : 'single'
     };
-    const sandbox = Oskari.getSandbox();
     sandbox.postRequestByName('DrawTools.StartDrawingRequest',
         [DRAW_OPERATION_ID, type.replace('Multi', ''), drawParams]);
 
@@ -34,10 +40,11 @@ const startDrawing = (type, isMulti = false, currentGeometry, listener) => {
     sandbox.registerForEventByName(fakeModule, EVENT_NAME);
 
 };
-const stopDrawing = () => {
+const stopDrawing = (clearPrevious = false) => {
     const sandbox = Oskari.getSandbox();
+    // should keep sketch until feature is saved.
     sandbox.postRequestByName('DrawTools.StopDrawingRequest',
-        [DRAW_OPERATION_ID, true, true]);
+        [DRAW_OPERATION_ID, clearPrevious, true]);
     sandbox.unregisterFromEventByName(fakeModule, EVENT_NAME);
     drawListener = null;
 };

--- a/src/react/components/FeatureEditor/DrawingHelper.js
+++ b/src/react/components/FeatureEditor/DrawingHelper.js
@@ -24,8 +24,7 @@ const startDrawing = (type, isMulti = false, currentGeometry, listener) => {
     const sandbox = Oskari.getSandbox();
 
     // clear old drawing in case there might a previous sketch on the map
-    sandbox.postRequestByName('DrawTools.StopDrawingRequest',
-        [DRAW_OPERATION_ID, true, true]);
+    stopDrawing(true);
 
     const drawParams = {
         allowMultipleDrawing: true,

--- a/src/react/components/FeatureEditor/FeaturePanel.jsx
+++ b/src/react/components/FeatureEditor/FeaturePanel.jsx
@@ -8,7 +8,7 @@ import { GeometryPanel } from './GeometryPanel';
 import { GeoJSONPanel } from './GeoJSONPanel';
 import { Helper } from './Helper';
 import { DrawingHelper } from './DrawingHelper';
-import { StyledSpace } from './styled';
+import { StyledSpace, Row } from './styled';
 
 export const FeaturePanel = ({ layer = {}, feature = {}, onCancel, onSave, onDelete, startNewFeature}) => {
     const type = Helper.detectGeometryType(layer.geometryType);
@@ -17,34 +17,40 @@ export const FeaturePanel = ({ layer = {}, feature = {}, onCancel, onSave, onDel
     const [currentFeature, setCurrentFeature] = useState(feature);
     // TODO: if feature === currentFeature differs -> there have been edits made
     const isNew = !currentFeature.id;
-    const stopDrawing = () => {
+    const stopDrawing = (clearPrevious = false) => {
         setDrawingMode(false);
-        DrawingHelper.stopDrawing();
+        DrawingHelper.stopDrawing(clearPrevious);
     };
+    
     const cancelCb = () => {
         stopDrawing();
         onCancel();
     };
+
     const saveCb = () => {
-        stopDrawing();
+        stopDrawing(true);
         onSave(currentFeature);
     };
+    
     const startNewCb = () => {
         stopDrawing();
         startNewFeature();
-    }
+    };
+
     const onPropsChange = (updated) => {
         setCurrentFeature({
             ...currentFeature,
             properties: updated.properties
         });
-    }
+    };
+
     useEffect(() => {
         // workaround for state issue when changing target feature
         if (currentFeature.id !== feature.id) {
             setCurrentFeature(feature);
         }
     });
+
     const updateGeometry = (updatedFeature) => {
         setCurrentFeature({
             ...currentFeature,
@@ -55,6 +61,7 @@ export const FeaturePanel = ({ layer = {}, feature = {}, onCancel, onSave, onDel
         DrawingHelper.startDrawing(type, isMulti, currentFeature.geometry, updateGeometry);
         setDrawingMode(true);
     };
+
     let title = <Message messageKey="FeatureEditorView.newTitle" />;
     if (!isNew) {
         title = `${currentFeature.id}`;
@@ -72,9 +79,18 @@ export const FeaturePanel = ({ layer = {}, feature = {}, onCancel, onSave, onDel
                     { isDrawing &&
                         <React.Fragment>
                             <Message messageKey="FeatureEditorView.geometrylist.editing" />
-                            <Button type="primary" onClick={() => stopDrawing()}>
-                                <Message messageKey="FeatureEditorView.tools.finishSketch" />
-                            </Button>
+                            <Row>
+                                <Button type="primary" onClick={() => stopDrawing(false)}>
+                                    <Message messageKey="FeatureEditorView.tools.finishSketch" />
+                                </Button>
+                                <Button type="default" onClick={() => { 
+                                    // reset geometry with the original feature and clear drawing.
+                                    updateGeometry(feature); 
+                                    stopDrawing(true); 
+                                }}>
+                                    <Message messageKey="FeatureEditorView.restoreOriginal" />
+                                </Button>
+                            </Row>
                         </React.Fragment>
                     }
                     { !isDrawing &&
@@ -83,6 +99,7 @@ export const FeaturePanel = ({ layer = {}, feature = {}, onCancel, onSave, onDel
                             feature={currentFeature}
                             original={feature}
                             startDrawing={startDrawing}
+                            stopDrawing={stopDrawing}
                             updateGeometry={updateGeometry} />
                     }
                     { !isDrawing &&

--- a/src/react/components/FeatureEditor/FeaturePanel.jsx
+++ b/src/react/components/FeatureEditor/FeaturePanel.jsx
@@ -23,7 +23,7 @@ export const FeaturePanel = ({ layer = {}, feature = {}, onCancel, onSave, onDel
     };
     
     const cancelCb = () => {
-        stopDrawing();
+        stopDrawing(true);
         onCancel();
     };
 
@@ -33,7 +33,7 @@ export const FeaturePanel = ({ layer = {}, feature = {}, onCancel, onSave, onDel
     };
     
     const startNewCb = () => {
-        stopDrawing();
+        stopDrawing(true);
         startNewFeature();
     };
 

--- a/src/react/components/FeatureEditor/GeometryPanel.jsx
+++ b/src/react/components/FeatureEditor/GeometryPanel.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Alert, Message, Button, Space } from 'oskari-ui';
-import { StyledSpace, StyledContainer, StyledModIndicator } from './styled';
+import { StyledSpace, StyledContainer, StyledModIndicator, Row, Column } from './styled';
 import styled from 'styled-components';
 
 export const StyledList = styled('ul')`
@@ -13,9 +13,6 @@ const StyledAlert = styled(Alert)`
     margin-bottom: 5px;
 `;
 
-const EditButton = styled(Button)`
-    margin-left: 10px;
-`;
 export const StyledListItem = styled('li')`
     padding: 5px;
     border: 1px solid gray;
@@ -48,7 +45,7 @@ const geometryMatch = (current = {}, original = {}) => {
     return currentList.every(item => originalList.includes(item));
 }
 
-export const GeometryPanel = ({ type = '', feature = {}, original = {}, startDrawing, updateGeometry}) => {
+export const GeometryPanel = ({ type = '', feature = {}, original = {}, startDrawing, stopDrawing, updateGeometry}) => {
     const isMulti = type.includes('Multi');
     const isGeomBtnShown = (btnType) => type.includes(btnType);
     const isPoint = isGeomBtnShown('Point');
@@ -103,18 +100,28 @@ export const GeometryPanel = ({ type = '', feature = {}, original = {}, startDra
         return (
             <StyledSpace>
                 <StyledContainer>
-                    <Message messageKey="FeatureEditorView.geometrylist.title" />
-                    <EditButton onClick={() => startDrawing(feature.geometry?.type || type)}>
-                        <Message messageKey="FeatureEditorView.tools.geometryEdit" />
-                    </EditButton>
+                    <Column>
+                        <Row>
+                            <Message messageKey="FeatureEditorView.geometrylist.title" />
+                            { geometryChanged && <Message messageKey="FeatureEditorView.modified" LabelComponent={StyledModIndicator}  /> }
+                        </Row>
+                        <Row>
+                            <Button onClick={() => startDrawing(feature.geometry?.type || type)}>
+                                <Message messageKey="FeatureEditorView.tools.geometryEdit" />
+                            </Button>
+
+                            { geometryChanged && <Button type="default" onClick={() => { 
+                                updateFeatureGeometry(feature, original.geometry);
+                                stopDrawing(true);
+                            }}>
+                                <Message messageKey="FeatureEditorView.restoreOriginal" />
+                            </Button> 
+                            }
+
+                        </Row>
+                    </Column>
                 </StyledContainer>
                 <br />
-                {geometryChanged && <StyledContainer>
-                    <Message messageKey="FeatureEditorView.modified" LabelComponent={StyledModIndicator}  />
-                    <Button type="link" onClick={() => updateFeatureGeometry(feature, original.geometry)}>
-                        <Message messageKey="FeatureEditorView.restoreOriginal" />
-                    </Button>
-                </StyledContainer>}
             </StyledSpace>);
     }
 
@@ -148,7 +155,10 @@ export const GeometryPanel = ({ type = '', feature = {}, original = {}, startDra
                 </StyledList> }
                 {geometryChanged && <StyledContainer>
                     <Message messageKey="FeatureEditorView.modified" LabelComponent={StyledModIndicator} />
-                    <Button type="link" onClick={() => updateFeatureGeometry(feature, original.geometry)}>
+                    <Button type="default" onClick={() => {
+                        updateFeatureGeometry(feature, original.geometry);
+                        stopDrawing(true);
+                    }}>
                         <Message messageKey="FeatureEditorView.restoreOriginal" />
                     </Button>
                 </StyledContainer>}

--- a/src/react/components/FeatureEditor/styled.jsx
+++ b/src/react/components/FeatureEditor/styled.jsx
@@ -8,7 +8,7 @@ export const StyledSpace = styled(Space)`
 
 export const StyledContainer = styled('div')`
     display: inline-flex;
-    justify-content: space-between;       
+    justify-content: space-between;
     width: 100%;
     align-items: center;
 `;

--- a/src/react/components/FeatureEditor/styled.jsx
+++ b/src/react/components/FeatureEditor/styled.jsx
@@ -8,10 +8,22 @@ export const StyledSpace = styled(Space)`
 
 export const StyledContainer = styled('div')`
     display: inline-flex;
-    justify-content: space-between;
+    justify-content: space-between;       
     width: 100%;
     align-items: center;
 `;
 export const StyledModIndicator = styled('span')`
     color: orange;
+`;
+
+export const Column = styled('div')`
+    display: flex;
+    flex-direction: column;
+    gap: 1em;  zdx
+`;
+
+export const Row = styled('div')`
+    display: flex;
+    flex-direction: row;
+    gap: 1em;
 `;


### PR DESCRIPTION
keep updated temp geometry on map until excplicitly discarded or saved. The layout changed a bit and replaced the action link with a normal button.


<img width="1052" height="786" alt="image" src="https://github.com/user-attachments/assets/6d4e9440-7973-4312-ad0c-43ce684414a6" />

<img width="1021" height="800" alt="image" src="https://github.com/user-attachments/assets/986e22f3-0c0d-4ce6-ae39-5da72f343ed5" />

<img width="1086" height="871" alt="image" src="https://github.com/user-attachments/assets/e82ffd22-917a-419a-93c1-471c96ddf503" />


multi-geometry mode layout stayed the same apart from the link -> button change
Multipolygon:

<img width="1450" height="842" alt="image" src="https://github.com/user-attachments/assets/973ffdef-18f1-4c4f-b6e9-84e1850a5e23" />

<img width="1488" height="1007" alt="image" src="https://github.com/user-attachments/assets/0f95b37c-ac90-4ccd-9c55-5630aa642b5b" />

