### PR TITLE
fix antd selectors

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/LayerList/LayerCollapse/LayerCollapse.jsx
@@ -15,7 +15,7 @@ const StyledCollapse = styled(Collapse)`
         }
     }
 
-    .ant-collapse-content > .ant-collapse-content-box {
+    .ant-collapse-panel > .ant-collapse-body {
         padding: 0px;
         & > .ant-list {
             width: 100%;


### PR DESCRIPTION
bring back padding: 0 to layerlist

<img width="896" height="448" alt="image" src="https://github.com/user-attachments/assets/0b610f42-fd7d-49f1-8933-a0a24cc10c12" />
