### PR TITLE
Featureeditor from featuredata

### DIFF
--- a/bundles/framework/featuredata/resources/locale/en.js
+++ b/bundles/framework/featuredata/resources/locale/en.js
@@ -14,6 +14,11 @@ Oskari.registerLocalization(
             "visibleColumns": {
                 "propertiesSelected": "selected"
             },
+            "table": {
+                "featureTools": {
+                    "title": "Tools"
+                }
+            },
             "selectByPropertiesPopup": {
                 "title":"Select features from layer:",
                 "valueInputPlaceholder": "Value",

--- a/bundles/framework/featuredata/resources/locale/fi.js
+++ b/bundles/framework/featuredata/resources/locale/fi.js
@@ -14,6 +14,11 @@ Oskari.registerLocalization(
             "visibleColumns": {
                 "propertiesSelected": "valittu"
             },
+            "table": {
+                "featureTools": {
+                    "title": "Työkalut"
+                }
+            },
             "selectByPropertiesPopup": {
                 "title":"Valitse kohteita tasolta:",
                 "valueInputPlaceholder": "Arvo",

--- a/bundles/framework/featuredata/resources/locale/sv.js
+++ b/bundles/framework/featuredata/resources/locale/sv.js
@@ -14,6 +14,11 @@ Oskari.registerLocalization(
             "visibleColumns": {
                 "propertiesSelected": "vald"
             },
+            "table": {
+                "featureTools": {
+                    "title": "Tools"
+                }
+            },
             "selectByPropertiesPopup": {
                 "title":"Välj objekt från kartlager:",
                 "valueInputPlaceholder": "Värde",

--- a/bundles/framework/featuredata/view/FeatureDataContainer.jsx
+++ b/bundles/framework/featuredata/view/FeatureDataContainer.jsx
@@ -11,7 +11,6 @@ import { ExportButton } from './ExportData';
 import { CompressedView } from './CompressedView';
 import { FEATURE_EDITOR_TOOLNAME } from '../../myfeatures/constants';
 import { IconButton } from 'oskari-ui/components/buttons';
-import { EditOutlined } from '@ant-design/icons';
 
 export const FEATUREDATA_BUNDLE_ID = 'FeatureData';
 export const FEATUREDATA_WFS_STATUS = { loading: 'loading', error: 'error' };
@@ -145,17 +144,34 @@ const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, 
 };
 
 const createFeatureToolsColumn = (layer) => {
-    const featureEditorTool = layer?.getFeatureTool(FEATURE_EDITOR_TOOLNAME);
+
+    const featureTools = layer?.getFeatureTools() || null;
+    if (!featureTools) {
+        return;
+    };
+
     return {
         align: 'left',
         title: <Message bundleKey={FEATUREDATA_BUNDLE_ID} messageKey='table.featureTools.title' />,
         render: (item) => {
-            return <IconButton
-                title={featureEditorTool.getTitle()}
-                icon={<EditOutlined />}
-                onClick={() => featureEditorTool.getCallback()(layer.getId(), item.key)}
-            />;
+            return <>
+                { featureTools.map((tool) => {
+                    if (tool.getIconComponent()) {
+                        return <IconButton
+                            key={item.key + tool.getTitle()}
+                            title={tool.getTitle()}
+                            icon={tool.getIconComponent()}
+                            onClick={() => tool.getCallback()(layer.getId(), item.key)}
+                        />;
+                    }
 
+                    return <span
+                        key={item.key + tool.getTitle()}
+                        onClick={() => {tool.getCallback()(layer.getId(), item.key)}}>
+                        {tool.getTitle()}
+                    </span>;
+                })}
+            </>;
         }
     };
 };

--- a/bundles/framework/featuredata/view/FeatureDataContainer.jsx
+++ b/bundles/framework/featuredata/view/FeatureDataContainer.jsx
@@ -9,6 +9,9 @@ import { TabTitle } from './TabStatusIndicator';
 import { FilterVisibleColumns } from './FilterVisibleColumns';
 import { ExportButton } from './ExportData';
 import { CompressedView } from './CompressedView';
+import { FEATURE_EDITOR_TOOLNAME } from '../../myfeatures/constants';
+import { IconButton } from 'oskari-ui/components/buttons';
+import { EditOutlined } from '@ant-design/icons';
 
 export const FEATUREDATA_BUNDLE_ID = 'FeatureData';
 export const FEATUREDATA_WFS_STATUS = { loading: 'loading', error: 'error' };
@@ -89,11 +92,11 @@ const SelectionRowGroup = styled('div')`
     margin: auto 0;
 `;
 
-const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, showCompressed, sorting, visibleColumnsSettings, showExportButton, controller) => {
+const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, showCompressed, sorting, visibleColumnsSettings, showExportButton, layer, controller) => {
     if (!features || !features.length) {
         return <Message bundleKey={FEATUREDATA_BUNDLE_ID} messageKey={'layer.outOfContentArea'}/>;
     };
-    const columnSettings = createColumnSettings(selectedFeatureIds, showSelectedFirst, showCompressed, sorting, visibleColumnsSettings);
+    const columnSettings = createColumnSettings(selectedFeatureIds, showSelectedFirst, showCompressed, sorting, visibleColumnsSettings, layer);
     const dataSource = createDatasourceFromFeatures(features);
     const featureTable = <FeatureDataTable>
         <SelectionsContainer>
@@ -141,9 +144,25 @@ const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, 
     return featureTable;
 };
 
-const createColumnSettings = (selectedFeatureIds, showSelectedFirst, showCompressed, sorting, visibleColumnsSettings) => {
+const createFeatureToolsColumn = (layer) => {
+    const featureEditorTool = layer?.getFeatureTool(FEATURE_EDITOR_TOOLNAME);
+    return {
+        align: 'left',
+        title: 'Tools',
+        render: (item) => {
+            return <IconButton
+                title={featureEditorTool.getTitle()}
+                icon={<EditOutlined />}
+                onClick={() => featureEditorTool.getCallback()(layer.getId(), item.key)}
+            />;
+
+        }
+    }
+};
+
+const createColumnSettings = (selectedFeatureIds, showSelectedFirst, showCompressed, sorting, visibleColumnsSettings, layer) => {
     const { allColumns, visibleColumns, activeLayerPropertyLabels } = visibleColumnsSettings;
-    return allColumns
+    const retVal = allColumns
         .filter(key => visibleColumns.includes(key))
         .map(key => {
             return {
@@ -171,6 +190,13 @@ const createColumnSettings = (selectedFeatureIds, showSelectedFirst, showCompres
                 ellipsis: true
             };
         });
+
+    if (layer?.getFeatureTool(FEATURE_EDITOR_TOOLNAME)) {
+        retVal.push(createFeatureToolsColumn(layer));
+    }
+
+    return retVal;
+
 };
 
 const createDatasourceFromFeatures = (features) => {
@@ -194,7 +220,7 @@ const createLayerTabs = (layerId, layers, features, selectedFeatureIds, showSele
                 openSelectByPropertiesPopup={controller.openSelectByPropertiesPopup}
             />,
             children: layer.getId() === layerId
-                ? createFeaturedataGrid(features, selectedFeatureIds, showSelectedFirst, showCompressed, sorting, visibleColumnsSettings, showExportButton, controller)
+                ? createFeaturedataGrid(features, selectedFeatureIds, showSelectedFirst, showCompressed, sorting, visibleColumnsSettings, showExportButton, layer, controller)
                 : null
         };
     }) || [];
@@ -230,6 +256,7 @@ export const FeatureDataContainer = ({ state, controller }) => {
         loadingStatus,
         visibleColumnsSettings,
         controller);
+
     return (
         <ContainerDiv isMobile={Oskari.util.isMobile()}>
             <Tabs

--- a/bundles/framework/featuredata/view/FeatureDataContainer.jsx
+++ b/bundles/framework/featuredata/view/FeatureDataContainer.jsx
@@ -207,7 +207,7 @@ const createColumnSettings = (selectedFeatureIds, showSelectedFirst, showCompres
             };
         });
 
-    if (layer?.getFeatureTool(FEATURE_EDITOR_TOOLNAME)) {
+    if (layer?.getFeatureTools()?.length) {
         retVal.push(createFeatureToolsColumn(layer));
     }
 

--- a/bundles/framework/featuredata/view/FeatureDataContainer.jsx
+++ b/bundles/framework/featuredata/view/FeatureDataContainer.jsx
@@ -148,7 +148,7 @@ const createFeatureToolsColumn = (layer) => {
     const featureEditorTool = layer?.getFeatureTool(FEATURE_EDITOR_TOOLNAME);
     return {
         align: 'left',
-        title: 'Tools',
+        title: <Message bundleKey={FEATUREDATA_BUNDLE_ID} messageKey='table.featureTools.title' />,
         render: (item) => {
             return <IconButton
                 title={featureEditorTool.getTitle()}
@@ -157,7 +157,7 @@ const createFeatureToolsColumn = (layer) => {
             />;
 
         }
-    }
+    };
 };
 
 const createColumnSettings = (selectedFeatureIds, showSelectedFirst, showCompressed, sorting, visibleColumnsSettings, layer) => {

--- a/bundles/framework/myfeatures/service/MyFeaturesService.js
+++ b/bundles/framework/myfeatures/service/MyFeaturesService.js
@@ -1,7 +1,9 @@
+import React from 'react';
 import { handleMyFeaturesLayers, parseLayerData } from './layerHandling';
 import { MyFeaturesImportError } from './MyFeaturesImportError';
 import { DESCRIBE_LAYER } from '../../../mapping/mapmodule/domain/constants';
 import { FEATURE_EDITOR_TOOLNAME } from '../constants';
+import { EditOutlined } from '@ant-design/icons';
 
 export class MyFeaturesService {
     constructor (sandbox, mapLayerService, getMsg) {
@@ -80,7 +82,8 @@ export class MyFeaturesService {
         const featureEditorTool =  Oskari.clazz.create('Oskari.mapframework.domain.Tool');
         featureEditorTool.setName(FEATURE_EDITOR_TOOLNAME);
         featureEditorTool.setTitle(Oskari.getMsg('myfeatures', 'featureEditor.title'));
-
+        featureEditorTool.setIconComponent(<EditOutlined/>);
+        featureEditorTool.setTypes([]);
         featureEditorTool.setCallback((layerId, featureId) => {
             this.sandbox.postRequestByName('ShowFeatureEditorRequest', [layerId, featureId]);
         });

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -299,10 +299,17 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
          * @param {Oskari.mapframework.domain.AbstractLayer} newLayer layer to use in place of the old one
          */
         replaceLayer: function(layerId, newLayer) {
-            this.removeLayer(layerId, true, true);
-            this.addLayer(newLayer, true);
+            const shouldAddToSelectedMapLayers = !!this.getSandbox().findMapLayerFromSelectedMapLayers(layerId);
+            this.removeLayer(layerId, true, false);
+            this.addLayer(newLayer, false);
+
             const mapLayerEvent = Oskari.eventBuilder('MapLayerEvent');
             this.getSandbox().notifyAll(mapLayerEvent(layerId, 'update'));
+
+            if (shouldAddToSelectedMapLayers) {
+                this.getSandbox().postRequestByName('AddMapLayerRequest', [layerId]);
+            }
+
         },
 
         /**

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -299,17 +299,15 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
          * @param {Oskari.mapframework.domain.AbstractLayer} newLayer layer to use in place of the old one
          */
         replaceLayer: function(layerId, newLayer) {
-            const shouldAddToSelectedMapLayers = !!this.getSandbox().findMapLayerFromSelectedMapLayers(layerId);
-            this.removeLayer(layerId, true, false);
-            this.addLayer(newLayer, false);
-
+            this.removeLayer(layerId, true, true);
+            this.addLayer(newLayer, true);
             const mapLayerEvent = Oskari.eventBuilder('MapLayerEvent');
             this.getSandbox().notifyAll(mapLayerEvent(layerId, 'update'));
 
-            if (shouldAddToSelectedMapLayers) {
-                this.getSandbox().postRequestByName('AddMapLayerRequest', [layerId]);
+            const map = this.getSandbox().getMap();
+            if (map.isLayerSelected(layerId)) {
+                map.mergeLayer(layerId, newLayer);
             }
-
         },
 
         /**

--- a/bundles/mapping/mapmodule/service/map.state.js
+++ b/bundles/mapping/mapmodule/service/map.state.js
@@ -415,6 +415,21 @@ import { UnsupportedLayerReason } from '../domain/UnsupportedLayerReason';
             this._sandbox.notifyAll(evt);
             return true;
         },
+        /**
+         * Merge myfeatures layer with the wfs - layer we got with myfeatures - layer.
+         * @param {*} id
+         * @param {*} newLayer
+         */
+        mergeLayer: function(id, newLayer) {
+            const index = this.getLayerIndex(id);
+            if (index > -1) {
+                const wfs = _selectedLayers[index];
+                wfs._featureTools = [].concat(newLayer._featureTools);
+                wfs._layerType = newLayer._layerType;
+                _selectedLayers[index] = wfs;
+            }
+
+        },
         moveLayer: function (id, newIndex, triggeredBy) {
             var list = this.getLayers();
             var oldIndex = this.getLayerIndex(id);


### PR DESCRIPTION
Open feature editor from featuredata table. The createFeatureToolsColumn - method is not might be something we wanna make more general at some point if we have more feature-specific tools to add etc. But that requires for instance that the tools share the same arguments to their callback functions etc.

<img width="758" height="323" alt="image" src="https://github.com/user-attachments/assets/40b87594-1419-40b8-affb-65c8e7725fda" />
 
