### PR TITLE
Layer admin url params

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -41,7 +41,11 @@ Oskari.registerLocalization(
                 },
                 "opacity": "Opacity",
                 "params": {
-                    "selectedTime": "Selected time"
+                    "selectedTime": "Selected time",
+                    "key": "Parameter",
+                    "value": "Value",
+                    "show": "Show parameters",
+                    "hide": "Hide parameters"
                 },
                 "singleTile": "Single Tile",
                 "realtime": "Real time layer",

--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -44,8 +44,7 @@ Oskari.registerLocalization(
                     "selectedTime": "Selected time",
                     "key": "Parameter",
                     "value": "Value",
-                    "show": "Show parameters",
-                    "hide": "Hide parameters"
+                    "title": "Parameters"
                 },
                 "singleTile": "Single Tile",
                 "realtime": "Real time layer",

--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -44,7 +44,11 @@ Oskari.registerLocalization(
                     "selectedTime": "Selected time",
                     "key": "Parameter",
                     "value": "Value",
-                    "title": "Parameters"
+                    "title": "Parameters",
+                    "errors": {
+                        "keyExists": "A parameter with this name already exists.",
+                        "reservedKey": "This parameter name is reserved."
+                    }
                 },
                 "singleTile": "Single Tile",
                 "realtime": "Real time layer",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -43,8 +43,7 @@ Oskari.registerLocalization(
                     "selectedTime": "Valittu aika",
                     "key": "Parametri",
                     "value": "Arvo",
-                    "show": "Näytä parametrit",
-                    "hide": "Piilota parametrit"
+                    "title": "Parametrit"
                 },
                 "singleTile": "Single Tile",
                 "realtime": "Reaaliaikataso",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -40,7 +40,11 @@ Oskari.registerLocalization(
                 },
                 "opacity": "Peittävyys",
                 "params": {
-                    "selectedTime": "Valittu aika"
+                    "selectedTime": "Valittu aika",
+                    "key": "Parametri",
+                    "value": "Arvo",
+                    "show": "Näytä parametrit",
+                    "hide": "Piilota parametrit"
                 },
                 "singleTile": "Single Tile",
                 "realtime": "Reaaliaikataso",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -43,7 +43,11 @@ Oskari.registerLocalization(
                     "selectedTime": "Valittu aika",
                     "key": "Parametri",
                     "value": "Arvo",
-                    "title": "Parametrit"
+                    "title": "Parametrit",
+                    "errors": {
+                        "keyExists": "Parametri tällä nimellä on jo olemassa.",
+                        "reservedKey": "Parametrin nimi on varattu."
+                    }
                 },
                 "singleTile": "Single Tile",
                 "realtime": "Reaaliaikataso",

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -41,7 +41,11 @@ Oskari.registerLocalization(
                 },
                 "opacity": "Opacitet",
                 "params": {
-                    "selectedTime": "Vald tid"
+                    "selectedTime": "Vald tid",
+                    "key": "Parameter",
+                    "value": "Värde",
+                    "show": "Visa parametrar",
+                    "hide": "Dölj parametrar"
                 },
                 "singleTile": "Single Tile",
                 "realtime": "Realtidslager",

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -44,7 +44,11 @@ Oskari.registerLocalization(
                     "selectedTime": "Vald tid",
                     "key": "Parameter",
                     "value": "Värde",
-                    "title": "Parametrar"
+                    "title": "Parametrar",
+                    "errors": {
+                        "keyExists": "En parameter med detta namn finns redan.",
+                        "reservedKey": "Parameternamnet är reserverat."
+                    }
                 },
                 "singleTile": "Single Tile",
                 "realtime": "Realtidslager",

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -44,8 +44,7 @@ Oskari.registerLocalization(
                     "selectedTime": "Vald tid",
                     "key": "Parameter",
                     "value": "Värde",
-                    "show": "Visa parametrar",
-                    "hide": "Dölj parametrar"
+                    "title": "Parametrar"
                 },
                 "singleTile": "Single Tile",
                 "realtime": "Realtidslager",

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -123,6 +123,14 @@ class UIHandler extends StateHandler {
                 preserve: ['capabilities'],
                 roles: typesAndRoles.roles
             });
+            const currentParams = layer.params || {};
+            const selectedLayerParams = updateLayer.params || {};
+            if (Object.keys(currentParams).length > 0 || Object.keys(selectedLayerParams).length > 0) {
+                updateLayer.params = {
+                    ...currentParams,
+                    ...selectedLayerParams
+                };
+            }
             this.updateState({
                 layer: updateLayer,
                 propertyFields: this.getPropertyFields(updateLayer)

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -62,6 +62,16 @@ class UIHandler extends StateHandler {
         });
     }
 
+    setLayerParams (params = {}) {
+        const layer = { ...this.getState().layer };
+        const currentParams = layer.params || {};
+        layer.params = {
+            ...currentParams,
+            ...params
+        };
+        this.updateState({ layer });
+    }
+
     versionSelected (version) {
         const layer = { ...this.getState().layer, version };
         if (typeof version === 'undefined') {
@@ -1257,6 +1267,7 @@ const wrapped = controllerMixin(UIHandler, [
     'setHoverJSON',
     'setHover',
     'setLayerName',
+    'setLayerParams',
     'setLayerUrl',
     'setLegendUrl',
     'setLocalizedNames',

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/JsonTabPane/JsonTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/JsonTabPane/JsonTabPane.jsx
@@ -135,7 +135,6 @@ export const JsonTabPane = ({ layer, propertyFields, controller }) => {
                     <ParsedCollapse skipEdit json={layer.capabilities} jsonKey='capabilities'/>
                 }
                 <ParsedCollapse json={layer.options} jsonKey='options' controller={controller}/>
-                <ParsedCollapse json={layer.params} jsonKey='params' controller={controller}/>
             </StyledFormField>
         </Fragment>
     );

--- a/bundles/admin/admin-layereditor/view/LayerWizard/ServiceStep.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard/ServiceStep.jsx
@@ -26,7 +26,13 @@ const hasServiceEndpoint = ({ url, options }, propertyFields) => {
 };
 
 const VersionButton = ({ version, controller, ...rest }) => (
-    <StyledButton type="primary" onClick={() => controller.versionSelected(version)} { ...rest }>
+    <StyledButton
+        type="primary"
+        onClick={() => {
+            // Allow pending blur/update cycle to complete before moving to next step.
+            window.setTimeout(() => controller.versionSelected(version), 0);
+        }}
+        { ...rest }>
         { version && version }
         { !version && <Message messageKey='ok'/> }
     </StyledButton>

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceEndPoint.jsx
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceEndPoint.jsx
@@ -2,11 +2,14 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Message } from 'oskari-ui';
 import { Controller } from 'oskari-ui/util';
+import { styled } from 'styled-components';
 import { CesiumIon } from './CesiumIon';
 import { StyledFormField } from '../AdminLayerForm/styled';
 import { ApiKey } from './ApiKey';
 import { ServiceUrlInput } from './ServiceUrlInput';
 import { MandatoryIcon } from '../AdminLayerForm/Mandatory';
+import { CopyButton } from 'oskari-ui/components/buttons';
+import { getFullServiceUrl } from './ServiceUrlInputHelper';
 
 const {
     API_KEY,
@@ -16,7 +19,19 @@ const {
 
 const protocols = ['http://', 'https://'];
 
+const HeaderRow = styled('div')`
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+`;
+
+const HeaderActions = styled('div')`
+    margin-left: auto;
+`;
+
 export const ServiceEndPoint = ({ layer, propertyFields, disabled, credentialsCollapseOpen, controller }) => {
+    const fullServiceUrl = getFullServiceUrl(layer);
+
     let serviceUrlInput = null;
     const ionAssetSelected = propertyFields.includes(CESIUM_ION) && !!layer.options.ionAssetId;
     if (propertyFields.includes(URL) && !ionAssetSelected) {
@@ -38,7 +53,12 @@ export const ServiceEndPoint = ({ layer, propertyFields, disabled, credentialsCo
         <Fragment>
             { (serviceUrlInput || cesiumIonSettings) &&
                 <Fragment>
-                    <Message messageKey='fields.url' /> (<Message messageKey={`layertype.${layer.type}`} defaultMsg={layer.type} />) <MandatoryIcon />
+                    <HeaderRow>
+                        <Message messageKey='fields.url' /> (<Message messageKey={`layertype.${layer.type}`} defaultMsg={layer.type} />) <MandatoryIcon />
+                        <HeaderActions>
+                            <CopyButton value={fullServiceUrl} disabled={!fullServiceUrl} />
+                        </HeaderActions>
+                    </HeaderRow>
                     <StyledFormField>
                         {serviceUrlInput}
                         {cesiumIonSettings}

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlAddParam.jsx
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlAddParam.jsx
@@ -3,12 +3,20 @@ import PropTypes from 'prop-types';
 import { styled } from 'styled-components';
 import { Message, TextInput } from 'oskari-ui';
 import { PrimaryButton } from 'oskari-ui/components/buttons';
+import { RESERVED_LAYER_PARAMS } from './ServiceUrlInputHelper';
 
 const AddParamContainer = styled('div')`
     display: flex;
+    flex-direction: column;
+    width: 100%;
+    margin-top: 0.5em;
+`;
+
+const AddParamRow = styled('div')`
+    display: flex;
     flex-direction: row;
     column-gap: 1em;
-    margin-top: 0.5em;
+    width: 100%;
 `;
 
 const AddParamColumn = styled('div')`
@@ -22,47 +30,85 @@ const AddParamButtonColumn = styled(AddParamColumn)`
     flex: 0;
 `;
 
+const Error = styled('div')`
+    color: red;
+    font-style: italic;
+`;
+
 const ENTER_KEY = 'Enter';
+
+const validate = (key, params) => {
+    if (!key?.length) {
+        return null;
+    }
+
+    if (Object.keys(params).includes(key)) {
+        return {
+            keyExists: true
+        };
+    }
+
+    if (RESERVED_LAYER_PARAMS.includes(key.toLowerCase())) {
+        return {
+            reservedKey: true
+        };
+    }
+
+    return null;
+};
+
+const getErrorMessage = (error) => {
+    const allKeys = Object.keys(error || {});
+    if (allKeys.length) {
+        return <Message messageKey={`fields.params.errors.${allKeys[0]}`}/>;
+    }
+    return null;
+};
 
 export const ServiceUrlAddParam = ({ disabled, params = {}, onAdd }) => {
     const [paramKey, setParamKey] = useState('');
     const [paramValue, setParamValue] = useState('');
 
-    const keyExists = Object.prototype.hasOwnProperty.call(params, paramKey);
-    const canAdd = !disabled && !!paramKey && !keyExists;
+    const trimmedKey = paramKey.trim();
+    const trimmedValue = paramValue.trim();
+    const error = validate(trimmedKey, params);
+    const canAdd = !disabled && !!trimmedKey && !!trimmedValue && !error;
 
     const addParam = () => {
         if (!canAdd) {
             return;
         }
-        onAdd(paramKey, paramValue);
+        onAdd(trimmedKey, paramValue);
         setParamKey('');
         setParamValue('');
     };
 
     return (
         <AddParamContainer>
-            <AddParamColumn>
-                <Message messageKey='fields.params.key'/>
-                <TextInput
-                    disabled={disabled}
-                    value={paramKey}
-                    onChange={(evt) => setParamKey(evt.target.value)}
-                    onKeyUp={(evt) => { if (evt.key === ENTER_KEY) addParam(); }}
-                />
-            </AddParamColumn>
-            <AddParamColumn>
-                <Message messageKey='fields.params.value'/>
-                <TextInput
-                    disabled={disabled}
-                    value={paramValue}
-                    onChange={(evt) => setParamValue(evt.target.value)}
-                    onKeyUp={(evt) => { if (evt.key === ENTER_KEY) addParam(); }}
-                />
-            </AddParamColumn>
-            <AddParamButtonColumn>
-                <PrimaryButton type='add' onClick={addParam} disabled={!canAdd} />
-            </AddParamButtonColumn>
+            <AddParamRow>
+                <AddParamColumn>
+                    <Message messageKey='fields.params.key'/>
+                    <TextInput
+                        disabled={disabled}
+                        value={paramKey}
+                        onChange={(evt) => setParamKey(evt.target.value)}
+                        onKeyUp={(evt) => { if (evt.key === ENTER_KEY) addParam(); }}
+                    />
+                </AddParamColumn>
+                <AddParamColumn>
+                    <Message messageKey='fields.params.value'/>
+                    <TextInput
+                        disabled={disabled}
+                        value={paramValue}
+                        onChange={(evt) => setParamValue(evt.target.value)}
+                        onKeyUp={(evt) => { if (evt.key === ENTER_KEY) addParam(); }}
+                    />
+                </AddParamColumn>
+                <AddParamButtonColumn>
+                    <PrimaryButton type='add' onClick={addParam} disabled={!canAdd} />
+                </AddParamButtonColumn>
+            </AddParamRow>
+            {error && <Error>{getErrorMessage(error)}</Error>}
         </AddParamContainer>
     );
 };

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlAddParam.jsx
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlAddParam.jsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { styled } from 'styled-components';
+import { Message, TextInput } from 'oskari-ui';
+import { PrimaryButton } from 'oskari-ui/components/buttons';
+
+const AddParamContainer = styled('div')`
+    display: flex;
+    flex-direction: row;
+    column-gap: 1em;
+    margin-top: 0.5em;
+`;
+
+const AddParamColumn = styled('div')`
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+`;
+
+const AddParamButtonColumn = styled(AddParamColumn)`
+    justify-content: flex-end;
+    flex: 0;
+`;
+
+const ENTER_KEY = 'Enter';
+
+export const ServiceUrlAddParam = ({ disabled, params = {}, onAdd }) => {
+    const [paramKey, setParamKey] = useState('');
+    const [paramValue, setParamValue] = useState('');
+
+    const keyExists = Object.prototype.hasOwnProperty.call(params, paramKey);
+    const canAdd = !disabled && !!paramKey && !keyExists;
+
+    const addParam = () => {
+        if (!canAdd) {
+            return;
+        }
+        onAdd(paramKey, paramValue);
+        setParamKey('');
+        setParamValue('');
+    };
+
+    return (
+        <AddParamContainer>
+            <AddParamColumn>
+                <Message messageKey='fields.params.key'/>
+                <TextInput
+                    disabled={disabled}
+                    value={paramKey}
+                    onChange={(evt) => setParamKey(evt.target.value)}
+                    onKeyUp={(evt) => { if (evt.key === ENTER_KEY) addParam(); }}
+                />
+            </AddParamColumn>
+            <AddParamColumn>
+                <Message messageKey='fields.params.value'/>
+                <TextInput
+                    disabled={disabled}
+                    value={paramValue}
+                    onChange={(evt) => setParamValue(evt.target.value)}
+                    onKeyUp={(evt) => { if (evt.key === ENTER_KEY) addParam(); }}
+                />
+            </AddParamColumn>
+            <AddParamButtonColumn>
+                <PrimaryButton type='add' onClick={addParam} disabled={!canAdd} />
+            </AddParamButtonColumn>
+        </AddParamContainer>
+    );
+};
+
+ServiceUrlAddParam.propTypes = {
+    disabled: PropTypes.bool,
+    params: PropTypes.object,
+    onAdd: PropTypes.func.isRequired
+};

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInput.jsx
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInput.jsx
@@ -1,14 +1,20 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { Message, UrlInput } from 'oskari-ui';
+import { styled } from 'styled-components';
+import { Badge, Collapse, Message, UrlInput } from 'oskari-ui';
 import { Controller } from 'oskari-ui/util';
 import { cleanUrlAndExtractParams } from './ServiceUrlInputHelper';
-import { ParamsToggle, ServiceUrlParams } from './ServiceUrlParams';
+import { ServiceUrlParams } from './ServiceUrlParams';
 
 const { CREDENTIALS } = Oskari.clazz.get('Oskari.mapframework.domain.LayerComposingModel');
 
+const CollapseTitle = styled('div')`
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5em;
+`;
+
 export const ServiceUrlInput = ({ layer, propertyFields, disabled, controller, credentialsCollapseOpen = false }) => {
-    const [showParams, setShowParams] = useState(false);
     const params = layer.params || {};
     const paramCount = Object.keys(params).length;
     const onUrlCleanup = (url) => {
@@ -28,14 +34,21 @@ export const ServiceUrlInput = ({ layer, propertyFields, disabled, controller, c
         usernameOnChange: controller.setUsername,
         passwordOnChange: controller.setPassword
     };
+
+    const paramsItems = [{
+        key: 'params',
+        label: <CollapseTitle>
+            <Message messageKey='fields.params.title'/>
+            {paramCount > 0 && <Badge count={paramCount} />}
+        </CollapseTitle>,
+        children: <ServiceUrlParams
+            params={params}
+            disabled={disabled}
+            controller={controller} />
+    }];
+
     return (
         <>
-            <ParamsToggle
-                count={paramCount}
-                open={showParams}
-                disabled={disabled}
-                onClick={() => setShowParams(!showParams)}
-            />
             <UrlInput
                 key={`refreshOnLayerChange_${layer.id}`}
                 value={layer.url}
@@ -44,11 +57,7 @@ export const ServiceUrlInput = ({ layer, propertyFields, disabled, controller, c
                 onBlur={url => controller.setLayerUrl(url)}
                 urlCleanupFunction={onUrlCleanup}
                 credentials={credentialProps}/>
-            <ServiceUrlParams
-                params={params}
-                open={showParams}
-                disabled={disabled}
-                controller={controller} />
+            <Collapse items={paramsItems} />
         </>
     );
 };

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInput.jsx
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInput.jsx
@@ -1,13 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Message, UrlInput } from 'oskari-ui';
 import { Controller } from 'oskari-ui/util';
 import { cleanUrlAndExtractParams } from './ServiceUrlInputHelper';
-import { ServiceUrlParams } from './ServiceUrlParams';
+import { ParamsToggle, ServiceUrlParams } from './ServiceUrlParams';
 
 const { CREDENTIALS } = Oskari.clazz.get('Oskari.mapframework.domain.LayerComposingModel');
 
 export const ServiceUrlInput = ({ layer, propertyFields, disabled, controller, credentialsCollapseOpen = false }) => {
+    const [showParams, setShowParams] = useState(false);
+    const params = layer.params || {};
+    const paramCount = Object.keys(params).length;
     const onUrlCleanup = (url) => {
         const { cleanedUrl, params = {} } = cleanUrlAndExtractParams(url);
         controller.setLayerParams(params);
@@ -27,10 +30,12 @@ export const ServiceUrlInput = ({ layer, propertyFields, disabled, controller, c
     };
     return (
         <>
-            <ServiceUrlParams
-                params={layer.params}
+            <ParamsToggle
+                count={paramCount}
+                open={showParams}
                 disabled={disabled}
-                controller={controller} />
+                onClick={() => setShowParams(!showParams)}
+            />
             <UrlInput
                 key={`refreshOnLayerChange_${layer.id}`}
                 value={layer.url}
@@ -39,6 +44,11 @@ export const ServiceUrlInput = ({ layer, propertyFields, disabled, controller, c
                 onBlur={url => controller.setLayerUrl(url)}
                 urlCleanupFunction={onUrlCleanup}
                 credentials={credentialProps}/>
+            <ServiceUrlParams
+                params={params}
+                open={showParams}
+                disabled={disabled}
+                controller={controller} />
         </>
     );
 };

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInput.jsx
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInput.jsx
@@ -2,11 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Message, UrlInput } from 'oskari-ui';
 import { Controller } from 'oskari-ui/util';
-import { cleanUrl } from './ServiceUrlInputHelper';
+import { cleanUrlAndExtractParams } from './ServiceUrlInputHelper';
 
 const { CREDENTIALS } = Oskari.clazz.get('Oskari.mapframework.domain.LayerComposingModel');
 
 export const ServiceUrlInput = ({ layer, propertyFields, disabled, controller, credentialsCollapseOpen = false }) => {
+    const onUrlCleanup = (url) => {
+        const { cleanedUrl, params = {} } = cleanUrlAndExtractParams(url);
+        controller.setLayerParams(params);
+        return cleanedUrl;
+    };
+
     const credentialProps = {
         allowCredentials: propertyFields.includes(CREDENTIALS),
         defaultOpen: credentialsCollapseOpen,
@@ -25,7 +31,7 @@ export const ServiceUrlInput = ({ layer, propertyFields, disabled, controller, c
             disabled={disabled}
             onChange={url => controller.setLayerUrl(url)}
             onBlur={url => controller.setLayerUrl(url)}
-            urlCleanupFunction={url => cleanUrl(url)}
+            urlCleanupFunction={onUrlCleanup}
             credentials={credentialProps}/>
     );
 };

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInput.jsx
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInput.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Message, UrlInput } from 'oskari-ui';
 import { Controller } from 'oskari-ui/util';
 import { cleanUrlAndExtractParams } from './ServiceUrlInputHelper';
+import { ServiceUrlParams } from './ServiceUrlParams';
 
 const { CREDENTIALS } = Oskari.clazz.get('Oskari.mapframework.domain.LayerComposingModel');
 
@@ -25,14 +26,20 @@ export const ServiceUrlInput = ({ layer, propertyFields, disabled, controller, c
         passwordOnChange: controller.setPassword
     };
     return (
-        <UrlInput
-            key={`refreshOnLayerChange_${layer.id}`}
-            value={layer.url}
-            disabled={disabled}
-            onChange={url => controller.setLayerUrl(url)}
-            onBlur={url => controller.setLayerUrl(url)}
-            urlCleanupFunction={onUrlCleanup}
-            credentials={credentialProps}/>
+        <>
+            <ServiceUrlParams
+                params={layer.params}
+                disabled={disabled}
+                controller={controller} />
+            <UrlInput
+                key={`refreshOnLayerChange_${layer.id}`}
+                value={layer.url}
+                disabled={disabled}
+                onChange={url => controller.setLayerUrl(url)}
+                onBlur={url => controller.setLayerUrl(url)}
+                urlCleanupFunction={onUrlCleanup}
+                credentials={credentialProps}/>
+        </>
     );
 };
 ServiceUrlInput.propTypes = {

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInputHelper.js
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInputHelper.js
@@ -31,7 +31,7 @@ export const cleanUrlAndExtractParams = (url) => {
 export const getFullServiceUrl = (layer) => {
     const { url, params = {} } = layer;
     if (!url) {
-        return '';
+        return null;
     }
     const normalized = url.includes('://') ? url : `https://${url}`;
     const urlObj = new URL(normalized);

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInputHelper.js
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInputHelper.js
@@ -27,3 +27,18 @@ export const cleanUrlAndExtractParams = (url) => {
         params
     };
 };
+
+export const getFullServiceUrl = (layer) => {
+    const { url, params = {} } = layer;
+    if (!url) {
+        return '';
+    }
+    const normalized = url.includes('://') ? url : `https://${url}`;
+    const urlObj = new URL(normalized);
+    Object.entries(params).forEach(([key, value]) => {
+        if (value != null) {
+            urlObj.searchParams.set(key, String(value));
+        }
+    });
+    return urlObj.toString();
+};

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInputHelper.js
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInputHelper.js
@@ -1,25 +1,29 @@
 export const RESERVED_LAYER_PARAMS = ['service', 'request', 'version'];
-export const cleanUrl = (url) => {
+
+export const cleanUrlAndExtractParams = (url) => {
     if (!url) {
-        return;
-    };
+        return {};
+    }
 
     if (url.indexOf('http') === -1) {
         url = 'http://' + url;
     }
 
     const urlObj = new URL(url);
-    const keysToDelete = [];
+    const params = {};
     urlObj.searchParams.forEach((value, key) => {
-        if (RESERVED_LAYER_PARAMS.includes(key.toLowerCase())) {
-            keysToDelete.push(key);
+        if (!RESERVED_LAYER_PARAMS.includes(key.toLowerCase())) {
+            params[key] = value;
         }
     });
-
-    keysToDelete.forEach((key) => urlObj.searchParams.delete(key));
+    // All URL params are removed from the URL and persisted separately in layer.params.
+    urlObj.search = '';
 
     const parts = urlObj.toString().split('://');
     const retValString = parts.length > 1 ? parts[1] : urlObj.toString();
     const decoded = decodeURIComponent(retValString);
-    return decoded;
+    return {
+        cleanedUrl: decoded,
+        params
+    };
 };

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInputHelper.test.js
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInputHelper.test.js
@@ -1,10 +1,10 @@
-import { RESERVED_LAYER_PARAMS, cleanUrl } from './ServiceUrlInputHelper.js';
+import { RESERVED_LAYER_PARAMS, cleanUrlAndExtractParams } from './ServiceUrlInputHelper.js';
 
 describe('ServiceUrlInputHelper Tests ', () => {
     describe('clean url', () => {
         it('should clean out the reserved params ', () => {
             const url = 'http://www.com/?service=WMS&request=GetCapabilities&version=1.1.1';
-            const strippedUrl = cleanUrl(url);
+            const { cleanedUrl: strippedUrl } = cleanUrlAndExtractParams(url);
             RESERVED_LAYER_PARAMS.forEach((param) => {
                 expect(url.toLowerCase().indexOf(param.toLowerCase())).toBeGreaterThan(-1);
                 expect(strippedUrl.toLowerCase().indexOf(param.toLowerCase())).toBe(-1);
@@ -13,7 +13,7 @@ describe('ServiceUrlInputHelper Tests ', () => {
 
         it('should clean out reserved params regardless of casing', () => {
             const url = 'http://www.com/?SERVICE=WMS&ReQuEsT=GetCapabilities&version=1.1.1';
-            const strippedUrl = cleanUrl(url);
+            const { cleanedUrl: strippedUrl } = cleanUrlAndExtractParams(url);
             RESERVED_LAYER_PARAMS.forEach((param) => {
                 expect(url.toLowerCase().indexOf(param.toLowerCase())).toBeGreaterThan(-1);
                 expect(strippedUrl.toLowerCase().indexOf(param.toLowerCase())).toBe(-1);
@@ -22,50 +22,56 @@ describe('ServiceUrlInputHelper Tests ', () => {
 
         it('should clean out all instances of the same reserved param regardless of casing', () => {
             const url = 'http://www.com/?SERVICE=WMS&service=WFS&SeRViCe=wfs&serVICE=WMS&verSION=6.6.5&VERSion=6.6.4&VeRSion=6.3.0';
-            const strippedUrl = cleanUrl(url);
+            const { cleanedUrl: strippedUrl } = cleanUrlAndExtractParams(url);
             RESERVED_LAYER_PARAMS.forEach((param) => {
                 expect(strippedUrl.toLowerCase().indexOf(param.toLowerCase())).toBe(-1);
             });
         });
 
-        it('should keep other params and their casing', () => {
+        it('should clean out also non-reserved params from url', () => {
             const url = 'http://www.com/?first=1&SECOND=2&thiRd=3&SERVICE=WMS';
-            const strippedUrl = cleanUrl(url);
-            expect(strippedUrl.indexOf('first')).toBeGreaterThan(-1);
-            expect(strippedUrl.indexOf('FIRST')).toBe(-1);
-
-            expect(strippedUrl.indexOf('SECOND')).toBeGreaterThan(-1);
-            expect(strippedUrl.indexOf('second')).toBe(-1);
-
-            expect(strippedUrl.indexOf('thiRd')).toBeGreaterThan(-1);
-            expect(strippedUrl.indexOf('third')).toBe(-1);
-            expect(strippedUrl.indexOf('THIRD')).toBe(-1);
-
+            const { cleanedUrl: strippedUrl } = cleanUrlAndExtractParams(url);
+            expect(strippedUrl.indexOf('first')).toBe(-1);
+            expect(strippedUrl.indexOf('SECOND')).toBe(-1);
+            expect(strippedUrl.indexOf('thiRd')).toBe(-1);
             expect(strippedUrl.indexOf('SERVICE')).toBe(-1);
         });
 
+        it('should extract non-reserved params and keep their casing in params object', () => {
+            const url = 'http://www.com/?first=1&SECOND=2&thiRd=3&SERVICE=WMS';
+            const { params } = cleanUrlAndExtractParams(url);
+            expect(params).toEqual({
+                first: '1',
+                SECOND: '2',
+                thiRd: '3'
+            });
+            expect(params.SERVICE).toBeUndefined();
+        });
+
         it('should return undefined with no url provided', () => {
-            expect(cleanUrl(null)).toBeUndefined();
+            const result = cleanUrlAndExtractParams(null);
+            expect(result.cleanedUrl).toBeUndefined();
+            expect(result.params).toBeUndefined();
         });
 
         it('should strip protocol from the returned url', () => {
             const httpUrl = 'http://www.com/';
             const httpsUrl = 'https://www.com/';
-            expect(cleanUrl(httpUrl)).toBe('www.com/');
-            expect(cleanUrl(httpsUrl)).toBe('www.com/');
+            expect(cleanUrlAndExtractParams(httpUrl).cleanedUrl).toBe('www.com/');
+            expect(cleanUrlAndExtractParams(httpsUrl).cleanedUrl).toBe('www.com/');
         });
 
         it('should be able to handle url without protocol', () => {
             const url = 'www.com/';
-            expect(cleanUrl(url)).toBe(url);
+            expect(cleanUrlAndExtractParams(url).cleanedUrl).toBe(url);
         });
 
         it('should NOT encode URL params', () => {
             const url = 'avoin-karttakuva.maanmittauslaitos.fi/kiinteisto-avoin/tiles/wmts/1.0.0/kiinteistojaotus/default/v3/ETRS-TM35FIN/{z}/{y}/{x}.pbf';
-            expect(cleanUrl(url)).toBe(url);
+            expect(cleanUrlAndExtractParams(url).cleanedUrl).toBe(url);
 
             const url2 = 'www.com/?first=1&SECOND=2&thiRd=3';
-            expect(cleanUrl(url2)).toBe(url2);
+            expect(cleanUrlAndExtractParams(url2).cleanedUrl).toBe('www.com/');
         });
     });
 });

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInputHelper.test.js
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInputHelper.test.js
@@ -76,9 +76,9 @@ describe('ServiceUrlInputHelper Tests ', () => {
     });
 
     describe('get full service url', () => {
-        it('should return empty string with no url provided', () => {
-            expect(getFullServiceUrl({})).toBe('');
-            expect(getFullServiceUrl({ url: '' })).toBe('');
+        it('should return null with no url provided', () => {
+            expect(getFullServiceUrl({})).toBe(null);
+            expect(getFullServiceUrl({ url: null })).toBe(null);
         });
 
         it('should add https protocol when missing and append params', () => {

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInputHelper.test.js
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlInputHelper.test.js
@@ -1,4 +1,4 @@
-import { RESERVED_LAYER_PARAMS, cleanUrlAndExtractParams } from './ServiceUrlInputHelper.js';
+import { RESERVED_LAYER_PARAMS, cleanUrlAndExtractParams, getFullServiceUrl } from './ServiceUrlInputHelper.js';
 
 describe('ServiceUrlInputHelper Tests ', () => {
     describe('clean url', () => {
@@ -72,6 +72,48 @@ describe('ServiceUrlInputHelper Tests ', () => {
 
             const url2 = 'www.com/?first=1&SECOND=2&thiRd=3';
             expect(cleanUrlAndExtractParams(url2).cleanedUrl).toBe('www.com/');
+        });
+    });
+
+    describe('get full service url', () => {
+        it('should return empty string with no url provided', () => {
+            expect(getFullServiceUrl({})).toBe('');
+            expect(getFullServiceUrl({ url: '' })).toBe('');
+        });
+
+        it('should add https protocol when missing and append params', () => {
+            const fullUrl = getFullServiceUrl({
+                url: 'www.com/path',
+                params: {
+                    first: '1',
+                    second: 'two'
+                }
+            });
+            expect(fullUrl).toBe('https://www.com/path?first=1&second=two');
+        });
+
+        it('should preserve existing protocol', () => {
+            const fullUrl = getFullServiceUrl({
+                url: 'http://www.com/path',
+                params: {
+                    first: '1'
+                }
+            });
+            expect(fullUrl).toBe('http://www.com/path?first=1');
+        });
+
+        it('should stringify param values and skip nullish values', () => {
+            const fullUrl = getFullServiceUrl({
+                url: 'https://www.com/',
+                params: {
+                    bool: false,
+                    num: 0,
+                    empty: '',
+                    nil: null,
+                    undef: undefined
+                }
+            });
+            expect(fullUrl).toBe('https://www.com/?bool=false&num=0&empty=');
         });
     });
 });

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlParams.jsx
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlParams.jsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { styled } from 'styled-components';
+import { Badge, Button, Message, TextInput } from 'oskari-ui';
+import { Table, ToolsContainer } from 'oskari-ui/components/Table';
+import { Controller } from 'oskari-ui/util';
+import { IconButton } from 'oskari-ui/components/buttons';
+
+const ParamsToggleContainer = styled('div')`
+    margin-bottom: 0.5em;
+`;
+
+const ParamsTableContainer = styled('div')`
+    margin-top: 0.5em;
+`;
+
+export const ServiceUrlParams = ({ params = {}, disabled, controller }) => {
+    const [showParams, setShowParams] = useState(false);
+
+    const updateParams = (nextParams) => {
+        controller.setValueForLayer('params', nextParams);
+    };
+
+    const onParamValueChange = (key, value) => {
+        updateParams({
+            ...params,
+            [key]: value
+        });
+    };
+
+    const onDeleteParam = (keyToDelete) => {
+        const nextParams = { ...params };
+        delete nextParams[keyToDelete];
+        updateParams(nextParams);
+    };
+
+    const paramKeys = Object.keys(params);
+    const dataSource = paramKeys.map(key => ({ key, value: params[key] }));
+
+    const columns = [
+        {
+            title: 'Key',
+            dataIndex: 'key',
+            width: '35%'
+        },
+        {
+            title: 'Value',
+            dataIndex: 'value',
+            render: (value, record) => (
+                <TextInput
+                    disabled={disabled}
+                    value={value === undefined || value === null ? '' : String(value)}
+                    onChange={(evt) => onParamValueChange(record.key, evt.target.value)}
+                />
+            )
+        },
+        {
+            dataIndex: 'key',
+            width: '2.5em',
+            render: (key) => (
+                <ToolsContainer>
+                    <IconButton
+                        type='delete'
+                        disabled={disabled}
+                        onClick={() => onDeleteParam(key)} />
+                </ToolsContainer>
+            )
+        }
+    ];
+
+    return (
+        <>
+            <ParamsToggleContainer>
+                <Badge count={paramKeys.length}>
+                    <Button
+                        onClick={() => setShowParams(!showParams)}
+                        disabled={disabled}>
+                        <Message messageKey='jsonTab.fields.params'/>
+                    </Button>
+                </Badge>
+            </ParamsToggleContainer>
+            {showParams && (
+                <ParamsTableContainer>
+                    <Table
+                        columns={columns}
+                        dataSource={dataSource}
+                        pagination={false}
+                    />
+                </ParamsTableContainer>
+            )}
+        </>
+    );
+};
+
+ServiceUrlParams.propTypes = {
+    params: PropTypes.object,
+    disabled: PropTypes.bool,
+    controller: PropTypes.instanceOf(Controller).isRequired
+};

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlParams.jsx
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlParams.jsx
@@ -1,42 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { styled } from 'styled-components';
-import { Badge, Button, Message, TextInput } from 'oskari-ui';
+import { Message, TextInput } from 'oskari-ui';
 import { Table, ToolsContainer, getSorterFor } from 'oskari-ui/components/Table';
 import { Controller } from 'oskari-ui/util';
 import { IconButton } from 'oskari-ui/components/buttons';
 import { ServiceUrlAddParam } from './ServiceUrlAddParam';
 
-const ParamsToggleContainer = styled('div')`
-    margin-bottom: 0.5em;
-`;
-
-export const ParamsToggle = ({ count, open, disabled, onClick }) => (
-    <ParamsToggleContainer>
-        <Badge count={count}>
-            <Button onClick={onClick} disabled={disabled}>
-                <Message messageKey={open ? 'fields.params.hide' : 'fields.params.show'}/>
-            </Button>
-        </Badge>
-    </ParamsToggleContainer>
-);
-
-ParamsToggle.propTypes = {
-    count: PropTypes.number,
-    open: PropTypes.bool,
-    disabled: PropTypes.bool,
-    onClick: PropTypes.func
-};
-
 const ParamsTableContainer = styled('div')`
     margin-top: 0.5em;
 `;
 
-export const ServiceUrlParams = ({ params = {}, open, disabled, controller }) => {
-    if (!open) {
-        return null;
-    }
-
+export const ServiceUrlParams = ({ params = {}, disabled, controller }) => {
     const updateParams = (nextParams) => {
         controller.setValueForLayer('params', nextParams);
     };
@@ -114,7 +89,6 @@ export const ServiceUrlParams = ({ params = {}, open, disabled, controller }) =>
 
 ServiceUrlParams.propTypes = {
     params: PropTypes.object,
-    open: PropTypes.bool,
     disabled: PropTypes.bool,
     controller: PropTypes.instanceOf(Controller).isRequired
 };

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlParams.jsx
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlParams.jsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { styled } from 'styled-components';
 import { Badge, Button, Message, TextInput } from 'oskari-ui';
-import { Table, ToolsContainer } from 'oskari-ui/components/Table';
+import { Table, ToolsContainer, getSorterFor } from 'oskari-ui/components/Table';
 import { Controller } from 'oskari-ui/util';
 import { IconButton } from 'oskari-ui/components/buttons';
 
@@ -10,12 +10,31 @@ const ParamsToggleContainer = styled('div')`
     margin-bottom: 0.5em;
 `;
 
+export const ParamsToggle = ({ count, open, disabled, onClick }) => (
+    <ParamsToggleContainer>
+        <Badge count={count}>
+            <Button onClick={onClick} disabled={disabled}>
+                <Message messageKey={open ? 'fields.params.hide' : 'fields.params.show'}/>
+            </Button>
+        </Badge>
+    </ParamsToggleContainer>
+);
+
+ParamsToggle.propTypes = {
+    count: PropTypes.number,
+    open: PropTypes.bool,
+    disabled: PropTypes.bool,
+    onClick: PropTypes.func
+};
+
 const ParamsTableContainer = styled('div')`
     margin-top: 0.5em;
 `;
 
-export const ServiceUrlParams = ({ params = {}, disabled, controller }) => {
-    const [showParams, setShowParams] = useState(false);
+export const ServiceUrlParams = ({ params = {}, open, disabled, controller }) => {
+    if (!open) {
+        return null;
+    }
 
     const updateParams = (nextParams) => {
         controller.setValueForLayer('params', nextParams);
@@ -39,12 +58,14 @@ export const ServiceUrlParams = ({ params = {}, disabled, controller }) => {
 
     const columns = [
         {
-            title: 'Key',
+            title: <Message messageKey='fields.params.key'/>,
             dataIndex: 'key',
-            width: '35%'
+            width: '35%',
+            sorter: getSorterFor('key'),
+            defaultSortOrder: 'ascend'
         },
         {
-            title: 'Value',
+            title: <Message messageKey='fields.params.value'/>,
             dataIndex: 'value',
             render: (value, record) => (
                 <TextInput
@@ -69,31 +90,19 @@ export const ServiceUrlParams = ({ params = {}, disabled, controller }) => {
     ];
 
     return (
-        <>
-            <ParamsToggleContainer>
-                <Badge count={paramKeys.length}>
-                    <Button
-                        onClick={() => setShowParams(!showParams)}
-                        disabled={disabled}>
-                        <Message messageKey='jsonTab.fields.params'/>
-                    </Button>
-                </Badge>
-            </ParamsToggleContainer>
-            {showParams && (
-                <ParamsTableContainer>
-                    <Table
-                        columns={columns}
-                        dataSource={dataSource}
-                        pagination={false}
-                    />
-                </ParamsTableContainer>
-            )}
-        </>
+        <ParamsTableContainer>
+            <Table
+                columns={columns}
+                dataSource={dataSource}
+                pagination={false}
+            />
+        </ParamsTableContainer>
     );
 };
 
 ServiceUrlParams.propTypes = {
     params: PropTypes.object,
+    open: PropTypes.bool,
     disabled: PropTypes.bool,
     controller: PropTypes.instanceOf(Controller).isRequired
 };

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlParams.jsx
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlParams.jsx
@@ -5,6 +5,7 @@ import { Badge, Button, Message, TextInput } from 'oskari-ui';
 import { Table, ToolsContainer, getSorterFor } from 'oskari-ui/components/Table';
 import { Controller } from 'oskari-ui/util';
 import { IconButton } from 'oskari-ui/components/buttons';
+import { ServiceUrlAddParam } from './ServiceUrlAddParam';
 
 const ParamsToggleContainer = styled('div')`
     margin-bottom: 0.5em;
@@ -53,6 +54,13 @@ export const ServiceUrlParams = ({ params = {}, open, disabled, controller }) =>
         updateParams(nextParams);
     };
 
+    const onAddParam = (key, value) => {
+        updateParams({
+            ...params,
+            [key]: value
+        });
+    };
+
     const paramKeys = Object.keys(params);
     const dataSource = paramKeys.map(key => ({ key, value: params[key] }));
 
@@ -96,6 +104,10 @@ export const ServiceUrlParams = ({ params = {}, open, disabled, controller }) =>
                 dataSource={dataSource}
                 pagination={false}
             />
+            <ServiceUrlAddParam
+                disabled={disabled}
+                params={params}
+                onAdd={onAddParam} />
         </ParamsTableContainer>
     );
 };

--- a/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlParams.jsx
+++ b/bundles/admin/admin-layereditor/view/ServiceEndPoint/ServiceUrlParams.jsx
@@ -11,6 +11,16 @@ const ParamsTableContainer = styled('div')`
     margin-top: 0.5em;
 `;
 
+const BaseCell = styled('div')`
+    display: flex;
+    align-items: center;
+    width: 100%;
+`;
+
+const ActionCell = styled(BaseCell)`
+    justify-content: flex-end;
+`;
+
 export const ServiceUrlParams = ({ params = {}, disabled, controller }) => {
     const updateParams = (nextParams) => {
         controller.setValueForLayer('params', nextParams);
@@ -38,6 +48,9 @@ export const ServiceUrlParams = ({ params = {}, disabled, controller }) => {
 
     const paramKeys = Object.keys(params);
     const dataSource = paramKeys.map(key => ({ key, value: params[key] }));
+    const middleCell = () => ({
+        style: { verticalAlign: 'middle' }
+    });
 
     const columns = [
         {
@@ -45,29 +58,37 @@ export const ServiceUrlParams = ({ params = {}, disabled, controller }) => {
             dataIndex: 'key',
             width: '35%',
             sorter: getSorterFor('key'),
-            defaultSortOrder: 'ascend'
+            defaultSortOrder: 'ascend',
+            onCell: middleCell,
+            render: (key) => <BaseCell>{key}</BaseCell>
         },
         {
             title: <Message messageKey='fields.params.value'/>,
             dataIndex: 'value',
+            onCell: middleCell,
             render: (value, record) => (
-                <TextInput
-                    disabled={disabled}
-                    value={value === undefined || value === null ? '' : String(value)}
-                    onChange={(evt) => onParamValueChange(record.key, evt.target.value)}
-                />
+                <BaseCell>
+                    <TextInput
+                        disabled={disabled}
+                        value={value === undefined || value === null ? '' : String(value)}
+                        onChange={(evt) => onParamValueChange(record.key, evt.target.value)}
+                    />
+                </BaseCell>
             )
         },
         {
             dataIndex: 'key',
             width: '2.5em',
+            onCell: middleCell,
             render: (key) => (
-                <ToolsContainer>
-                    <IconButton
-                        type='delete'
-                        disabled={disabled}
-                        onClick={() => onDeleteParam(key)} />
-                </ToolsContainer>
+                <ActionCell>
+                    <ToolsContainer>
+                        <IconButton
+                            type='delete'
+                            disabled={disabled}
+                            onClick={() => onDeleteParam(key)} />
+                    </ToolsContainer>
+                </ActionCell>
             )
         }
     ];

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "paths": {
+      "oskari-ui": ["./src/react/index.js"],
       "oskari-ui/*": ["./src/react/*"]
     }
   }

--- a/src/react/components/buttons/CopyButton.jsx
+++ b/src/react/components/buttons/CopyButton.jsx
@@ -9,22 +9,25 @@ const copy = (value) => {
     Messaging.success(<Message bundleKey='oskariui' messageKey='messages.copied' />);
 };
 
-export const CopyButton = ({ value, onClick }) => {
+export const CopyButton = ({ value, onClick, disabled = false, ...other }) => {
 
     return (
         <PrimaryButton
             type='copy'
+            disabled={disabled}
             onClick={() => {
                 if (typeof onClick === 'function') {
-                    onClick()
+                    onClick();
                 }
                 copy(value);
             }}
+            {...other}
         />
     );
 };
 
 CopyButton.propTypes = {
     value: PropTypes.string,
-    onClick: PropTypes.func
+    onClick: PropTypes.func,
+    disabled: PropTypes.bool
 };


### PR DESCRIPTION
* Add a separate params - section in layeradmin to manage url params for layer.
* Reserved parameter SERVICE, VERSION & REQUEST are cleaned out as before and added to outbound requests under the hood. Adding said params isn't allowed using the table either.
* removed the params - collapse from under JSON tab.

TODO - regarding copy to clipboard functionality: should we be adding said params to url when copying and should we display those inside the params table (not editable)?

Add a new fresh layer:
<img width="642" height="401" alt="image" src="https://github.com/user-attachments/assets/5823a673-c407-4144-a3c5-2d7821d8f718" />
   
params snatched from url input field:
<img width="646" height="607" alt="image" src="https://github.com/user-attachments/assets/d79c9048-4437-404c-b370-4e2e98a44d33" />

layer selected and in edit view:
<img width="624" height="620" alt="image" src="https://github.com/user-attachments/assets/c298500b-3923-4868-9ba8-defe9f7ade84" />

reserved params not allowed
<img width="610" height="605" alt="image" src="https://github.com/user-attachments/assets/4665141d-e0ed-4dc8-9ace-834239ab6fef" />
