### PR TITLE
Feature editor localized labels

### DIFF
--- a/src/react/components/FeatureEditor/FeatureEditorPanelHandler.js
+++ b/src/react/components/FeatureEditor/FeatureEditorPanelHandler.js
@@ -112,12 +112,14 @@ export class FeatureEditorPanelHandler extends StateHandler {
 
     setCurrentLayer (layerId, geometryType, types) {
         const mapLayer = this.mapLayerService.findMapLayer(layerId);
+        const fieldLabels = mapLayer.getAttributes('data')?.locale?.[Oskari.getLang()] || {};
         this.getSandbox().postRequestByName('AddMapLayerRequest', [layerId]);
         this.hideOtherVectorLayers(layerId);
         const newState = {
             id: layerId,
             geometryType: geometryType,
             fieldTypes: types,
+            fieldLabels,
             name: mapLayer.getName(Oskari.getDefaultLanguage())
         };
 

--- a/src/react/components/FeatureEditor/FeatureForm.jsx
+++ b/src/react/components/FeatureEditor/FeatureForm.jsx
@@ -21,32 +21,20 @@ const FieldNameLabel = ({ label, name }) => {
     return <Tooltip title={name}>{label}</Tooltip>;
 };
 
-const Label = ({ label, name, children }) => (<label><FieldNameLabel label={label} name={name} /> {children}</label>);
+const StyledFieldRow = styled('div')`
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    > *:last-child {
+        flex: 1;
+    }
+`;
 
-const IntegerField = ({ label, name, value, disabled, onUpdate }) => (
-    <React.Fragment>
-        <Label label={label} name={name}>
-            <NumberInput
-                disabled={disabled}
-                name={name}
-                value={value}
-                precision={0}
-                onChange={(newValue) => onUpdate(name, newValue)}/>
-        </Label><br/>
-    </React.Fragment>
-);
-
-const DoubleField = ({ label, name, value, disabled, onUpdate }) => (
-    <React.Fragment>
-        <Label label={label} name={name}>
-            <NumberInput
-                disabled={disabled}
-                name={name}
-                value={value}
-                onKeyDown={null}
-                onChange={(newValue) => onUpdate(name, newValue)}/>
-        </Label><br/>
-    </React.Fragment>
+const FieldWrapper = ({ label, name, children }) => (
+    <StyledFieldRow>
+        <FieldNameLabel label={label} name={name} />
+        {children}
+    </StyledFieldRow>
 );
 
 const BOOLEAN_OPTIONS = [
@@ -58,29 +46,47 @@ const StyledBooleanSelect = styled(Select)`
     min-width: fit-content;
 `;
 
+const IntegerField = ({ label, name, value, disabled, onUpdate }) => (
+    <FieldWrapper label={label} name={name}>
+        <NumberInput
+            disabled={disabled}
+            name={name}
+            value={value}
+            precision={0}
+            onChange={(newValue) => onUpdate(name, newValue)}/>
+    </FieldWrapper>
+);
+
+const DoubleField = ({ label, name, value, disabled, onUpdate }) => (
+    <FieldWrapper label={label} name={name}>
+        <NumberInput
+            disabled={disabled}
+            name={name}
+            value={value}
+            onKeyDown={null}
+            onChange={(newValue) => onUpdate(name, newValue)}/>
+    </FieldWrapper>
+);
+
 const BooleanField = ({ label, name, value, disabled, onUpdate }) => (
-    <React.Fragment>
-        <Label label={label} name={name}>
-            <StyledBooleanSelect
-                disabled={disabled}
-                value={value ?? null}
-                options={BOOLEAN_OPTIONS}
-                allowClear
-                onChange={(val) => onUpdate(name, val ?? null)}/>
-        </Label><br/>
-    </React.Fragment>
+    <FieldWrapper label={label} name={name}>
+        <StyledBooleanSelect
+            disabled={disabled}
+            value={value ?? null}
+            options={BOOLEAN_OPTIONS}
+            allowClear
+            onChange={(val) => onUpdate(name, val ?? null)}/>
+    </FieldWrapper>
 );
 
 const DateTimeField = ({ label, name, value, disabled, showTime, onUpdate }) => (
-    <React.Fragment>
-        <Label label={label} name={name}>
-            <DateTimePicker
-                disabled={disabled}
-                showTime={showTime}
-                value={value ? dayjs(value) : null}
-                onChange={(val) => onUpdate(name, val ? val.toISOString() : null)}/>
-        </Label><br/>
-    </React.Fragment>
+    <FieldWrapper label={label} name={name}>
+        <DateTimePicker
+            disabled={disabled}
+            showTime={showTime}
+            value={value ? dayjs(value) : null}
+            onChange={(val) => onUpdate(name, val ? val.toISOString() : null)}/>
+    </FieldWrapper>
 );
 
 const getFieldForType = (name, type, value, onUpdate, disabled, fieldLabels = {}) => {
@@ -101,12 +107,13 @@ const getFieldForType = (name, type, value, onUpdate, disabled, fieldLabels = {}
     if (isDateTimeField) {
         return <DateTimeField label={label} name={name} value={value} disabled={isDisabled} showTime={isTimestampField} onUpdate={onUpdate}/>;
     }
-    return (<TextInput
-        disabled={isDisabled}
-        name={name}
-        value={value}
-        addonBefore={<Label label={label} name={name} />}
-        onChange={(evt) => onUpdate(name, evt.target.value)} />);
+    return (<FieldWrapper label={label} name={name}>
+        <TextInput
+            disabled={isDisabled}
+            name={name}
+            value={value}
+            onChange={(evt) => onUpdate(name, evt.target.value)} />
+    </FieldWrapper>);
 };
 
 const getDecorated = ({ name, type, value, originalValue, isNew, onUpdate, disabled, fieldLabels }) => {

--- a/src/react/components/FeatureEditor/FeatureForm.jsx
+++ b/src/react/components/FeatureEditor/FeatureForm.jsx
@@ -1,8 +1,9 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, TextInput, NumberInput, Select, Message, Tooltip } from 'oskari-ui';
 import { StyledContainer, StyledModIndicator } from './styled';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 import { DateTimePicker } from 'oskari-ui/components/DateRange';
 import dayjs from 'dayjs';
 import { FIELD_TYPE_DATE, FIELD_TYPE_DATETIME, FIELD_TYPE_NUMBER_INT, FIELD_TYPE_NUMBER_DOUBLE, FIELD_TYPE_BOOLEAN, FIELD_NAME_ID } from './Helper';
@@ -13,11 +14,18 @@ export const StyledFormField = styled('div')`
     width: 100%;
 `;
 
-const Label = ({name, children}) => (<label>{name} {children}</label>);
+const FieldNameLabel = ({ label, name }) => {
+    if (label === name) {
+        return label;
+    }
+    return <Tooltip title={name}>{label}</Tooltip>;
+};
 
-const IntegerField = ({ name, value, disabled, onUpdate }) => (
+const Label = ({ label, name, children }) => (<label><FieldNameLabel label={label} name={name} /> {children}</label>);
+
+const IntegerField = ({ label, name, value, disabled, onUpdate }) => (
     <React.Fragment>
-        <Label name={name}>
+        <Label label={label} name={name}>
             <NumberInput
                 disabled={disabled}
                 name={name}
@@ -28,9 +36,9 @@ const IntegerField = ({ name, value, disabled, onUpdate }) => (
     </React.Fragment>
 );
 
-const DoubleField = ({ name, value, disabled, onUpdate }) => (
+const DoubleField = ({ label, name, value, disabled, onUpdate }) => (
     <React.Fragment>
-        <Label name={name}>
+        <Label label={label} name={name}>
             <NumberInput
                 disabled={disabled}
                 name={name}
@@ -50,9 +58,9 @@ const StyledBooleanSelect = styled(Select)`
     min-width: fit-content;
 `;
 
-const BooleanField = ({ name, value, disabled, onUpdate }) => (
+const BooleanField = ({ label, name, value, disabled, onUpdate }) => (
     <React.Fragment>
-        <Label name={name}>
+        <Label label={label} name={name}>
             <StyledBooleanSelect
                 disabled={disabled}
                 value={value ?? null}
@@ -63,9 +71,9 @@ const BooleanField = ({ name, value, disabled, onUpdate }) => (
     </React.Fragment>
 );
 
-const DateTimeField = ({ name, value, disabled, showTime, onUpdate }) => (
+const DateTimeField = ({ label, name, value, disabled, showTime, onUpdate }) => (
     <React.Fragment>
-        <Label name={name}>
+        <Label label={label} name={name}>
             <DateTimePicker
                 disabled={disabled}
                 showTime={showTime}
@@ -75,44 +83,45 @@ const DateTimeField = ({ name, value, disabled, showTime, onUpdate }) => (
     </React.Fragment>
 );
 
-const getFieldForType = (name, type, value, onUpdate, disabled) => {
+const getFieldForType = (name, type, value, onUpdate, disabled, fieldLabels = {}) => {
     const isDisabled = disabled || name === FIELD_NAME_ID;
+    const label = fieldLabels[name] || name;
     if (type === FIELD_TYPE_NUMBER_INT) {
-        return <IntegerField name={name} value={value} disabled={isDisabled} onUpdate={onUpdate}/>;
+        return <IntegerField label={label} name={name} value={value} disabled={isDisabled} onUpdate={onUpdate}/>;
     }
     if (type === FIELD_TYPE_NUMBER_DOUBLE || type === 'number') {
-        return <DoubleField name={name} value={value} disabled={isDisabled} onUpdate={onUpdate}/>;
+        return <DoubleField label={label} name={name} value={value} disabled={isDisabled} onUpdate={onUpdate}/>;
     }
     if (type === FIELD_TYPE_BOOLEAN) {
-        return <BooleanField name={name} value={value} disabled={isDisabled} onUpdate={onUpdate}/>;
+        return <BooleanField label={label} name={name} value={value} disabled={isDisabled} onUpdate={onUpdate}/>;
     }
     const typeLowerCase = (type || '').toLowerCase();
     const isTimestampField = typeLowerCase.includes(FIELD_TYPE_DATETIME);
     const isDateTimeField = isTimestampField || typeLowerCase.endsWith(FIELD_TYPE_DATE);
     if (isDateTimeField) {
-        return <DateTimeField name={name} value={value} disabled={isDisabled} showTime={isTimestampField} onUpdate={onUpdate}/>;
+        return <DateTimeField label={label} name={name} value={value} disabled={isDisabled} showTime={isTimestampField} onUpdate={onUpdate}/>;
     }
     return (<TextInput
         disabled={isDisabled}
         name={name}
         value={value}
-        addonBefore={<Label name={name} />}
+        addonBefore={<Label label={label} name={name} />}
         onChange={(evt) => onUpdate(name, evt.target.value)} />);
-}
+};
 
-const getDecorated = ({ name, type, value, originalValue, isNew, onUpdate, disabled }) => {
+const getDecorated = ({ name, type, value, originalValue, isNew, onUpdate, disabled, fieldLabels }) => {
     if (type === 'geometry') {
         return null;
     }
     const hasChanged = !isNew && originalValue !== value;
     let labelForOriginal = originalValue;
     if (!labelForOriginal) {
-        labelForOriginal = (<Message messageKey="FeatureEditorView.missingValue" />)
+        labelForOriginal = (<Message messageKey="FeatureEditorView.missingValue" />);
     }
     const noteForOriginal = (<Message messageKey="FeatureEditorView.originalValue">: {labelForOriginal}</Message>);
     return (
         <StyledFormField key={name}>
-            { getFieldForType(name, type, value, onUpdate, disabled) }
+            { getFieldForType(name, type, value, onUpdate, disabled, fieldLabels) }
             { hasChanged && <StyledContainer>
                 <Message messageKey="FeatureEditorView.modified" LabelComponent={StyledModIndicator} />
                 <Tooltip title={noteForOriginal}>
@@ -127,6 +136,7 @@ const getDecorated = ({ name, type, value, originalValue, isNew, onUpdate, disab
 
 export const FeatureForm = ({config = {}, feature = {}, original = {}, onChange, disabled = false}) => {
     const fieldsTypes = config.fieldTypes || {};
+    const fieldLabels = config.fieldLabels || {};
     const featureProperties = feature.properties || {};
     const originalProperties = original.properties || {};
 
@@ -148,7 +158,8 @@ export const FeatureForm = ({config = {}, feature = {}, original = {}, onChange,
             value: featureProperties[field],
             originalValue: originalProperties[field],
             onUpdate,
-            disabled
+            disabled,
+            fieldLabels
         }));
     return (
         <React.Fragment>


### PR DESCRIPTION
* use localised fieldname in feature editor if one is found
* unify label styling for difeerent input types (=lose the grey background of text input because that was a deprecated antd prop that caused the style).

<img width="642" height="585" alt="image" src="https://github.com/user-attachments/assets/23de7d64-feac-4b14-b74e-e44348579ac6" />
