### PR TITLE
Initial testing for myf prefix/source from user input

### DIFF
--- a/bundles/mapping/mapmodule/plugin/logo/DataProviderPopup.jsx
+++ b/bundles/mapping/mapmodule/plugin/logo/DataProviderPopup.jsx
@@ -19,8 +19,22 @@ const createLink = (item) => {
     return <a href={item.url} target='_blank'>{item.name}</a>;
 };
 
-const formatSource = (src) => {
+const formatSource = (item) => {
+    console.log(item);
+    let { source: src } = item;
+    const { id = '' } = item;
+    const prefixIndex = ('' + id).indexOf('_');
+    let prefix = '';
+    if (prefixIndex !== -1) {
+        prefix = id.substring(0, prefixIndex);
+    }
     let source = [];
+    if (prefix) {
+        // TODO: search localization for prefix (myf -> My features and wrap in a span with class to be used as selector for hiding, if localization not found, just use src as is)
+        // TODO: if src is empty/null -> replace with string from localization like "Unknown"
+        // TODO: if layer type is actual MyFeatures layer == we are in the geoportal -> do something different
+        src = prefix + ' ' + src;
+    }
     if (!src) return source;
     if (Array.isArray(src)) {
         source = src.map(s => createLink(s));
@@ -40,7 +54,7 @@ export const PopupContent = ({ dataProviders, onClose }) => {
                     <div>
                         {data.items.map(item => (
                             <div key={item.id}>
-                                {item.name} {formatSource(item.source).map((src, index, arr) => {
+                                {item.name} {formatSource(item).map((src, index, arr) => {
                                     if (!src) return;
                                     if (arr.length > 1 && index < (arr.length - 1)) {
                                         return <span key={index}>{index === 0 && (' - ')}{src} - </span>

--- a/bundles/mapping/mapmodule/plugin/logo/DataProviderPopup.jsx
+++ b/bundles/mapping/mapmodule/plugin/logo/DataProviderPopup.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { showPopup } from 'oskari-ui/components/window';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 import { PrimaryButton, ButtonContainer } from 'oskari-ui/components/buttons';
 
 const StyledContent = styled('div')`
@@ -12,37 +12,70 @@ const DataSection = styled('div')`
     margin-bottom: 20px;
 `;
 
-const createLink = (item) => {
-    if (typeof item === 'string') return item;
-    if (!item || !item.name) return null;
-    if (!item.url) return item.name;
-    return <a href={item.url} target='_blank'>{item.name}</a>;
+// id can be number like 801 or a string like:
+// - 'STATS_LAYER' as ref to thematic map layer
+// - myf_[uuid] as ref to myfeatures layer
+// - 1_7 as ref to statistic indicator from datasource 1 and indicator 7
+const getIdPrefix = id => {
+    if (typeof id !== 'string') {
+        // number
+        return null;
+    }
+    const prefixIndex = id.indexOf('_');
+    if (prefixIndex === -1) {
+        return null;
+    }
+    return id.substring(0, prefixIndex);
 };
 
-const formatSource = (item) => {
-    console.log(item);
-    let { source: src } = item;
-    const { id = '' } = item;
-    const prefixIndex = ('' + id).indexOf('_');
-    let prefix = '';
-    if (prefixIndex !== -1) {
-        prefix = id.substring(0, prefixIndex);
+const SourcePrefix = ({ itemId }) => {
+    const prefix = getIdPrefix(itemId);
+    if (!prefix) {
+        return null;
     }
-    let source = [];
-    if (prefix) {
-        // TODO: search localization for prefix (myf -> My features and wrap in a span with class to be used as selector for hiding, if localization not found, just use src as is)
-        // TODO: if src is empty/null -> replace with string from localization like "Unknown"
-        // TODO: if layer type is actual MyFeatures layer == we are in the geoportal -> do something different
-        src = prefix + ' ' + src;
+    // search localization for prefix (myf -> My features)
+    // if we found a localization -> add the localization wrapped in a span with class to be used as selector for hiding
+    // if localization not found, don't add anything to the UI
+    // TODO: if layer type is actual MyFeatures layer == we are in the geoportal -> do something different (now we get layer name<span> - Own datasets</span> - Own datasets (from organization))
+    const localeString = Oskari.getMsg('MapModule', `plugin.LogoPlugin.layerPrefix.${prefix}`, null, null);
+    if (localeString) {
+        return <span className={'logoplugin-dataprovider-prefix-' + prefix}> - { localeString } </span>;
     }
-    if (!src) return source;
-    if (Array.isArray(src)) {
-        source = src.map(s => createLink(s));
-        return source;
-    } else {
-        source.push(createLink(src));
+    return null;
+};
+
+const createLink = (item) => {
+    if (!item && !item.name) {
+        // missing src replaced with string from localization like "Unknown"
+        return Oskari.getMsg('MapModule', `plugin.LogoPlugin.unknownSource`, null, null);
     }
-    return source;
+    if (typeof item === 'string') {
+        return item;
+    }
+    if (!item.url) {
+        return item.name;
+    }
+    return <a href={item.url} rel='noreferrer' target='_blank'>{item.name}</a>;
+};
+
+const formatSource = (source) => {
+    if (!source) {
+        return [Oskari.getMsg('MapModule', `plugin.LogoPlugin.unknownSource`, null, null)];
+    }
+    if (Array.isArray(source)) {
+        return source.map(s => createLink(s));
+    }
+    return [createLink(source)];
+};
+
+const DataProviderSource = ({item}) => {
+    const sources = formatSource(item.source).filter(item => item !== null);
+    if (!sources.length) {
+        return null;
+    }
+    return (<React.Fragment><SourcePrefix itemId={item.id} /> {sources.map((src, index) => {
+        return (<React.Fragment key={index}> - {src}</React.Fragment>);
+    })}</React.Fragment>);
 };
 
 export const PopupContent = ({ dataProviders, onClose }) => {
@@ -53,16 +86,7 @@ export const PopupContent = ({ dataProviders, onClose }) => {
                     <h4>{data.name}</h4>
                     <div>
                         {data.items.map(item => (
-                            <div key={item.id}>
-                                {item.name} {formatSource(item).map((src, index, arr) => {
-                                    if (!src) return;
-                                    if (arr.length > 1 && index < (arr.length - 1)) {
-                                        return <span key={index}>{index === 0 && (' - ')}{src} - </span>
-                                    } else {
-                                        return <span key={index}>{index === 0 && (' - ')}{src}</span>
-                                    }
-                                })}
-                            </div>
+                            <div key={item.id}>{item.name}<DataProviderSource item={item} /></div>
                         ))}
                     </div>
                 </DataSection>
@@ -79,6 +103,6 @@ export const showDataProviderPopup = (title, dataProviders, onClose) => {
     const options = {
         id: 'dataProviders',
         theme: mapModule.getMapTheme()
-    }
+    };
     return showPopup(title, <PopupContent dataProviders={dataProviders} onClose={onClose} />, onClose, options);
 };

--- a/bundles/mapping/mapmodule/resources/locale/en.js
+++ b/bundles/mapping/mapmodule/resources/locale/en.js
@@ -26,7 +26,11 @@ Oskari.registerLocalization(
             "LogoPlugin": {
                 "terms": "Terms of Use",
                 "dataSources": "Data Sources",
-                "layersHeader": "Map Layers"
+                "layersHeader": "Map Layers",
+                "unknownSource": "Unknown data source",
+                "layerPrefix": {
+                    "myf": "User provided"
+                }
             },
             "DataSourcePlugin": {
                 "link": "Data source",

--- a/bundles/mapping/mapmodule/resources/locale/fi.js
+++ b/bundles/mapping/mapmodule/resources/locale/fi.js
@@ -26,7 +26,11 @@ Oskari.registerLocalization(
             "LogoPlugin": {
                 "terms": "Käyttöehdot",
                 "dataSources": "Tietolähteet",
-                "layersHeader": "Karttatasot"
+                "layersHeader": "Karttatasot",
+                "unknownSource": "Tietolähde ei tiedossa",
+                "layerPrefix": {
+                    "myf": "Käyttäjän syöttämä"
+                }
             },
             "DataSourcePlugin": {
                 "link": "Tietolähde",

--- a/bundles/mapping/mapmodule/resources/locale/sv.js
+++ b/bundles/mapping/mapmodule/resources/locale/sv.js
@@ -26,7 +26,11 @@ Oskari.registerLocalization(
             "LogoPlugin": {
                 "terms": "Användarvillkor",
                 "dataSources": "Datakällor",
-                "layersHeader": "Kartlager"
+                "layersHeader": "Kartlager",
+                "unknownSource": "Unknown data source",
+                "layerPrefix": {
+                    "myf": "Egna dataset"
+                }
             },
             "DataSourcePlugin": {
                 "link": "Datakälla",

--- a/bundles/mapping/mapmodule/service/map.layer.js
+++ b/bundles/mapping/mapmodule/service/map.layer.js
@@ -301,13 +301,12 @@ Oskari.clazz.define('Oskari.mapframework.service.MapLayerService',
         replaceLayer: function(layerId, newLayer) {
             this.removeLayer(layerId, true, true);
             this.addLayer(newLayer, true);
-            const mapLayerEvent = Oskari.eventBuilder('MapLayerEvent');
-            this.getSandbox().notifyAll(mapLayerEvent(layerId, 'update'));
-
             const map = this.getSandbox().getMap();
             if (map.isLayerSelected(layerId)) {
                 map.mergeLayer(layerId, newLayer);
             }
+            const mapLayerEvent = Oskari.eventBuilder('MapLayerEvent');
+            this.getSandbox().notifyAll(mapLayerEvent(layerId, 'update'));
         },
 
         /**


### PR DESCRIPTION
PoC impl for https://github.com/oskariorg/oskari-server/pull/1280
Related to #3014

When the user has not added the source for layer (left is embedded, right is geoportal):
<img width="1488" height="495" alt="image" src="https://github.com/user-attachments/assets/4dbf16b3-bc50-4038-8088-a68a94f71226" />

When the user has added a source:
<img width="1380" height="615" alt="image" src="https://github.com/user-attachments/assets/ebb8024a-01a4-4a62-9631-cfeaea700e4d" />

In geoportal we always show the organization "Omat aineistot" that is used for grouping in the layer listing. In embedded maps the myfeatures layers are presented as wfs layers with nothing to show the organization so we can pass the user inputed source as organization to have it shown on the data provider popup.

The layer listing uses the organization for grouping so it's more difficult to show the user inputed value on the geoportal side. However, we might want to do something about it anyway. Maybe adding a new getter for maplayers for the data provider popup that defaults to the organization?

The additional prefix for data provider can be styled with css-locator: `logoplugin-dataprovider-prefix-myf` in applications.

Example for hiding it if the application trusts its users to not input anything misleading: 
```
.logoplugin-dataprovider-prefix-myf {
    display:none;
}
```
<img width="359" height="222" alt="image" src="https://github.com/user-attachments/assets/c7adcb20-febe-4cb6-a4ef-09251d2153ec" />

Or to highlight it:
```
.logoplugin-dataprovider-prefix-myf {
    color:red;
    font-weight: bold;
}
```
<img width="383" height="232" alt="image" src="https://github.com/user-attachments/assets/0f7a01a2-390e-4cdd-941a-f10f1b4c720b" />
