### PR TITLE
Myfeatures bugs

### DIFF
--- a/bundles/framework/myfeatures/MyFeaturesList.jsx
+++ b/bundles/framework/myfeatures/MyFeaturesList.jsx
@@ -28,7 +28,7 @@ export const MyFeaturesList = ({ data = [], controller, loading }) => {
             align: 'left',
             title: <Message messageKey='tab.grid.desc' />,
             dataIndex: 'desc',
-            sorter: getSorterFor('description')
+            sorter: getSorterFor('desc')
         },
         {
             align: 'left',

--- a/bundles/framework/myfeatures/MyFeaturesList.jsx
+++ b/bundles/framework/myfeatures/MyFeaturesList.jsx
@@ -82,6 +82,7 @@ export const MyFeaturesList = ({ data = [], controller, loading }) => {
                 created: item.getCreated(),
                 name: item.getName(),
                 desc: item.getDescription(),
+                source: item.getOrganizationName(),
                 hasFeatureEditorTool: !!item.getFeatureTool(FEATURE_EDITOR_TOOLNAME)
             }))}
             pagination={false}

--- a/bundles/framework/myfeatures/service/MyFeaturesService.js
+++ b/bundles/framework/myfeatures/service/MyFeaturesService.js
@@ -268,7 +268,8 @@ export class MyFeaturesService {
             this.addLayerToService({
                 ...json,
                 name: localeForLang?.name || '',
-                subtitle: localeForLang?.desc || ''
+                subtitle: localeForLang?.desc || '',
+                orgName: localeForLang?.source || ''
             });
             return true;
         });
@@ -287,7 +288,10 @@ export class MyFeaturesService {
             subtitle: localeForLang?.desc
         });
         // for some reason, modelbuilders are not called in mapLayerService.updateLayer()
-        parseLayerData(layer, updatedLayer);
+        parseLayerData(layer, {
+            ...updatedLayer,
+            orgName: localeForLang?.source || ''
+        });
         // force mapmodule to reload a style when the layer is added/refreshed on the map
         layer.setDescribeLayerStatus(DESCRIBE_LAYER.UNDEFINED);
         if (this.sandbox.isLayerAlreadySelected(id)) {

--- a/bundles/framework/myfeatures/service/layerHandling.js
+++ b/bundles/framework/myfeatures/service/layerHandling.js
@@ -44,4 +44,7 @@ export const handleMyFeaturesLayers = (sandbox, mapLayerService, getMsg) => {
 
 export const parseLayerData = (layer, mapLayerJson) => {
     layer.setFeatureCount(mapLayerJson.featureCount);
+    // MyFeatures layers always have a dataprovider registered so the generic organization name set by
+    // MapLayerService would override the layer's own orgName. Restore the real per-layer value here.
+    layer.setOrganizationName(mapLayerJson.orgName || '');
 };

--- a/bundles/framework/myfeatures/service/layerHandling.js
+++ b/bundles/framework/myfeatures/service/layerHandling.js
@@ -47,4 +47,10 @@ export const parseLayerData = (layer, mapLayerJson) => {
     // MyFeatures layers always have a dataprovider registered so the generic organization name set by
     // MapLayerService would override the layer's own orgName. Restore the real per-layer value here.
     layer.setOrganizationName(mapLayerJson.orgName || '');
+    // "created" is an epoch timestamp in seconds (with fractional sub-second precision), but
+    // MapLayerService only accepts it via Date.parse() (which fails for epoch numbers) and Date()
+    // expects milliseconds, so convert and set it explicitly here instead.
+    if (mapLayerJson.created) {
+        layer.setCreated(new Date(mapLayerJson.created * 1000));
+    }
 };


### PR DESCRIPTION
- fix sorting for dcesc- field.
- use the value provided in "data source" field for the layer in the list of myfeatures layers. Not quite sure if this breaks stuff elsewhere given the fuzzy logic by which organisation name or datasource are determined elsewhere.  
-also add value for "created" field

<img width="566" height="374" alt="image" src="https://github.com/user-attachments/assets/443a0946-b8c2-4d41-bf06-487360495c2d" />

<img width="922" height="370" alt="image" src="https://github.com/user-attachments/assets/5ff471af-3bdd-4714-b618-3288bb85a0eb" />