### PR TITLE
Restore map button drop shadows

### DIFF
--- a/src/react/components/buttons/MapButton.jsx
+++ b/src/react/components/buttons/MapButton.jsx
@@ -23,7 +23,7 @@ const StyledButton = styled(Button)`
     border-radius: ${props => props.rounding};
     color: ${props => props.$active ? props.hover : props.iconcolor};
     background: ${props => props.bg};
-    box-shadow: 1px 1px 2px rgb(0 0 0 / 60%);
+    box-shadow: 1px 1px 2px rgb(0 0 0 / 60%) !important;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -43,6 +43,7 @@ const StyledButton = styled(Button)`
         border-color: transparent !important;
         box-shadow: none !important;
         outline: none;
+        box-shadow: 1px 1px 2px rgb(0 0 0 / 60%) !important;
     }
 `;
 const FilledButton = styled(StyledButton)`

--- a/src/react/theme/ThemeHelper.js
+++ b/src/react/theme/ThemeHelper.js
@@ -30,6 +30,11 @@ export const getAntdTheme = (theme) => {
                 // colorFillContentHover: accentColor
                 // fixes an issue where close icon has white bg while hovering
                 colorBgContainer: 'inherit'
+                /*
+                // Could be used to configure dropshadow, but couldn't make them work with mapbuttons
+                boxShadow: 'none',
+                boxShadowSecondary: 'none'
+                */
             },
             Slider: {
                 handleColor: DEFAULT_COLORS.SLIDER_BG,


### PR DESCRIPTION
Not really noticeable with a darker theme, but with white or light colored buttons. The drop shadow styling for buttons on top of the map has been overwritten in an AntD dependency update. This change restores the visual presentation of the buttons to what it was before.

Side by side comparison with white buttons:
<img width="161" height="409" alt="image" src="https://github.com/user-attachments/assets/b4b15821-0d75-49c8-be3e-c98a0b30f893" />

Side by side with dark buttons:
<img width="167" height="367" alt="image" src="https://github.com/user-attachments/assets/1647e42d-b73c-49e4-bc58-b02f5e9ec9a1" />



AntD has a theme config that allows customization of the style, but I feel it's too global of a config even when configured to buttons as we do have buttons in other places as well, not just on the map itself. So decided to have the custom map button drop-shadows to have !important in them to override the default AntD functionality.