### PR TITLE
show external source icon for rss annoucenments

### DIFF
--- a/bundles/framework/announcements/view/flyout/FlyoutCollapse.jsx
+++ b/bundles/framework/announcements/view/flyout/FlyoutCollapse.jsx
@@ -1,13 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Message, Collapse, Divider } from 'oskari-ui';
+import { styled } from 'styled-components';
+import { Message, Collapse, Divider, Tooltip } from 'oskari-ui';
+import { SelectOutlined } from '@ant-design/icons';
 import { AnnouncementsContent, CollapseTools } from '../';
 import { getDateRange } from '../../service/util';
+
+const LabelContainer = styled.span`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+`;
+
+const ExternalIcon = styled(SelectOutlined)`
+    font-size: 14px;
+`;
 
 export const FlyoutCollapse = ({
     announcements,
     toolController
 }) => {
+    const isAdmin = Oskari.user().isAdmin();
     if (!announcements.length) {
         return (
             <Message messageKey={'flyout.noAnnouncements'}/>
@@ -16,12 +29,24 @@ export const FlyoutCollapse = ({
     const items = announcements.map((announcement) => {
         const { locale, id } = announcement;
         const { title } = Oskari.getLocalized(locale);
+        const hasExternalSource = !!announcement?.options?.externalId;
         const dateRange = getDateRange(announcement);
 
         return {
             key: announcement.id,
-            label: title,
-            extra: <CollapseTools toolController={toolController} announcementId={id}/>,
+            label: (
+                <LabelContainer>
+                    <span>{title}</span>
+                    {isAdmin && hasExternalSource && (
+                        <Tooltip title={announcement.options.externalId}>
+                            <ExternalIcon className='t_external_source' />
+                        </Tooltip>
+                    )}
+                </LabelContainer>
+            ),
+            extra: (
+                <CollapseTools toolController={toolController} announcementId={id}/>
+            ),
             children: <>
                 <AnnouncementsContent announcement={announcement}/>
                 <Divider />


### PR DESCRIPTION
Indicate announcement from an external feed with an icon on the list (for admins). No other changes yet. We need to figure out what we should be able to edit, what happens when we delete and when the scheduled job updates from rss. 

<img width="807" height="267" alt="image" src="https://github.com/user-attachments/assets/92f94247-bfc2-429c-b244-854ac0096d6f" />
