### PR TITLE
only show/save the props defined by the dataset

### DIFF
--- a/bundles/framework/myfeatures/handler/MyFeaturesHandler.js
+++ b/bundles/framework/myfeatures/handler/MyFeaturesHandler.js
@@ -188,7 +188,7 @@ class MyFeaturesHandler extends StateHandler {
                     ...layerJson?.options?.styles?.default?.featureStyle
                 },
                 layerFields: layerJson?.layerFields,
-                attributes: layerJson?.attributes || { data: {}}
+                attributes: attributes
             };
             this.showLayerDialog(values);
         } catch (err) {
@@ -291,7 +291,7 @@ class MyFeaturesHandler extends StateHandler {
             layerId: layerId,
             id: feature.id,
             geometry: feature.geometry,
-            properties: feature.properties
+            properties: this.cleanProperties(layer?.fieldTypes, feature)
         };
         const isNew = typeof feature.id === 'undefined';
         const url = Oskari.urls.getRoute('MyFeaturesFeature', {
@@ -347,6 +347,22 @@ class MyFeaturesHandler extends StateHandler {
             }, 500);
             return;
         }).catch((exception) => Messaging.error(this.loc('featureEditor.featureDelete.error') + exception));
+    }
+
+    cleanProperties(fieldTypes, feature) {
+        // clean up excess properties not defined in layers fieldtypes
+        // might include stuff added by openlayers (__fid) or additional attributes obtained from server
+        if (!fieldTypes || !Object.keys(fieldTypes).length) {
+            return feature?.properties || {};
+        }
+
+        const propsToSave = Object.fromEntries(
+            Object.keys(fieldTypes)
+                .filter(key => key in feature.properties)
+                .map(key => [key, feature?.properties[key]])
+        );
+
+        return propsToSave;
     }
 
     createEventHandlers () {

--- a/bundles/framework/myfeatures/view/LayerForm/LayerFormContent.jsx
+++ b/bundles/framework/myfeatures/view/LayerForm/LayerFormContent.jsx
@@ -35,6 +35,20 @@ const getTabTitle = (isValid, messageKey) => (
     </Fragment>
 );
 
+/**
+ * Helper method to create the default filter for a new layer to avoid additional
+ * metadatafields such as created, updated, __fid or fid to appear in ui
+ **/
+const getDefaultAttributes = (layerFields) => {
+    return {
+        data: {
+            filter: {
+                default: layerFields?.map(field => field.name)
+            }
+        }
+    };
+};
+
 export const LayerFormContent = ({ values, config, onOk, onCancel, error, addFeature }) => {
     // TODO: refactor this thing as it's getting way overly complicated
     const { maxSize, unzippedMaxSize, isImport } = config;
@@ -54,7 +68,7 @@ export const LayerFormContent = ({ values, config, onOk, onCancel, error, addFea
             locale: state.locale,
             file: state.file,
             layerFields: state.layerFields,
-            attributes: state.attributes
+            attributes: state.attributes ? state.attributes : getDefaultAttributes(state.layerFields)
         };
         if (showSrs) {
             // add sourceSrs only if field is visible


### PR DESCRIPTION
, no additional metadatafields.

Save only the props defined by dataset. Also always create default filter when creating a new layer by hand.

See related oskari-server pr: https://github.com/oskariorg/oskari-server/pull/1241