### PR TITLE
Add localization for optional terrain profile results

### DIFF
--- a/bundles/framework/findbycoordinates/resources/locale/en.js
+++ b/bundles/framework/findbycoordinates/resources/locale/en.js
@@ -14,7 +14,8 @@ Oskari.registerLocalization(
             "WHAT3WORDS_CHANNEL": "what3words",
             "NLS_NEAREST_FEATURE_CHANNEL": "Nearest address",
             "ELFGEOLOCATOR_CHANNEL": "GeoLocator",
-            "TM35LEHTIJAKO_CHANNEL": "TM35 map sheet"
+            "TM35LEHTIJAKO_CHANNEL": "TM35 map sheet",
+            "TerrainElevationSearchChannel": "Elevation from sea level (m)"
         },
         "channelDescriptions": {
             "WHAT3WORDS_CHANNEL": "what3words is a unique combination of just 3 words that identifies a 3mx3m square, anywhere on the planet."

--- a/bundles/framework/findbycoordinates/resources/locale/fi.js
+++ b/bundles/framework/findbycoordinates/resources/locale/fi.js
@@ -13,7 +13,8 @@ Oskari.registerLocalization(
         "channels": {
             "WHAT3WORDS_CHANNEL": "what3words",
             "NLS_NEAREST_FEATURE_CHANNEL": "Lähin osoite",
-            "TM35LEHTIJAKO_CHANNEL": "TM35-karttalehti"
+            "TM35LEHTIJAKO_CHANNEL": "TM35-karttalehti",
+            "TerrainElevationSearchChannel": "Korkeus merenpinnasta (m)"
         },
         "channelDescriptions": {
             "WHAT3WORDS_CHANNEL": "what3words on 3 sanan yhdistelmä, joka määrittää tietyn 3 m x 3 m -ruudun missä tahansa maapallolla."

--- a/bundles/framework/findbycoordinates/resources/locale/sv.js
+++ b/bundles/framework/findbycoordinates/resources/locale/sv.js
@@ -13,7 +13,8 @@ Oskari.registerLocalization(
         "channels": {
             "WHAT3WORDS_CHANNEL": "what3words",
             "NLS_NEAREST_FEATURE_CHANNEL": "Närmaste adress",
-            "TM35LEHTIJAKO_CHANNEL": "TM35-kartblad"
+            "TM35LEHTIJAKO_CHANNEL": "TM35-kartblad",
+            "TerrainElevationSearchChannel": "Höjd från havsnivån (m)"
         },
         "channelDescriptions": {
             "WHAT3WORDS_CHANNEL": "what3words är en unik kombination av bara 3 ord som identifierar en ruta på 3 m x 3 m var som helst på planeten."


### PR DESCRIPTION
Related to: https://github.com/nlsfi/oskari-server-extras/pull/43

We could try injecting the name from terrain profile bundle, but the same is true for NLS_NEAREST_FEATURE_CHANNEL and TM35LEHTIJAKO_CHANNEL

<img width="558" height="151" alt="image" src="https://github.com/user-attachments/assets/f0e06c61-c7ad-4e01-8759-b8ea1dc478b7" />
