### PR TITLE
Timeslider fix

### DIFF
--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/TimeSeries/TimeSeriesMetadataLayerSelect.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/TimeSeries/TimeSeriesMetadataLayerSelect.jsx
@@ -22,7 +22,7 @@ export const TimeSeriesMetadataLayerSelect = ({ layer, controller }) => {
                 <Select
                     showSearch
                     placeholder={placeholder}
-                    filterOption={(input, option) => option.children.toLowerCase().indexOf(input.toLowerCase()) >= 0}
+                    optionFilterProp='label'
                     value={metadata.layer}
                     onChange={(value) => controller.setTimeSeriesMetadataLayer(value)}
                     options={metadataOptions.map((option) => ({

--- a/src/react/components/TimeSeries/TimeSeriesSlider.jsx
+++ b/src/react/components/TimeSeries/TimeSeriesSlider.jsx
@@ -49,19 +49,19 @@ const Handle = styled('rect')`
 const calcDataPointX = (data, widthUnit, min, elemWidth, calculator) => {
     const differenceToStart = calculator(data, min);
     return (differenceToStart * widthUnit) - (elemWidth / 2)
-}
+};
 
 const calcHandlePosition = (data, min, widthUnit, elemWidth, unit) => {
     const calculator = getDifferenceCalculator(unit);
     const differenceToStart = calculator(data, min);
     return (differenceToStart * widthUnit) - (elemWidth / 2);
-}
+};
 
 const findSnapPoint = (x, dataPoints) => {
     const xArray = dataPoints.map(point => point.x);
     const closest = xArray.sort((a, b) => Math.abs(x - a) - Math.abs(x - b))[0];
     return dataPoints.find(point => point.x === closest);
-}
+};
 
 const SVG_PADDING = 35;
 const POINT_RADIUS = 3;
@@ -100,8 +100,10 @@ export const TimeSeriesSlider = ThemeConsumer(({
     const onHandlePositionChange = (e, target) => {
         const svgX = calculateSvgX(e.clientX, target);
         const snap = findSnapPoint(svgX, sliderPoints);
-        target.setAttributeNS(null, 'x', snap.x - state.dragOffsetX);
-        handleChange(snap.data, target.id);
+        if (snap) {
+            target.setAttributeNS(null, 'x', snap.x - state.dragOffsetX);
+            handleChange(snap.data, target.id);
+        }
     };
 
     const onRailClick = (e) => {

--- a/src/react/components/TimeSeries/TimeSeriesSlider.jsx
+++ b/src/react/components/TimeSeries/TimeSeriesSlider.jsx
@@ -57,10 +57,10 @@ const calcHandlePosition = (data, min, widthUnit, elemWidth, unit) => {
     return (differenceToStart * widthUnit) - (elemWidth / 2);
 };
 
-const findSnapPoint = (x, dataPoints) => {
-    const xArray = dataPoints.map(point => point.x);
+const findSnapPoint = (x, sliderPoints) => {
+    const xArray = sliderPoints.map(point => point.x);
     const closest = xArray.sort((a, b) => Math.abs(x - a) - Math.abs(x - b))[0];
-    return dataPoints.find(point => point.x === closest);
+    return sliderPoints.find(point => point.x === closest);
 };
 
 const SVG_PADDING = 35;
@@ -109,7 +109,9 @@ export const TimeSeriesSlider = ThemeConsumer(({
     const onRailClick = (e) => {
         const svgX = calculateSvgX(e.clientX, e.target);
         const snap = findSnapPoint(svgX, sliderPoints);
-        handleChange(snap.data);
+        if (snap) {
+            handleChange(snap.data);
+        }
     };
 
     const handleChange = (val, el) => {
@@ -120,14 +122,14 @@ export const TimeSeriesSlider = ThemeConsumer(({
                 if (el === 'handle1') {
                     if (val > value[1]) {
                         newValue[1] = val;
-                        newValue[0] = value[1]
+                        newValue[0] = value[1];
                     } else {
                         newValue[0] = val;
                     }
                 } else {
                     if (val < value[0]) {
                         newValue[0] = val;
-                        newValue[1] = value[0]
+                        newValue[1] = value[0];
                     } else {
                         newValue[1] = val;
                     }
@@ -141,7 +143,7 @@ export const TimeSeriesSlider = ThemeConsumer(({
             newValue.sort((a, b) => a - b);
             onChange(newValue);
         } else {
-            onChange(val)
+            onChange(val);
         }
     };
 


### PR DESCRIPTION
If dataPoints is missing (empty list) => sliderPoints [] => can't find snapPoint (undefined) => js error

Fix admin-layereditor timeseries metadata layer select's search. No children => js error
Could also use own `filterOption={(input, option) => option.label?.toLowerCase().includes(input.toLowerCase())}` but antd default search is case insensitive