### PR TITLE
fix mergelayer to use correct opacity and visibility

### DIFF
--- a/bundles/mapping/mapmodule/service/map.state.js
+++ b/bundles/mapping/mapmodule/service/map.state.js
@@ -423,10 +423,15 @@ import { UnsupportedLayerReason } from '../domain/UnsupportedLayerReason';
         mergeLayer: function(id, newLayer) {
             const index = this.getLayerIndex(id);
             if (index > -1) {
-                // do this to preserve layer specific stuff such as getFeatureCount on myfeatures layer
-                // when cloning
+                const current = _selectedLayers[index];
+                const opacity = current.getOpacity();
+                const visibilityInfo = current.getVisibilityInfo();
                 const emptyLayer = Object.create(Object.getPrototypeOf(newLayer));
-                _selectedLayers[index] = Object.assign(emptyLayer, newLayer);
+                const merged = Object.assign(emptyLayer, newLayer);
+                // TODO: we should move to a direction where maplayer and selectedlayer are in fact the same instance so there would be no need for this hacky and error prone copying props one by one
+                merged._opacity = opacity;
+                merged._visibilityInfo = { ...merged._visibilityInfo, ...visibilityInfo };
+                _selectedLayers[index] = merged;
             }
         },
         moveLayer: function (id, newIndex, triggeredBy) {


### PR DESCRIPTION
preserve opacity and visibility in case my features layer was already in selectedlayers and we needed to merge values after refresh.

<img width="1405" height="748" alt="image" src="https://github.com/user-attachments/assets/2e38e6b0-653c-4b69-a2e5-91ca33c92c43" />
