### PR TITLE
Message label as listitem

### DIFF
--- a/bundles/framework/publisher2/view/dialog/ValidationErrorMessage.jsx
+++ b/bundles/framework/publisher2/view/dialog/ValidationErrorMessage.jsx
@@ -25,12 +25,11 @@ const ButtonContainer = styled('div')`
     justify-content: center;
 `;
 // Use li as label component to make bullet match the message on multi-row messages
-const ListItem = styled.li``;
 const ValidationErrorMessage = ({ errors, closeCallback }) => {
     return <MessageContainer>
         <ErrorList>
             { errors.map(({ error, field, args }) => (
-                <Message key={field} LabelComponent={ ListItem }
+                <Message key={field} LabelComponent='li'
                     bundleKey={BUNDLE_KEY}
                     messageKey={error}
                     messageArgs={args} />

--- a/src/react/components/Message.jsx
+++ b/src/react/components/Message.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { LocaleConsumer } from 'oskari-ui/util';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 const Label = styled('div')`
     display: ${props => props.allowTextEllipsis ? 'inline' : 'inline-block'};
@@ -16,6 +16,9 @@ const Label = styled('div')`
  * @memberof module:oskari-ui
  * @see {@link module:oskari-ui/util.LocaleProvider|LocaleProvider}
  * @param {Object} props - { bundleKey, messageKey, messageArgs:optional, getMessage:optional, LabelComponent:optional }
+ * @param {React.ElementType} [props.LabelComponent] Wrapper used for rendering the localized content.
+ * Accepts either a React component or a dom element name as a string, for example 'div', 'span' or 'li'.
+ * The wrapper must be able to render children, so void elements such as img are not supported (=will throw a runtime error).
  *
  * @example <caption>Registering bundle localization</caption>
  * Oskari.registerLocalization({
@@ -33,6 +36,9 @@ const Label = styled('div')`
  * <LocaleProvider value={{bundleKey: 'helloworld'}}>
  *     <Message messageKey="hello" messageArgs={['Jack']}/>
  * </LocaleProvider>
+ *
+ * @example <caption>Using an intrinsic DOM element as wrapper</caption>
+ * <Message messageKey="error.required" LabelComponent='li' />
  */
 const Message = ({ bundleKey, messageKey, messageArgs, defaultMsg, getMessage, fallback, children, LabelComponent = Label, allowHTML = false, allowTextEllipsis = false }) => {
     if (!messageKey) {
@@ -63,10 +69,15 @@ const Message = ({ bundleKey, messageKey, messageArgs, defaultMsg, getMessage, f
         return (<LabelComponent dangerouslySetInnerHTML={{ __html: message }} { ...injectedProps }></LabelComponent>);
     }
 
+    const labelProps = { ...injectedProps };
+    // Only default Label - component will handle text ellipsis. For custom components / dom element strings we should just ignore it.
+    if (LabelComponent === Label) {
+        labelProps.allowTextEllipsis = allowTextEllipsis;
+    }
+
     return (
         <LabelComponent
-            allowTextEllipsis={allowTextEllipsis}
-            { ...injectedProps }>
+            { ...labelProps }>
             { message } { children }
         </LabelComponent>
     );


### PR DESCRIPTION
Use the before undocumented feature that you can actually provide the name of a dom element as string to LabelComponent and there's no need to wrap this in styled('li') where used.

<img width="536" height="197" alt="image" src="https://github.com/user-attachments/assets/463cf0ea-889e-467e-ad4b-5d4e252436f2" />

pti-frontend also had some changes using the "old way" of doing things. https://github.com/nls-oskari/pti-frontend/pull/205
