### PR TITLE
Update AntD to latest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,6 +31,6 @@ As an example if you see something like this as an error:
 You need to add the module (path after node_modules) to the list below (here it's 'earcut')
          */
         // oskari-frontend is included to make sharing jest.config possible when oskari-frontend is a dependency of the app being tested (for example pti-frontend)
-        'node_modules/(?!(oskari-frontend|ol|color-parse|color-space|color-rgba|color-name|antd|earcut|rc-util|jsts|geotiff|quick-lru|rbush|quickselect|pbf|mapbox-to-css-font)).+\\.js$'
+        'node_modules/(?!(oskari-frontend|ol|color-parse|color-space|color-rgba|@ant-design|color-name|antd|earcut|rc-util|jsts|geotiff|quick-lru|rbush|quickselect|pbf|mapbox-to-css-font)).+\\.js$'
     ]
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@ant-design/icons": "6.1.1",
+    "@ant-design/icons": "6.3.2",
     "@babel/core": "7.29.7",
     "@babel/preset-env": "7.29.7",
     "@babel/preset-react": "7.29.7",
@@ -40,7 +40,7 @@
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.4",
-    "antd": "6.3.5",
+    "antd": "6.6.1",
     "async": "3.2.6",
     "babel-loader": "10.1.1",
     "babel-plugin-styled-components": "2.1.4",


### PR DESCRIPTION
Required to modify jest transform ignore pattern because of errors running the tests:

```
    /home/runner/work/oskari-frontend/oskari-frontend/node_modules/@ant-design/colors/es/generate.js:1
    import { FastColor } from '@ant-design/fast-color';
    ^^^^^^

    SyntaxError: Cannot use import statement outside a module
```