### PR TITLE
Layer admin coverage

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -49,6 +49,8 @@ Oskari.registerLocalization(
                 "scale": "Scale",
                 "coverage":"Show map layer coverage on the map",
                 "metadataCoverage":"Show map layer metadata coverage on the map",
+                "ignoreCoverage":"Ignore map layer coverage",
+                "ignoreMetadataCoverage":"Ignore map layer metadata coverage",
                 "declutter": "Draw object names separately (declutter).",
                 "gfiContent": "Additional GFI info",
                 "gfiType": "GFI response type",

--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -48,6 +48,7 @@ Oskari.registerLocalization(
                 "refreshRate": "Refresh rate in seconds",
                 "scale": "Scale",
                 "coverage":"Show map layer coverage on the map",
+                "metadataCoverage":"Show map layer metadata coverage on the map",
                 "declutter": "Draw object names separately (declutter).",
                 "gfiContent": "Additional GFI info",
                 "gfiType": "GFI response type",
@@ -305,6 +306,7 @@ Oskari.registerLocalization(
                 "deleteErrorGroupHasSubgroups": "The group you are trying to remove contains subgroups. Delete the subgroups first.",
                 "errorFetchCoverage": "Failed to get the map layer coverage from the service.",
                 "noCoverage": "The map layer coverage isn't restricted.",
+                "noMetadataCoverage": "Metadata coverage isn't available for this layer.",
                 "invalidScale": "Check the layer scale limits.",
                 "noFeatureProperties": "Layer doesn't have feature properties information."
             },

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -48,6 +48,8 @@ Oskari.registerLocalization(
                 "scale": "Mittakaava",
                 "coverage":"Näytä karttatason kattavuusalue kartalla",
                 "metadataCoverage":"Näytä karttatason metadatan kattavuusalue kartalla",
+                "ignoreCoverage":"Ohita karttatason kattavuusalue",
+                "ignoreMetadataCoverage":"Ohita karttatason metadatan kattavuusalue",
                 "declutter": "Piirrä kohteiden nimet erikseen (declutter).",
                 "gfiContent": "Kohdetietoikkunan lisäsisältö",
                 "gfiType": "GFI-vastaustyyppi",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -47,6 +47,7 @@ Oskari.registerLocalization(
                 "refreshRate": " Virkistystaajuus sekunteina",
                 "scale": "Mittakaava",
                 "coverage":"Näytä karttatason kattavuusalue kartalla",
+                "metadataCoverage":"Näytä karttatason metadatan kattavuusalue kartalla",
                 "declutter": "Piirrä kohteiden nimet erikseen (declutter).",
                 "gfiContent": "Kohdetietoikkunan lisäsisältö",
                 "gfiType": "GFI-vastaustyyppi",
@@ -305,6 +306,7 @@ Oskari.registerLocalization(
                 "deleteErrorGroupHasSubgroups": "Ryhmä jota yrität poistaa sisältää aliryhmiä. Poista ensin aliryhmät.",
                 "errorFetchCoverage": "Palvelusta ei saatu haettua karttatason kattavuusaluetta.",
                 "noCoverage": "Karttatason kattavuutta ei ole rajoitettu.",
+                "noMetadataCoverage": "Tasolle ei ole saatavilla metadatan kattavuusaluetta.",
                 "invalidScale": "Tarkista tason mittakaavarajat.",
                 "noFeatureProperties": "Kohteiden ominaisuustietoja ei ole saatavilla tasolle."
             },

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -48,6 +48,7 @@ Oskari.registerLocalization(
                 "refreshRate": "Uppdateringsfrekvens (i sekunder)",
                 "scale": "Skala",
                 "coverage":"Visa kartlagrets täckningsområde på kartan",
+                "metadataCoverage":"Visa kartlagrets metadatas täckningsområde på kartan",
                 "declutter": "Rita objektnamn separat (declutter).",
                 "gfiContent": "Tilläggande text för GFI-dialog",
                 "gfiType": "GFI svartyp",
@@ -304,6 +305,7 @@ Oskari.registerLocalization(
                 "deleteErrorGroupHasSubgroups": "Gruppen du försöker ta bort innehåller undergrupper. Ta bort undergrupperna först.",
                 "errorFetchCoverage": "Kan inte hämtas kartlagrets täckningsområde från tjänsten.",
                 "noCoverage": "Kartlagrets täckningsområde är inte begränsat.",
+                "noMetadataCoverage": "Metadata-täckning finns inte tillgänglig för kartlagret.",
                 "invalidScale": "Kontrollera skalbegränsningarna för kartlagret."
             },
             "dynamicScreenSpaceErrorOptions": "Dynamic screen space error options",

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -49,6 +49,8 @@ Oskari.registerLocalization(
                 "scale": "Skala",
                 "coverage":"Visa kartlagrets täckningsområde på kartan",
                 "metadataCoverage":"Visa kartlagrets metadatas täckningsområde på kartan",
+                "ignoreCoverage":"Ignorera kartlagrets täckningsområde",
+                "ignoreMetadataCoverage":"Ignorera kartlagrets metadatas täckningsområde",
                 "declutter": "Rita objektnamn separat (declutter).",
                 "gfiContent": "Tilläggande text för GFI-dialog",
                 "gfiType": "GFI svartyp",

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -303,6 +303,28 @@ class UIHandler extends StateHandler {
         this.updateLayerAttributes(attributes, layer);
     }
 
+    setIgnoreCoverage (ignoreCoverage) {
+        const layer = { ...this.getState().layer };
+        const attributes = { ...(layer.attributes || {}) };
+        if (ignoreCoverage) {
+            attributes.ignoreCoverage = true;
+        } else {
+            delete attributes.ignoreCoverage;
+        }
+        this.updateLayerAttributes(attributes, layer);
+    }
+
+    setIgnoreMetadataCoverage (ignoreMetadataCoverage) {
+        const layer = { ...this.getState().layer };
+        const attributes = { ...(layer.attributes || {}) };
+        if (ignoreMetadataCoverage) {
+            attributes.ignoreMetadataCoverage = true;
+        } else {
+            delete attributes.ignoreMetadataCoverage;
+        }
+        this.updateLayerAttributes(attributes, layer);
+    }
+
     setAttributesData (key, value) {
         const layer = { ...this.getState().layer };
         const { data = {} } = layer.attributes || {};
@@ -1257,6 +1279,8 @@ const wrapped = controllerMixin(UIHandler, [
     'setAttributes',
     'setAttributesData',
     'setFeatureFilter',
+    'setIgnoreCoverage',
+    'setIgnoreMetadataCoverage',
     'setAttributionsJSON',
     'setCapabilitiesUpdateRate',
     'setClusteringDistance',

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -606,7 +606,8 @@ class UIHandler extends StateHandler {
         }
         this.resetLayer(keepCapabilities);
         this.ajaxStarted();
-        fetch(Oskari.urls.getRoute('LayerAdmin', { id }), {
+        const srs = Oskari.getSandbox().getMap().getSrsName();
+        fetch(Oskari.urls.getRoute('LayerAdmin', { id, srs }), {
             method: 'GET',
             headers: {
                 'Accept': 'application/json'
@@ -1203,31 +1204,20 @@ class UIHandler extends StateHandler {
         Oskari.getSandbox().postRequestByName('MapModulePlugin.RemoveFeaturesFromMapRequest', [null, null, COVERAGE_LAYER]);
     }
 
-    showLayerCoverage (id) {
-        const srs = Oskari.getSandbox().getMap().getSrsName();
-        fetch(Oskari.urls.getRoute('DescribeLayer', { id, srs }), {
-            method: 'GET',
-            headers: {
-                'Accept': 'application/json'
-            }
-        }).then(response => response.json())
-            .then(({ coverage }) => {
-                if (!coverage) {
-                    Messaging.info(getMessage('messages.noCoverage'));
-                    this.clearLayerCoverage();
-                    return;
-                }
-                const opts = {
-                    centerTo: true,
-                    clearPrevious: true,
-                    layerId: COVERAGE_LAYER
-                };
-                Oskari.getSandbox().postRequestByName('MapModulePlugin.AddFeaturesToMapRequest', [coverage, opts]);
-            }).catch((error) => {
-                Messaging.error(getMessage('messages.errorFetchCoverage'));
-                this.log.error(`Failed to get layer coverage for id: ${id}`, error);
-                this.clearLayerCoverage();
-            });
+    showLayerCoverage () {
+        const { layer = {} } = this.getState();
+        const { coverage } = layer;
+        if (!coverage) {
+            Messaging.info(getMessage('messages.noCoverage'));
+            this.clearLayerCoverage();
+            return;
+        }
+        const opts = {
+            centerTo: true,
+            clearPrevious: true,
+            layerId: COVERAGE_LAYER
+        };
+        Oskari.getSandbox().postRequestByName('MapModulePlugin.AddFeaturesToMapRequest', [coverage, opts]);
     }
 
     toggleDeclutter (checked) {

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/AdminLayerFormHandler.js
@@ -9,6 +9,7 @@ import { TIME_SERIES_UI } from './VisualizationTabPane/TimeSeries';
 const LayerComposingModel = Oskari.clazz.get('Oskari.mapframework.domain.LayerComposingModel');
 const DEFAULT_TAB = 'general';
 const COVERAGE_LAYER = 'AdminLayerEditorCoverage';
+const METADATA_COVERAGE_LAYER = 'AdminLayerEditorMetadataCoverage';
 
 const getMessage = (key, args) => <Message messageKey={key} messageArgs={args} bundleKey='admin-layereditor' />;
 
@@ -546,6 +547,7 @@ class UIHandler extends StateHandler {
 
     resetMap () {
         this.clearLayerCoverage();
+        this.clearLayerMetadataCoverage();
     }
 
     ajaxStarted () {
@@ -1204,6 +1206,10 @@ class UIHandler extends StateHandler {
         Oskari.getSandbox().postRequestByName('MapModulePlugin.RemoveFeaturesFromMapRequest', [null, null, COVERAGE_LAYER]);
     }
 
+    clearLayerMetadataCoverage () {
+        Oskari.getSandbox().postRequestByName('MapModulePlugin.RemoveFeaturesFromMapRequest', [null, null, METADATA_COVERAGE_LAYER]);
+    }
+
     showLayerCoverage () {
         const { layer = {} } = this.getState();
         const { coverage } = layer;
@@ -1214,10 +1220,26 @@ class UIHandler extends StateHandler {
         }
         const opts = {
             centerTo: true,
-            clearPrevious: true,
+            clearPrevious: false,
             layerId: COVERAGE_LAYER
         };
         Oskari.getSandbox().postRequestByName('MapModulePlugin.AddFeaturesToMapRequest', [coverage, opts]);
+    }
+
+    showLayerMetadataCoverage () {
+        const { layer = {} } = this.getState();
+        const { coverageMetadata } = layer;
+        if (!coverageMetadata) {
+            Messaging.info(getMessage('messages.noMetadataCoverage'));
+            this.clearLayerMetadataCoverage();
+            return;
+        }
+        const opts = {
+            centerTo: true,
+            clearPrevious: false,
+            layerId: METADATA_COVERAGE_LAYER
+        };
+        Oskari.getSandbox().postRequestByName('MapModulePlugin.AddFeaturesToMapRequest', [coverageMetadata, opts]);
     }
 
     toggleDeclutter (checked) {
@@ -1279,7 +1301,9 @@ const wrapped = controllerMixin(UIHandler, [
     'versionSelected',
     'showLayerMetadata',
     'clearLayerCoverage',
+    'clearLayerMetadataCoverage',
     'showLayerCoverage',
+    'showLayerMetadataCoverage',
     'toggleDeclutter'
 ]);
 export { wrapped as AdminLayerFormHandler };

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Coverage.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Coverage.jsx
@@ -1,15 +1,16 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Controller } from 'oskari-ui/util';
-import { Message, Switch } from 'oskari-ui';
+import { Checkbox, Message, Switch } from 'oskari-ui';
 import { StyledFormField, SpacedLabel } from '../styled';
 
-export const Coverage = ({ id, controller }) => {
+export const Coverage = ({ layer, controller }) => {
     const [checked, setChecked] = useState(false);
     const [metadataChecked, setMetadataChecked] = useState(false);
+    const { attributes = {} } = layer;
     const toggle = checked => {
         if (checked) {
-            controller.showLayerCoverage(id);
+            controller.showLayerCoverage();
         } else {
             controller.clearLayerCoverage();
         }
@@ -39,11 +40,22 @@ export const Coverage = ({ id, controller }) => {
                     <Message messageKey='fields.metadataCoverage' LabelComponent={SpacedLabel} />
                 </label>
             </StyledFormField>
+            <StyledFormField>
+                <Checkbox checked={!!attributes.ignoreCoverage} onChange={evt => controller.setIgnoreCoverage(evt.target.checked)}>
+                    <Message messageKey='fields.ignoreCoverage' />
+                </Checkbox>
+            </StyledFormField>
+            <StyledFormField>
+                <Checkbox checked={!!attributes.ignoreMetadataCoverage} onChange={evt => controller.setIgnoreMetadataCoverage(evt.target.checked)}>
+                    <Message messageKey='fields.ignoreMetadataCoverage' />
+                </Checkbox>
+            </StyledFormField>
         </>
     );
 };
 
 Coverage.propTypes = {
     id: PropTypes.number.isRequired,
+    layer: PropTypes.object.isRequired,
     controller: PropTypes.instanceOf(Controller).isRequired
 };

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Coverage.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Coverage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Controller } from 'oskari-ui/util';
 import { Checkbox, Message, Switch } from 'oskari-ui';
@@ -8,6 +8,14 @@ export const Coverage = ({ layer, controller }) => {
     const [checked, setChecked] = useState(false);
     const [metadataChecked, setMetadataChecked] = useState(false);
     const { attributes = {} } = layer;
+    const isMetadataCoverageDisabled = attributes.ignoreCoverage || !layer.metadataid;
+
+    useEffect(() => {
+        if (isMetadataCoverageDisabled && attributes.ignoreMetadataCoverage) {
+            controller.setIgnoreMetadataCoverage(false);
+        }
+    }, [isMetadataCoverageDisabled, attributes.ignoreMetadataCoverage, controller]);
+
     const toggle = checked => {
         if (checked) {
             controller.showLayerCoverage();
@@ -46,7 +54,7 @@ export const Coverage = ({ layer, controller }) => {
                 </Checkbox>
             </StyledFormField>
             <StyledFormField>
-                <Checkbox checked={!!attributes.ignoreMetadataCoverage} onChange={evt => controller.setIgnoreMetadataCoverage(evt.target.checked)}>
+                <Checkbox disabled={isMetadataCoverageDisabled} checked={!!attributes.ignoreMetadataCoverage} onChange={evt => controller.setIgnoreMetadataCoverage(evt.target.checked)}>
                     <Message messageKey='fields.ignoreMetadataCoverage' />
                 </Checkbox>
             </StyledFormField>
@@ -55,7 +63,6 @@ export const Coverage = ({ layer, controller }) => {
 };
 
 Coverage.propTypes = {
-    id: PropTypes.number.isRequired,
     layer: PropTypes.object.isRequired,
     controller: PropTypes.instanceOf(Controller).isRequired
 };

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Coverage.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Coverage.jsx
@@ -6,22 +6,40 @@ import { StyledFormField, SpacedLabel } from '../styled';
 
 export const Coverage = ({ id, controller }) => {
     const [checked, setChecked] = useState(false);
+    const [metadataChecked, setMetadataChecked] = useState(false);
     const toggle = checked => {
         if (checked) {
-            controller.showLayerCoverage();
+            controller.showLayerCoverage(id);
         } else {
             controller.clearLayerCoverage();
         }
         setChecked(checked);
     };
 
+    const toggleMetadata = checked => {
+        if (checked) {
+            controller.showLayerMetadataCoverage();
+        } else {
+            controller.clearLayerMetadataCoverage();
+        }
+        setMetadataChecked(checked);
+    };
+
     return (
-        <StyledFormField>
-            <label>
-                <Switch size='small' checked={checked} onChange={checked => toggle(checked)} />
-                <Message messageKey='fields.coverage' LabelComponent={SpacedLabel} />
-            </label>
-        </StyledFormField>
+        <>
+            <StyledFormField>
+                <label>
+                    <Switch size='small' checked={checked} onChange={checked => toggle(checked)} />
+                    <Message messageKey='fields.coverage' LabelComponent={SpacedLabel} />
+                </label>
+            </StyledFormField>
+            <StyledFormField>
+                <label>
+                    <Switch size='small' checked={metadataChecked} onChange={checked => toggleMetadata(checked)} />
+                    <Message messageKey='fields.metadataCoverage' LabelComponent={SpacedLabel} />
+                </label>
+            </StyledFormField>
+        </>
     );
 };
 

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Coverage.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/Coverage.jsx
@@ -8,7 +8,7 @@ export const Coverage = ({ id, controller }) => {
     const [checked, setChecked] = useState(false);
     const toggle = checked => {
         if (checked) {
-            controller.showLayerCoverage(id);
+            controller.showLayerCoverage();
         } else {
             controller.clearLayerCoverage();
         }

--- a/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VisualizationTabPane.jsx
+++ b/bundles/admin/admin-layereditor/view/AdminLayerForm/VisualizationTabPane/VisualizationTabPane.jsx
@@ -44,7 +44,7 @@ export const VisualizationTabPane = ({ layer, scales, propertyFields, controller
                 <Opacity layer={layer} controller={controller} />
             }
             { propertyFields.includes(COVERAGE) &&
-                <Coverage id={layer.id} controller={controller} />
+                <Coverage layer={layer} controller={controller} />
             }
             { propertyFields.includes(DECLUTTER) &&
                 <Declutter layer={layer} controller={controller} />


### PR DESCRIPTION
Toggles in layeradmin for controlling how (and if) coverage info is shown for layer.

Related oskari-server pr: https://github.com/oskariorg/oskari-server/pull/1275

* in admin view both coverages can be toggled on simlultaneosly or separately for comparison
* toggle to prevent using the coverage info from metadata, in which case the backend wioll fall back to coverage from capabilities
* if ignoreCoverage is toggled on no coverage info whatsoever will be used for layer

<img width="492" height="189" alt="image" src="https://github.com/user-attachments/assets/28603ba5-eb0e-4603-bf37-7f6f1c2a0447" />
