### PR TITLE
style editor pattern selection fix

### DIFF
--- a/src/react/components/StyleEditor/SvgRadioButton.jsx
+++ b/src/react/components/StyleEditor/SvgRadioButton.jsx
@@ -23,7 +23,7 @@ const RadioIcon = styled(Radio.Button)`
 `;
 
 const ButtonVisualization = ({ content, src, data }) => {
-    if (content && content.$$typeof == Symbol.for('react.element')) {
+    if (content && React.isValidElement(content)) {
         // assume React-component
         return content;
     }


### PR DESCRIPTION
fix for pattern svgs not showing in style editor area tab

<img width="533" height="544" alt="image" src="https://github.com/user-attachments/assets/df419cc4-17c6-4e4a-a09c-0eac284255d9" />

