### PR TITLE
add tooltip to featuredata table-cells

### DIFF
--- a/bundles/framework/featuredata/view/FeatureDataContainer.jsx
+++ b/bundles/framework/featuredata/view/FeatureDataContainer.jsx
@@ -167,7 +167,8 @@ const createColumnSettings = (selectedFeatureIds, showSelectedFirst, showCompres
                         }
                         return Oskari.util.naturalSort(a[key], b[key]);
                     }
-                }
+                },
+                ellipsis: true
             };
         });
 };


### PR DESCRIPTION
antd's  ellipsis: true now works (=it shows the entire clipped text as tooltip) Cells and headers with clipped content now show the tooltip when hovered over. Tooltips were not caught in the screenshot unfortunately, but they are there.

<img width="759" height="446" alt="image" src="https://github.com/user-attachments/assets/ac0ae4db-77e9-4964-8843-d94c919e36a7" />
 