### PR TITLE
Fix .ol-viewport.ol-touch selector. Update .olMap reference to modern form

### DIFF
--- a/bundles/mapping/mapmodule/MapModuleClass.ol.js
+++ b/bundles/mapping/mapmodule/MapModuleClass.ol.js
@@ -54,7 +54,7 @@ export class MapModule extends AbstractMapModule {
      * @return {OpenLayers.Map}
      */
     _initImpl (sandbox, options, map) {
-        // css references use olMap as selectors so we need to add it
+        // css references have used olMap as selectors so we might need to add it
         this.getMapEl().addClass('olMap');
         return map;
     }

--- a/bundles/mapping/mapmodule/resources/scss/mapmodule.ol.scss
+++ b/bundles/mapping/mapmodule/resources/scss/mapmodule.ol.scss
@@ -46,23 +46,19 @@ $pluginMargin: 10px;
     margin-right: 15px;
 }
 
-.ol-viewport {
-    .ol-touch {
-        /*
-         Prevent device gestures for example page zooming from map.
-         Note that the ol-touch element is only created on devices with touch screen
-         (or is not present on desktop mode, but is on DOM when using browser with mobile simulator mode).
-         */
-        touch-action: none;
-    }
-}
-/*
- FIXME: check if olMap is still there in DOM.
- Looks like it isn't by default!
- We should probably use .oskari-map-impl-el as selector instead!
-*/
-div.olMap {
+.oskari-map-impl-el {
     position : relative;
+
+    .ol-viewport {
+        &.ol-touch {
+            /*
+            Prevent device gestures for example page zooming from map.
+            Note that the ol-touch element is only created on devices with touch screen
+            (or is not present on desktop mode, but is on DOM when using browser with mobile simulator mode).
+            */
+            touch-action: none;
+        }
+    }
 
     .ol-overlaycontainer-stopevent {
         z-index: 16000 !important;


### PR DESCRIPTION
Fixes selector added in #3036 where we want both classes on the same element (`.ol-viewport.ol-touch`)  instead of nested elements (`.ol-viewport .ol-touch`).

Also change `div.olMap` to `.oskari-map-impl-el` as that is the way we now reference the element in code. MapModule.init() adds the olMap class to the element still, but that probably could be removed.