### PR TITLE
UI fixes

### DIFF
--- a/bundles/framework/announcements/view/flyout/FlyoutCollapse.jsx
+++ b/bundles/framework/announcements/view/flyout/FlyoutCollapse.jsx
@@ -26,7 +26,10 @@ export const FlyoutCollapse = ({
             <Message messageKey={'flyout.noAnnouncements'}/>
         );
     }
-    const items = announcements.map((announcement) => {
+    const sortedAnnouncements = [...announcements].sort((a, b) =>
+        new Date(b.beginDate) - new Date(a.beginDate)
+    );
+    const items = sortedAnnouncements.map((announcement) => {
         const { locale, id } = announcement;
         const { title } = Oskari.getLocalized(locale);
         const hasExternalSource = !!announcement?.options?.externalId;

--- a/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/getinfo/GetInfoPlugin.js
@@ -554,6 +554,8 @@ Oskari.clazz.define(
             contentData.actions = layer?.getFeatureTools()?.map(tool => {
                 return {
                     name: tool.getTitle(),
+                    type: 'link',
+                    group: 'featuretools',
                     action: () => { tool.getCallback()(layerId, featureId); }
                 };
             });

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "oskari-ui/*": ["./src/react/*"]
+    }
+  }
+}

--- a/src/react/components/FeatureEditor/DrawingHelper.js
+++ b/src/react/components/FeatureEditor/DrawingHelper.js
@@ -49,20 +49,13 @@ const startDrawing = (type, isMulti = false, currentGeometry, listener) => {
     sandbox.registerForEventByName(fakeModule, EVENT_NAME);
 
 };
+
 const stopDrawing = (clearPrevious = false, finishDrawing = false) => {
     const sandbox = Oskari.getSandbox();
-    if (finishDrawing) {
-        // Call DrawPlugin.stopDrawing() directly with suppressEvent=false.
-        // This runs forceFinishDrawing() (handles in-progress sketch, trims ghost point)
-        // and then sendDrawingEvent(true) — the same path as a double-click on the map.
-        // fakeModule.onEvent receives the isFinished=true event, updates geometry and does cleanup.
-        const drawPlugin = sandbox.findRegisteredModuleInstance('DrawTools')?.getPlugin();
-        drawPlugin?.stopDrawing(DRAW_OPERATION_ID, clearPrevious, false);
-        // Fallback: if event was not sent (e.g. geometry too short), clean up listener here.
-        cleanupDrawingListener();
-    } else {
-        sandbox.postRequestByName('DrawTools.StopDrawingRequest',
-            [DRAW_OPERATION_ID, clearPrevious, true]);
+    sandbox.postRequestByName('DrawTools.StopDrawingRequest',
+            [DRAW_OPERATION_ID, clearPrevious, !finishDrawing]);
+
+    if (!finishDrawing) {
         cleanupDrawingListener();
     }
 };

--- a/src/react/components/FeatureEditor/DrawingHelper.js
+++ b/src/react/components/FeatureEditor/DrawingHelper.js
@@ -3,14 +3,24 @@ const DRAW_OPERATION_ID = 'FeatureEditor';
 const EVENT_NAME = 'DrawingEvent'
 
 let drawListener = null;
+const cleanupDrawingListener = () => {
+    const sandbox = Oskari.getSandbox();
+    sandbox.unregisterFromEventByName(fakeModule, EVENT_NAME);
+    drawListener = null;
+};
+
 const fakeModule = {
     getName: () => DRAW_OPERATION_ID + 'FeaturePanel',
     onEvent: (event) => {
-        if (event.getName() !== EVENT_NAME || !event.getIsFinished()) {
+        const isFinished = event.getIsFinished();
+        if (event.getName() !== EVENT_NAME || !isFinished) {
             return;
         }
         const featureCollection = event.getGeoJson() || {};
         if (!featureCollection.features || !featureCollection.features.length) {
+            if (isFinished) {
+                cleanupDrawingListener();
+            }
             return;
         }
         if (typeof drawListener === 'function') {
@@ -39,13 +49,22 @@ const startDrawing = (type, isMulti = false, currentGeometry, listener) => {
     sandbox.registerForEventByName(fakeModule, EVENT_NAME);
 
 };
-const stopDrawing = (clearPrevious = false) => {
+const stopDrawing = (clearPrevious = false, finishDrawing = false) => {
     const sandbox = Oskari.getSandbox();
-    // should keep sketch until feature is saved.
-    sandbox.postRequestByName('DrawTools.StopDrawingRequest',
-        [DRAW_OPERATION_ID, clearPrevious, true]);
-    sandbox.unregisterFromEventByName(fakeModule, EVENT_NAME);
-    drawListener = null;
+    if (finishDrawing) {
+        // Call DrawPlugin.stopDrawing() directly with suppressEvent=false.
+        // This runs forceFinishDrawing() (handles in-progress sketch, trims ghost point)
+        // and then sendDrawingEvent(true) — the same path as a double-click on the map.
+        // fakeModule.onEvent receives the isFinished=true event, updates geometry and does cleanup.
+        const drawPlugin = sandbox.findRegisteredModuleInstance('DrawTools')?.getPlugin();
+        drawPlugin?.stopDrawing(DRAW_OPERATION_ID, clearPrevious, false);
+        // Fallback: if event was not sent (e.g. geometry too short), clean up listener here.
+        cleanupDrawingListener();
+    } else {
+        sandbox.postRequestByName('DrawTools.StopDrawingRequest',
+            [DRAW_OPERATION_ID, clearPrevious, true]);
+        cleanupDrawingListener();
+    }
 };
 
 export const DrawingHelper = {

--- a/src/react/components/FeatureEditor/FeaturePanel.jsx
+++ b/src/react/components/FeatureEditor/FeaturePanel.jsx
@@ -23,9 +23,9 @@ export const FeaturePanel = ({ layer = {}, feature = {}, onCancel, onSave, onDel
     const [currentFeature, setCurrentFeature] = useState(feature);
     // TODO: if feature === currentFeature differs -> there have been edits made
     const isNew = !currentFeature.id;
-    const stopDrawing = (clearPrevious = false) => {
+    const stopDrawing = (clearPrevious = false, finishDrawing = false) => {
         setDrawingMode(false);
-        DrawingHelper.stopDrawing(clearPrevious);
+        DrawingHelper.stopDrawing(clearPrevious, finishDrawing);
     };
 
     const cancelCb = () => {
@@ -86,7 +86,9 @@ export const FeaturePanel = ({ layer = {}, feature = {}, onCancel, onSave, onDel
                         <React.Fragment>
                             <Message messageKey="FeatureEditorView.geometrylist.editing" />
                             <WrappingRow>
-                                <Button type="primary" onClick={() => stopDrawing(false)}>
+                                <Button type="primary" onClick={() => {
+                                    stopDrawing(false, true);
+                                }}>
                                     <Message messageKey="FeatureEditorView.tools.finishSketch" />
                                 </Button>
                                 <Button type="default" onClick={() => {

--- a/src/react/components/window/Modal.jsx
+++ b/src/react/components/window/Modal.jsx
@@ -7,7 +7,7 @@ const styles = {
     body: {
         padding: '0 0 0.5em 0'
     },
-    content: {
+    container: {
         padding: '0'
     }
 };


### PR DESCRIPTION
* fix the bug of drawing not ending correctly when button pressed
* fix modal padding that antd update broke.
<img width="536" height="116" alt="image" src="https://github.com/user-attachments/assets/a377dc98-75a5-46a7-88db-0a9d75827030" />

*replace the ugly buttons with links and add group
<img width="363" height="245" alt="image" src="https://github.com/user-attachments/assets/92849a03-64c0-4051-8913-9d211c21e330" />

* bonus: sort announcements by begin date