### PR TITLE
Fix props bleeding through styled-comps to React/DOM

### DIFF
--- a/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/SelectedTab.jsx
+++ b/bundles/framework/layerlist/view/LayerViewTabs/SelectedLayers/SelectedTab.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Message } from 'oskari-ui';
 import { ThemeConsumer } from 'oskari-ui/util';
-import styled, { css, keyframes } from 'styled-components';
+import { styled, css, keyframes } from 'styled-components';
 import { getTextColor, getHeaderTheme } from 'oskari-ui/theme/ThemeHelper';
 
 const animation = keyframes`
@@ -28,15 +28,15 @@ const StyledBadge = styled.div`
     line-height: 20px;
     margin-left: 8px;
     font-weight: 700;
-    ${props => props.blink && css`
+    ${props => props.$blink && css`
         animation: ${animation} ${BLINK_DURATION_IN_SECONDS}s;
         animation-iteration-count: ${BLINK_COUNT};`}
 `;
 const NumberBadge = ThemeConsumer(({theme, isBlinking, count}) => {
     const helper = getHeaderTheme(theme);
-    return (<StyledBadge color={helper.getAccentColor()} blink={isBlinking}>
-                {count}
-            </StyledBadge>);
+    return (<StyledBadge color={helper.getAccentColor()} $blink={isBlinking}>
+        {count}
+    </StyledBadge>);
 });
 
 export const SelectedTab = ({ num, messageKey }) => {

--- a/bundles/mapping/mapmodule/MapModuleButton.jsx
+++ b/bundles/mapping/mapmodule/MapModuleButton.jsx
@@ -7,8 +7,8 @@ const Container = styled('div')`
     width: 32px;
     height: 32px;
     position: relative;
-    ${props => props.noMargin ? 'margin: 0' : 'margin: 10px 10px 0 10px'};
-    ${props => props.withToolbar && props.toolbarOpen && props.toolbarMargin};
+    ${props => props.$noMargin ? 'margin: 0' : 'margin: 10px 10px 0 10px'};
+    ${props => props.$withToolbar && props.$toolbarOpen && props.$toolbarMargin};
     display: flex;
     justify-content: center;
     align-items: center;
@@ -43,7 +43,7 @@ export const MapModuleButton = ({ visible = true, title, icon, onClick, size = '
     const mapModule = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule');
     return (
         <ThemeProvider value={mapModule.getMapTheme()}>
-            <Container size={size} noMargin={noMargin} withToolbar={withToolbar} toolbarOpen={toolbarOpen} toolbarMargin={toolbarMargin}>
+            <Container size={size} $noMargin={noMargin} $withToolbar={withToolbar} $toolbarOpen={toolbarOpen} $toolbarMargin={toolbarMargin}>
                 {withToolbar && children?.length === 1 ? (
                     <StyledButton
                         onClick={children[0].props.onClick}

--- a/src/react/components/Message.jsx
+++ b/src/react/components/Message.jsx
@@ -4,10 +4,10 @@ import { LocaleConsumer } from 'oskari-ui/util';
 import { styled } from 'styled-components';
 
 const Label = styled('div')`
-    display: ${props => props.allowTextEllipsis ? 'inline' : 'inline-block'};
-    overflow: ${props => props.allowTextEllipsis ? 'hidden' : ''};
-    white-space: ${props => props.allowTextEllipsis ? 'nowrap' : ''};
-    text-overflow: ${props => props.allowTextEllipsis ? 'ellipsis' : ''};
+    display: ${props => props.$allowTextEllipsis ? 'inline' : 'inline-block'};
+    overflow: ${props => props.$allowTextEllipsis ? 'hidden' : ''};
+    white-space: ${props => props.$allowTextEllipsis ? 'nowrap' : ''};
+    text-overflow: ${props => props.$allowTextEllipsis ? 'ellipsis' : ''};
 `;
 
 /**
@@ -72,7 +72,7 @@ const Message = ({ bundleKey, messageKey, messageArgs, defaultMsg, getMessage, f
     const labelProps = { ...injectedProps };
     // Only default Label - component will handle text ellipsis. For custom components / dom element strings we should just ignore it.
     if (LabelComponent === Label) {
-        labelProps.allowTextEllipsis = allowTextEllipsis;
+        labelProps.$allowTextEllipsis = allowTextEllipsis;
     }
 
     return (

--- a/src/react/components/Slider.jsx
+++ b/src/react/components/Slider.jsx
@@ -10,7 +10,7 @@ const handler = 12;
 const hover = DEFAULT_COLORS.SLIDER_HOVER;
 
 const StyledAntSlider = styled(AntSlider)`
-    ${props => props.noMargin ? 'margin: 0;' : ''}
+    ${props => props.$noMargin ? 'margin: 0;' : ''}
     .ant-slider-mark-text {
         white-space: nowrap;
         font-size: 11px;
@@ -25,7 +25,7 @@ const StyledAntSlider = styled(AntSlider)`
 
 const ThemedAntSlider = styled(AntSlider)`
     &&& {
-        ${props => props.noMargin ? 'margin: 0;' : ''}
+        ${props => props.$noMargin ? 'margin: 0;' : ''}
     }
     .ant-slider-mark {
         ${props => props.vertical ? '' : 'top: -18px;'}
@@ -75,12 +75,12 @@ const getThemedStyle = (theme, vertical, useThick) => {
     };
 };
 
-export const Slider = ({ theme, useThick, vertical, ...rest }) => {
-    return <StyledAntSlider vertical= {vertical} {...rest} />
+export const Slider = ({ theme, useThick, vertical, noMargin, ...rest }) => {
+    return <StyledAntSlider vertical={vertical} $noMargin={noMargin} {...rest} />;
 };
 
-export const ThemedSlider = ThemeConsumer(({ theme, useThick, vertical, ...rest }) => {
+export const ThemedSlider = ThemeConsumer(({ theme, useThick, vertical, noMargin, ...rest }) => {
     const helper = getNavigationTheme(theme);
     const style = getThemedStyle(helper, vertical, useThick);
-    return <ThemedAntSlider styles={style} theme={helper} useThick={useThick} vertical={vertical} {...rest} />
+    return <ThemedAntSlider styles={style} theme={helper} useThick={useThick} vertical={vertical} $noMargin={noMargin} {...rest} />;
 });

--- a/src/react/components/window/Header.jsx
+++ b/src/react/components/window/Header.jsx
@@ -13,7 +13,7 @@ const Container = styled('div')`
     color:  ${props => props.theme.getTextColor()};
     padding: 8px 10px;
     margin: 0px;
-    cursor: ${props => props.isDraggable ? 'grab' : undefined};
+    cursor: ${props => props.$isDraggable ? 'grab' : undefined};
 `;
 const ToolsContainer = styled('div')`
     display: flex;
@@ -42,7 +42,7 @@ export const Header = ThemeConsumer(({ title, isDraggable = false, onClose, them
     const headerTheme = getHeaderTheme(theme);
     return (
         <Container
-            isDraggable={isDraggable}
+            $isDraggable={isDraggable}
             theme={headerTheme}
             {...rest}
         >


### PR DESCRIPTION
Prefix props used for styled-components with $ to prevent warnings/errors like this:

<img width="1004" height="83" alt="image" src="https://github.com/user-attachments/assets/0ff6723d-5e60-4b09-8b42-a08285760417" />

No API change for components, just internal prop references when using styled-components to style divs etc.