### PR TITLE
reset _currentStyle

### DIFF
--- a/bundles/mapping/mapmodule/domain/AbstractVectorLayer.js
+++ b/bundles/mapping/mapmodule/domain/AbstractVectorLayer.js
@@ -12,6 +12,8 @@ export class AbstractVectorLayer extends AbstractLayer {
 
     /* override */
     selectStyle (name) {
+        // reset current style in case some custom style was set and then deleted
+        this._currentStyle = null;
         // style is seleced on createMapLayer and styles are loaded async for VectorLayer
         // store selected style name to try selecting it when styles are available
         this._storedStyleName = name;


### PR DESCRIPTION
Fix the bug where the last added own style kept hanging around even after deleting it and not resetting to default style 

<img width="684" height="203" alt="image" src="https://github.com/user-attachments/assets/05f2ad29-4cf5-4f29-b2f0-d6039b157366" />
