### PR TITLE
FeatureEvent: check for touch event - fix clicks for features on runtime layers

### DIFF
--- a/bundles/mapping/mapmodule/AbstractMapModule.js
+++ b/bundles/mapping/mapmodule/AbstractMapModule.js
@@ -2119,13 +2119,14 @@ Oskari.clazz.define(
         /**
          * @method getOLMapLayers
          * Returns references to OpenLayers layer objects for requested layer or null if layer is not added to map.
+         * Note!! Also returns null for layers that are NOT registered to MapLayerService (= runtime vector layers etc)
          * Internally calls getOLMapLayers() on all registered layersplugins.
          * @param {String} layerId
          * @return {OpenLayers.Layer[]}
          */
         getOLMapLayers: function (layerId) {
-            var sandbox = this.getSandbox();
-            var layer = sandbox.findMapLayerFromSelectedMapLayers(layerId);
+            const sandbox = this.getSandbox();
+            const layer = sandbox.findMapLayerFromSelectedMapLayers(layerId);
             if (!layer) {
                 // not found
                 return null;

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -22,7 +22,7 @@ import 'ol/ol.css';
 import { OskariImageWMS } from './plugin/wmslayer/OskariImageWMS';
 import { getOlStyles, getOlStyleForLayer, setDefaultStyle } from './oskariStyle/generator.ol';
 import { STYLE_TYPE } from './oskariStyle/constants';
-import { LAYER_ID } from '../mapmodule/domain/constants';
+import { LAYER_ID, LAYER_HOVER } from '../mapmodule/domain/constants';
 import { VectorFeatureSelectionService } from './service/VectorFeatureSelectionService';
 import proj4 from '../../../libraries/Proj4js/proj4js-2.2.1/proj4-src.js';
 // import code so it's usable via Oskari global
@@ -362,6 +362,11 @@ export class MapModule extends AbstractMapModule {
             opts.hitTolerance = 10;
         }
         this.getMap().forEachFeatureAtPixel([x, y], (feature, layer) => {
+            if (layer.get(LAYER_HOVER) === true) {
+                // we don't want to process hits for our hover layer as
+                //  it duplicates features that are under it/oin the same pixel on the _actual layer_
+                return;
+            }
             // Cluster source
             if (feature && feature.get('features')) {
                 feature.get('features').forEach(cur => addHit(cur, layer));
@@ -379,8 +384,8 @@ export class MapModule extends AbstractMapModule {
     /* OL3 specific - check if this can be done in a common way
 ------------------------------------------------------------------> */
     getInteractionInstance (interactionName) {
-        var interactions = this.getMap().getInteractions().getArray();
-        var interactionInstance = interactions.filter(function (interaction) {
+        const interactions = this.getMap().getInteractions().getArray();
+        const interactionInstance = interactions.filter(function (interaction) {
             return interaction instanceof interactionName;
         })[0];
         return interactionInstance;

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -364,7 +364,7 @@ export class MapModule extends AbstractMapModule {
         this.getMap().forEachFeatureAtPixel([x, y], (feature, layer) => {
             if (layer.get(LAYER_HOVER) === true) {
                 // we don't want to process hits for our hover layer as
-                //  it duplicates features that are under it/oin the same pixel on the _actual layer_
+                //  it duplicates features that are under it/on the same pixel on the _actual layer_
                 return;
             }
             // Cluster source

--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -350,7 +350,8 @@ export class MapModule extends AbstractMapModule {
             hits.push({
                 feature: ftr,
                 featureProperties: ftr.getProperties(),
-                layerId: layer.get(LAYER_ID)
+                layerId: layer.get(LAYER_ID),
+                layer: layer
             });
         };
         const opts = {};

--- a/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/vectorlayer/VectorLayerPlugin.ol.js
@@ -197,6 +197,7 @@ Oskari.clazz.define(
         _registerToFeatureService: function () {
             var defaultHandlerDef = [SERVICE_LAYER_REQUEST];
             var vectorFeatureService = this.getSandbox().getService('Oskari.mapframework.service.VectorFeatureService');
+            // this makes FeatureEvent happen for runtime vector features
             vectorFeatureService.registerLayerType('vector', this, defaultHandlerDef);
         },
         /**

--- a/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
+++ b/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
@@ -300,44 +300,27 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
             if (!features.length) {
                 return;
             }
-            const layers = {};
-            // gather layer refs, TODO: can we streamline this?
-            features.forEach(hits => {
-                if (!hits.layerId || layers[hits.layerId]) {
-                    // for example the hover layer doesn't have an id
-                    return;
-                }
-                const layer = this._mapmodule.getOLMapLayers(hits.layerId);
-                if (layer.length) {
-                    layers[hits.layerId] = layer[0];
-                }
-            });
             // process features
             const clickHits = [];
             features.forEach(item => {
-                const { feature, layerId } = item;
-                const layer = layers[layerId];
-                if (!layer) {
-                    return;
-                }
-                const layerType = layer.get(LAYER_TYPE);
+                const { feature, layer, layerId } = item;
+                const layerType = layer?.get(LAYER_TYPE);
                 const isRegisteredLayerType = layerType && me.layerTypeHandlers[layerType];
                 if (isRegisteredLayerType) {
                     const handler = me._getRegisteredHandler(layerType, SERVICE_CLICK);
                     if (handler) {
                         handler(event, feature, layer);
                     }
-                    clickHits.push({ feature, layer });
+                    clickHits.push({ feature, layerId });
                 }
             });
 
             if (clickHits.length > 0) {
                 const clickEvent = Oskari.eventBuilder('FeatureEvent')().setOpClick();
                 clickHits.forEach(obj => {
-                    const { feature, layer } = obj;
-                    const geojson = me._getGeojson(feature, layer);
+                    const { feature, layerId } = obj;
+                    const geojson = me._getGeojson(feature);
                     const propertyId = feature.get(FTR_PROPERTY_ID);
-                    const layerId = layer.get(LAYER_ID);
                     clickEvent.addFeature(propertyId, geojson, layerId);
                 });
                 me.getSandbox().notifyAll(clickEvent);

--- a/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
+++ b/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
@@ -300,7 +300,11 @@ Oskari.clazz.defineES('Oskari.mapframework.service.VectorFeatureService',
             if (!features.length) {
                 return;
             }
-            // process features
+            // Check if feature clicks should trigger a FeatureEvent (and possibly call another handler as well)
+            // Note! This handles everything from WFS-layers, runtime vector layers (RPC vectorlayers, statsgrid etc)
+            // Plugins register themselves as layerTypeHandlers -> if the LAYER_TYPE on the layer isn't present OR
+            //   it is on layer BUT does NOT match any registered typeHandler -> FeatureEvent is not sent
+            // On WFS-layers the type is 'wfs', on runtime vector layers it's 'vector' etc
             const clickHits = [];
             features.forEach(item => {
                 const { feature, layer, layerId } = item;

--- a/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
+++ b/bundles/mapping/mapmodule/service/VectorFeatureService.ol.js
@@ -4,7 +4,7 @@ import olRenderFeature from 'ol/render/Feature';
 import { fromExtent } from 'ol/geom/Polygon';
 import { HoverHandler } from './HoverHandler';
 import {
-    LAYER_ID, LAYER_TYPE, FTR_PROPERTY_ID, VECTOR_TYPE,
+    LAYER_TYPE, FTR_PROPERTY_ID, VECTOR_TYPE,
     SERVICE_HOVER, SERVICE_CLICK, SERVICE_LAYER_REQUEST
 } from '../domain/constants';
 


### PR DESCRIPTION
Fixes an issue raised by #2962 where clicks on features located on runtime layers caused a js error as the layer the feature "clicked" was not on the `sandbox.findMapLayerFromSelectedLayers()` / MapLayerService (most runtime layers are not registered there). Added a note that `MapModule.getOLMapLayers()` does NOT usually return any runtime layers.

`MapModule.getFeaturesAtPixel()` now returns the layer implementation (OL layer) in addition to the feature implementation (OL VectorFeature), feature properties and layerId. Note that layerId can be null for internal layers like the layer we use for visualizing features that are hovered over by the cursor. Added special handling for the additional hover feature so it's not returned on `getFeaturesAtPixel()` as the actual feature that the hover is duplicating is already in the list and has the correct layer id.

Added a bit of documentary comments about the lessons learned with this change.