### PR TITLE
Rss announhcements admin

### DIFF
--- a/bundles/admin/admin-announcements/resources/locale/en.js
+++ b/bundles/admin/admin-announcements/resources/locale/en.js
@@ -10,6 +10,8 @@ Oskari.registerLocalization(
         },
         "fields": {
             "date": "Date range",
+            "endDate": "End time",
+            "externalInfo": "This announcement has been imported from an external source. You can only edit the end time and content in other languages.",
             "show": {
                 "label": "Show announcement as",
                 "popup": "Popup-window",

--- a/bundles/admin/admin-announcements/resources/locale/fi.js
+++ b/bundles/admin/admin-announcements/resources/locale/fi.js
@@ -10,6 +10,8 @@ Oskari.registerLocalization(
             },
             "fields": {
                 "date": "Aikaväli",
+                "endDate": "Päättymisaika",
+                "externalInfo": "Tämä ilmoitus on luettu ulkoisesta lähteestä. Voit muokata vain ilmoituksen päättymisaikaa ja muiden kielten sisältöä.",
                 "show": {
                     "label": "Näytä ilmoitus",
                     "popup": "Ponnahdusikkunassa",

--- a/bundles/admin/admin-announcements/resources/locale/sv.js
+++ b/bundles/admin/admin-announcements/resources/locale/sv.js
@@ -10,6 +10,8 @@ Oskari.registerLocalization(
             },
             "fields": {
                 "date": "Datumintervall",
+                "endDate": "Sluttid",
+                "externalInfo": "Den här aviseringen har importerats från en extern källa. Du kan bara redigera sluttiden och innehållet på andra språk.",
                 "show": {
                     "label": "Visa annonsen i",
                     "popup": "Popupfönster",

--- a/bundles/admin/admin-announcements/view/AnnouncementsForm.jsx
+++ b/bundles/admin/admin-announcements/view/AnnouncementsForm.jsx
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 import dayjs from 'dayjs';
 import { RichEditor } from 'oskari-ui/components/RichEditor';
 import { DATE_FORMAT, TIME_FORMAT, TYPE, OPTIONS } from './constants';
+import { ExternalAnnouncement } from './ExternalAnnouncement';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import weekday from "dayjs/plugin/weekday"
 import localeData from "dayjs/plugin/localeData"
@@ -49,6 +50,9 @@ const getFields = type => {
 };
 const getMandatoryFields = () => {
     return ['title'];
+};
+const isExternalAnnouncement = (announcement) => {
+    return announcement?.options?.externalId;
 };
 const getLocaleForSubmit = (state) => {
     const { type, locale } = state;
@@ -104,6 +108,7 @@ export const AnnouncementsForm = LocaleConsumer(({
     const defaultLang = languages[0];
 
     const isEdit = !!state.id;
+    const isExternal = isExternalAnnouncement(state);
     const errorKeys = validateLocale(state, defaultLang);
     const tooltip = errorKeys.length ? errorKeys.map(key => <div key={`validate-${key}`}><Message messageKey={`fields.validate.${key}`} /></div>) : null;
 
@@ -123,6 +128,19 @@ export const AnnouncementsForm = LocaleConsumer(({
         options[key] = value;
         setState({ ...state, options });
     };
+
+    if (isExternal) {
+        return (
+            <ExternalAnnouncement
+                state={state}
+                setState={setState}
+                languages={languages}
+                getMessage={getMessage}
+                onSubmitClick={onSubmitClick}
+                onClose={onClose}
+            />
+        );
+    }
 
     return (
         <Fragment>
@@ -189,8 +207,7 @@ export const AnnouncementsForm = LocaleConsumer(({
                     <PrimaryButton disabled={errorKeys.length > 0} type="save" onClick={onSubmitClick}/>
                 </Tooltip>
             </ButtonContainer>
-        </Fragment>
-    );
+        </Fragment>);
 });
 
 AnnouncementsForm.propTypes = {

--- a/bundles/admin/admin-announcements/view/ExternalAnnouncement.jsx
+++ b/bundles/admin/admin-announcements/view/ExternalAnnouncement.jsx
@@ -1,0 +1,76 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { Message, Label, LabeledInput } from 'oskari-ui';
+import { SecondaryButton, PrimaryButton, ButtonContainer } from 'oskari-ui/components/buttons';
+import { LocalizationComponent } from 'oskari-ui/components/LocalizationComponent';
+import { DateRange } from 'oskari-ui/components/DateRange';
+import { styled } from 'styled-components';
+import { RichEditor } from 'oskari-ui/components/RichEditor';
+import { DATE_FORMAT, TIME_FORMAT } from './constants';
+
+const PaddingTop = styled('div')`
+    padding-top: 0.25em;
+`;
+
+const InfoText = styled('div')`
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+    font-style: italic;
+`;
+
+export const ExternalAnnouncement = ({
+    state,
+    setState,
+    languages,
+    getMessage,
+    onSubmitClick,
+    onClose
+}) => {
+    const defaultLang = languages[0];
+
+    return (
+        <Fragment>
+            <PaddingTop/>
+            <InfoText>
+                <Message messageKey='fields.externalInfo' />
+            </InfoText>
+            <PaddingTop/>
+            <Label>
+                <Message messageKey='fields.endDate' />
+            </Label>
+            <DateRange
+                value={[state.date[0], state.date[1]]}
+                allowClear={false}
+                format={DATE_FORMAT}
+                showTime={{ format: TIME_FORMAT }}
+                onChange={(date) => setState({ ...state, date })}
+                disabled={[true, false]}
+            />
+            <PaddingTop/>
+            <LocalizationComponent
+                languages={languages}
+                onChange={(locale) => setState({ ...state, locale })}
+                value={state.locale}
+            >
+                <LabeledInput type='text' name='title' label={getMessage('fields.locale.title')} mandatory={false}/>
+                { state.type === 'link' && <LabeledInput label={getMessage('fields.locale.link')} name='link' mandatory={false}/> }
+                { state.type === 'content' && <RichEditor label={getMessage('fields.locale.content')} name='content' mandatory={false}/> }
+                { state.type === 'content' && <PaddingTop/> }
+            </LocalizationComponent>
+
+            <ButtonContainer>
+                <SecondaryButton type='cancel' onClick={() => onClose()}/>
+                <PrimaryButton type="save" onClick={onSubmitClick}/>
+            </ButtonContainer>
+        </Fragment>
+    );
+};
+
+ExternalAnnouncement.propTypes = {
+    state: PropTypes.object.isRequired,
+    setState: PropTypes.func.isRequired,
+    languages: PropTypes.array.isRequired,
+    getMessage: PropTypes.func.isRequired,
+    onSubmitClick: PropTypes.func.isRequired,
+    onClose: PropTypes.func.isRequired
+};

--- a/bundles/admin/admin-announcements/view/ExternalAnnouncement.jsx
+++ b/bundles/admin/admin-announcements/view/ExternalAnnouncement.jsx
@@ -51,6 +51,7 @@ export const ExternalAnnouncement = ({
                 languages={languages}
                 onChange={(locale) => setState({ ...state, locale })}
                 value={state.locale}
+                disabledLanguages={[defaultLang]}
             >
                 <LabeledInput type='text' name='title' label={getMessage('fields.locale.title')} mandatory={false}/>
                 { state.type === 'link' && <LabeledInput label={getMessage('fields.locale.link')} name='link' mandatory={false}/> }

--- a/bundles/admin/admin-announcements/view/ExternalAnnouncement.jsx
+++ b/bundles/admin/admin-announcements/view/ExternalAnnouncement.jsx
@@ -13,7 +13,6 @@ const PaddingTop = styled('div')`
 `;
 
 const InfoText = styled('div')`
-    padding: 0.75rem 1rem;
     margin-bottom: 1rem;
     font-style: italic;
 `;

--- a/src/react/components/LocalizationComponent.jsx
+++ b/src/react/components/LocalizationComponent.jsx
@@ -64,6 +64,10 @@ const getElementValueChangeHandler = (values, lang, elementName, setValue, onCha
     };
 };
 
+const isLanguageDisabled = (disabledLanguages, lang, fieldDisabled) => {
+    return Boolean(fieldDisabled) || (Array.isArray(disabledLanguages) && disabledLanguages.includes(lang));
+};
+
 const renderDivider = lang => {
     return (
         <Divider orientation="left">
@@ -106,6 +110,7 @@ const getCollapseHeader = () => {
  * @param {Function} onChange Callback function to get a new "locale" value for user input. Example: (newValue) => doStuff(newValue)
  * @param {Object} value "locale" object like this { "en": { "name": "user input" }} means that there's a value for field "name" for the "en" (english) language
  * @param {String[]} mandatoryLanguages If a mandatory is required for more than default language, you can specify the languages that are required. Example: ["fi"]. Defaults to first language in languages array (optional)
+ * @param {String[]|null} disabledLanguages Languages where inputs are disabled. Example: ["fi"]. Defaults to null (optional)
  * @param {ReactElement} LabelComponent For custom label tag when not using LabeledInput (used when the input components DON'T define label prop in PropTypes). Example: const Label = ({children}) => <div>{children}</div>
  * @param {Boolean} collapse "false" to show "other languages" directly and not in a collapse element (useful when there's only one field to localize)
  * @param {Boolean} defaultOpen have "other languages" collapse open by default with true
@@ -119,6 +124,7 @@ export const LocalizationComponent = ({
     onChange,
     value,
     mandatoryLanguages = [languages[0]],
+    disabledLanguages = null,
     LabelComponent = Label,
     collapse = true,
     defaultOpen = false,
@@ -149,16 +155,18 @@ export const LocalizationComponent = ({
                 getElementValueChangeHandler(internalValue, lang, name, setInternalValue, onChange);
             let elementValue = internalValue[lang][name];
 
-            const { mandatory = false, label = name, ...restProps } = element.props; // don't pass mandatory and placeholder to element node
+            const { mandatory = false, label = name, disabled: fieldDisabled, ...restProps } = element.props; // don't pass mandatory and placeholder to element node
             const attachSuffix = !isDefaultLang || CURRENT_LANG !== DEFAULT_LANG;
             const fieldLabel = attachSuffix ? getWithLangSuffix(label, lang) : label;
             const currentMandatory = mandatory && mandatoryLanguages.includes(lang);
+            const currentDisabled = isLanguageDisabled(disabledLanguages, lang) || fieldDisabled;
             const elProps = {
                 label: fieldLabel,
                 value: elementValue,
                 onChange: onElementValueChange,
                 autoComplete: 'off',
-                ...restProps
+                ...restProps,
+                disabled: currentDisabled
             };
             // detect if the child component declares handling a "label" prop in it's propTypes
             const elementDeclaredProps = {...element.type.propTypes};
@@ -214,6 +222,7 @@ export const LocalizationComponent = ({
 LocalizationComponent.propTypes = {
     languages: PropTypes.arrayOf(PropTypes.string),
     mandatoryLanguages: PropTypes.arrayOf(PropTypes.string),
+    disabledLanguages: PropTypes.arrayOf(PropTypes.string),
     onChange: PropTypes.func,
     value: PropTypes.object,
     LabelComponent: PropTypes.elementType,


### PR DESCRIPTION
add an admin view for modifying announcements from an external source. Only allow editing end date & localisations excluding the default language (which would get overrun on next update anyway)

<img width="793" height="729" alt="image" src="https://github.com/user-attachments/assets/8a4c4768-820b-4543-bd8d-572e35813324" />
