### PR TITLE
fix organisationname not showing for myf layers and add wrapper

### DIFF
--- a/bundles/mapping/mapmodule/plugin/logo/DataProviderPopup.jsx
+++ b/bundles/mapping/mapmodule/plugin/logo/DataProviderPopup.jsx
@@ -13,21 +13,31 @@ const DataSection = styled('div')`
 `;
 
 const createLink = (item) => {
-    if (typeof item === 'string') return item;
-    if (!item || !item.name) return null;
-    if (!item.url) return item.name;
-    return <a href={item.url} target='_blank'>{item.name}</a>;
+    if (typeof item === 'string') {
+        return item;
+    }
+    if (!item || !item.name) {
+        return null;
+    }
+    if (!item.url && !item.className) {
+        return item.name;
+    }
+    if (!item.url) {
+        return <span className={item.className}>{item.name}</span>;
+    }
+    return <a className={item.className} href={item.url} target='_blank'>{item.name}</a>;
 };
 
 const formatSource = (src) => {
     let source = [];
-    if (!src) return source;
-    if (Array.isArray(src)) {
-        source = src.map(s => createLink(s));
+    if (!src) {
         return source;
-    } else {
-        source.push(createLink(src));
     }
+    if (Array.isArray(src)) {
+        source = src.map((s) => createLink(s));
+        return source;
+    }
+    source.push(createLink(src));
     return source;
 };
 

--- a/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/logo/LogoPlugin.js
@@ -52,12 +52,7 @@ Oskari.clazz.define(
                     var layers = me.getSandbox().findAllSelectedMapLayers();
                     // add initial layers
                     layers.forEach(function (layer) {
-                        me._service.addItemToGroup(me.constLayerGroupId, {
-                            'id': layer.getId(),
-                            'name': layer.getName(),
-                            // AH-2182 Show source for user layers
-                            'source': layer.getSource && layer.getSource() ? layer.getSource() : layer.getOrganizationName()
-                        });
+                        me._service.addItemToGroup(me.constLayerGroupId, me.getItemFromLayer(layer));
                     });
                     // if service was created, add a change listener
                     this._service.on('change', function () {
@@ -127,11 +122,18 @@ Oskari.clazz.define(
                 }
             };
         },
+        getMyFeaturesSource: function (layer) {
+            return { name: layer.getOrganizationName(), className: 'myfeatures-organisation-name' };
+        },
         getItemFromLayer: function (layer) {
+            const isMyFeatures = layer.getLayerType && layer.getLayerType() === 'myf';
+            const source = isMyFeatures
+                ? this.getMyFeaturesSource(layer)
+                : (layer.getSource && layer.getSource() ? layer.getSource() : layer.getOrganizationName());
             return {
                 id: layer.getId(),
                 name: layer.getName(),
-                source: layer.getSource && layer.getSource() ? layer.getSource() : layer.getOrganizationName()
+                source
             };
         },
 

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -301,13 +301,12 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
         replaceLayer: function(layerId, newLayer) {
             this.removeLayer(layerId, true, true);
             this.addLayer(newLayer, true);
-            const mapLayerEvent = Oskari.eventBuilder('MapLayerEvent');
-            this.getSandbox().notifyAll(mapLayerEvent(layerId, 'update'));
-
             const map = this.getSandbox().getMap();
             if (map.isLayerSelected(layerId)) {
                 map.mergeLayer(layerId, newLayer);
             }
+            const mapLayerEvent = Oskari.eventBuilder('MapLayerEvent');
+            this.getSandbox().notifyAll(mapLayerEvent(layerId, 'update'));
         },
 
         /**


### PR DESCRIPTION
make sure organisationname is shown for myfeatures layers as well, even if they were already in view when the view was (re)loaded.

wrap to a <span class="myfeatures_organisation-name"/> to be able to override / hide this in other apps.

layer.getSource never seems to be truthy, so the condition of checking whether to use source or organisationname always seems to fall back to organisation. But I didn't dare remove that just in case there might be some side effects I hadn't considered.

<img width="409" height="278" alt="image" src="https://github.com/user-attachments/assets/147032ae-c1f4-4bd5-91e7-f215b17c9526" />
 