### PR TITLE
UI tiny fixes

### DIFF
--- a/bundles/framework/featuredata/view/FeatureDataContainer.jsx
+++ b/bundles/framework/featuredata/view/FeatureDataContainer.jsx
@@ -93,6 +93,7 @@ const SelectionRowGroup = styled('div')`
 const FlexRow = styled('div')`
     display: flex;
     flex-direction: row;
+    gap: 1em;
 `;
 
 const createFeaturedataGrid = (features, selectedFeatureIds, showSelectedFirst, showCompressed, sorting, visibleColumnsSettings, showExportButton, layer, controller) => {

--- a/bundles/mapping/mapmodule/plugin/search/components/SearchBar.jsx
+++ b/bundles/mapping/mapmodule/plugin/search/components/SearchBar.jsx
@@ -50,7 +50,7 @@ const SearchContainer = styled('div')`
     background: ${props => props.backgroundColor};
     opacity: ${props => props.opacity};
     align-items: center;
-    padding: 0px 7px 3px 3px;
+    padding: 0px 7px 0px 3px;
     border-radius: calc(${props => props.rounding || 0} * 40px);
     box-shadow: 1px 1px 2px rgb(0 0 0 / 60%);
 

--- a/bundles/mapping/mapmodule/plugin/search/components/SearchInput.jsx
+++ b/bundles/mapping/mapmodule/plugin/search/components/SearchInput.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { TextInput, Message } from 'oskari-ui';
 import { AutoComplete } from 'antd';
@@ -13,7 +13,6 @@ This might go away by updating ant-d. It seems a bit weird that it isn't hidden
 */
 const WideAutoComplete = styled(AutoComplete)`
     width: 100%;
-
     &&.ant-select {
         border-radius: calc(${props => props.rounding || 0} * 35px);
     }
@@ -21,14 +20,6 @@ const WideAutoComplete = styled(AutoComplete)`
     && .ant-select-content {
         border-radius: calc(${props => props.rounding || 0} * 35px);
         background: transparent;
-    }
-
-    && .ant-input-affix-wrapper {
-        border-radius: calc(${props => props.rounding || 0} * 35px) !important;
-    }
-
-    && .ant-input {
-        border-radius: calc(${props => props.rounding || 0} * 35px) !important;
     }
 
     /* clears the 'X' from Internet Explorer */

--- a/bundles/mapping/mapmodule/plugin/search/components/SearchInput.jsx
+++ b/bundles/mapping/mapmodule/plugin/search/components/SearchInput.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { TextInput, Message } from 'oskari-ui';
 import { AutoComplete } from 'antd';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 /*
 The input type="search" has a duplicated "clear" function added by the browser.
@@ -13,6 +13,23 @@ This might go away by updating ant-d. It seems a bit weird that it isn't hidden
 */
 const WideAutoComplete = styled(AutoComplete)`
     width: 100%;
+
+    &&.ant-select {
+        border-radius: calc(${props => props.rounding || 0} * 35px);
+    }
+
+    && .ant-select-content {
+        border-radius: calc(${props => props.rounding || 0} * 35px);
+        background: transparent;
+    }
+
+    && .ant-input-affix-wrapper {
+        border-radius: calc(${props => props.rounding || 0} * 35px) !important;
+    }
+
+    && .ant-input {
+        border-radius: calc(${props => props.rounding || 0} * 35px) !important;
+    }
 
     /* clears the 'X' from Internet Explorer */
     input[type=search]::-ms-clear {  display: none; width : 0; height: 0; }
@@ -59,6 +76,7 @@ export const SearchInput = ({ query = '', suggestions = [], onChange = noop, onS
     return (
         <React.Fragment>
             <WideAutoComplete
+                rounding={rounding}
                 allowClear={false}
                 options={getSuggestionOptions(suggestions)}
                 onSelect={onSelect}>


### PR DESCRIPTION
padding here between the icons:

<img width="585" height="315" alt="image" src="https://github.com/user-attachments/assets/9e95534a-2b1d-4f50-b58e-b4634c4f3f05" />

fixed the styles here that were broken in antd update
<img width="297" height="63" alt="image" src="https://github.com/user-attachments/assets/53b2326b-64e3-4126-858f-e19f7c45cb42" />
