### PR TITLE
Prevent device zoom when pinching with 3 fingers on map

### DIFF
--- a/bundles/mapping/mapmodule/resources/scss/mapmodule.ol.scss
+++ b/bundles/mapping/mapmodule/resources/scss/mapmodule.ol.scss
@@ -46,6 +46,21 @@ $pluginMargin: 10px;
     margin-right: 15px;
 }
 
+.ol-viewport {
+    .ol-touch {
+        /*
+         Prevent device gestures for example page zooming from map.
+         Note that the ol-touch element is only created on devices with touch screen
+         (or is not present on desktop mode, but is on DOM when using browser with mobile simulator mode).
+         */
+        touch-action: none;
+    }
+}
+/*
+ FIXME: check if olMap is still there in DOM.
+ Looks like it isn't by default!
+ We should probably use .oskari-map-impl-el as selector instead!
+*/
 div.olMap {
     position : relative;
 


### PR DESCRIPTION
Also noticed a problematic `div.olMap` styling selector that only works if the application defines the `olMap` class for the `.oskari-map-impl-el element`. We should take a closer look at it.